### PR TITLE
Pass Python version to liboxen

### DIFF
--- a/oxen/src/lib.rs
+++ b/oxen/src/lib.rs
@@ -1,3 +1,4 @@
+use liboxen::config::RuntimeConfig;
 use pyo3::prelude::*;
 
 pub mod auth;
@@ -28,6 +29,15 @@ pub mod util;
 /// A Python module implemented in Rust.
 #[pymodule]
 fn oxen(m: Bound<'_, PyModule>) -> PyResult<()> {
+    let py_version = Python::version_info(m.py());
+    let _ = RuntimeConfig::set(
+        String::from("Python"),
+        format!(
+            "{}.{}.{}",
+            py_version.major, py_version.minor, py_version.patch
+        ),
+    );
+
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
     pyo3_async_runtimes::tokio::init(builder);

--- a/oxen/src/py_notebooks.rs
+++ b/oxen/src/py_notebooks.rs
@@ -3,13 +3,13 @@
 
 use pyo3::prelude::*;
 
-use liboxen::api;
-use liboxen::error::OxenError;
-use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_NOTEBOOK_BASE_IMAGE};
-use liboxen::opts::NotebookOpts;
-use liboxen::view::notebook::Notebook;
 use crate::error::PyOxenError;
 use crate::py_remote_repo::PyRemoteRepo;
+use liboxen::api;
+use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_NOTEBOOK_BASE_IMAGE};
+use liboxen::error::OxenError;
+use liboxen::opts::NotebookOpts;
+use liboxen::view::notebook::Notebook;
 
 #[pyclass]
 pub struct PyNotebook {
@@ -25,11 +25,18 @@ pub struct PyNotebook {
 impl PyNotebook {
     #[new]
     fn new(id: String, namespace: String, name: String) -> Self {
-        Self { id, namespace, name }
+        Self {
+            id,
+            namespace,
+            name,
+        }
     }
 
     pub fn url(&self) -> String {
-        format!("https://hub.oxen.ai/{}/{}/notebooks/{}", self.namespace, self.name, self.id)
+        format!(
+            "https://hub.oxen.ai/{}/{}/notebooks/{}",
+            self.namespace, self.name, self.id
+        )
     }
 
     // implement __str__
@@ -103,7 +110,11 @@ pub fn py_start_notebook(
         let notebook = api::client::notebooks::run(&repo.repo, &notebook).await?;
         Ok(notebook)
     })?;
-    let notebook = PyNotebook { id: notebook.id, namespace: repo.repo.namespace, name: repo.repo.name };
+    let notebook = PyNotebook {
+        id: notebook.id,
+        namespace: repo.repo.namespace,
+        name: repo.repo.name,
+    };
     println!("✅ Notebook {} started", notebook.id);
     Ok(notebook)
 }
@@ -111,15 +122,13 @@ pub fn py_start_notebook(
 /// Stop a notebook
 #[pyfunction]
 #[pyo3(signature = (repo, notebook_id))]
-pub fn py_stop_notebook(
-    repo: PyRemoteRepo,
-    notebook_id: String
-) -> Result<(), PyOxenError> {
-    let notebook: Result<Notebook, OxenError> = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-        let notebook = Notebook { id: notebook_id };
-        let notebook = api::client::notebooks::stop(&repo.repo, &notebook).await?;
-        Ok(notebook)
-    });
+pub fn py_stop_notebook(repo: PyRemoteRepo, notebook_id: String) -> Result<(), PyOxenError> {
+    let notebook: Result<Notebook, OxenError> =
+        pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+            let notebook = Notebook { id: notebook_id };
+            let notebook = api::client::notebooks::stop(&repo.repo, &notebook).await?;
+            Ok(notebook)
+        });
     println!("🛑 Notebook {} stopped", notebook.unwrap().id);
     Ok(())
 }

--- a/oxen/src/remote.rs
+++ b/oxen/src/remote.rs
@@ -17,7 +17,7 @@ pub fn get_repo(
     scheme: &str,
 ) -> Result<Option<PyRemoteRepo>, PyOxenError> {
     let Some(remote_repo) = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-        liboxen::api::client::repositories::get_by_name_and_host(name, &host).await
+        liboxen::api::client::repositories::get_by_name_host_and_scheme(name, &host, &scheme).await
     })?
     else {
         return Ok(None);


### PR DESCRIPTION
* Implements the changes in https://github.com/Oxen-AI/Oxen/pull/612.
* Applies `cargo fmt` on unrelated files.
* Fixes issue with `get_by_name_and_host` removed in https://github.com/Oxen-AI/Oxen/commit/311e8746ef72721c92f791a51fcc6f80bb0ef222.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code readability and organization in notebook management and module initialization.
  - Updated the method for retrieving remote repositories to use additional connection details.
- **Chores**
  - Enhanced runtime configuration by capturing and storing the Python interpreter version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->