### PR TITLE
Implement storage config command

### DIFF
--- a/oxen-rust/src/cli/src/cmd/config.rs
+++ b/oxen-rust/src/cli/src/cmd/config.rs
@@ -54,7 +54,7 @@ impl RunCmd for ConfigCmd {
                     .action(clap::ArgAction::Set),
             )
             .arg(
-                Arg::new("version_store")
+                Arg::new("version-store")
                     .long("version_store")
                     .help("Set the location where version files are saved in your repository")
                     .action(clap::ArgAction::Set),
@@ -146,7 +146,7 @@ impl RunCmd for ConfigCmd {
 
         if let Some(name) = args.get_one::<String>("version-store") {
             let mut repo = LocalRepository::from_current_dir()?;
-            let path = PathBuf::from(name); 
+            let path = PathBuf::from(name);
 
             match self.set_version_store(&mut repo, &path) {
                 Ok(_) => {}
@@ -189,7 +189,11 @@ impl ConfigCmd {
         Ok(())
     }
 
-     pub fn set_version_store(&self, repo: &mut LocalRepository, path: &Path) -> Result<(), OxenError> {
+    pub fn set_version_store(
+        &self,
+        repo: &mut LocalRepository,
+        path: &Path,
+    ) -> Result<(), OxenError> {
         command::config::set_version_store(repo, path)?;
 
         Ok(())

--- a/oxen-rust/src/cli/src/cmd/config.rs
+++ b/oxen-rust/src/cli/src/cmd/config.rs
@@ -6,6 +6,8 @@ use liboxen::config::{AuthConfig, UserConfig};
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 
+use std::path::{Path, PathBuf};
+
 use crate::cmd::RunCmd;
 pub const NAME: &str = "config";
 pub struct ConfigCmd;
@@ -49,6 +51,12 @@ impl RunCmd for ConfigCmd {
                     .long("delete-remote")
                     .value_name("REMOTE_NAME")
                     .help("Delete a remote from the current working repository.")
+                    .action(clap::ArgAction::Set),
+            )
+            .arg(
+                Arg::new("version_store")
+                    .long("version_store")
+                    .help("Set the location where version files are saved in your repository")
                     .action(clap::ArgAction::Set),
             )
             .arg(
@@ -136,6 +144,18 @@ impl RunCmd for ConfigCmd {
             }
         }
 
+        if let Some(name) = args.get_one::<String>("version-store") {
+            let mut repo = LocalRepository::from_current_dir()?;
+            let path = PathBuf::from(name); 
+
+            match self.set_version_store(&mut repo, &path) {
+                Ok(_) => {}
+                Err(err) => {
+                    eprintln!("{err}")
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -165,6 +185,12 @@ impl ConfigCmd {
 
     pub fn delete_remote(&self, repo: &mut LocalRepository, name: &str) -> Result<(), OxenError> {
         command::config::delete_remote(repo, name)?;
+
+        Ok(())
+    }
+
+     pub fn set_version_store(&self, repo: &mut LocalRepository, path: &Path) -> Result<(), OxenError> {
+        command::config::set_version_store(repo, path)?;
 
         Ok(())
     }

--- a/oxen-rust/src/lib/src/command/config.rs
+++ b/oxen-rust/src/lib/src/command/config.rs
@@ -6,6 +6,8 @@
 use crate::error::OxenError;
 use crate::model::{LocalRepository, Remote};
 
+use std::path::Path;
+
 /// # Set the remote for a repository
 /// Tells the CLI where to push the changes to
 pub fn set_remote(repo: &mut LocalRepository, name: &str, url: &str) -> Result<Remote, OxenError> {
@@ -52,5 +54,19 @@ pub fn set_workspace(repo: &mut LocalRepository, name: &str) -> Result<String, O
 pub fn delete_workspace(repo: &mut LocalRepository, name: &str) -> Result<(), OxenError> {
     repo.delete_workspace(name)?;
     repo.save()?;
+    Ok(())
+}
+
+/// # Set the version store location for a repository
+/// Tells the CLI where to save version files
+pub fn set_version_store(
+    repo: &mut LocalRepository,
+    path: impl AsRef<Path>,
+) -> Result<(), OxenError> {
+    let path = path.as_ref();
+
+    repo.set_version_store(path)?;
+    repo.save()?;
+
     Ok(())
 }

--- a/oxen-rust/src/lib/src/model/repository/local_repository.rs
+++ b/oxen-rust/src/lib/src/model/repository/local_repository.rs
@@ -97,6 +97,19 @@ impl LocalRepository {
         Ok(())
     }
 
+    /// Initialize the version store at a new location
+    pub fn set_version_store(&mut self, path: &Path) -> Result<(), OxenError> {
+        // Load config to get storage settings
+        let config_path = util::fs::config_filepath(&self.path);
+        let config = RepositoryConfig::from_file(&config_path)?;
+
+        // Create and initialize the store
+        let store = create_version_store(path, config.storage.as_ref())?;
+        self.version_store = Some(store);
+
+        Ok(())
+    }
+
     /// Load a repository from the current directory
     /// this traverses up the directory tree until it finds a .oxen/ directory
     pub fn from_current_dir() -> Result<LocalRepository, OxenError> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New --version-store CLI option in the config command to set a custom version store path.
  * Persist the repository's version store location so subsequent operations use the configured storage.
  * Provide a command to update an existing repository to point to a different version store location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->