### PR TITLE
Route merkle tree node download through temp dir

### DIFF
--- a/oxen-rust/src/cli/src/cmd/clone.rs
+++ b/oxen-rust/src/cli/src/cmd/clone.rs
@@ -71,6 +71,12 @@ impl RunCmd for CloneCmd {
                     .action(clap::ArgAction::Set),
             )
             .arg(
+                Arg::new("vfs")
+                    .long("vfs")
+                    .help("Configure the repo to be stored on a virtual file system")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
                 Arg::new("remote")
                     .long("remote")
                     .help("Clone the repo in 'remote mode', pulling the metadata but not the file contents")
@@ -95,6 +101,7 @@ impl RunCmd for CloneCmd {
         let depth: Option<i32> = args
             .get_one::<String>("depth")
             .map(|s| s.parse().expect("Invalid depth, must be an integer"));
+        let is_vfs = args.get_flag("vfs");
         let is_remote = args.get_flag("remote");
 
         let current_dir = std::env::current_dir().expect("Could not get current working directory");
@@ -156,6 +163,7 @@ impl RunCmd for CloneCmd {
                 ..FetchOpts::new()
             },
             storage_opts,
+            is_vfs,
             is_remote,
         };
 

--- a/oxen-rust/src/lib/src/config/repository_config.rs
+++ b/oxen-rust/src/lib/src/config/repository_config.rs
@@ -21,7 +21,9 @@ pub struct RepositoryConfig {
     pub vnode_size: Option<u64>,
     /// Storage configuration
     pub storage: Option<StorageConfig>,
-    /// Flag for remote repo
+    /// Flag for repositories stored on virtual file systems
+    pub vfs: Option<bool>,
+    /// Flag for remote-mode repositories
     pub remote_mode: Option<bool>,
     /// Currently used only for remote mode
     pub workspace_name: Option<String>,
@@ -47,6 +49,7 @@ impl RepositoryConfig {
             min_version: None,
             vnode_size: None,
             storage: None,
+            vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,

--- a/oxen-rust/src/lib/src/core/v_latest/branches.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/branches.rs
@@ -240,7 +240,7 @@ pub async fn checkout_subtrees(
         }
 
         if from_root.is_some() {
-            log::debug!("🔥 from node: {from_root:?}");
+            log::debug!("Cleanup_removed_files");
             cleanup_removed_files(repo, &from_root.unwrap(), &mut progress, &mut hashes).await?;
         } else {
             log::debug!("head commit missing, no cleanup");

--- a/oxen-rust/src/lib/src/core/v_latest/clone.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/clone.rs
@@ -37,6 +37,12 @@ pub async fn clone_repo(
     local_repo.set_depth(opts.fetch_opts.depth);
     local_repo.set_version_store(&opts.storage_opts)?;
 
+    if opts.is_vfs {
+        local_repo.set_vfs(Some(true));
+    } else {
+        local_repo.set_vfs(None);
+    }
+
     local_repo.save()?;
 
     if remote_repo.is_empty {
@@ -90,6 +96,12 @@ pub async fn clone_repo_remote_mode(
     local_repo.set_min_version(remote_repo.min_version());
     local_repo.set_remote_mode(Some(true));
     local_repo.set_version_store(&opts.storage_opts)?;
+
+    if opts.is_vfs {
+        local_repo.set_vfs(Some(true));
+    } else {
+        local_repo.set_vfs(None);
+    }
 
     let workspace = api::client::workspaces::create_with_new_branch(
         &remote_repo,

--- a/oxen-rust/src/lib/src/model/repository/local_repository.rs
+++ b/oxen-rust/src/lib/src/model/repository/local_repository.rs
@@ -26,6 +26,7 @@ pub struct LocalRepository {
     vnode_size: Option<u64>,     // Size of the vnodes
     subtree_paths: Option<Vec<PathBuf>>, // If the user clones a subtree, we store the paths here so that we know we don't have the full tree
     pub depth: Option<i32>, // If the user clones with a depth, we store the depth here so that we know we don't have the full tree
+    pub vfs: Option<bool>,  // Flag for repositories stored on virtual file systems
     pub remote_mode: Option<bool>, // Flag for remote repositories
     pub workspace_name: Option<String>, // ID of the associated workspace for remote mode
     workspaces: Option<Vec<String>>, // List of workspaces for remote mode
@@ -57,6 +58,7 @@ impl LocalRepository {
             subtree_paths: config.subtree_paths.clone(),
             depth: config.depth,
             version_store: None,
+            vfs: config.vfs,
             remote_mode: config.remote_mode,
             workspace_name: config.workspace_name,
             workspaces: config.workspaces,
@@ -146,6 +148,7 @@ impl LocalRepository {
             subtree_paths: None,
             depth: None,
             version_store: None,
+            vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
@@ -169,6 +172,7 @@ impl LocalRepository {
             subtree_paths: None,
             depth: None,
             version_store: None,
+            vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
@@ -188,6 +192,7 @@ impl LocalRepository {
             subtree_paths: None,
             depth: None,
             version_store: None,
+            vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
@@ -207,6 +212,7 @@ impl LocalRepository {
             subtree_paths: None,
             depth: None,
             version_store: None,
+            vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
@@ -284,6 +290,14 @@ impl LocalRepository {
         self.remote_mode.unwrap_or(false)
     }
 
+    pub fn is_vfs(&self) -> bool {
+        self.vfs.unwrap_or(false)
+    }
+
+    pub fn set_vfs(&mut self, is_vfs: Option<bool>) {
+        self.vfs = is_vfs;
+    }
+
     /// Save the repository configuration to disk
     pub fn save(&self) -> Result<(), OxenError> {
         let config_path = util::fs::config_filepath(&self.path);
@@ -302,6 +316,7 @@ impl LocalRepository {
             min_version: self.min_version.clone(),
             vnode_size: self.vnode_size,
             storage,
+            vfs: self.vfs,
             remote_mode: self.remote_mode,
             workspace_name: self.workspace_name.clone(),
             workspaces: self.workspaces.clone(),

--- a/oxen-rust/src/lib/src/opts/clone_opts.rs
+++ b/oxen-rust/src/lib/src/opts/clone_opts.rs
@@ -13,6 +13,8 @@ pub struct CloneOpts {
     pub fetch_opts: FetchOpts,
     // StorageOpts
     pub storage_opts: StorageOpts,
+    // Flag for cloning on VFS
+    pub is_vfs: bool,
     // Flag for remote mode
     pub is_remote: bool,
 }
@@ -25,6 +27,7 @@ impl CloneOpts {
             dst: dst.as_ref().to_path_buf(),
             fetch_opts: FetchOpts::new(),
             storage_opts: StorageOpts::from_path(dst.as_ref(), true),
+            is_vfs: false,
             is_remote: false,
         }
     }
@@ -37,6 +40,7 @@ impl CloneOpts {
         CloneOpts {
             fetch_opts: FetchOpts::from_branch(branch.as_ref()),
             storage_opts: StorageOpts::from_path(dst.as_ref(), true),
+            is_vfs: false,
             is_remote: false,
             ..CloneOpts::new(url, dst)
         }

--- a/oxen-rust/src/lib/src/repositories/clone.rs
+++ b/oxen-rust/src/lib/src/repositories/clone.rs
@@ -52,6 +52,7 @@ async fn _clone(
         dst: dst.as_ref().to_owned(),
         fetch_opts,
         storage_opts: StorageOpts::from_path(dst.as_ref(), true),
+        is_vfs: false,
         is_remote: false,
     };
     clone(&opts).await
@@ -59,13 +60,14 @@ async fn _clone(
 
 async fn clone_remote(opts: &CloneOpts) -> Result<Option<LocalRepository>, OxenError> {
     log::debug!(
-        "clone_remote {} -> {:?} -> subtree? {:?} -> depth? {:?} -> all? {} -> storage backend? {:?} -> is remote? {}",
+        "clone_remote {} -> {:?} -> subtree? {:?} -> depth? {:?} -> all? {} -> storage backend? {:?} -> is vfs? {} -> is remote? {}",
         opts.url,
         opts.dst,
         opts.fetch_opts.subtree_paths,
         opts.fetch_opts.depth,
         opts.fetch_opts.all,
         opts.storage_opts.type_,
+        opts.is_vfs,
         opts.is_remote,
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --vfs option to the clone command and persistent VFS configuration for repositories.
* **Bug Fixes**
  * Safer download/unpack flow for virtual filesystem clones: use temporary unpack locations then atomically copy to final locations to avoid partial/unpacked states.
* **Chores**
  * Updated log messages to clarify unpack destinations and completion.<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->