### PR TITLE
Add timeout support on EC2 windows self-hosted

### DIFF
--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -47,13 +47,14 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: crunchy234/ec2-github-runner@windows-support-18
+        uses: Oxen-AI/ec2-github-runner-windows@v1
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ env.EC2_IMAGE_ID }}
           ec2-instance-type: ${{ env.EC2_INSTANCE_TYPE }}
           ec2-os: windows
+          startup-timeout-minutes: 10
           subnet-id: subnet-0e28805edbdad482f
           security-group-id: sg-09c8aa5830122d671
           aws-resource-tags: >


### PR DESCRIPTION
Use Oxen's fork of ec2-github-runner for specifying registration timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows release workflow infrastructure to improve build process reliability and configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->