### PR TITLE
Use version store interface in text diff

### DIFF
--- a/oxen-rust/src/lib/src/core/index/schema_reader/objects_schema_reader.rs
+++ b/oxen-rust/src/lib/src/core/index/schema_reader/objects_schema_reader.rs
@@ -71,69 +71,6 @@ impl ObjectsSchemaReader {
         ObjectsSchemaReader::new(repository, &commit.id)
     }
 
-    pub fn get_schema_for_file<P: AsRef<Path>>(
-        &self,
-        path: P,
-    ) -> Result<Option<Schema>, OxenError> {
-        log::debug!("in get_schema_for_file path {:?}", path.as_ref());
-        let schema_path = Path::new(SCHEMAS_TREE_PREFIX).join(&path);
-        let path_parent = path.as_ref().parent().unwrap_or(Path::new(""));
-
-        let parent_dir_hash: Option<String> = path_db::get_entry(
-            &self.dir_hashes_db,
-            path_parent.to_str().unwrap().replace('\\', "/"),
-        )?;
-
-        if parent_dir_hash.is_none() {
-            return Ok(None);
-        }
-
-        let parent_dir_hash = parent_dir_hash.unwrap();
-        let parent_dir_obj: TreeObject = self.object_reader.get_dir(&parent_dir_hash)?.unwrap();
-        let full_path_str = schema_path.to_str().unwrap().replace('\\', "/");
-        let schema_path_hash_prefix = util::hasher::hash_path(full_path_str)[0..2].to_string();
-
-        let vnode_child: Option<TreeObjectChild> = parent_dir_obj
-            .binary_search_on_path(&PathBuf::from(schema_path_hash_prefix.clone()))?;
-
-        if vnode_child.is_none() {
-            return Ok(None);
-        }
-
-        let vnode_child = vnode_child.unwrap();
-        let vnode = self.object_reader.get_vnode(vnode_child.hash())?.unwrap();
-
-        log::debug!("got vnode");
-        log::debug!("here's the vnode {:?}", vnode);
-
-        let schema_child: Option<TreeObjectChild> =
-            vnode.binary_search_on_path(&PathBuf::from(SCHEMAS_TREE_PREFIX).join(path))?;
-
-        if schema_child.is_none() {
-            return Ok(None);
-        }
-
-        let schema_child = schema_child.unwrap();
-        log::debug!("got this schema child {:?}", schema_child);
-
-        let version_path = util::fs::version_path_from_schema_hash(
-            &self.repository.path,
-            schema_child.hash().to_string(),
-        );
-
-        log::debug!("got version path {:?}", version_path);
-
-        let schema: Result<Schema, serde_json::Error> =
-            serde_json::from_reader(std::fs::File::open(version_path)?);
-
-        log::debug!("get_schema_for_file() got schema {:?}", schema);
-
-        match schema {
-            Ok(schema) => Ok(Some(schema)),
-            Err(_) => Ok(None),
-        }
-    }
-
     pub fn list_schemas(&self) -> Result<HashMap<PathBuf, Schema>, OxenError> {
         log::debug!("calling list schemas");
         let root_hash: String = path_db::get_entry(&self.dir_hashes_db, "")?.unwrap();
@@ -251,12 +188,5 @@ impl ObjectsSchemaReader {
             }
         }
         Ok(found_schemas)
-    }
-
-    fn get_schema_by_hash(&self, hash: &str) -> Result<Schema, OxenError> {
-        let version_path =
-            util::fs::version_path_from_schema_hash(&self.repository.path, hash.to_string());
-        let schema = serde_json::from_reader(std::fs::File::open(version_path)?)?;
-        Ok(schema)
     }
 }

--- a/oxen-rust/src/lib/src/core/v_latest/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/workspaces/files.rs
@@ -286,7 +286,7 @@ pub async fn upload_zip(
         author: user.name.clone(),
         email: user.email.clone(),
     };
-    let res = repositories::workspaces::commit(workspace, &data, &branch.name);
+    let res = repositories::workspaces::commit(workspace, &data, &branch.name).await;
     match res {
         Ok(commit) => {
             log::debug!("workspace::commit ✅ success! commit {commit:?}");

--- a/oxen-rust/src/lib/src/model/diff/diff_entry.rs
+++ b/oxen-rust/src/lib/src/model/diff/diff_entry.rs
@@ -237,7 +237,9 @@ impl DiffEntry {
                 repo,
                 base_entry.as_ref(),
                 head_entry.as_ref(),
-            ) {
+            )
+            .await
+            {
                 Ok(text_diff) => Some(GenericDiff::TextDiff(text_diff)),
                 Err(_) => None,
             }

--- a/oxen-rust/src/lib/src/repositories/diffs/utf8_diff.rs
+++ b/oxen-rust/src/lib/src/repositories/diffs/utf8_diff.rs
@@ -2,7 +2,6 @@ use crate::error::OxenError;
 use crate::model::diff::change_type::ChangeType;
 use crate::model::diff::text_diff::LineDiff;
 use crate::model::diff::text_diff::TextDiff;
-use crate::util;
 
 use difference::{Changeset, Difference};
 use std::path::PathBuf;
@@ -34,7 +33,9 @@ fn add_lines_to_diff(
 }
 
 pub fn diff(
+    original_data: Option<String>,
     version_file_1: Option<PathBuf>,
+    compare_data: Option<String>,
     version_file_2: Option<PathBuf>,
 ) -> Result<TextDiff, OxenError> {
     let mut result = TextDiff {
@@ -46,8 +47,10 @@ pub fn diff(
             .map(|p| p.to_string_lossy().to_string()),
         ..Default::default()
     };
-    let original_data = util::fs::read_file(version_file_1)?;
-    let compare_data = util::fs::read_file(version_file_2)?;
+
+    let original_data = original_data.unwrap_or_default();
+    let compare_data = compare_data.unwrap_or_default();
+
     let Changeset { diffs, .. } = Changeset::new(&original_data, &compare_data, "\n");
     log::debug!("Changeset created with {} diffs", diffs.len());
 

--- a/oxen-rust/src/lib/src/repositories/workspaces.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces.rs
@@ -350,14 +350,14 @@ pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), O
     Ok(())
 }
 
-pub fn commit(
+pub async fn commit(
     workspace: &Workspace,
     new_commit: &NewCommitBody,
     branch_name: impl AsRef<str>,
 ) -> Result<Commit, OxenError> {
     match workspace.workspace_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::workspaces::commit::commit(workspace, new_commit, branch_name),
+        _ => core::v_latest::workspaces::commit::commit(workspace, new_commit, branch_name).await,
     }
 }
 
@@ -603,7 +603,8 @@ mod tests {
                         email: "bessie@oxen.ai".to_string(),
                     },
                     DEFAULT_BRANCH_NAME,
-                )?;
+                )
+                .await?;
             } // temp_workspace goes out of scope here and gets cleaned up
 
             {
@@ -624,7 +625,8 @@ mod tests {
                         email: "bessie@oxen.ai".to_string(),
                     },
                     DEFAULT_BRANCH_NAME,
-                )?;
+                )
+                .await?;
             } // temp_workspace goes out of scope here and gets cleaned up
 
             Ok(())
