### PR TITLE
Api 15/download paths

### DIFF
--- a/oxen-rust/src/lib/src/api/client/entries.rs
+++ b/oxen-rust/src/lib/src/api/client/entries.rs
@@ -134,8 +134,6 @@ pub async fn download_entry(
 ) -> Result<(), OxenError> {
     let remote_path = remote_path.as_ref();
     let download_path = util::fs::remove_leading_slash(remote_path);
-    // TODO: Normalize path; get rid of leading '/'
-    // Need util::fs function that does that
 
     let entry = get_entry(remote_repo, download_path.clone(), &revision).await?;
 

--- a/oxen-rust/src/lib/src/api/client/entries.rs
+++ b/oxen-rust/src/lib/src/api/client/entries.rs
@@ -133,10 +133,9 @@ pub async fn download_entry(
     revision: impl AsRef<str>,
 ) -> Result<(), OxenError> {
     let remote_path = remote_path.as_ref();
-    let download_path = util::fs::remove_leading_slash(&remote_path); 
+    let download_path = util::fs::remove_leading_slash(remote_path);
     // TODO: Normalize path; get rid of leading '/'
-    // Need util::fs function that does that 
-
+    // Need util::fs function that does that
 
     let entry = get_entry(remote_repo, download_path.clone(), &revision).await?;
 

--- a/oxen-rust/src/lib/src/api/client/entries.rs
+++ b/oxen-rust/src/lib/src/api/client/entries.rs
@@ -133,7 +133,12 @@ pub async fn download_entry(
     revision: impl AsRef<str>,
 ) -> Result<(), OxenError> {
     let remote_path = remote_path.as_ref();
-    let entry = get_entry(remote_repo, remote_path, &revision).await?;
+    let download_path = util::fs::remove_leading_slash(&remote_path); 
+    // TODO: Normalize path; get rid of leading '/'
+    // Need util::fs function that does that 
+
+
+    let entry = get_entry(remote_repo, download_path.clone(), &revision).await?;
 
     let entry = match entry {
         Some(EMetadataEntry::MetadataEntry(entry)) => entry,
@@ -143,11 +148,11 @@ pub async fn download_entry(
             ))
         }
         None => {
-            return Err(OxenError::path_does_not_exist(remote_path));
+            return Err(OxenError::path_does_not_exist(download_path));
         }
     };
 
-    let remote_file_name = remote_path.file_name();
+    let remote_file_name = download_path.file_name();
     let mut local_path = local_path.as_ref().to_path_buf();
 
     // Following the similar logic as cp or scp
@@ -178,9 +183,9 @@ pub async fn download_entry(
     }
 
     if entry.is_dir {
-        repositories::download::download_dir(remote_repo, &entry, remote_path, &local_path).await
+        repositories::download::download_dir(remote_repo, &entry, download_path, &local_path).await
     } else {
-        download_file(remote_repo, &entry, remote_path, local_path, revision).await
+        download_file(remote_repo, &entry, download_path, local_path, revision).await
     }
 }
 

--- a/oxen-rust/src/lib/src/util/fs.rs
+++ b/oxen-rust/src/lib/src/util/fs.rs
@@ -1599,6 +1599,17 @@ pub fn linux_path(path: &Path) -> PathBuf {
     Path::new(&linux_path_str(string)).to_path_buf()
 }
 
+pub fn remove_leading_slash(path: &Path) -> PathBuf {
+    let mut components = path.components();
+    
+    // If the first component of the path is '/', skip it and reconstruct the path
+    if components.next() == Some(std::path::Component::RootDir) {        
+        components.collect()
+    } else {
+        path.to_path_buf()
+    }
+}
+
 pub fn disk_usage_for_path(path: &Path) -> Result<DiskUsage, OxenError> {
     log::debug!("disk_usage_for_path: {path:?}");
     let disks = sysinfo::Disks::new_with_refreshed_list();

--- a/oxen-rust/src/lib/src/util/fs.rs
+++ b/oxen-rust/src/lib/src/util/fs.rs
@@ -1601,9 +1601,9 @@ pub fn linux_path(path: &Path) -> PathBuf {
 
 pub fn remove_leading_slash(path: &Path) -> PathBuf {
     let mut components = path.components();
-    
+
     // If the first component of the path is '/', skip it and reconstruct the path
-    if components.next() == Some(std::path::Component::RootDir) {        
+    if components.next() == Some(std::path::Component::RootDir) {
         components.collect()
     } else {
         path.to_path_buf()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Handles remote paths that start with a slash across entry lookup and file/directory downloads, preventing lookup failures and mismatched file names.
  * Error messages now reference normalized paths for clearer troubleshooting, while behavior for truly missing paths remains unchanged.

* **Refactor**
  * Added consistent path normalization to strip leading slashes so downstream operations use sanitized paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->