### PR TITLE
Push refactor

### DIFF
--- a/oxen-rust/src/benches/oxen/push.rs
+++ b/oxen-rust/src/benches/oxen/push.rs
@@ -191,7 +191,7 @@ pub fn push_benchmark(c: &mut Criterion, data: Option<String>, iters: Option<usi
                                 &repo, repo_new,
                             ))
                             .unwrap();
-                        std::thread::sleep(std::time::Duration::from_millis(10000));
+                        std::thread::sleep(std::time::Duration::from_millis(500));
                         let _ = command::config::set_remote(
                             &mut repo,
                             DEFAULT_REMOTE_NAME,

--- a/oxen-rust/src/benches/oxen/push.rs
+++ b/oxen-rust/src/benches/oxen/push.rs
@@ -1,9 +1,9 @@
 use criterion::{black_box, BenchmarkId, Criterion};
-use liboxen::constants::{DEFAULT_NAMESPACE, DEFAULT_REMOTE_NAME};
+use liboxen::constants::{DEFAULT_REMOTE_NAME, DEFAULT_NAMESPACE};
 use liboxen::error::OxenError;
-use liboxen::model::LocalRepository;
+use liboxen::model::{LocalRepository, RepoNew};
 use liboxen::repositories;
-use liboxen::test::{create_or_clear_remote_repo, create_remote_repo, test_host};
+use liboxen::test::test_host;
 use liboxen::util;
 use liboxen::{api, command};
 use rand::distributions::Alphanumeric;
@@ -24,7 +24,7 @@ fn write_file_for_push_benchmark(
     large_file_chance: f64,
 ) -> Result<(), OxenError> {
     if rand::thread_rng().gen_range(0.05..1.0) < large_file_chance {
-        let large_content_size = 1024 * 1024 + 1;
+        let large_content_size = 1024 * 1024 * 500 + 500;
         let mut large_content = vec![0u8; large_content_size];
         rand::thread_rng().fill_bytes(&mut large_content);
         fs::write(file_path, &large_content)?;
@@ -56,9 +56,7 @@ async fn setup_repo_for_push_benchmark(
         util::fs::remove_dir_all(&repo_dir)?;
     }
 
-    let mut repo = repositories::init(&repo_dir)?;
-    let remote_repo = create_or_clear_remote_repo(&repo).await?;
-    command::config::set_remote(&mut repo, DEFAULT_REMOTE_NAME, &remote_repo.remote.url)?;
+    let repo = repositories::init(&repo_dir)?;
 
     let mut rng = rand::thread_rng();
     let files_dir = if let Some(data_path) = data_path {
@@ -81,8 +79,8 @@ async fn setup_repo_for_push_benchmark(
         let large_file_percentage: f64;
         let min_repo_size_for_scaling = 1000.0;
         let max_repo_size_for_scaling = 100000.0;
-        let max_large_file_ratio = 0.5;
-        let min_large_file_ratio = 0.01;
+        let max_large_file_ratio = 1.0;
+        let min_large_file_ratio = 1.0;
 
         if (repo_size as f64) <= min_repo_size_for_scaling {
             large_file_percentage = max_large_file_ratio;
@@ -145,15 +143,13 @@ pub fn push_benchmark(c: &mut Criterion, data: Option<String>, iters: Option<usi
     let mut group = c.benchmark_group("push");
     group.sample_size(iters.unwrap_or(10));
     let params = [
-        (1000, 20),
-        (10000, 20),
-        (100000, 20),
-        (100000, 100),
-        (100000, 1000),
-        (1000000, 1000),
+        (5, 1),
+        (10, 1),
+        (10, 10),
+        (50, 10),
     ];
     for &(repo_size, dir_size) in params.iter() {
-        let num_files_to_push = repo_size / 1000;
+        let num_files_to_push = repo_size;
         let mut repo = rt
             .block_on(setup_repo_for_push_benchmark(
                 &base_dir,
@@ -164,36 +160,46 @@ pub fn push_benchmark(c: &mut Criterion, data: Option<String>, iters: Option<usi
             ))
             .unwrap();
 
-        // cleanup the remote repo for push
-        let remote_name = format!("/{}/{}", DEFAULT_NAMESPACE, repo.dirname());
-        let host = test_host();
-        let url = api::endpoint::url_from_host(&host, &remote_name);
-
-        let _ = rt
-            .block_on(api::client::repositories::delete_from_url(url))
-            .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(500));
-        let remote_repo = rt.block_on(create_remote_repo(&repo)).unwrap();
-        let _ =
-            command::config::set_remote(&mut repo, DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
-
         group.bench_with_input(
             BenchmarkId::new(
-                format!("{}k_files_in_{}dirs", num_files_to_push, dir_size),
+                format!("{}_files_in_{}dirs", num_files_to_push, dir_size),
                 format!("{:?}", (num_files_to_push, dir_size)),
             ),
             &(num_files_to_push, dir_size),
             |b, _| {
-                // TODO: Refactor to do the push to remotes that already have 'repo_size' files in them
-                //       Should be possible, but may be slow unless there's a good way to 'reverse' a push
-                b.to_async(&rt).iter(|| async {
-                    repositories::push(&repo).await.unwrap();
-                });
+                b.to_async(&rt).iter_batched(
+                    || {
+                        // Create a new remote for each iteration
+                        let iter_dirname = format!("push-run-{}", rand::thread_rng().gen::<u64>());
+
+                        let repo_new = RepoNew::from_namespace_name_host(
+                            DEFAULT_NAMESPACE,
+                            iter_dirname,
+                            test_host(),
+                        );
+                        
+                        let remote_repo = tokio::task::block_in_place(|| {
+                            rt.block_on(api::client::repositories::create_from_local(&repo, repo_new))
+                        }).unwrap();
+                        std::thread::sleep(std::time::Duration::from_millis(10000));
+                        let _ =
+                            command::config::set_remote(&mut repo, DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
+
+                        (repo.clone(), remote_repo)
+                    },
+                    |(repo, remote_repo)| async move {
+                        repositories::push(&repo)
+                            .await
+                            .unwrap();
+                        // cleanup the remote repo for push
+                        api::client::repositories::delete(&remote_repo)
+                            .await
+                            .unwrap();
+                    },
+                    criterion::BatchSize::PerIteration,
+                );
             },
         );
-        let _ = rt
-            .block_on(api::client::repositories::delete(&remote_repo))
-            .unwrap();
     }
     group.finish();
 

--- a/oxen-rust/src/benches/oxen/push.rs
+++ b/oxen-rust/src/benches/oxen/push.rs
@@ -186,12 +186,11 @@ pub fn push_benchmark(c: &mut Criterion, data: Option<String>, iters: Option<usi
                             test_host(),
                         );
 
-                        let remote_repo = tokio::task::block_in_place(|| {
-                            rt.block_on(api::client::repositories::create_from_local(
+                        let remote_repo = rt
+                            .block_on(api::client::repositories::create_from_local(
                                 &repo, repo_new,
                             ))
-                        })
-                        .unwrap();
+                            .unwrap();
                         std::thread::sleep(std::time::Duration::from_millis(10000));
                         let _ = command::config::set_remote(
                             &mut repo,

--- a/oxen-rust/src/lib/src/api/client/entries.rs
+++ b/oxen-rust/src/lib/src/api/client/entries.rs
@@ -857,10 +857,10 @@ pub async fn try_download_data_from_version_paths(
     }
     let body = encoder.finish()?;
     log::debug!("download_data_from_version_paths body len: {}", body.len());
-    let url = api::endpoint::url_from_repo(remote_repo, "/versions")?;
+    let url = api::endpoint::url_from_repo(remote_repo, "/versions/fetch")?;
 
     let client = client::new_for_url(&url)?;
-    if let Ok(res) = client.get(&url).body(body).send().await {
+    if let Ok(res) = client.post(&url).body(body).send().await {
         if reqwest::StatusCode::UNAUTHORIZED == res.status() {
             let err = "Err: unauthorized request to download data".to_string();
             log::error!("{}", err);

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -220,9 +220,9 @@ pub async fn try_download_data_from_version_paths(
     let body = encoder.finish()?;
     log::debug!("download_data_from_version_paths body len: {}", body.len());
 
-    let url = api::endpoint::url_from_repo(remote_repo, "/versions")?;
+    let url = api::endpoint::url_from_repo(remote_repo, "/versions/fetch")?;
     let client = client::new_for_url(&url)?;
-    if let Ok(res) = client.get(&url).body(body).send().await {
+    if let Ok(res) = client.post(&url).body(body).send().await {
         if reqwest::StatusCode::UNAUTHORIZED == res.status() {
             let err = "Err: unauthorized request to download data".to_string();
             log::error!("{}", err);

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -1,10 +1,11 @@
 use crate::api;
 use crate::api::client;
 use crate::constants::{AVG_CHUNK_SIZE, NUM_HTTP_RETRIES};
+use crate::core::progress::push_progress::PushProgress;
 use crate::error::OxenError;
 use crate::model::entry::commit_entry::Entry;
 use crate::model::{LocalRepository, MerkleHash, RemoteRepository};
-use crate::util::hasher;
+use crate::util::{self, concurrency, hasher};
 use crate::view::versions::{
     CompleteVersionUploadRequest, CompletedFileUpload, CreateVersionUploadRequest,
     MultipartLargeFileUpload, MultipartLargeFileUploadStatus, VersionFile, VersionFileResponse,
@@ -33,14 +34,12 @@ use tokio::sync::Semaphore;
 use tokio::time::sleep;
 
 use crate::repositories;
-use crate::util;
 
 // Multipart upload strategy, based off of AWS S3 Multipart Upload and huggingface hf_transfer
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html
 // https://github.com/huggingface/hf_transfer/blob/main/src/lib.rs#L104
 const BASE_WAIT_TIME: usize = 300;
 const MAX_WAIT_TIME: usize = 10_000;
-const MAX_FILES: usize = 64;
 const PARALLEL_FAILURES: usize = 63;
 const MAX_RETRIES: usize = 5;
 
@@ -88,19 +87,24 @@ pub async fn get(
 pub async fn parallel_large_file_upload(
     remote_repo: &RemoteRepository,
     file_path: impl AsRef<Path>,
-    dst_dir: Option<impl AsRef<Path>>,
+    dst_dir: Option<impl AsRef<Path>>, // dst_dir is provided for workspace add workflow
     workspace_id: Option<String>,
+    entry: Option<Entry>,                 // entry is provided for push workflow
+    progress: Option<&Arc<PushProgress>>, // for push workflow
 ) -> Result<MultipartLargeFileUpload, OxenError> {
     log::debug!("multipart_large_file_upload path: {:?}", file_path.as_ref());
-    let mut upload = create_multipart_large_file_upload(remote_repo, file_path, dst_dir).await?;
+
+    let mut upload =
+        create_multipart_large_file_upload(remote_repo, file_path, dst_dir, entry).await?;
+
     log::debug!("multipart_large_file_upload upload: {:?}", upload.hash);
     let results = upload_chunks(
         remote_repo,
         &mut upload,
         AVG_CHUNK_SIZE,
-        MAX_FILES,
         PARALLEL_FAILURES,
         MAX_RETRIES,
+        progress,
     )
     .await?;
     log::debug!(
@@ -118,23 +122,31 @@ async fn create_multipart_large_file_upload(
     remote_repo: &RemoteRepository,
     file_path: impl AsRef<Path>,
     dst_dir: Option<impl AsRef<Path>>,
+    entry: Option<Entry>,
 ) -> Result<MultipartLargeFileUpload, OxenError> {
     let file_path = file_path.as_ref();
     let dst_dir = dst_dir.as_ref();
 
-    // Figure out how many parts we need to upload
-    let Ok(metadata) = file_path.metadata() else {
-        return Err(OxenError::path_does_not_exist(file_path));
+    let (file_size, hash) = match entry {
+        Some(entry) => (entry.num_bytes(), entry.hash()),
+        None => {
+            // Figure out how many parts we need to upload
+            let Ok(metadata) = file_path.metadata() else {
+                return Err(OxenError::path_does_not_exist(file_path));
+            };
+            let file_size = metadata.len();
+            let hash =
+                MerkleHash::from_str(&util::hasher::hash_file_contents(file_path)?)?.to_string();
+            (file_size, hash)
+        }
     };
-    let file_size = metadata.len();
-    let hash = MerkleHash::from_str(&util::hasher::hash_file_contents(file_path)?)?;
 
     let uri = format!("/versions/{hash}/create");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     let client = client::new_for_url(&url)?;
 
     let body = CreateVersionUploadRequest {
-        hash: hash.to_string(),
+        hash: hash.clone(),
         file_name: file_path.file_name().unwrap().to_string_lossy().to_string(),
         size: file_size,
         dst_dir: dst_dir.map(|d| d.as_ref().to_path_buf()),
@@ -152,7 +164,7 @@ async fn create_multipart_large_file_upload(
     Ok(MultipartLargeFileUpload {
         local_path: file_path.to_path_buf(),
         dst_dir: dst_dir.map(|d| d.as_ref().to_path_buf()),
-        hash,
+        hash: MerkleHash::from_str(&hash)?,
         size: file_size,
         status: MultipartLargeFileUploadStatus::Pending,
         reason: None,
@@ -283,28 +295,25 @@ async fn upload_chunks(
     remote_repo: &RemoteRepository,
     upload: &mut MultipartLargeFileUpload,
     chunk_size: u64,
-    max_files: usize,
     parallel_failures: usize,
     max_retries: usize,
+    progress: Option<&Arc<PushProgress>>,
 ) -> Result<Vec<HashMap<String, String>>, OxenError> {
-    let file_path = &upload.local_path;
-    let client = api::client::builder_for_remote_repo(remote_repo)?.build()?;
+    let client = Arc::new(api::client::builder_for_remote_repo(remote_repo)?.build()?);
 
+    // Figure out how many parts we need to upload
+    let file_size = upload.size;
+    let num_chunks = file_size.div_ceil(chunk_size);
+
+    let max_files = concurrency::num_threads_for_items(num_chunks as usize);
     let mut handles = FuturesUnordered::new();
     let semaphore = Arc::new(Semaphore::new(max_files));
     let parallel_failures_semaphore = Arc::new(Semaphore::new(parallel_failures));
 
-    // Figure out how many parts we need to upload
-    let Ok(metadata) = file_path.metadata() else {
-        return Err(OxenError::path_does_not_exist(file_path));
-    };
-    let file_size = metadata.len();
-    let num_chunks = file_size.div_ceil(chunk_size);
-
     for chunk_number in 0..num_chunks {
         let remote_repo = remote_repo.clone();
         let upload = upload.clone();
-        let client = client.clone();
+        let client = Arc::clone(&client);
 
         let start = chunk_number * chunk_size;
         let semaphore = semaphore.clone();
@@ -353,6 +362,7 @@ async fn upload_chunks(
             Ok(Ok((chunk_number, headers, size))) => {
                 log::debug!("Uploaded part {chunk_number} with size {size}");
                 results[chunk_number as usize] = headers;
+                progress.map(|p| p.add_bytes(size));
             }
             Ok(Err(py_err)) => {
                 return Err(py_err);
@@ -364,7 +374,7 @@ async fn upload_chunks(
             }
         }
     }
-
+    progress.map(|p| p.add_files(1));
     Ok(results)
 }
 
@@ -378,7 +388,8 @@ async fn upload_chunk(
     let path = &upload.local_path;
     let mut options = OpenOptions::new();
     let mut file = options.read(true).open(path).await?;
-    let file_size = file.metadata().await?.len();
+
+    let file_size = upload.size;
     let bytes_transferred = std::cmp::min(file_size - start, chunk_size);
 
     file.seek(SeekFrom::Start(start)).await?;
@@ -765,6 +776,8 @@ mod tests {
                 path,
                 dst_dir,
                 workspace_id,
+                None,
+                None,
             )
             .await;
             assert!(result.is_ok());

--- a/oxen-rust/src/lib/src/api/client/versions.rs
+++ b/oxen-rust/src/lib/src/api/client/versions.rs
@@ -362,7 +362,9 @@ async fn upload_chunks(
             Ok(Ok((chunk_number, headers, size))) => {
                 log::debug!("Uploaded part {chunk_number} with size {size}");
                 results[chunk_number as usize] = headers;
-                progress.map(|p| p.add_bytes(size));
+                if let Some(p) = progress {
+                    p.add_bytes(size);
+                }
             }
             Ok(Err(py_err)) => {
                 return Err(py_err);
@@ -374,7 +376,9 @@ async fn upload_chunks(
             }
         }
     }
-    progress.map(|p| p.add_files(1));
+    if let Some(p) = progress {
+        p.add_files(1);
+    }
     Ok(results)
 }
 

--- a/oxen-rust/src/lib/src/api/client/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces/files.rs
@@ -180,6 +180,8 @@ pub async fn upload_single_file(
             path,
             Some(directory),
             Some(workspace_id.as_ref().to_string()),
+            None,
+            None,
         )
         .await
         {
@@ -250,6 +252,8 @@ async fn upload_multiple_files(
             &path,
             Some(directory),
             Some(workspace_id.to_string()),
+            None,
+            None,
         )
         .await
         {

--- a/oxen-rust/src/lib/src/core/v_latest/download.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/download.rs
@@ -50,6 +50,8 @@ pub async fn download_dir(
     )
     .await?;
 
+    pull_progress.finish();
+
     Ok(())
 }
 
@@ -83,6 +85,8 @@ pub async fn download_dir_entries(
         &pull_progress,
     )
     .await?;
+
+    pull_progress.finish();
 
     Ok(())
 }

--- a/oxen-rust/src/lib/src/core/v_latest/push.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/push.rs
@@ -502,7 +502,7 @@ async fn chunk_and_send_large_entries(
     }
 
     use tokio::time::sleep;
-    type PieceOfWork = (Entry, LocalRepository, Commit, RemoteRepository);
+    type PieceOfWork = (Entry, PathBuf, RemoteRepository);
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     log::debug!("Chunking and sending {} larger files", entries.len());
@@ -511,8 +511,7 @@ async fn chunk_and_send_large_entries(
         .map(|e| {
             (
                 e.to_owned(),
-                local_repo.to_owned(),
-                commit.to_owned(),
+                local_repo.path.clone(),
                 remote_repo.to_owned(),
             )
         })
@@ -522,6 +521,7 @@ async fn chunk_and_send_large_entries(
     for entry in entries.iter() {
         queue.try_push(entry.to_owned()).unwrap();
     }
+    let version_store = local_repo.version_store()?;
 
     let worker_count = concurrency::num_threads_for_items(entries.len());
     log::debug!(
@@ -538,6 +538,7 @@ async fn chunk_and_send_large_entries(
         let bar = Arc::clone(progress);
         let should_stop = should_stop.clone();
         let first_error = first_error.clone();
+        let version_store = Arc::clone(&version_store);
 
         let handle = tokio::spawn(async move {
             loop {
@@ -545,18 +546,39 @@ async fn chunk_and_send_large_entries(
                     break;
                 }
 
-                let Some((entry, repo, commit, remote_repo)) = queue.try_pop() else {
+                let Some((entry, repo_path, remote_repo)) = queue.try_pop() else {
                     // reached end of queue
                     break;
                 };
 
-                match upload_large_file_chunks(
-                    entry.clone(),
-                    repo,
-                    commit,
-                    remote_repo,
-                    chunk_size,
-                    &bar,
+                let version_path = match version_store.get_version_path(&entry.hash()) {
+                    Ok(path) => path,
+                    Err(e) => {
+                        log::error!("Failed to get version path: {}", e);
+                        should_stop.store(true, Ordering::Relaxed);
+                        *first_error.lock().await = Some(e.to_string());
+                        break;
+                    }
+                };
+                let relative_path = util::fs::path_relative_to_dir(version_path, &repo_path)
+                    .unwrap_or_else(|e| {
+                        log::error!("Failed to get relative path: {}", e);
+                        entry.path()
+                    });
+                let path = if relative_path.exists() {
+                    relative_path
+                } else {
+                    // for test environment
+                    repo_path.join(relative_path)
+                };
+
+                match api::client::versions::parallel_large_file_upload(
+                    &remote_repo,
+                    path,
+                    None::<PathBuf>,
+                    None,
+                    Some(entry.clone()),
+                    Some(&bar),
                 )
                 .await
                 {
@@ -600,216 +622,6 @@ async fn chunk_and_send_large_entries(
     // Sleep again to let things sync...
     sleep(Duration::from_millis(100)).await;
 
-    Ok(())
-}
-
-/// Chunk and send large file in parallel
-async fn upload_large_file_chunks(
-    entry: Entry,
-    repo: LocalRepository,
-    commit: Commit,
-    remote_repo: RemoteRepository,
-    chunk_size: u64,
-    progress: &Arc<PushProgress>,
-) -> Result<(), OxenError> {
-    // Open versioned file
-    let version_store = repo.version_store().unwrap();
-    let file = version_store.open_version(&entry.hash()).unwrap();
-    let mut reader = BufReader::new(file);
-    // The version path is just being used for compatibility with the server endpoint,
-    // we aren't using it to read the file.
-    // TODO: This should be migrated to use the new versions API
-    let version_path = util::fs::version_path_for_entry(&repo, &entry);
-
-    // These variables are the same for every chunk
-    // let is_compressed = false;
-    let hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
-    let path = util::fs::path_relative_to_dir(&version_path, &hidden_dir).unwrap();
-    let file_name = Some(String::from(path.to_str().unwrap()));
-
-    // Calculate chunk sizes
-    let total_bytes = entry.num_bytes();
-    let total_chunks = ((total_bytes / chunk_size) + 1) as usize;
-    let mut total_bytes_read = 0;
-    let mut chunk_size = chunk_size;
-
-    // Create a client for uploading chunks
-    let client = Arc::new(
-        api::client::builder_for_remote_repo(&remote_repo)
-            .unwrap()
-            .build()
-            .unwrap(),
-    );
-
-    // Create queues for sending data to workers
-    type PieceOfWork = (
-        Vec<u8>,
-        u64,   // chunk size
-        usize, // chunk num
-        usize, // total chunks
-        u64,   // total size
-        Arc<reqwest::Client>,
-        RemoteRepository,
-        String, // entry hash
-        Commit,
-        Option<String>, // filename
-    );
-
-    // In order to upload chunks in parallel
-    // We should only read N chunks at a time so that
-    // the whole file does not get read into memory
-    let sub_chunk_size = concurrency::num_threads_for_items(total_chunks);
-
-    let mut total_chunk_idx = 0;
-    let mut processed_chunk_idx = 0;
-    let num_sub_chunks = (total_chunks / sub_chunk_size) + 1;
-    log::debug!(
-        "upload_large_file_chunks {:?} processing file in {} subchunks of size {} from total {} chunk size {} file size {}",
-        entry.path(),
-        num_sub_chunks,
-        sub_chunk_size,
-        total_chunks,
-        chunk_size,
-        total_bytes
-    );
-    for i in 0..num_sub_chunks {
-        log::debug!(
-            "upload_large_file_chunks Start reading subchunk {i}/{num_sub_chunks} of size {sub_chunk_size} from total {total_chunks} chunk size {chunk_size} file size {total_bytes_read}/{total_bytes}"
-        );
-        // Read and send the subset of buffers sequentially
-        let mut sub_buffers: Vec<Vec<u8>> = Vec::new();
-        for _ in 0..sub_chunk_size {
-            // If we have read all the bytes, break
-            if total_bytes_read >= total_bytes {
-                break;
-            }
-
-            // Make sure we read the last size correctly
-            if (total_bytes_read + chunk_size) > total_bytes {
-                chunk_size = total_bytes % chunk_size;
-            }
-
-            let percent_read = (total_bytes_read as f64 / total_bytes as f64) * 100.0;
-            log::debug!("upload_large_file_chunks has read {total_bytes_read}/{total_bytes} = {percent_read}% about to read {chunk_size}");
-
-            // Only read as much as you need to send so we don't blow up memory on large files
-            let mut buffer = vec![0u8; chunk_size as usize];
-            match reader.read_exact(&mut buffer) {
-                Ok(_) => {}
-                Err(err) => {
-                    log::error!("upload_large_file_chunks Error reading file {:?} chunk {total_chunk_idx}/{total_chunks} chunk size {chunk_size} total_bytes_read: {total_bytes_read} total_bytes: {total_bytes} {:?}", entry.path(), err);
-                    return Err(OxenError::from(err));
-                }
-            }
-            total_bytes_read += chunk_size;
-            total_chunk_idx += 1;
-
-            sub_buffers.push(buffer);
-        }
-        log::debug!(
-            "upload_large_file_chunks Done, have read subchunk {}/{} subchunk {}/{} of size {}",
-            processed_chunk_idx,
-            total_chunks,
-            i,
-            num_sub_chunks,
-            sub_chunk_size
-        );
-
-        // Then send sub_buffers over network in parallel
-        // let queue = Arc::new(TaskQueue::new(sub_buffers.len()));
-        // let finished_queue = Arc::new(FinishedTaskQueue::new(sub_buffers.len()));
-        let mut tasks: Vec<PieceOfWork> = Vec::new();
-        for buffer in sub_buffers.iter() {
-            tasks.push((
-                buffer.to_owned(),
-                chunk_size,
-                processed_chunk_idx, // Needs to be the overall chunk num
-                total_chunks,
-                total_bytes,
-                client.clone(),
-                remote_repo.to_owned(),
-                entry.hash().to_owned(),
-                commit.to_owned(),
-                file_name.to_owned(),
-            ));
-            // finished_queue.try_push(false).unwrap();
-            processed_chunk_idx += 1;
-        }
-
-        // Setup the stream chunks in parallel
-        let bodies = stream::iter(tasks)
-            .map(|item| async move {
-                let (
-                    buffer,
-                    chunk_size,
-                    chunk_num,
-                    total_chunks,
-                    total_size,
-                    client,
-                    remote_repo,
-                    entry_hash,
-                    _commit,
-                    file_name,
-                ) = item;
-                let size = buffer.len() as u64;
-                log::debug!(
-                    "upload_large_file_chunks Streaming entry buffer {}/{} of size {}",
-                    chunk_num,
-                    total_chunks,
-                    size
-                );
-
-                let params = ChunkParams {
-                    chunk_num,
-                    total_chunks,
-                    total_size: total_size as usize,
-                };
-
-                let is_compressed = false;
-                match api::client::commits::upload_data_chunk_to_server_with_retry(
-                    &client,
-                    &remote_repo,
-                    &buffer,
-                    &entry_hash,
-                    &params,
-                    is_compressed,
-                    &file_name,
-                )
-                .await
-                {
-                    Ok(_) => {
-                        log::debug!(
-                            "upload_large_file_chunks Successfully uploaded subchunk overall chunk {}/{}",
-                            chunk_num,
-                            total_chunks
-                        );
-                        Ok(chunk_size)
-                    }
-                    Err(err) => {
-                        log::error!("Error uploading chunk: {err}");
-                        Err(err)
-                    }
-                }
-            })
-            .buffer_unordered(sub_chunk_size);
-
-        // Wait for all requests to finish
-        bodies
-            .for_each(|b| async {
-                match b {
-                    Ok(_) => {
-                        progress.add_bytes(chunk_size);
-                    }
-                    Err(err) => {
-                        log::error!("Error uploading chunk: {err}")
-                    }
-                }
-            })
-            .await;
-
-        log::debug!("upload_large_file_chunks Subchunk {i}/{num_sub_chunks} tasks done. :-)");
-    }
-    progress.add_files(1);
     Ok(())
 }
 

--- a/oxen-rust/src/lib/src/core/v_latest/push.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/push.rs
@@ -1,13 +1,10 @@
-use futures::prelude::*;
 use std::collections::HashSet;
-use std::io::{BufReader, Read};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::Duration;
 
-use crate::api::client::commits::ChunkParams;
 use crate::constants::AVG_CHUNK_SIZE;
 use crate::constants::DEFAULT_REMOTE_NAME;
 use crate::core::progress::push_progress::PushProgress;
@@ -455,14 +452,8 @@ pub async fn push_entries(
         .map(|e| e.to_owned())
         .collect();
 
-    let large_entries_sync = chunk_and_send_large_entries(
-        local_repo,
-        remote_repo,
-        larger_entries,
-        commit,
-        AVG_CHUNK_SIZE,
-        progress,
-    );
+    let large_entries_sync =
+        chunk_and_send_large_entries(local_repo, remote_repo, larger_entries, progress);
     let small_entries_sync = bundle_and_send_small_entries(
         local_repo,
         remote_repo,
@@ -493,8 +484,6 @@ async fn chunk_and_send_large_entries(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
     entries: Vec<Entry>,
-    commit: &Commit,
-    chunk_size: u64,
     progress: &Arc<PushProgress>,
 ) -> Result<(), OxenError> {
     if entries.is_empty() {

--- a/oxen-rust/src/lib/src/storage/s3.rs
+++ b/oxen-rust/src/lib/src/storage/s3.rs
@@ -108,6 +108,15 @@ impl VersionStore for S3VersionStore {
         Err(OxenError::basic_str("S3VersionStore not yet implemented"))
     }
 
+    async fn get_version_chunk_writer(
+        &self,
+        _hash: &str,
+        _offset: u64,
+    ) -> Result<Box<dyn tokio::io::AsyncWrite + Send + Unpin>, OxenError> {
+        // TODO: Implement S3 version chunk stream storage
+        Err(OxenError::basic_str("S3VersionStore not yet implemented"))
+    }
+
     async fn get_version_chunk(
         &self,
         _hash: &str,

--- a/oxen-rust/src/lib/src/storage/version_store.rs
+++ b/oxen-rust/src/lib/src/storage/version_store.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncRead, AsyncSeek};
+use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use tokio_stream::Stream;
 
 use crate::constants;
@@ -32,6 +32,12 @@ pub trait AsyncReadSeek: AsyncRead + AsyncSeek + Send + Sync + Unpin {}
 
 /// Implement AsyncReadSeek for any type that implements both AsyncRead and AsyncSeek
 impl<T: AsyncRead + AsyncSeek + Send + Sync + Unpin> AsyncReadSeek for T {}
+
+/// Trait for async write operations
+pub trait AsyncWriteSeek: AsyncWrite + AsyncSeek + Send + Sync + Unpin {}
+
+/// Implement AsyncWriteSeek for any type that implements both AsyncWrite and AsyncSeek
+impl<T: AsyncWrite + AsyncSeek + Send + Sync + Unpin> AsyncWriteSeek for T {}
 
 /// Trait for sync read and seek operations
 pub trait ReadSeek: Read + Seek + Send + Sync {}
@@ -82,6 +88,17 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         offset: u64,
         data: &[u8],
     ) -> Result<(), OxenError>;
+
+    /// Get a writer for a chunk of a version file
+    ///
+    /// # Arguments
+    /// * `hash` - The content hash that identifies this version
+    /// * `offset` - The starting byte position of the chunk
+    async fn get_version_chunk_writer(
+        &self,
+        hash: &str,
+        offset: u64,
+    ) -> Result<Box<dyn AsyncWrite + Send + Unpin>, OxenError>;
 
     /// Retrieve a chunk of a version file
     ///

--- a/oxen-rust/src/server/src/controllers/entries.rs
+++ b/oxen-rust/src/server/src/controllers/entries.rs
@@ -25,6 +25,7 @@ pub struct ChunkQuery {
     pub chunk_size: Option<u64>,
 }
 
+// Deprecated. Only kept to support older clients before v0.37.2
 pub async fn download_data_from_version_paths(
     req: HttpRequest,
     mut body: web::Payload,

--- a/oxen-rust/src/server/src/controllers/versions/chunks.rs
+++ b/oxen-rust/src/server/src/controllers/versions/chunks.rs
@@ -132,6 +132,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
 
         return Ok(HttpResponse::Ok().json(StatusMessage::resource_found()));
     }
+
     Ok(HttpResponse::BadRequest().json(StatusMessage::error("Invalid request body")))
 }
 

--- a/oxen-rust/src/server/src/services/versions.rs
+++ b/oxen-rust/src/server/src/services/versions.rs
@@ -7,8 +7,16 @@ pub mod chunks;
 
 pub fn versions() -> Scope {
     web::scope("/versions")
-        .route("", web::get().to(controllers::versions::batch_download))
+        .route(
+            // Deprecated. Only kept to support older clients before v0.37.2
+            "",
+            web::get().to(controllers::entries::download_data_from_version_paths),
+        )
         .route("", web::post().to(controllers::versions::batch_upload))
+        .route(
+            "/fetch",
+            web::post().to(controllers::versions::batch_download),
+        )
         .route(
             "/{version_id}/metadata",
             web::get().to(controllers::versions::metadata),


### PR DESCRIPTION
The performance benchmark result is tested against uploading large files(~500MB)
| file_dir | Main     | push_refactor | delta   |
|----------|----------|---------------|---------|
| 5_1      | 16s 700ms | 19s 400ms     | 16.17%  |
| 10_1     | 30s 700ms | 37s           | 20.52%  |
| 10_10    | 31s 700ms | 37s 700ms     | 18.93%  |

The refactor mainly changes the large file push logic to reuse the workspace add logic (both client and server side). At first it was a 2x slowdown when testing the above benchmark. After changing the max concurrency limit from 64 to the same as the original push (cpu_num), the performance is as listed above. The best concurrency setup needs further research.

Other changes:
1. Added async writer in the version store interface, `upload_chunk` code on the server side now support streaming. 
2. batch download endpoint now changed to 'POST /versions/fetch', the old endpoint 'GET /versions' is kept for backwards compatibility.

I suggest testing push large files(>10MB), fetch and download (clone)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Large file uploads now report progress during chunked transfers and use version-aware upload paths.

- **Performance**
  - Large file uploads are parallelized with improved chunk handling for faster, more reliable pushes.
  - Server streams incoming chunks directly to storage, reducing memory usage.

- **API Changes**
  - New POST endpoint for fetching versioned data: /versions/fetch. The older GET route remains deprecated but available.

- **Bug Fixes**
  - Clearer authentication errors when downloading versioned data.
  - Pull progress now properly finishes after downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->