@@ -659,7 +661,8 @@ mod tests {
                         email: "bessie@oxen.ai".to_string(),
                     },
                     DEFAULT_BRANCH_NAME,
-                )?;
+                )
+                .await?;
             } // temp_workspace goes out of scope here and gets cleaned up
 
             {
@@ -679,7 +682,8 @@ mod tests {
                         email: "bessie@oxen.ai".to_string(),
                     },
                     DEFAULT_BRANCH_NAME,
-                );
+                )
+                .await;
 
                 // We should get a merge conflict error
                 assert!(result.is_err());
@@ -720,7 +724,8 @@ mod tests {
                         email: "bessie@oxen.ai".to_string(),
                     },
                     DEFAULT_BRANCH_NAME,
-                )?;
+                )
+                .await?;
             } // temp_workspace goes out of scope here and gets cleaned up
 
             {
@@ -742,7 +747,8 @@ mod tests {
                         email: "bessie@oxen.ai".to_string(),
                     },
                     DEFAULT_BRANCH_NAME,
-                )?;
+                )
+                .await?;
             } // temp_workspace goes out of scope here and gets cleaned up
 
             Ok(())

--- a/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
@@ -389,7 +389,8 @@ pub async fn from_directory(
 
     repositories::workspaces::files::add(workspace, &output_path).await?;
 
-    let commit = repositories::workspaces::commit(workspace, new_commit, branch.name.as_str())?;
+    let commit =
+        repositories::workspaces::commit(workspace, new_commit, branch.name.as_str()).await?;
     println!(
         "Created parquet file with {} file paths at: {:?}",
         file_paths.len(),
@@ -782,7 +783,7 @@ mod tests {
                 email: "email".to_string(),
                 message: "Deleting a row allegedly".to_string(),
             };
-            let commit_2 = workspaces::commit(&workspace, &new_commit, branch_name)?;
+            let commit_2 = workspaces::commit(&workspace, &new_commit, branch_name).await?;
 
             let file_1 = repositories::revisions::get_version_file_from_commit_id(
                 &repo, &commit.id, &file_path,
@@ -1257,7 +1258,7 @@ mod tests {
                 message: "Appending tabular data".to_string(),
             };
 
-            let commit = workspaces::commit(&workspace, &new_commit, DEFAULT_BRANCH_NAME)?;
+            let commit = workspaces::commit(&workspace, &new_commit, DEFAULT_BRANCH_NAME).await?;
 
             // Make sure version file is updated
             let entry = repositories::entries::get_commit_entry(&repo, &commit, &path)?.unwrap();

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -196,7 +196,7 @@ pub async fn put(
         )),
     };
 
-    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name)?;
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
 
     log::debug!("file::put workspace commit ✅ success! commit {commit:?}");
 
@@ -409,7 +409,7 @@ pub async fn import(
         ),
     };
 
-    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name)?;
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
     log::debug!("workspace::commit ✅ success! commit {commit:?}");
 
     Ok(HttpResponse::Ok().json(CommitResponse {

--- a/oxen-rust/src/server/src/controllers/workspaces.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces.rs
@@ -326,7 +326,7 @@ pub async fn commit(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
         return Ok(HttpResponse::NotFound().json(StatusMessageDescription::not_found(branch_name)));
     };
 
-    match repositories::workspaces::commit(&workspace, &data, &branch_name) {
+    match repositories::workspaces::commit(&workspace, &data, &branch_name).await {
         Ok(commit) => {
             log::debug!("workspace::commit ✅ success! commit {commit:?}");
             Ok(HttpResponse::Ok().json(CommitResponse {


### PR DESCRIPTION
Test with 
1. `oxen diff` command with two text files 
2. Edit and commit a dataframe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Text file diffing now reads and compares versioned content directly and operates asynchronously for non-blocking diffs.
* **Behavior Changes**
  * Commit and related workspace flows converted to async, improving responsiveness for large operations and requiring awaited calls.
* **Removed**
  * Path- and hash-based schema lookup methods were removed from the schema reader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->