### PR TITLE
Updates upgrade instructions with correct binaries name

### DIFF
--- a/oxen-rust/src/cli/src/helpers.rs
+++ b/oxen-rust/src/cli/src/helpers.rs
@@ -72,7 +72,7 @@ pub async fn check_remote_version_blocking(
 
             if local_oxen_version < min_oxen_version {
                 return Err(OxenError::OxenUpdateRequired(format!(
-                    "Error: Oxen CLI out of date. Pushing to OxenHub requires version >= {min_oxen_version:?}, found version {local_oxen_version:?}.\n\nVisit https://docs.oxen.ai/getting-started/intro for update instructions.\n\nOn Mac:\n\n  brew update\n  brew install oxen\n\nOn Ubuntu:\n\n  wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-ubuntu-latest.deb\n  sudo dpkg -i oxen-ubuntu-latest.deb"
+                    "Error: Oxen CLI out of date. Pushing to OxenHub requires version >= {min_oxen_version:?}, found version {local_oxen_version:?}.\n\nVisit https://docs.oxen.ai/getting-started/intro for update instructions.\n\nOn Mac:\n\n  brew update\n  brew upgrade oxen\n\nOn Ubuntu:\n\n  For x86-64:\n    wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-x86_64.deb\n    sudo dpkg -i oxen-linux-x86_64.deb\n\n  For ARM64:\n    wget https://github.com/Oxen-AI/Oxen/releases/latest/download/oxen-linux-arm64.deb\n    sudo dpkg -i oxen-linux-arm64.deb"
                 ).into()));
             }
         }


### PR DESCRIPTION
Found this outdated instructions when upgrading the oxen-to-git client.

`oxen-ubuntu-latest.deb` does not exists. They are instead denominated by the architecture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance in error messages for macOS (with upgrade command) and Ubuntu (with architecture-specific download options and instructions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->