### PR TITLE
add image metadata on dir to df query automatically

### DIFF
--- a/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
@@ -328,7 +328,6 @@ pub async fn from_directory(
         })
         .collect();
 
-
     let is_image_column: Vec<bool> = files
         .iter()
         .map(|file_with_dir| {
@@ -336,7 +335,7 @@ pub async fn from_directory(
             mime_type == "image/jpeg" || mime_type == "image/png"
         })
         .collect();
-    
+
     let db_path = workspace.dir().join("temp_file_listing.db");
 
     let mut df = with_df_db_manager(&db_path, |manager| {
@@ -406,7 +405,7 @@ pub async fn from_directory(
                 }
             }
         });
-        
+
         repositories::workspaces::data_frames::columns::add_column_metadata(
             repo,
             workspace,

--- a/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/oxen-rust/src/lib/src/repositories/workspaces/data_frames.rs
@@ -14,7 +14,7 @@ use crate::core::db::data_frames::{df_db, workspace_df_db};
 use crate::core::df::sql;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::{Branch, Commit, LocalRepository, NewCommitBody, Workspace};
+use crate::model::{Branch, Commit, EntryDataType, LocalRepository, NewCommitBody, Workspace};
 use crate::opts::DFOpts;
 use crate::{repositories, util};
 
@@ -413,8 +413,8 @@ pub async fn set_image_metadata_if_applicable(
     let is_image_column: Vec<bool> = files
         .iter()
         .map(|file_with_dir| {
-            let mime_type = file_with_dir.file_node.mime_type();
-            mime_type == "image/jpeg" || mime_type == "image/png"
+            let data_type = file_with_dir.file_node.data_type();
+            *data_type == EntryDataType::Image
         })
         .collect();
 


### PR DESCRIPTION
We check if all files getting passed in are images, if they are we automatically add image metadata to the new column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data-frame file-path columns containing JPEG/PNG images now receive rendering metadata when importing from directories or reading/writing Parquet, so image files display inline in data-frame views. This improves visual inspection of image datasets while preserving existing behavior for non-image datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->