### PR TITLE
Api 46/auto generated docs

### DIFF
--- a/oxen-python/Cargo.lock
+++ b/oxen-python/Cargo.lock
@@ -3793,6 +3793,7 @@ dependencies = [
  "toml 0.8.23",
  "url",
  "urlencoding",
+ "utoipa",
  "uuid",
  "walkdir",
  "xxhash-rust",
@@ -7646,6 +7647,29 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.12.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
+]
 
 [[package]]
 name = "uuid"

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -106,10 +106,12 @@ dependencies = [
  "toml 0.8.23",
  "url",
  "urlencoding",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
  "walkdir",
  "xxhash-rust",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -3962,10 +3964,12 @@ dependencies = [
  "toml 0.8.23",
  "url",
  "urlencoding",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
  "walkdir",
  "xxhash-rust",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -6188,6 +6192,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.104",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7677,6 +7715,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "actix-web",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip 3.0.0",
+]
+
+[[package]]
 name = "uuid"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8464,6 +8543,20 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.10.0",
+ "memchr",
+ "zopfli",
 ]
 
 [[package]]

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -141,6 +141,8 @@ tokio-console = "0.1.13"
 toml = "0.8.19"
 url = "2.4.1"
 urlencoding = "2.1.3"
+utoipa = "5"
+utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
 walkdir = "2.5.0"
 xxhash-rust = { version = "0.8.7", features = ["xxh3"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -141,7 +141,7 @@ tokio-console = "0.1.13"
 toml = "0.8.19"
 url = "2.4.1"
 urlencoding = "2.1.3"
-utoipa = "5"
+utoipa = { version = "5", features = ["time"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
 walkdir = "2.5.0"

--- a/oxen-rust/src/lib/Cargo.toml
+++ b/oxen-rust/src/lib/Cargo.toml
@@ -128,6 +128,8 @@ tokio-console = "0.1.13"
 toml = "0.8.12"
 url = "2.2.2"
 urlencoding = "2.1.0"
+utoipa = "5"
+utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
 walkdir = "2.5.0"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }

--- a/oxen-rust/src/lib/Cargo.toml
+++ b/oxen-rust/src/lib/Cargo.toml
@@ -128,7 +128,7 @@ tokio-console = "0.1.13"
 toml = "0.8.12"
 url = "2.2.2"
 urlencoding = "2.1.0"
-utoipa = "5"
+utoipa = { version = "5", features = ["time"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
 walkdir = "2.5.0"

--- a/oxen-rust/src/lib/src/model/branch.rs
+++ b/oxen-rust/src/lib/src/model/branch.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct Branch {
     pub name: String,
     pub commit_id: String,

--- a/oxen-rust/src/lib/src/model/commit.rs
+++ b/oxen-rust/src/lib/src/model/commit.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use time::OffsetDateTime;
+use utoipa::ToSchema;
 
 use super::{MerkleHash, User};
 use crate::config::UserConfig;
@@ -9,7 +10,7 @@ use crate::error::OxenError;
 use crate::view::workspaces::WorkspaceCommit;
 
 /// NewCommitBody is used to parse the json into a Commit from the API
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct NewCommitBody {
     pub message: String,
     pub author: String,
@@ -39,7 +40,19 @@ impl NewCommit {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[schema(
+    example = json!({
+        "id": "a1b2c3d4e5f67890abcdef1234567890",
+        "parent_ids": [
+            "f1e2d3c4b5a67890fedcba9876543210"
+        ],
+        "message": "Refactor data loading pipeline.",
+        "author": "ox",
+        "email": "ox@example.com",
+        "timestamp": "2025-01-01T10:00:00Z"
+    })
+)]
 pub struct Commit {
     pub id: String,
     pub parent_ids: Vec<String>,
@@ -210,7 +223,23 @@ impl NewCommitBody {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "commit": {
+            "id": "a1b2c3d4e5f67890abcdef1234567890",
+            "parent_ids": [
+                "f1e2d3c4b5a67890fedcba9876543210"
+            ],
+            "message": "Refactor data loading pipeline.",
+            "author": "ox",
+            "email": "ox@example.com",
+            "timestamp": "2025-01-01T10:00:00Z"
+        },
+        "num_entries": 12000,
+        "num_synced_files": 11950,
+    })
+)]
 pub struct CommitStats {
     pub commit: Commit,
     pub num_entries: usize, // this is how many entries are in our commit db

--- a/oxen-rust/src/lib/src/model/data_frame.rs
+++ b/oxen-rust/src/lib/src/model/data_frame.rs
@@ -6,10 +6,11 @@ use crate::model::data_frame::data_frame_size::DataFrameSize;
 use crate::model::data_frame::schema::Schema;
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use polars::frame::DataFrame;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct DataFrameSchemaSize {
     pub schema: Schema,
     pub size: DataFrameSize,

--- a/oxen-rust/src/lib/src/model/data_frame/data_frame_size.rs
+++ b/oxen-rust/src/lib/src/model/data_frame/data_frame_size.rs
@@ -1,7 +1,8 @@
 use polars::frame::DataFrame;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct DataFrameSize {
     pub height: usize,
     pub width: usize,

--- a/oxen-rust/src/lib/src/model/data_frame/schema.rs
+++ b/oxen-rust/src/lib/src/model/data_frame/schema.rs
@@ -6,6 +6,7 @@ pub mod staged_schema;
 pub use custom_data_type::CustomDataType;
 pub use data_type::DataType;
 pub use field::Field;
+use utoipa::ToSchema;
 
 use crate::util::hasher;
 use itertools::Itertools;
@@ -14,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, fmt, path::PathBuf};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Schema {
     pub hash: String,
     pub fields: Vec<Field>,

--- a/oxen-rust/src/lib/src/model/data_frame/schema/field.rs
+++ b/oxen-rust/src/lib/src/model/data_frame/schema/field.rs
@@ -1,12 +1,13 @@
 use polars::prelude::PlSmallStr;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use utoipa::ToSchema;
 
 use crate::model::data_frame::schema::DataType;
 
 use super::CustomDataType;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Field {
     pub name: String,
     pub dtype: String,
@@ -14,14 +15,14 @@ pub struct Field {
     pub changes: Option<Changes>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct PreviousField {
     pub name: String,
     pub dtype: String,
     pub metadata: Option<Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Changes {
     pub status: String,
     pub previous: Option<PreviousField>,

--- a/oxen-rust/src/lib/src/model/diff/add_remove_modify_counts.rs
+++ b/oxen-rust/src/lib/src/model/diff/add_remove_modify_counts.rs
@@ -1,9 +1,10 @@
 use polars::frame::DataFrame;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::{constants::DIFF_STATUS_COL, error::OxenError};
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct AddRemoveModifyCounts {
     pub added: usize,
     pub removed: usize,

--- a/oxen-rust/src/lib/src/model/diff/change_type.rs
+++ b/oxen-rust/src/lib/src/model/diff/change_type.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash, Copy, ToSchema)]
 pub enum ChangeType {
     Added,
     Removed,

--- a/oxen-rust/src/lib/src/model/diff/diff_entry.rs
+++ b/oxen-rust/src/lib/src/model/diff/diff_entry.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::{DirNode, FileNode};
@@ -15,7 +16,7 @@ use super::generic_diff::GenericDiff;
 use super::generic_diff_summary::GenericDiffSummary;
 use super::tabular_diff_summary::TabularDiffWrapper;
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct DiffEntry {
     pub status: String,
     pub data_type: EntryDataType,

--- a/oxen-rust/src/lib/src/model/diff/diff_entry_status.rs
+++ b/oxen-rust/src/lib/src/model/diff/diff_entry_status.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum DiffEntryStatus {
     Added,

--- a/oxen-rust/src/lib/src/model/diff/dir_diff.rs
+++ b/oxen-rust/src/lib/src/model/diff/dir_diff.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::dir_diff_summary::DirDiffSummary;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct DirDiff {
     #[serde(flatten)]
     pub summary: DirDiffSummary,

--- a/oxen-rust/src/lib/src/model/diff/dir_diff_summary.rs
+++ b/oxen-rust/src/lib/src/model/diff/dir_diff_summary.rs
@@ -1,17 +1,18 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::{
     error::OxenError,
     model::{diff::AddRemoveModifyCounts, merkle_tree::node::DirNode},
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct DirDiffSummary {
     pub dir: DirDiffSummaryImpl,
 }
 
 // Impl is so that we can wrap the json response in the "dir" field to make summaries easier to distinguish
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct DirDiffSummaryImpl {
     pub file_counts: AddRemoveModifyCounts,
 }

--- a/oxen-rust/src/lib/src/model/diff/generic_diff.rs
+++ b/oxen-rust/src/lib/src/model/diff/generic_diff.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::model::diff::dir_diff::DirDiff;
 use crate::model::diff::text_diff::TextDiff;
 use crate::view::tabular_diff_view::TabularDiffView;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 #[serde(untagged)]
 pub enum GenericDiff {
     DirDiff(DirDiff),

--- a/oxen-rust/src/lib/src/model/diff/generic_diff_summary.rs
+++ b/oxen-rust/src/lib/src/model/diff/generic_diff_summary.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::model::diff::dir_diff_summary::DirDiffSummary;
 use crate::model::diff::tabular_diff_summary::TabularDiffWrapper;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 #[serde(untagged)]
 pub enum GenericDiffSummary {
     DirDiffSummary(DirDiffSummary),

--- a/oxen-rust/src/lib/src/model/diff/tabular_diff.rs
+++ b/oxen-rust/src/lib/src/model/diff/tabular_diff.rs
@@ -4,45 +4,49 @@ use crate::{
 };
 use polars::frame::DataFrame;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::AddRemoveModifyCounts;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct TabularSchemaDiff {
     pub added: Vec<Field>,
     pub removed: Vec<Field>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TabularDiffMods {
     pub row_counts: AddRemoveModifyCounts,
     pub col_changes: TabularSchemaDiff,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TabularDiffSummary {
     pub modifications: TabularDiffMods,
     pub schemas: TabularDiffSchemas,
     pub dupes: TabularDiffDupes,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TabularDiff {
     pub filename1: Option<String>,
     pub filename2: Option<String>,
     pub summary: TabularDiffSummary,
     pub parameters: TabularDiffParameters,
+
+    // TODO: Not sure if this is the best way to represent polars data frames
+    #[schema(value_type = Object)]
     pub contents: DataFrame,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TabularDiffSchemas {
     pub left: Schema,
     pub right: Schema,
     pub diff: Schema,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TabularDiffParameters {
     pub keys: Vec<String>,
     pub targets: Vec<String>,
@@ -50,7 +54,7 @@ pub struct TabularDiffParameters {
 }
 
 // Need to serialize here because we directly write this to disk to cache compares
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TabularDiffDupes {
     pub left: u64,
     pub right: u64,

--- a/oxen-rust/src/lib/src/model/diff/tabular_diff_summary.rs
+++ b/oxen-rust/src/lib/src/model/diff/tabular_diff_summary.rs
@@ -1,5 +1,6 @@
 use polars::prelude::DataFrame;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::core::df::tabular;
 use crate::error::OxenError;
@@ -10,18 +11,18 @@ use crate::opts::DFOpts;
 use crate::util;
 
 // THE DIFFERENCE BETWEEN WRAPPER AND SUMMARY IS JUST THE KEY NAME IN THE JSON RESPONSE
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularDiffWrapper {
     pub tabular: TabularDiffSummaryImpl,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularDiffSummary {
     pub summary: TabularDiffSummaryImpl,
 }
 
 // Impl is so that we can wrap the json response in the "tabular" field to make summaries easier to distinguish
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularDiffSummaryImpl {
     pub num_added_rows: usize,
     pub num_added_cols: usize,

--- a/oxen-rust/src/lib/src/model/diff/text_diff.rs
+++ b/oxen-rust/src/lib/src/model/diff/text_diff.rs
@@ -1,13 +1,14 @@
 use crate::model::diff::change_type::ChangeType;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct LineDiff {
     pub modification: ChangeType,
     pub text: String,
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TextDiff {
     pub lines: Vec<LineDiff>,
     pub filename1: Option<String>,

--- a/oxen-rust/src/lib/src/model/entry/commit_entry.rs
+++ b/oxen-rust/src/lib/src/model/entry/commit_entry.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
+use utoipa::ToSchema;
+
 #[derive(Clone, Debug)]
 pub enum Entry {
     CommitEntry(CommitEntry),
@@ -94,9 +96,10 @@ pub struct CommitPath {
     pub path: PathBuf,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct CommitEntry {
     pub commit_id: String,
+    #[schema(value_type = String)]
     pub path: PathBuf,
     pub hash: String,
     pub num_bytes: u64,

--- a/oxen-rust/src/lib/src/model/entry/entry_data_type.rs
+++ b/oxen-rust/src/lib/src/model/entry/entry_data_type.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::str::FromStr;
+use utoipa::ToSchema;
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, Eq, Hash, PartialEq, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum EntryDataType {
     Dir,

--- a/oxen-rust/src/lib/src/model/entry/metadata_entry.rs
+++ b/oxen-rust/src/lib/src/model/entry/metadata_entry.rs
@@ -6,6 +6,8 @@ use crate::model::parsed_resource::ParsedResourceView;
 use crate::model::{Commit, EntryDataType, LocalRepository, ParsedResource, StagedEntryStatus};
 use crate::repositories;
 
+use utoipa::ToSchema;
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct CLIMetadataEntry {
     pub filename: String,
@@ -22,7 +24,7 @@ pub struct CLIMetadataEntry {
     pub extension: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataEntry {
     pub filename: String,
     pub hash: String,
@@ -43,7 +45,7 @@ pub struct MetadataEntry {
     pub is_queryable: Option<bool>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct WorkspaceMetadataEntry {
     pub filename: String,
     pub hash: String,
@@ -66,7 +68,7 @@ pub struct WorkspaceMetadataEntry {
     pub changes: Option<WorkspaceChanges>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct WorkspaceChanges {
     pub status: StagedEntryStatus,
 }

--- a/oxen-rust/src/lib/src/model/entry/remote_entry.rs
+++ b/oxen-rust/src/lib/src/model/entry/remote_entry.rs
@@ -1,7 +1,8 @@
 use crate::model::CommitEntry;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct RemoteEntry {
     pub filename: String,
     pub hash: String,

--- a/oxen-rust/src/lib/src/model/entry/staged_entry.rs
+++ b/oxen-rust/src/lib/src/model/entry/staged_entry.rs
@@ -1,8 +1,9 @@
 use crate::model::ContentHashable;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, ToSchema)]
 pub enum StagedEntryStatus {
     Added,
     Modified,

--- a/oxen-rust/src/lib/src/model/file.rs
+++ b/oxen-rust/src/lib/src/model/file.rs
@@ -4,8 +4,9 @@ use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::path::{Path, PathBuf};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ToSchema)]
 pub enum FileContents {
     Text(String),
     Binary(Vec<u8>),
@@ -56,8 +57,9 @@ impl<'de> Deserialize<'de> for FileContents {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct FileNew {
+    #[schema(value_type = String)]
     pub path: PathBuf,
     pub contents: FileContents,
     pub user: User,

--- a/oxen-rust/src/lib/src/model/merkle_tree/merkle_hash.rs
+++ b/oxen-rust/src/lib/src/model/merkle_tree/merkle_hash.rs
@@ -3,12 +3,14 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
+use utoipa::ToSchema;
+
 use crate::error::OxenError;
 
 // The derived serializer here will serialize the hash as a u128. This is used
 // in the binary representation on disk. We define a custom serializer that uses
 // the string representation of the hash below.
-#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize, ToSchema)]
 pub struct MerkleHash(u128);
 
 impl MerkleHash {

--- a/oxen-rust/src/lib/src/model/merkle_tree/merkle_hash.rs
+++ b/oxen-rust/src/lib/src/model/merkle_tree/merkle_hash.rs
@@ -11,6 +11,7 @@ use crate::error::OxenError;
 // in the binary representation on disk. We define a custom serializer that uses
 // the string representation of the hash below.
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize, ToSchema)]
+#[schema(value_type = String)]
 pub struct MerkleHash(u128);
 
 impl MerkleHash {

--- a/oxen-rust/src/lib/src/model/metadata/generic_metadata.rs
+++ b/oxen-rust/src/lib/src/model/metadata/generic_metadata.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::model::metadata::{
     MetadataAudio, MetadataDir, MetadataImage, MetadataTabular, MetadataText, MetadataVideo,
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 #[serde(untagged)]
 pub enum GenericMetadata {
     MetadataDir(MetadataDir),

--- a/oxen-rust/src/lib/src/model/metadata/metadata_audio.rs
+++ b/oxen-rust/src/lib/src/model/metadata/metadata_audio.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataAudio {
     pub audio: MetadataAudioImpl,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataAudioImpl {
     pub num_seconds: f64,
     pub num_channels: usize,

--- a/oxen-rust/src/lib/src/model/metadata/metadata_dir.rs
+++ b/oxen-rust/src/lib/src/model/metadata/metadata_dir.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 use crate::view::DataTypeCount;
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataDir {
     pub dir: MetadataDirImpl,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataDirImpl {
     pub data_types: Vec<DataTypeCount>,
 }

--- a/oxen-rust/src/lib/src/model/metadata/metadata_image.rs
+++ b/oxen-rust/src/lib/src/model/metadata/metadata_image.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub enum ImgColorSpace {
@@ -33,7 +34,7 @@ pub struct MetadataImageImpl {
     pub color_space: Option<ImgColorSpace>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams, ToSchema)]
 pub struct ImgResize {
     pub width: Option<u32>,
     pub height: Option<u32>,

--- a/oxen-rust/src/lib/src/model/metadata/metadata_image.rs
+++ b/oxen-rust/src/lib/src/model/metadata/metadata_image.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
 pub enum ImgColorSpace {
     // 8-bit
     RGB,
@@ -22,12 +22,12 @@ pub enum ImgColorSpace {
     Unknown,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataImage {
     pub image: MetadataImageImpl,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataImageImpl {
     pub width: u32,
     pub height: u32,

--- a/oxen-rust/src/lib/src/model/metadata/metadata_tabular.rs
+++ b/oxen-rust/src/lib/src/model/metadata/metadata_tabular.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 use crate::model::Schema;
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataTabular {
     pub tabular: MetadataTabularImpl,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataTabularImpl {
     pub width: usize,
     pub height: usize,

--- a/oxen-rust/src/lib/src/model/metadata/metadata_text.rs
+++ b/oxen-rust/src/lib/src/model/metadata/metadata_text.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataText {
     pub text: MetadataTextImpl,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataTextImpl {
     pub num_lines: usize,
     pub num_chars: usize,

--- a/oxen-rust/src/lib/src/model/metadata/metadata_video.rs
+++ b/oxen-rust/src/lib/src/model/metadata/metadata_video.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataVideo {
     pub video: MetadataVideoImpl,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataVideoImpl {
     pub num_seconds: f64,
     pub width: usize,

--- a/oxen-rust/src/lib/src/model/namespace.rs
+++ b/oxen-rust/src/lib/src/model/namespace.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct Namespace {
     pub name: String,
     pub storage_usage_gb: f64,

--- a/oxen-rust/src/lib/src/model/parsed_resource.rs
+++ b/oxen-rust/src/lib/src/model/parsed_resource.rs
@@ -1,16 +1,20 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use utoipa::ToSchema;
 
 use super::{workspace::WorkspaceView, Branch, Commit, Workspace};
 
 /// Internal model
-#[derive(Default, Deserialize, Serialize, Debug, Clone)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct ParsedResource {
     pub commit: Option<Commit>,
     pub branch: Option<Branch>,
     pub workspace: Option<Workspace>,
+    #[schema(value_type = String)]
     pub path: PathBuf,
+    #[schema(value_type = String)]
     pub version: PathBuf,
+    #[schema(value_type = String)]
     pub resource: PathBuf,
 }
 
@@ -26,13 +30,16 @@ impl std::fmt::Display for ParsedResource {
 }
 
 /// External (view) model that is returned to the client with fewer fields.
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct ParsedResourceView {
     pub workspace: Option<WorkspaceView>,
     pub commit: Option<Commit>,
     pub branch: Option<Branch>,
+    #[schema(value_type = String)]
     pub path: PathBuf,
+    #[schema(value_type = String)]
     pub version: PathBuf,
+    #[schema(value_type = String)]
     pub resource: PathBuf,
 }
 

--- a/oxen-rust/src/lib/src/model/remote.rs
+++ b/oxen-rust/src/lib/src/model/remote.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
-#[derive(Serialize, Deserialize, Debug, Clone)]
+use utoipa::ToSchema;
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Remote {
     pub name: String,
     pub url: String,

--- a/oxen-rust/src/lib/src/model/repository/local_repository.rs
+++ b/oxen-rust/src/lib/src/model/repository/local_repository.rs
@@ -15,15 +15,18 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct LocalRepository {
+    #[schema(value_type = String)]
     pub path: PathBuf,
     // Optional remotes to sync the data to
     remote_name: Option<String>, // name of the current remote ("origin" by default)
     min_version: Option<String>, // write the version if it is past v0.18.4
     remotes: Vec<Remote>,        // List of possible remotes
     vnode_size: Option<u64>,     // Size of the vnodes
+    #[schema(value_type = Option<Vec<String>>)]
     subtree_paths: Option<Vec<PathBuf>>, // If the user clones a subtree, we store the paths here so that we know we don't have the full tree
     pub depth: Option<i32>, // If the user clones with a depth, we store the depth here so that we know we don't have the full tree
     pub remote_mode: Option<bool>, // Flag for remote repositories
@@ -32,6 +35,7 @@ pub struct LocalRepository {
 
     // Skip this field during serialization/deserialization
     #[serde(skip)]
+    #[schema(ignore)]
     version_store: Option<Arc<dyn VersionStore>>,
 }
 

--- a/oxen-rust/src/lib/src/model/repository/repo_new.rs
+++ b/oxen-rust/src/lib/src/model/repository/repo_new.rs
@@ -1,12 +1,13 @@
 use http::Uri;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::constants::DEFAULT_HOST;
 use crate::error::OxenError;
 use crate::model::commit::Commit;
 use crate::model::file::FileNew;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct RepoNew {
     pub namespace: String,
     pub name: String,

--- a/oxen-rust/src/lib/src/model/user.rs
+++ b/oxen-rust/src/lib/src/model/user.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct User {
     pub email: String,
     pub name: String,

--- a/oxen-rust/src/lib/src/model/workspace.rs
+++ b/oxen-rust/src/lib/src/model/workspace.rs
@@ -5,6 +5,8 @@ use crate::constants::{OXEN_HIDDEN_DIR, WORKSPACES_DIR, WORKSPACE_CONFIG};
 use crate::model::{Commit, LocalRepository};
 use crate::util;
 
+use utoipa::ToSchema;
+
 // Define a struct for the workspace config to make it easier to serialize
 #[derive(Serialize, Deserialize)]
 pub struct WorkspaceConfig {
@@ -14,7 +16,7 @@ pub struct WorkspaceConfig {
     pub workspace_id: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Workspace {
     pub id: String,
     pub name: Option<String>,
@@ -75,7 +77,7 @@ impl From<Workspace> for WorkspaceView {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct WorkspaceView {
     pub name: Option<String>,
     pub id: String,

--- a/oxen-rust/src/lib/src/opts/df_opts.rs
+++ b/oxen-rust/src/lib/src/opts/df_opts.rs
@@ -11,6 +11,7 @@ use crate::core::df::filter::{self, DFFilterExp};
 use crate::error::OxenError;
 use crate::model::data_frame::schema::Field;
 use crate::model::Schema;
+use utoipa::ToSchema;
 
 use super::{EmbeddingQueryOpts, PaginateOpts};
 
@@ -27,7 +28,7 @@ pub struct IndexedItem {
     pub index: usize,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ToSchema)]
 pub struct DFOpts {
     pub add_col: Option<String>,
     pub add_row: Option<String>,
@@ -41,14 +42,17 @@ pub struct DFOpts {
     pub filter: Option<String>,
     pub head: Option<usize>,
     pub host: Option<String>,
+    #[schema(value_type = Option<String>)]
     pub output: Option<PathBuf>,
     pub output_column: Option<String>,
     pub page_size: Option<usize>,
     pub page: Option<usize>,
+    #[schema(value_type = Option<String>)]
     pub path: Option<PathBuf>,
     pub row: Option<usize>,
     pub item: Option<String>,
     pub quote_char: Option<String>,
+    #[schema(value_type = Option<String>)]
     pub repo_dir: Option<PathBuf>,
     pub should_randomize: bool,
     pub should_reverse: bool,
@@ -61,16 +65,18 @@ pub struct DFOpts {
     pub tail: Option<usize>,
     pub take: Option<String>,
     pub unique: Option<String>,
+    #[schema(value_type = Option<Vec<String>>)]
     pub vstack: Option<Vec<PathBuf>>,
+    #[schema(value_type = Option<String>)]
     pub write: Option<PathBuf>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct DFOptsView {
     pub opts: Vec<DFOptView>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct DFOptView {
     pub name: String,
     pub value: serde_json::Value,

--- a/oxen-rust/src/lib/src/view/branch.rs
+++ b/oxen-rust/src/lib/src/view/branch.rs
@@ -1,16 +1,16 @@
 use crate::model::Branch;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::StatusMessage;
-
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct BranchResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
     pub branch: Branch,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct BranchWithCacherStatusResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -18,7 +18,7 @@ pub struct BranchWithCacherStatusResponse {
     pub is_cacher_pending: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct BranchLockResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -26,40 +26,40 @@ pub struct BranchLockResponse {
     pub is_locked: bool,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct BranchNew {
     pub name: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct BranchName {
     pub branch_name: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct BranchNewFromBranchName {
     pub new_name: String,
     pub from_name: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct BranchNewFromCommitId {
     pub new_name: String,
     pub commit_id: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct BranchUpdate {
     pub commit_id: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct BranchRemoteMerge {
     pub client_commit_id: String,
     pub server_commit_id: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct ListBranchesResponse {
     #[serde(flatten)]
     pub status: StatusMessage,

--- a/oxen-rust/src/lib/src/view/commit.rs
+++ b/oxen-rust/src/lib/src/view/commit.rs
@@ -1,46 +1,161 @@
+use super::{Pagination, StatusMessage};
 use crate::model::{Commit, CommitStats};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-use super::{Pagination, StatusMessage};
-
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "commit": {
+            "id": "a1b2c3d4e5f67890abcdef1234567890",
+            "parent_ids": ["f1e2d3c4b5a67890fedcba9876543210"],
+            "message": "Refactor data loading pipeline.",
+            "author": "ox",
+            "email": "ox@example.com",
+            "timestamp": "2025-01-01T10:00:00Z"
+        },
+    })
+)]
 pub struct CommitResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "resource_found"})
+    )]
     pub status: StatusMessage,
     pub commit: Commit,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "commit": {
+            "id": "a1b2c3d4e5f67890abcdef1234567890",
+            "parent_ids": ["f1e2d3c4b5a67890fedcba9876543210"],
+            "message": "Initial upload.",
+            "author": "ox",
+            "email": "ox@example.com",
+            "timestamp": "2025-01-01T10:00:00Z"
+        },
+    })
+)]
 pub struct UploadCommitResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "resource_created"})
+    )]
     pub status: StatusMessage,
     pub commit: Option<Commit>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "commit": {
+            "id": "a1b2c3d4e5f67890abcdef1234567890",
+            "parent_ids": [],
+            "message": "Initial empty repository commit.",
+            "author": "ox",
+            "email": "ox@example.com",
+            "timestamp": "2025-01-01T10:00:00Z"
+        },
+    })
+)]
 pub struct RootCommitResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "resource_found"})
+    )]
     pub status: StatusMessage,
     pub commit: Option<Commit>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "stats": {
+            "commit": {
+                "id": "a1b2c3d4e5f67890abcdef1234567890",
+                "parent_ids": ["f1e2d3c4b5a67890fedcba9876543210"],
+                "message": "Refactor data loading pipeline.",
+                "author": "ox",
+                "email": "ox@example.com",
+                "timestamp": "2025-01-01T10:00:00Z"
+            },
+            "num_entries": 12000,
+            "num_synced_files": 11950,
+        },
+    })
+)]
 pub struct CommitStatsResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "resource_found"})
+    )]
     pub status: StatusMessage,
     pub stats: CommitStats,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "commits": [
+            {
+                "id": "a1b2c3d4e5f67890abcdef1234567890",
+                "parent_ids": ["f1e2d3c4b5a67890fedcba9876543210"],
+                "message": "Refactor data loading pipeline.",
+                "author": "ox",
+                "email": "ox@example.com",
+                "timestamp": "2025-01-01T10:00:00Z"
+            },
+            {
+                "id": "b0a9f8e7d6c543210fedcba987654321",
+                "parent_ids": ["a1b2c3d4e5f67890abcdef1234567890"],
+                "message": "Update ImageNet-1k labels.",
+                "author": "bessie",
+                "email": "bessie@example.com",
+                "timestamp": "2025-01-02T11:00:00Z"
+            }
+        ],
+    })
+)]
 pub struct ListCommitResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "resource_found"})
+    )]
     pub status: StatusMessage,
     pub commits: Vec<Commit>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "commit_validation_success",
+        "can_merge": true,
+    })
+)]
 pub struct CommitTreeValidationResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "commit_validation_success"})
+    )]
     pub status: StatusMessage,
     pub can_merge: bool,
 }
@@ -54,12 +169,45 @@ impl ListCommitResponse {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "commits": [
+            {
+                "id": "a1b2c3d4e5f67890abcdef1234567890",
+                "parent_ids": ["f1e2d3c4b5a67890fedcba9876543210"],
+                "message": "Refactor data loading pipeline.",
+                "author": "ox",
+                "email": "ox@example.com",
+                "timestamp": "2025-01-01T10:00:00Z"
+            }
+        ],
+        "page_number": 1,
+        "page_size": 10,
+        "total_pages": 5,
+        "total_entries": 45
+    })
+)]
 pub struct PaginatedCommits {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "resource_found"})
+    )]
     pub status: StatusMessage,
     pub commits: Vec<Commit>,
     #[serde(flatten)]
+    #[schema(
+        value_type = Pagination,
+        example = json!({
+            "page_number": 1,
+            "page_size": 10,
+            "total_pages": 5,
+            "total_entries": 45
+        })
+    )]
     pub pagination: Pagination,
 }
 

--- a/oxen-rust/src/lib/src/view/compare.rs
+++ b/oxen-rust/src/lib/src/view/compare.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use polars::frame::DataFrame;
 use polars::prelude::SchemaExt;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::constants::DIFF_STATUS_COL;
 use crate::error::OxenError;
@@ -16,14 +17,14 @@ use crate::view::Pagination;
 use super::schema::SchemaWithPath;
 use super::{JsonDataFrame, JsonDataFrameViews, StatusMessage};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct CompareCommits {
     pub base_commit: Commit,
     pub head_commit: Commit,
     pub commits: Vec<Commit>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularCompareSummary {
     pub num_left_only_rows: usize,
     pub num_right_only_rows: usize,
@@ -31,7 +32,7 @@ pub struct TabularCompareSummary {
     pub num_match_rows: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct CompareCommitsResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -41,7 +42,7 @@ pub struct CompareCommitsResponse {
     pub compare: CompareCommits,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct CompareEntries {
     pub base_commit: Commit,
     pub head_commit: Commit,
@@ -51,14 +52,14 @@ pub struct CompareEntries {
     pub self_diff: Option<DiffEntry>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct CompareEntryResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
     pub compare: DiffEntry,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct CompareEntriesResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -67,7 +68,7 @@ pub struct CompareEntriesResponse {
     pub compare: CompareEntries,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct CompareTabularResponse {
     pub dfs: CompareTabular,
     #[serde(flatten)]
@@ -75,7 +76,7 @@ pub struct CompareTabularResponse {
     pub messages: Vec<OxenMessage>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct CompareTabularResponseWithDF {
     pub dfs: CompareTabular,
     pub data: JsonDataFrameViews,
@@ -96,7 +97,7 @@ pub struct CompareTabularWithDF {
     pub source_schemas: CompareSourceSchemas,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct CompareSchemaDiff {
     pub added_cols: Vec<CompareSchemaColumn>,
     pub removed_cols: Vec<CompareSchemaColumn>,
@@ -119,26 +120,26 @@ impl CompareSchemaDiff {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct CompareSummary {
     pub modifications: CompareTabularMods,
     pub schema: Schema,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, ToSchema)]
 pub struct CompareTabularMods {
     pub added_rows: usize,
     pub removed_rows: usize,
     pub modified_rows: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct CompareDisplayFields {
     pub left: Vec<String>,
     pub right: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct CompareDupes {
     pub left: u64,
     pub right: u64,
@@ -153,7 +154,7 @@ impl CompareDupes {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct CompareSchemaColumn {
     pub name: String,
     pub key: String,
@@ -166,7 +167,7 @@ impl CompareSchemaColumn {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct CompareTabular {
     pub dupes: CompareDupes,
     pub summary: Option<CompareSummary>,
@@ -177,7 +178,7 @@ pub struct CompareTabular {
     pub display: Option<Vec<TabularCompareTargetBody>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct CompareSourceSchemas {
     pub left: Schema,
     pub right: Schema,
@@ -217,7 +218,7 @@ pub struct TabularCompare {
     pub diff_rows: Option<JsonDataFrame>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularCompareBody {
     pub compare_id: String,
     pub left: TabularCompareResourceBody,
@@ -227,13 +228,13 @@ pub struct TabularCompareBody {
     pub display: Vec<TabularCompareTargetBody>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularCompareResourceBody {
     pub path: String,
     pub version: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularCompareFieldBody {
     pub left: String,
     pub right: String,
@@ -254,7 +255,7 @@ pub struct TabularCompareFields {
     pub display: Vec<TabularCompareTargetBody>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularCompareTargetBody {
     pub left: Option<String>,
     pub right: Option<String>,

--- a/oxen-rust/src/lib/src/view/data_frames.rs
+++ b/oxen-rust/src/lib/src/view/data_frames.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::view::data_frames::columns::NewColumn;
+use utoipa::ToSchema;
 
 pub mod columns;
 pub mod embeddings;
@@ -32,7 +33,7 @@ pub struct DataFrameRowChange {
     pub new_value: Option<Value>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct FromDirectoryRequest {
     pub output_path: Option<String>,
     pub extra_columns: Option<Vec<NewColumn>>,

--- a/oxen-rust/src/lib/src/view/data_frames/columns.rs
+++ b/oxen-rust/src/lib/src/view/data_frames/columns.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct NewColumn {
     pub name: String,
     pub data_type: String,

--- a/oxen-rust/src/lib/src/view/data_type_count.rs
+++ b/oxen-rust/src/lib/src/view/data_type_count.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct DataTypeCount {
     pub count: usize,
     pub data_type: String,

--- a/oxen-rust/src/lib/src/view/diff.rs
+++ b/oxen-rust/src/lib/src/view/diff.rs
@@ -1,19 +1,21 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::model::diff::diff_entry_status::DiffEntryStatus;
 
 use super::StatusMessage;
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct DirTreeDiffResponse {
     pub dirs: Vec<DirDiffTreeSummary>,
     #[serde(flatten)]
     pub status: StatusMessage,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct DirDiffTreeSummary {
+    #[schema(value_type = String)]
     pub name: PathBuf,
     pub status: DiffEntryStatus,
     pub num_subdirs: usize,
@@ -21,8 +23,9 @@ pub struct DirDiffTreeSummary {
     pub children: Vec<DirDiffStatus>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct DirDiffStatus {
+    #[schema(value_type = String)]
     pub name: PathBuf,
     pub status: DiffEntryStatus,
 }

--- a/oxen-rust/src/lib/src/view/entries.rs
+++ b/oxen-rust/src/lib/src/view/entries.rs
@@ -16,7 +16,7 @@ pub struct ListMissingFilesRequest {
     pub file_hashes: Option<std::collections::HashSet<MerkleHash>>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct ListCommitEntryResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -63,14 +63,14 @@ pub struct PaginatedEntries {
     pub total_entries: usize,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct PaginatedMetadataEntries {
     pub entries: Vec<MetadataEntry>,
     #[serde(flatten)]
     pub pagination: Pagination,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct PaginatedMetadataEntriesResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -81,7 +81,7 @@ pub struct PaginatedMetadataEntriesResponse {
 // ignoring because the size difference isn't that big
 // look into updating at some point as a small optimization
 #[allow(clippy::large_enum_variant)]
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 #[serde(untagged)]
 pub enum EMetadataEntry {
     MetadataEntry(MetadataEntry),
@@ -162,7 +162,7 @@ impl EMetadataEntry {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct PaginatedDirEntries {
     pub dir: Option<EMetadataEntry>,
     pub entries: Vec<EMetadataEntry>,
@@ -189,7 +189,7 @@ impl PaginatedDirEntries {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct PaginatedDirEntriesResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -212,26 +212,27 @@ pub struct BranchEntryVersion {
     pub resource: ResourceVersion,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct CommitEntryVersion {
     pub commit: crate::model::Commit,
     pub resource: ResourceVersion,
     pub schema_hash: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct PaginatedEntryVersions {
     pub versions: Vec<CommitEntryVersion>,
     #[serde(flatten)]
     pub pagination: Pagination,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct PaginatedEntryVersionsResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
     #[serde(flatten)]
     pub versions: PaginatedEntryVersions,
     pub branch: Branch,
+    #[schema(value_type = String)]
     pub path: PathBuf,
 }

--- a/oxen-rust/src/lib/src/view/entries.rs
+++ b/oxen-rust/src/lib/src/view/entries.rs
@@ -7,6 +7,7 @@ use crate::model::{
     Branch, Commit, CommitEntry, EntryDataType, MerkleHash, ParsedResource, RemoteEntry,
 };
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::{Pagination, StatusMessage};
 
@@ -29,14 +30,14 @@ pub struct EntryResponse {
     pub entry: CommitEntry,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct RemoteEntryResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
     pub entry: RemoteEntry,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct ResourceVersion {
     pub path: String,
     pub version: String,

--- a/oxen-rust/src/lib/src/view/entry_metadata.rs
+++ b/oxen-rust/src/lib/src/view/entry_metadata.rs
@@ -4,14 +4,16 @@ use super::StatusMessage;
 use crate::model::entry::metadata_entry::MetadataEntry;
 use crate::view::entries::EMetadataEntry;
 
-#[derive(Deserialize, Serialize, Debug)]
+use utoipa::ToSchema;
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct MetadataEntryResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
     pub entry: MetadataEntry,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct EMetadataEntryResponseView {
     #[serde(flatten)]
     pub status: StatusMessage,

--- a/oxen-rust/src/lib/src/view/file_metadata.rs
+++ b/oxen-rust/src/lib/src/view/file_metadata.rs
@@ -1,31 +1,34 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::entries::ResourceVersion;
 use super::StatusMessage;
 
-#[derive(Deserialize, Serialize, Debug)]
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct FileMetadata {
     pub size: u64,
     pub data_type: String,
     pub resource: ResourceVersion,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct FileMetadataResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
     pub meta: FileMetadata,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct FilePathsResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
+    #[schema(value_type = Vec<String>)]
     pub paths: Vec<PathBuf>,
 }
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct ErrorFilesResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -33,15 +36,17 @@ pub struct ErrorFilesResponse {
     pub err_files: Vec<ErrorFileInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct ErrorFileInfo {
     pub hash: String,
+    #[schema(value_type = Option<String>)]
     pub path: Option<PathBuf>,
     pub error: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct FileWithHash {
     pub hash: String,
+    #[schema(value_type = String)] 
     pub path: PathBuf,
 }

--- a/oxen-rust/src/lib/src/view/file_metadata.rs
+++ b/oxen-rust/src/lib/src/view/file_metadata.rs
@@ -6,7 +6,6 @@ use utoipa::ToSchema;
 use super::entries::ResourceVersion;
 use super::StatusMessage;
 
-
 #[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct FileMetadata {
     pub size: u64,
@@ -47,6 +46,6 @@ pub struct ErrorFileInfo {
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct FileWithHash {
     pub hash: String,
-    #[schema(value_type = String)] 
+    #[schema(value_type = String)]
     pub path: PathBuf,
 }

--- a/oxen-rust/src/lib/src/view/fork.rs
+++ b/oxen-rust/src/lib/src/view/fork.rs
@@ -1,14 +1,15 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
+use utoipa::ToSchema;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub struct ForkRequest {
     pub namespace: String,
     pub new_repo_name: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub enum ForkStatus {
     Started,
     Counting(u32),
@@ -17,20 +18,20 @@ pub enum ForkStatus {
     Failed(String),
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct ForkStatusFile {
     pub status: ForkStatus,
     pub progress: Option<f32>,
     pub error: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct ForkStartResponse {
     pub repository: String,
     pub fork_status: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct ForkStatusResponse {
     pub repository: String,
     pub status: String,

--- a/oxen-rust/src/lib/src/view/json_data_frame.rs
+++ b/oxen-rust/src/lib/src/view/json_data_frame.rs
@@ -6,13 +6,14 @@ use std::str;
 use polars::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
+use utoipa::ToSchema;
 
 use crate::core::df::tabular;
 use crate::model::DataFrameSize;
 use crate::opts::PaginateOpts;
 use crate::{model::Schema, opts::DFOpts};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct JsonDataFrame {
     pub schema: Schema,
     pub view_schema: Schema,

--- a/oxen-rust/src/lib/src/view/json_data_frame_view.rs
+++ b/oxen-rust/src/lib/src/view/json_data_frame_view.rs
@@ -6,6 +6,7 @@ use std::str;
 use polars::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
+use utoipa::ToSchema;
 
 use super::data_frames::DataFrameColumnChange;
 use super::data_frames::DataFrameRowChange;
@@ -22,7 +23,7 @@ use crate::view::entries::ResourceVersion;
 use crate::view::Pagination;
 use crate::{model::Schema, opts::DFOpts};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct JsonDataFrameView {
     pub schema: Schema,
     pub size: DataFrameSize,
@@ -32,13 +33,13 @@ pub struct JsonDataFrameView {
     pub opts: DFOptsView,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct JsonDataFrameViews {
     pub source: DataFrameSchemaSize,
     pub view: JsonDataFrameView,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct JsonDataFrameViewResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -96,7 +97,7 @@ pub struct JsonDataFrameColumnResponse {
     pub resource: Option<ResourceVersion>,
     pub derived_resource: Option<DerivedDFResource>,
 }
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum DFResourceType {
     Compare,
@@ -104,7 +105,7 @@ pub enum DFResourceType {
     Query,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct DerivedDFResource {
     pub resource_id: String,
     pub path: String,

--- a/oxen-rust/src/lib/src/view/merge.rs
+++ b/oxen-rust/src/lib/src/view/merge.rs
@@ -1,22 +1,22 @@
-use serde::{Deserialize, Serialize};
-
 use crate::model::Commit;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::StatusMessage;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct MergeConflictFile {
     pub path: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Mergeable {
     pub is_mergeable: bool,
     pub conflicts: Vec<MergeConflictFile>,
     pub commits: Vec<Commit>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct MergeableResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
@@ -24,14 +24,14 @@ pub struct MergeableResponse {
     pub mergeable: Mergeable,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct MergeResult {
     pub head: Commit,
     pub base: Commit,
     pub merge: Commit,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct MergeSuccessResponse {
     #[serde(flatten)]
     pub status: StatusMessage,

--- a/oxen-rust/src/lib/src/view/message.rs
+++ b/oxen-rust/src/lib/src/view/message.rs
@@ -1,15 +1,16 @@
 //! User-facing messages resulting from Oxen operations
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct OxenMessage {
     pub level: MessageLevel,
     pub title: String,
     pub description: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub enum MessageLevel {
     Info,
     Warning,

--- a/oxen-rust/src/lib/src/view/namespace.rs
+++ b/oxen-rust/src/lib/src/view/namespace.rs
@@ -23,12 +23,10 @@ pub struct ListNamespacesResponse {
     #[serde(flatten)]
     #[schema(
         value_type = StatusMessage,
-        example = json!(
-            { 
-                "status": "success",
-                "status_message": "resource_found" 
-            }
-        )
+        example = json!({
+            "status": "success",
+            "status_message": "resource_found" 
+        })
     )]
     pub status: StatusMessage,
     pub namespaces: Vec<NamespaceView>,

--- a/oxen-rust/src/lib/src/view/namespace.rs
+++ b/oxen-rust/src/lib/src/view/namespace.rs
@@ -1,21 +1,40 @@
 use crate::model::Namespace;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::StatusMessage;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct NamespaceView {
     pub namespace: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+    "status": "success", 
+    "status_message": "resource_found", 
+    "namespaces": [
+        { "name": "my_namespace" },
+        { "name": "oxen" }
+    ],
+}))]
 pub struct ListNamespacesResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!(
+            { 
+                "status": "success",
+                "status_message": "resource_found" 
+            }
+        )
+    )]
     pub status: StatusMessage,
     pub namespaces: Vec<NamespaceView>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct NamespaceResponse {
     #[serde(flatten)]
     pub status: StatusMessage,

--- a/oxen-rust/src/lib/src/view/pagination.rs
+++ b/oxen-rust/src/lib/src/view/pagination.rs
@@ -1,7 +1,8 @@
 use crate::opts::PaginateOpts;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct Pagination {
     pub page_size: usize,
     pub page_number: usize,

--- a/oxen-rust/src/lib/src/view/repository.rs
+++ b/oxen-rust/src/lib/src/view/repository.rs
@@ -229,7 +229,7 @@ pub struct DataTypeView {
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 #[schema(
     example = json!({
-        "data_size": 1073741824,
+        "data_size": 1074288000,
         "data_types": [
             { "data_type": "image", "data_size": 524288000, "file_count": 500 },
             { "data_type": "tabular", "data_size": 550000000, "file_count": 5 },

--- a/oxen-rust/src/lib/src/view/repository.rs
+++ b/oxen-rust/src/lib/src/view/repository.rs
@@ -1,10 +1,17 @@
+use super::{DataTypeCount, StatusMessage};
 use crate::model::{Commit, EntryDataType, MetadataEntry, RemoteRepository};
 use serde::{Deserialize, Serialize};
-
-use super::{DataTypeCount, StatusMessage};
 use std::str::FromStr;
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[schema(
+    example = json!({
+        "namespace": "ox",
+        "name": "ImageNet-1k",
+        "is_empty": false,
+    })
+)]
 pub struct RepositoryView {
     pub namespace: String,
     pub name: String,
@@ -12,14 +19,34 @@ pub struct RepositoryView {
     pub is_empty: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[schema(
+    example = json!({
+        "namespace": "bessie",
+        "name": "my-farm-data",
+    })
+)]
 pub struct RepositoryListView {
     pub namespace: String,
     pub name: String,
     pub min_version: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[schema(
+    example = json!({
+        "namespace": "ox",
+        "name": "ImageNet-1k",
+        "latest_commit": {
+            "id": "a1b2c3d4e5f67890abcdef1234567890",
+            "parent_ids": ["f1e2d3c4b5a67890fedcba9876543210"],
+            "message": "Initial dataset import.",
+            "author": "ox",
+            "email": "ox@example.com",
+            "timestamp": "2025-01-01T10:00:00Z"
+        },
+    })
+)]
 pub struct RepositoryCreationView {
     pub namespace: String,
     pub name: String,
@@ -27,7 +54,19 @@ pub struct RepositoryCreationView {
     pub min_version: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[schema(
+    example = json!({
+        "namespace": "bessie",
+        "name": "my-corn-pics",
+        "size": 1073741824, // 1 GB
+        "data_types": [
+            { "data_type": "image", "count": 1000 },
+            { "data_type": "tabular", "count": 5 }
+        ],
+        "is_empty": false,
+    })
+)]
 pub struct RepositoryDataTypesView {
     pub namespace: String,
     pub name: String,
@@ -37,14 +76,51 @@ pub struct RepositoryDataTypesView {
     pub is_empty: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "repository": {
+            "namespace": "ox",
+            "name": "ImageNet-1k",
+            "is_empty": false,
+        },
+    })
+)]
 pub struct RepositoryResponse {
     pub status: String,
     pub status_message: String,
     pub repository: RepositoryView,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_created",
+        "repository": {
+            "namespace": "ox",
+            "name": "ImageNet-1k",
+            "latest_commit": {
+                "id": "a1b2c3d4e5f678902e41",
+                "parent_ids": ["f1e2d3c4b5a67890fedc"],
+                "message": "Initial dataset import.",
+                "author": "ox",
+                "email": "ox@example.com",
+                "timestamp": "2025-01-01T10:00:00Z"
+            },
+        },
+        "metadata_entries": [
+            {
+                "path": "data/images/cow.jpg",
+                "data_type": "image",
+                "content_hash": "a1b2c3d4e5f678902e41",
+                "file_size": 1024000,
+            }
+        ],
+    })
+)]
 pub struct RepositoryCreationResponse {
     pub status: String,
     pub status_message: String,
@@ -52,42 +128,114 @@ pub struct RepositoryCreationResponse {
     pub metadata_entries: Option<Vec<MetadataEntry>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "repository": {
+            "namespace": "bessie",
+            "name": "my-corn-pics",
+            "size": 1073741824,
+            "data_types": [
+                { "data_type": "image", "count": 1000 },
+                { "data_type": "tabular", "count": 5 }
+            ],
+            "is_empty": false,
+        },
+    })
+)]
 pub struct RepositoryDataTypesResponse {
     pub status: String,
     pub status_message: String,
     pub repository: RepositoryDataTypesView,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[schema(example = json!({
+    "status": "success",
+    "status_message": "resource_found",
+    "repositories": [
+        { "name": "data-fields", "namespace": "ox" },
+        { "name": "my-corn-pics", "namespace": "bessie" }
+    ],
+}))]
 pub struct ListRepositoryResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "resource_found"})
+    )]
     pub status: StatusMessage,
+    #[schema(example = json!([
+        { "name": "data-fields", "namespace": "ox" },
+        { "name": "my-corn-pics", "namespace": "bessie" }
+    ]))]
     pub repositories: Vec<RepositoryListView>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "repository_api_url": "http://localhost:3000/api/repos/ox/ImageNet-1k",
+    })
+)]
 pub struct RepositoryResolveResponse {
     pub status: String,
     pub status_message: String,
     pub repository_api_url: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[schema(
+    example = json!({
+        "status": "success",
+        "status_message": "resource_found",
+        "repository": {
+            "data_size": 1073741824, // 1 GB
+            "data_types": [
+                { "data_type": "image", "data_size": 524288000, "file_count": 500 },
+                { "data_type": "tabular", "data_size": 550000000, "file_count": 5 },
+            ],
+        },
+    })
+)]
 pub struct RepositoryStatsResponse {
     #[serde(flatten)]
+    #[schema(
+        value_type = StatusMessage,
+        example = json!({"status": "success", "status_message": "resource_found"})
+    )]
     pub status: StatusMessage,
     pub repository: RepositoryStatsView,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[schema(
+    example = json!({
+        "data_type": "image",
+        "data_size": 524288000,
+        "file_count": 500,
+    })
+)]
 pub struct DataTypeView {
     pub data_type: EntryDataType,
     pub data_size: u64,
     pub file_count: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[schema(
+    example = json!({
+        "data_size": 1073741824, 
+        "data_types": [
+            { "data_type": "image", "data_size": 524288000, "file_count": 500 },
+            { "data_type": "tabular", "data_size": 550000000, "file_count": 5 },
+        ],
+    })
+)]
 pub struct RepositoryStatsView {
     pub data_size: u64,
     pub data_types: Vec<DataTypeView>,

--- a/oxen-rust/src/lib/src/view/repository.rs
+++ b/oxen-rust/src/lib/src/view/repository.rs
@@ -59,7 +59,7 @@ pub struct RepositoryCreationView {
     example = json!({
         "namespace": "bessie",
         "name": "my-corn-pics",
-        "size": 1073741824, // 1 GB
+        "size": 1073741824,
         "data_types": [
             { "data_type": "image", "count": 1000 },
             { "data_type": "tabular", "count": 5 }
@@ -136,7 +136,7 @@ pub struct RepositoryCreationResponse {
         "repository": {
             "namespace": "bessie",
             "name": "my-corn-pics",
-            "size": 1073741824,
+            "size": 1074288000,
             "data_types": [
                 { "data_type": "image", "count": 1000 },
                 { "data_type": "tabular", "count": 5 }
@@ -194,7 +194,7 @@ pub struct RepositoryResolveResponse {
         "status": "success",
         "status_message": "resource_found",
         "repository": {
-            "data_size": 1073741824, // 1 GB
+            "data_size": 1074288000,
             "data_types": [
                 { "data_type": "image", "data_size": 524288000, "file_count": 500 },
                 { "data_type": "tabular", "data_size": 550000000, "file_count": 5 },
@@ -229,7 +229,7 @@ pub struct DataTypeView {
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 #[schema(
     example = json!({
-        "data_size": 1073741824, 
+        "data_size": 1073741824,
         "data_types": [
             { "data_type": "image", "data_size": 524288000, "file_count": 500 },
             { "data_type": "tabular", "data_size": 550000000, "file_count": 5 },

--- a/oxen-rust/src/lib/src/view/revision.rs
+++ b/oxen-rust/src/lib/src/view/revision.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::model::ParsedResource;
 
 use super::StatusMessage;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct ParseResourceResponse {
     #[serde(flatten)]
     pub status: StatusMessage,

--- a/oxen-rust/src/lib/src/view/status_message.rs
+++ b/oxen-rust/src/lib/src/view/status_message.rs
@@ -2,7 +2,9 @@ use crate::constants::OXEN_VERSION;
 use crate::view;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct StatusMessage {
     pub status: String,
     pub status_message: String,

--- a/oxen-rust/src/lib/src/view/tabular_diff_view.rs
+++ b/oxen-rust/src/lib/src/view/tabular_diff_view.rs
@@ -1,6 +1,7 @@
 use polars::prelude::*;
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::{CommitEntry, LocalRepository, Schema};
@@ -12,12 +13,12 @@ use crate::model::diff::tabular_diff_summary::{
     TabularDiffSummary, TabularDiffSummaryImpl, TabularDiffWrapper,
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularDiffView {
     pub tabular: TabularDiffViewImpl,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct TabularDiffViewImpl {
     #[serde(flatten)]
     pub summary: TabularDiffSummary,

--- a/oxen-rust/src/lib/src/view/tree/merkle_hash.rs
+++ b/oxen-rust/src/lib/src/view/tree/merkle_hash.rs
@@ -4,7 +4,9 @@ use crate::model::merkle_tree::merkle_hash::MerkleHashAsString;
 use crate::model::MerkleHash;
 use crate::view::StatusMessage;
 
-#[derive(Deserialize, Serialize, Debug)]
+use utoipa::ToSchema;
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct MerkleHashResponse {
     #[serde(flatten)]
     pub status: StatusMessage,

--- a/oxen-rust/src/lib/src/view/tree/merkle_hashes.rs
+++ b/oxen-rust/src/lib/src/view/tree/merkle_hashes.rs
@@ -7,8 +7,10 @@ use crate::model::merkle_tree::merkle_hash::MerkleHashAsString;
 use crate::model::{CommitEntry, MerkleHash};
 use crate::view::StatusMessage;
 
+use utoipa::ToSchema;
+
 #[serde_as]
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct MerkleHashes {
     #[serde_as(as = "HashSet<MerkleHashAsString>")]
     pub hashes: HashSet<MerkleHash>,
@@ -24,7 +26,7 @@ pub struct NodeHashes {
 }
 
 #[serde_as]
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct MerkleHashesResponse {
     #[serde(flatten)]
     pub status: StatusMessage,

--- a/oxen-rust/src/lib/src/view/workspaces.rs
+++ b/oxen-rust/src/lib/src/view/workspaces.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
-
 use time::OffsetDateTime;
+use utoipa::ToSchema;
 
 use super::StatusMessage;
 use crate::model::Commit;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct NewWorkspace {
     pub workspace_id: String,
     pub branch_name: String,
@@ -14,10 +14,9 @@ pub struct NewWorkspace {
     pub name: Option<String>,
     pub force: Option<bool>,
 }
-
 // HACK to get this to work with our hub where we don't keep parent_ids 🤦‍♂️
 // TODO: it should just be a Commit object
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct WorkspaceCommit {
     pub id: String,
     pub message: String,
@@ -40,7 +39,7 @@ impl From<WorkspaceCommit> for Commit {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct WorkspaceResponse {
     pub id: String,
     pub name: Option<String>,
@@ -55,14 +54,14 @@ pub struct WorkspaceResponseWithStatus {
     pub status: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct WorkspaceResponseView {
     #[serde(flatten)]
     pub status: StatusMessage,
     pub workspace: WorkspaceResponse,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct ListWorkspaceResponseView {
     #[serde(flatten)]
     pub status: StatusMessage,

--- a/oxen-rust/src/server/src/controllers/branches.rs
+++ b/oxen-rust/src/server/src/controllers/branches.rs
@@ -30,7 +30,7 @@ use liboxen::{constants, repositories};
     ),
     responses(
         (
-            status = 200, 
+            status = 200,
             description = "List of branches", 
             body = ListBranchesResponse,
             example = json!({

--- a/oxen-rust/src/server/src/controllers/commits.rs
+++ b/oxen-rust/src/server/src/controllers/commits.rs
@@ -445,7 +445,7 @@ pub async fn parents(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHt
         ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
     ),
     responses(
-        (status = 200, description = "Tarball of commits DB", content_type = "application/x-tar"),
+        (status = 200, description = "Tarball of commits DB"),
         (status = 404, description = "Repository not found")
     )
 )]
@@ -496,7 +496,7 @@ fn compress_commits_db(repository: &LocalRepository) -> Result<Vec<u8>, OxenErro
         ("base_head" = String, Path, description = "Commit ID range (base..head) or single commit ID", example = "abc1234..84c76a5"),
     ),
     responses(
-        (status = 200, description = "Tarball of dir hashes DB", content_type = "application/x-tar"),
+        (status = 200, description = "Tarball of dir hashes DB"),
         (status = 400, description = "Invalid base_head format"),
         (status = 404, description = "Repository or commit not found")
     )
@@ -547,7 +547,7 @@ pub async fn download_dir_hashes_db(
         ("commit_or_branch" = String, Path, description = "Commit ID or Branch name", example = "main"),
     ),
     responses(
-        (status = 200, description = "Tarball of commit entries DB", content_type = "application/x-tar"),
+        (status = 200, description = "Tarball of commit entries DB"),
         (status = 404, description = "Repository or commit not found")
     )
 )]
@@ -662,14 +662,12 @@ fn compress_commit(repository: &LocalRepository, commit: &Commit) -> Result<Vec<
         content = Commit,
         description = "Commit object and target branch name.",
         example = json!({
-            "commit": {
-                "author": "Bessie Oxington",
-                "email": "bessie@oxen.ai",
-                "message": "Empty commit for testing",
-                "id": "abc1234567890def1234567890fedcba"
-            },
+            "author": "Bessie Oxington",
+            "email": "bessie@oxen.ai",
+            "message": "Empty commit for testing",
+            "id": "abc1234567890def1234567890fedcba",
             "branch_name": "main"
-        })
+        }),
     ),
     responses(
         (status = 200, description = "Commit created", body = CommitResponse),
@@ -1188,8 +1186,7 @@ pub async fn upload_tree(
         ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
     ),
     responses(
-        (status = 200, description = "Root commit found", body = RootCommitResponse),
-        (status = 404, description = "Root commit not found (empty repo)")
+        (status = 200, description = "Root commit found (None if empty repository)", body = RootCommitResponse),
     )
 )]
 pub async fn root_commit(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {

--- a/oxen-rust/src/server/src/controllers/commits.rs
+++ b/oxen-rust/src/server/src/controllers/commits.rs
@@ -43,18 +43,48 @@ use std::path::Path;
 use std::path::PathBuf;
 use tokio::io::BufReader;
 use tokio_tar::Archive;
+use utoipa::IntoParams;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct ChunkedDataUploadQuery {
-    hash: String,             // UUID to tie all the chunks together (hash of the contents)
-    chunk_num: usize,         // which chunk it is, so that we can combine it all in the end
-    total_chunks: usize,      // how many chunks to expect
-    total_size: usize,        // total size so we can know when we are finished
-    is_compressed: bool,      // whether or not we need to decompress the archive
-    filename: Option<String>, // maybe a file name if !compressed
+    #[param(example = "a2c3d4e5f67890b1c2d3e4f5a6b7c8d9")]
+    pub hash: String, // UUID to tie all the chunks together (hash of the contents)
+    #[param(example = 1)]
+    pub chunk_num: usize, // which chunk it is, so that we can combine it all in the end
+    #[param(example = 10)]
+    pub total_chunks: usize, // how many chunks to expect
+    #[param(example = 100000000)]
+    pub total_size: usize, // total size so we can know when we are finished
+    #[param(example = true)]
+    pub is_compressed: bool, // whether or not we need to decompress the archive
+    #[param(example = "images/cow.jpg")]
+    pub filename: Option<String>, // maybe a file name if !compressed
 }
 
-// List commits for a repository
+#[derive(Deserialize, IntoParams)]
+pub struct ListMissingFilesQuery {
+    #[param(example = "abc1234567890def1234567890fedcba")]
+    pub base: Option<String>,
+    #[param(example = "84c76a5b2e9a2637f9091991475c404d")]
+    pub head: String,
+}
+
+/// List commits
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits",
+    operation_id = "list_commits",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+    ),
+    responses(
+        (status = 200, description = "List of commits", body = ListCommitResponse),
+        (status = 404, description = "Repository not found")
+    )
+)]
 pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -65,6 +95,24 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     Ok(HttpResponse::Ok().json(ListCommitResponse::success(commits)))
 }
 
+/// List commit history
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/history/{resource}",
+    operation_id = "list_commit_history",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("resource" = String, Path, description = "Commit ID, Branch name, or path to a file/directory", example = "main/data/train/image.jpg"),
+        PageNumQuery
+    ),
+    responses(
+        (status = 200, description = "Paginated list of commits", body = PaginatedCommits),
+        (status = 404, description = "Repository or resource not found")
+    )
+)]
 pub async fn history(
     req: HttpRequest,
     query: web::Query<PageNumQuery>,
@@ -127,7 +175,23 @@ pub async fn history(
     }
 }
 
-// List all commits in the repository
+/// List all commits
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/all",
+    operation_id = "list_all_commits",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        PageNumQuery
+    ),
+    responses(
+        (status = 200, description = "Paginated list of all commits", body = PaginatedCommits),
+        (status = 404, description = "Repository not found")
+    )
+)]
 pub async fn list_all(
     req: HttpRequest,
     query: web::Query<PageNumQuery>,
@@ -146,6 +210,30 @@ pub async fn list_all(
     Ok(HttpResponse::Ok().json(paginated_commits))
 }
 
+/// List missing commits
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/missing",
+    operation_id = "list_missing_commits",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+    ),
+    request_body(
+        content = MerkleHashes,
+        description = "List of commit hashes present on the client.",
+        example = json!({
+            "hashes": ["abc1234567890def1234567890fedcba", "84c76a5b2e9a2637f9091991475c404d"]
+        })
+    ),
+    responses(
+        (status = 200, description = "List of commit hashes missing on the server", body = MerkleHashesResponse),
+        (status = 400, description = "Invalid JSON body"),
+        (status = 404, description = "Repository not found")
+    )
+)]
 pub async fn list_missing(
     req: HttpRequest,
     body: String,
@@ -179,12 +267,23 @@ pub async fn list_missing(
     Ok(HttpResponse::Ok().json(response))
 }
 
-#[derive(Deserialize)]
-pub struct ListMissingFilesQuery {
-    pub base: Option<String>,
-    pub head: String,
-}
-
+/// List files missing on the server within a commit range
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/missing_files",
+    operation_id = "list_missing_files",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ListMissingFilesQuery
+    ),
+    responses(
+        (status = 200, description = "List of missing file entries", body = ListCommitEntryResponse),
+        (status = 404, description = "Repository or commit not found")
+    )
+)]
 pub async fn list_missing_files(
     req: HttpRequest,
     query: web::Query<ListMissingFilesQuery>,
@@ -215,6 +314,29 @@ pub async fn list_missing_files(
     Ok(HttpResponse::Ok().json(response))
 }
 
+/// Mark commits as synced
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/commits/synced",
+    operation_id = "mark_commits_synced",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+    ),
+    request_body(
+        content = MerkleHashes,
+        description = "List of commit hashes successfully synced to the server.",
+        example = json!({
+            "hashes": ["abc1234567890def1234567890fedcba", "84c76a5b2e9a2637f9091991475c404d"]
+        })
+    ),
+    responses(
+        (status = 200, description = "Commits marked as synced", body = MerkleHashesResponse),
+        (status = 404, description = "Repository not found")
+    )
+)]
 pub async fn mark_commits_as_synced(
     req: HttpRequest,
     mut body: web::Payload,
@@ -247,6 +369,23 @@ pub async fn mark_commits_as_synced(
     }))
 }
 
+/// Get commit
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/{commit_id}",
+    operation_id = "get_commit",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("commit_id" = String, Path, description = "Hash ID of the commit", example = "84c76a5b2e9a2637f9091991475c404d"),
+    ),
+    responses(
+        (status = 200, description = "Commit", body = CommitResponse),
+        (status = 404, description = "Commit not found")
+    )
+)]
 pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -262,6 +401,23 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     }))
 }
 
+/// List commit parents
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/{commit_or_branch}/parents",
+    operation_id = "get_commit_parents",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("commit_or_branch" = String, Path, description = "Commit ID or Branch name", example = "main"),
+    ),
+    responses(
+        (status = 200, description = "List of parent commits", body = ListCommitResponse),
+        (status = 404, description = "Commit or Branch not found")
+    )
+)]
 pub async fn parents(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -277,7 +433,22 @@ pub async fn parents(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHt
     }))
 }
 
-/// Download the database that holds all the commits and their parents
+/// Download commits DB
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits_db",
+    operation_id = "download_commits_db",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+    ),
+    responses(
+        (status = 200, description = "Tarball of commits DB", content_type = "application/x-tar"),
+        (status = 404, description = "Repository not found")
+    )
+)]
 pub async fn download_commits_db(
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
@@ -312,7 +483,24 @@ fn compress_commits_db(repository: &LocalRepository) -> Result<Vec<u8>, OxenErro
     Ok(buffer)
 }
 
-/// Download the database of all entries given a specific commit
+/// Download dir hashes DB
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/{base_head}/dir_hashes_db",
+    operation_id = "download_dir_hashes_db",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("base_head" = String, Path, description = "Commit ID range (base..head) or single commit ID", example = "abc1234..84c76a5"),
+    ),
+    responses(
+        (status = 200, description = "Tarball of dir hashes DB", content_type = "application/x-tar"),
+        (status = 400, description = "Invalid base_head format"),
+        (status = 404, description = "Repository or commit not found")
+    )
+)]
 pub async fn download_dir_hashes_db(
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
@@ -346,7 +534,23 @@ pub async fn download_dir_hashes_db(
     Ok(HttpResponse::Ok().body(buffer))
 }
 
-/// Download the database of all entries given a specific commit
+/// Download commit entries DB
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/{commit_or_branch}/commit_entries_db",
+    operation_id = "download_commit_entries_db",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("commit_or_branch" = String, Path, description = "Commit ID or Branch name", example = "main"),
+    ),
+    responses(
+        (status = 200, description = "Tarball of commit entries DB", content_type = "application/x-tar"),
+        (status = 404, description = "Repository or commit not found")
+    )
+)]
 pub async fn download_commit_entries_db(
     req: HttpRequest,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
@@ -443,7 +647,35 @@ fn compress_commit(repository: &LocalRepository, commit: &Commit) -> Result<Vec<
     Ok(buffer)
 }
 
-/// This creates an empty commit on the given branch
+/// Create commit
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/commits",
+    operation_id = "create_commit",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+    ),
+    request_body(
+        content = Commit,
+        description = "Commit object and target branch name.",
+        example = json!({
+            "commit": {
+                "author": "Bessie Oxington",
+                "email": "bessie@oxen.ai",
+                "message": "Empty commit for testing",
+                "id": "abc1234567890def1234567890fedcba"
+            },
+            "branch_name": "main"
+        })
+    ),
+    responses(
+        (status = 200, description = "Commit created", body = CommitResponse),
+        (status = 400, description = "Invalid commit data or mismatched remote history"),
+    )
+)]
 pub async fn create(
     req: HttpRequest,
     body: String,
@@ -490,7 +722,27 @@ pub async fn create(
     }
 }
 
-/// Controller to upload large chunks of data that will be combined at the end
+/// Upload data chunk
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/commits/upload_chunk",
+    operation_id = "upload_chunk",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ChunkedDataUploadQuery
+    ),
+    request_body(
+        content_type = "application/octet-stream", 
+        description = "Chunk of data (binary bytes)", 
+        content = Vec<u8>
+    ),
+    responses(
+        (status = 200, description = "Chunk uploaded successfully", body = StatusMessage),
+    )
+)]
 pub async fn upload_chunk(
     req: HttpRequest,
     mut chunk: web::Payload,                   // the chunk of the file body,
@@ -681,78 +933,6 @@ async fn check_if_upload_complete_and_unpack(
     }
 }
 
-pub async fn upload_tree(
-    req: HttpRequest,
-    mut body: web::Payload,
-) -> Result<HttpResponse, OxenHttpError> {
-    let app_data = app_data(&req)?;
-    let namespace = path_param(&req, "namespace")?;
-    let name = path_param(&req, "repo_name")?;
-    let client_head_id = path_param(&req, "commit_id")?;
-    let repo = get_repo(&app_data.path, namespace, name)?;
-    // Get head commit on sever repo
-    let server_head_commit = repositories::commits::head_commit(&repo)?;
-
-    // Unpack in tmp/tree/commit_id
-    let tmp_dir = util::fs::oxen_hidden_dir(&repo.path).join("tmp");
-
-    let mut bytes = web::BytesMut::new();
-    while let Some(item) = body.next().await {
-        bytes.extend_from_slice(&item.map_err(|_| OxenHttpError::FailedToReadRequestPayload)?);
-    }
-
-    let total_size: u64 = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
-    log::debug!(
-        "Got compressed data for tree {} -> {}",
-        client_head_id,
-        ByteSize::b(total_size)
-    );
-
-    log::debug!("Decompressing {} bytes to {:?}", bytes.len(), tmp_dir);
-
-    // let mut archive = Archive::new(GzDecoder::new(&bytes[..]));
-
-    unpack_tree_tarball(&tmp_dir, &bytes).await?;
-
-    Ok(HttpResponse::Ok().json(CommitResponse {
-        status: StatusMessage::resource_found(),
-        commit: server_head_commit.to_owned(),
-    }))
-}
-
-pub async fn root_commit(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
-    let app_data = app_data(&req)?;
-    let namespace = path_param(&req, "namespace")?;
-    let name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, name)?;
-
-    let root = repositories::commits::root_commit_maybe(&repo)?;
-
-    Ok(HttpResponse::Ok().json(RootCommitResponse {
-        status: StatusMessage::resource_found(),
-        commit: root,
-    }))
-}
-
-async fn unpack_compressed_data(
-    files: &[PathBuf],
-    repo: &LocalRepository,
-) -> Result<(), OxenError> {
-    let mut buffer: Vec<u8> = Vec::new();
-    for file in files.iter() {
-        log::debug!("Reading file bytes {file:?}");
-        let mut f = std::fs::File::open(file).map_err(|e| OxenError::file_open_error(file, e))?;
-
-        f.read_to_end(&mut buffer)
-            .map_err(|e| OxenError::file_read_error(file, e))?;
-    }
-
-    // Unpack tarball to our hidden dir using async streaming
-    unpack_entry_tarball_async(repo, &buffer).await?;
-
-    Ok(())
-}
-
 fn unpack_to_file(
     files: &[PathBuf],
     repo: &LocalRepository,
@@ -801,7 +981,45 @@ fn unpack_to_file(
     Ok(())
 }
 
-/// Controller to upload the commit database
+async fn unpack_compressed_data(
+    files: &[PathBuf],
+    repo: &LocalRepository,
+) -> Result<(), OxenError> {
+    let mut buffer: Vec<u8> = Vec::new();
+    for file in files.iter() {
+        log::debug!("Reading file bytes {file:?}");
+        let mut f = std::fs::File::open(file).map_err(|e| OxenError::file_open_error(file, e))?;
+
+        f.read_to_end(&mut buffer)
+            .map_err(|e| OxenError::file_read_error(file, e))?;
+    }
+
+    // Unpack tarball to our hidden dir using async streaming
+    unpack_entry_tarball_async(repo, &buffer).await?;
+
+    Ok(())
+}
+
+/// Upload commits DB
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/commits/upload",
+    operation_id = "upload_commits_db",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+    ),
+    request_body(
+        content_type = "application/octet-stream", 
+        description = "Compressed commit database (tar.gz)", 
+        content = Vec<u8>
+    ),
+    responses(
+        (status = 200, description = "Commits DB uploaded successfully", body = StatusMessage),
+    )
+)]
 pub async fn upload(
     req: HttpRequest,
     mut body: web::Payload, // the actual file body
@@ -842,7 +1060,23 @@ pub async fn upload(
     Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))
 }
 
-/// Notify that the push should be complete, and we should start doing our background processing
+/// Notify upload complete
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/commits/{commit_id}/complete",
+    operation_id = "commit_upload_complete",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("commit_id" = String, Path, description = "ID of the commit to complete", example = "84c76a5b2e9a2637f9091991475c404d"),
+    ),
+    responses(
+        (status = 200, description = "Commit push completed successfully", body = CommitResponse),
+        (status = 404, description = "Repository or commit not found"),
+    )
+)]
 pub async fn complete(req: HttpRequest) -> Result<HttpResponse, Error> {
     let app_data = req.app_data::<OxenAppData>().unwrap();
     // name to the repo, should be in url path so okay to unwrap
@@ -880,6 +1114,96 @@ pub async fn complete(req: HttpRequest) -> Result<HttpResponse, Error> {
             Ok(HttpResponse::InternalServerError().json(StatusMessage::internal_server_error()))
         }
     }
+}
+
+/// Upload commit tree
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/commits/{commit_id}/upload_tree",
+    operation_id = "upload_tree",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("commit_id" = String, Path, description = "Client head commit ID", example = "84c76a5b2e9a2637f9091991475c404d"),
+    ),
+    request_body(
+        content_type = "application/octet-stream", 
+        description = "Compressed tree data (tar.gz)", 
+        content = Vec<u8>
+    ),
+    responses(
+        (status = 200, description = "Tree uploaded successfully", body = CommitResponse),
+    )
+)]
+pub async fn upload_tree(
+    req: HttpRequest,
+    mut body: web::Payload,
+) -> Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let name = path_param(&req, "repo_name")?;
+    let client_head_id = path_param(&req, "commit_id")?;
+    let repo = get_repo(&app_data.path, namespace, name)?;
+    // Get head commit on sever repo
+    let server_head_commit = repositories::commits::head_commit(&repo)?;
+
+    // Unpack in tmp/tree/commit_id
+    let tmp_dir = util::fs::oxen_hidden_dir(&repo.path).join("tmp");
+
+    let mut bytes = web::BytesMut::new();
+    while let Some(item) = body.next().await {
+        bytes.extend_from_slice(&item.map_err(|_| OxenHttpError::FailedToReadRequestPayload)?);
+    }
+
+    let total_size: u64 = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    log::debug!(
+        "Got compressed data for tree {} -> {}",
+        client_head_id,
+        ByteSize::b(total_size)
+    );
+
+    log::debug!("Decompressing {} bytes to {:?}", bytes.len(), tmp_dir);
+
+    // let mut archive = Archive::new(GzDecoder::new(&bytes[..]));
+
+    unpack_tree_tarball(&tmp_dir, &bytes).await?;
+
+    Ok(HttpResponse::Ok().json(CommitResponse {
+        status: StatusMessage::resource_found(),
+        commit: server_head_commit.to_owned(),
+    }))
+}
+
+/// Get root commit
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/commits/root",
+    operation_id = "get_root_commit",
+    tag = "Commits",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+    ),
+    responses(
+        (status = 200, description = "Root commit found", body = RootCommitResponse),
+        (status = 404, description = "Root commit not found (empty repo)")
+    )
+)]
+pub async fn root_commit(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, name)?;
+
+    let root = repositories::commits::root_commit_maybe(&repo)?;
+
+    Ok(HttpResponse::Ok().json(RootCommitResponse {
+        status: StatusMessage::resource_found(),
+        commit: root,
+    }))
 }
 
 async fn unpack_tree_tarball(tmp_dir: &Path, data: &[u8]) -> Result<(), OxenError> {
@@ -998,252 +1322,4 @@ fn extract_hash_from_path(path: &Path) -> Result<String, OxenError> {
     Err(OxenError::basic_str(format!(
         "Could not get hash for file: {path:?}"
     )))
-}
-
-#[cfg(test)]
-mod tests {
-
-    use actix_web::body::to_bytes;
-    use actix_web::{web, App};
-    use flate2::write::GzEncoder;
-    use flate2::Compression;
-    use std::path::Path;
-    use std::thread;
-
-    use liboxen::constants::OXEN_HIDDEN_DIR;
-    use liboxen::error::OxenError;
-    use liboxen::repositories;
-    use liboxen::util;
-    use liboxen::view::{ListCommitResponse, StatusMessage};
-
-    use crate::app_data::OxenAppData;
-    use crate::controllers;
-    use crate::params::PageNumQuery;
-    use crate::test::{self, init_test_env};
-
-    #[actix_web::test]
-    async fn test_controllers_commits_index_empty() -> Result<(), OxenError> {
-        init_test_env();
-        let sync_dir = test::get_sync_dir()?;
-        let namespace = "Testing-Namespace";
-        let name = "Testing-Name";
-        test::create_local_repo(&sync_dir, namespace, name)?;
-
-        let uri = format!("/oxen/{namespace}/{name}/commits");
-        let req = test::repo_request(&sync_dir, &uri, namespace, name);
-
-        let resp = controllers::commits::index(req).await.unwrap();
-
-        let body = to_bytes(resp.into_body()).await.unwrap();
-        let text = std::str::from_utf8(&body).unwrap();
-        let list: ListCommitResponse = serde_json::from_str(text)?;
-        assert_eq!(list.commits.len(), 0);
-
-        // cleanup
-        test::cleanup_sync_dir(&sync_dir)?;
-
-        Ok(())
-    }
-
-    #[actix_web::test]
-    async fn test_controllers_commits_list_two_commits() -> Result<(), OxenError> {
-        let sync_dir = test::get_sync_dir()?;
-        let namespace = "Testing-Namespace";
-        let name = "Testing-Name";
-        let repo = test::create_local_repo(&sync_dir, namespace, name)?;
-
-        let path = liboxen::test::add_txt_file_to_dir(&repo.path, "hello")?;
-        repositories::add(&repo, path).await?;
-        repositories::commit(&repo, "first commit")?;
-        let path = liboxen::test::add_txt_file_to_dir(&repo.path, "world")?;
-        repositories::add(&repo, path).await?;
-        repositories::commit(&repo, "second commit")?;
-
-        let uri = format!("/oxen/{namespace}/{name}/commits");
-        let req = test::repo_request(&sync_dir, &uri, namespace, name);
-
-        let resp = controllers::commits::index(req).await.unwrap();
-        let body = to_bytes(resp.into_body()).await.unwrap();
-        let text = std::str::from_utf8(&body).unwrap();
-        let list: ListCommitResponse = serde_json::from_str(text)?;
-        assert_eq!(list.commits.len(), 2);
-
-        // cleanup
-        test::cleanup_sync_dir(&sync_dir)?;
-
-        Ok(())
-    }
-
-    #[actix_web::test]
-    async fn test_controllers_commits_list_commits_on_branch() -> Result<(), OxenError> {
-        let sync_dir = test::get_sync_dir()?;
-        let namespace = "Testing-Namespace";
-        let repo_name = "Testing-Name";
-        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
-
-        let path = liboxen::test::add_txt_file_to_dir(&repo.path, "hello")?;
-        repositories::add(&repo, path).await?;
-        repositories::commit(&repo, "first commit")?;
-
-        let branch_name = "feature/list-commits";
-        repositories::branches::create_checkout(&repo, branch_name)?;
-
-        let path = liboxen::test::add_txt_file_to_dir(&repo.path, "world")?;
-        repositories::add(&repo, path).await?;
-        repositories::commit(&repo, "second commit")?;
-
-        let uri = format!("/oxen/{namespace}/{repo_name}/commits/history/{branch_name}");
-        let req = test::repo_request_with_param(
-            &sync_dir,
-            &uri,
-            namespace,
-            repo_name,
-            "resource",
-            branch_name,
-        );
-
-        let query: web::Query<PageNumQuery> =
-            web::Query::from_query("page=1&page_size=10").unwrap();
-        let resp = controllers::commits::history(req, query).await.unwrap();
-        let body = to_bytes(resp.into_body()).await.unwrap();
-        let text = std::str::from_utf8(&body).unwrap();
-        let list: ListCommitResponse = serde_json::from_str(text)?;
-        assert_eq!(list.commits.len(), 2);
-
-        // cleanup
-        test::cleanup_sync_dir(&sync_dir)?;
-
-        Ok(())
-    }
-
-    // Switch branches, add a commit, and only list commits from first branch
-    #[actix_web::test]
-    async fn test_controllers_commits_list_some_commits_on_branch() -> Result<(), OxenError> {
-        let sync_dir = test::get_sync_dir()?;
-        let namespace = "Testing-Namespace";
-        let repo_name = "Testing-Name";
-        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
-        let hello_file = repo.path.join("hello.txt");
-        util::fs::write_to_path(&hello_file, "Hello")?;
-        repositories::add(&repo, &hello_file).await?;
-        repositories::commit(&repo, "First commit")?;
-        let og_branch = repositories::branches::current_branch(&repo)?.unwrap();
-
-        let path = liboxen::test::add_txt_file_to_dir(&repo.path, "hello")?;
-        repositories::add(&repo, path).await?;
-        repositories::commit(&repo, "first commit")?;
-
-        let branch_name = "feature/list-commits";
-        repositories::branches::create_checkout(&repo, branch_name)?;
-
-        let path = liboxen::test::add_txt_file_to_dir(&repo.path, "world")?;
-        repositories::add(&repo, path).await?;
-        repositories::commit(&repo, "second commit")?;
-
-        // List commits from the first branch
-        let uri = format!(
-            "/oxen/{}/{}/commits/history/{}",
-            namespace, repo_name, og_branch.name
-        );
-        let req = test::repo_request_with_param(
-            &sync_dir,
-            &uri,
-            namespace,
-            repo_name,
-            "resource",
-            og_branch.name,
-        );
-
-        let query: web::Query<PageNumQuery> =
-            web::Query::from_query("page=1&page_size=10").unwrap();
-        let resp = controllers::commits::history(req, query).await.unwrap();
-        let body = to_bytes(resp.into_body()).await.unwrap();
-        let text = std::str::from_utf8(&body).unwrap();
-        let list: ListCommitResponse = serde_json::from_str(text)?;
-        // there should be 2 instead of the 3 total
-        assert_eq!(list.commits.len(), 2);
-
-        // cleanup
-        test::cleanup_sync_dir(&sync_dir)?;
-
-        Ok(())
-    }
-
-    #[actix_web::test]
-    async fn test_controllers_commits_upload() -> Result<(), OxenError> {
-        let sync_dir = test::get_sync_dir()?;
-        let namespace = "Testing-Namespace";
-        let repo_name = "Testing-Name";
-        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
-        let hello_file = repo.path.join("hello.txt");
-        util::fs::write_to_path(&hello_file, "Hello")?;
-        repositories::add(&repo, &hello_file).await?;
-        let commit = repositories::commit(&repo, "First commit")?;
-
-        // create random tarball to post.. currently no validation that it is a valid commit dir
-        let path_to_compress = format!("history/{}", commit.id);
-        let commit_dir_name = format!("data/test/runs/{}", commit.id);
-        let commit_dir = Path::new(&commit_dir_name);
-        util::fs::create_dir_all(commit_dir)?;
-        // Write a random file to it
-        let zipped_filename = "blah.txt";
-        let zipped_file_contents = "sup";
-        let random_file = commit_dir.join(zipped_filename);
-        util::fs::write_to_path(&random_file, zipped_file_contents)?;
-
-        println!("Compressing commit {}...", commit.id);
-        let enc = GzEncoder::new(Vec::new(), Compression::default());
-        let mut tar = tar::Builder::new(enc);
-
-        tar.append_dir_all(&path_to_compress, commit_dir)?;
-        tar.finish()?;
-        let payload: Vec<u8> = tar.into_inner()?.finish()?;
-        println!("Uploading commit {}... {} bytes", commit.id, payload.len());
-
-        let uri = format!("/oxen/{namespace}/{repo_name}/commits/upload");
-        let app = actix_web::test::init_service(
-            App::new()
-                .app_data(OxenAppData::new(sync_dir.clone()))
-                .route(
-                    "/oxen/{namespace}/{repo_name}/commits/upload",
-                    web::post().to(controllers::commits::upload),
-                ),
-        )
-        .await;
-
-        let req = actix_web::test::TestRequest::post()
-            .uri(&uri)
-            .set_payload(payload)
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
-        let body = std::str::from_utf8(&bytes).unwrap();
-        println!("Upload response: {body}");
-        let resp: StatusMessage = serde_json::from_str(body)?;
-        assert_eq!(resp.status, "success");
-
-        // We unzip in a background thread, so give it a second
-        thread::sleep(std::time::Duration::from_secs(1));
-
-        // Make sure we unzipped the tar ball
-        let uploaded_file = sync_dir
-            .join(namespace)
-            .join(repo_name)
-            .join(OXEN_HIDDEN_DIR)
-            .join(path_to_compress)
-            .join(zipped_filename);
-        println!("Looking for file: {uploaded_file:?}");
-        assert!(uploaded_file.exists());
-        assert_eq!(
-            util::fs::read_from_path(&uploaded_file)?,
-            zipped_file_contents
-        );
-
-        // cleanup
-        test::cleanup_sync_dir(&sync_dir)?;
-        util::fs::remove_dir_all(commit_dir)?;
-
-        Ok(())
-    }
 }

--- a/oxen-rust/src/server/src/controllers/data_frames.rs
+++ b/oxen-rust/src/server/src/controllers/data_frames.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 /// Get data frame slice
 #[utoipa::path(
     get,
-    path = "/api/repos/{namespace}/{repo_name}/workspaces/{workspace_id}/data_frames/{resource}",
+    path = "/api/repos/{namespace}/{repo_name}/data_frames/{resource}",
     operation_id = "get_data_frame_slice",
     tag = "DataFrames",
     security( ("api_key" = []) ),
@@ -32,7 +32,7 @@ use uuid::Uuid;
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
         ("resource" = String, Path, description = "Path to the tabular file (including branch/commit info)", example = "main/data/labels.csv"),
-        DFOptsQuery // Assumes DFOptsQuery derives IntoParams
+        DFOptsQuery
     ),
     responses(
         (status = 200, description = "Data frame slice found", body = JsonDataFrameViewResponse),

--- a/oxen-rust/src/server/src/controllers/dir.rs
+++ b/oxen-rust/src/server/src/controllers/dir.rs
@@ -8,7 +8,26 @@ use liboxen::view::PaginatedDirEntriesResponse;
 use liboxen::{constants, repositories};
 
 use actix_web::{web, HttpRequest, HttpResponse};
+use utoipa;
 
+/// List directory contents
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/dir/{resource}",
+    operation_id = "list_directory_contents",
+    tag = "Directories",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("resource" = String, Path, description = "Path to the directory (including branch/commit ID)", example = "main/data/train"),
+        PageNumVersionQuery 
+    ),
+    responses(
+        (status = 200, description = "Paginated list of directory entries", body = PaginatedDirEntriesResponse),
+        (status = 404, description = "Directory or repository not found")
+    )
+)]
 pub async fn get(
     req: HttpRequest,
     query: web::Query<PageNumVersionQuery>,

--- a/oxen-rust/src/server/src/controllers/dir.rs
+++ b/oxen-rust/src/server/src/controllers/dir.rs
@@ -21,7 +21,7 @@ use utoipa;
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
         ("resource" = String, Path, description = "Path to the directory (including branch/commit ID)", example = "main/data/train"),
-        PageNumVersionQuery 
+        PageNumVersionQuery
     ),
     responses(
         (status = 200, description = "Paginated list of directory entries", body = PaginatedDirEntriesResponse),

--- a/oxen-rust/src/server/src/controllers/fork.rs
+++ b/oxen-rust/src/server/src/controllers/fork.rs
@@ -7,6 +7,26 @@ use liboxen::repositories;
 use liboxen::view::fork::ForkRequest;
 use liboxen::view::StatusMessage;
 
+/// Fork a repository
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/fork",
+    tag = "Fork",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository to fork", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository to fork", example = "yolov7-repo"),
+    ),
+    request_body(
+        content = ForkRequest,
+        description = "Fork target details, including the new namespace and optional new repository name.",
+    ),
+    responses(
+        (status = 202, description = "Fork initiated successfully", body = StatusMessage),
+        (status = 409, description = "Repository already exists at destination namespace/name", body = StatusMessage),
+        (status = 404, description = "Original repository not found")
+    )
+)]
 pub async fn fork(
     req: HttpRequest,
     body: web::Json<ForkRequest>,
@@ -41,6 +61,21 @@ pub async fn fork(
     }
 }
 
+/// Fork Status
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/fork/status",
+    tag = "Fork",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the forked repository", example = "new-user"),
+        ("repo_name" = String, Path, description = "Name of the forked repository", example = "yolov7-repo"),
+    ),
+    responses(
+        (status = 200, description = "Fork status returned successfully", body = StatusMessage),
+        (status = 404, description = "Fork status not found or repository does not exist")
+    )
+)]
 pub async fn get_status(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;

--- a/oxen-rust/src/server/src/controllers/merger.rs
+++ b/oxen-rust/src/server/src/controllers/merger.rs
@@ -11,6 +11,22 @@ use liboxen::view::merge::{
 };
 use liboxen::view::StatusMessage;
 
+/// Check if branches are mergeable
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/merge/{base_head}",
+    tag = "Merge",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "satellite-images"),
+        ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
+    ),
+    responses(
+        (status = 200, description = "Merge status returned successfully", body = MergeableResponse),
+        (status = 404, description = "Repository or one of the revisions not found")
+    )
+)]
 pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -53,6 +69,23 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     Ok(HttpResponse::Ok().json(response))
 }
 
+/// Merge branches
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/merge/{base_head}",
+    tag = "Merge",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "satellite-images"),
+        ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
+    ),
+    responses(
+        (status = 200, description = "Branches merged successfully", body = MergeSuccessResponse),
+        (status = 409, description = "Merge conflict", body = StatusMessage),
+        (status = 404, description = "Repository or one of the revisions not found"),
+    )
+)]
 pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;

--- a/oxen-rust/src/server/src/controllers/metadata.rs
+++ b/oxen-rust/src/server/src/controllers/metadata.rs
@@ -10,7 +10,26 @@ use liboxen::view::StatusMessage;
 use liboxen::{current_function, repositories};
 
 use actix_web::{HttpRequest, HttpResponse};
+use utoipa;
 
+/// Get entry metadata
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/metadata/{resource}",
+    operation_id = "get_entry_metadata",
+    tag = "Entries",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("resource" = String, Path, description = "Path to the file/dir (including branch/commit info)", example = "main/images/train/dog_1.jpg"),
+    ),
+    responses(
+        (status = 200, description = "Metadata for the entry found", body = EMetadataEntryResponseView),
+        (status = 404, description = "Entry not found"),
+        (status = 400, description = "Invalid resource path")
+    )
+)]
 pub async fn file(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -81,6 +100,24 @@ pub async fn file(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     Ok(HttpResponse::Ok().json(meta))
 }
 
+/// Update metadata
+#[utoipa::path(
+    put,
+    path = "/api/repos/{namespace}/{repo_name}/metadata/{resource}",
+    operation_id = "update_entry_metadata",
+    tag = "Entries",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("resource" = String, Path, description = "Path to the file (including version to update)", example = "versions/files/b4/158b417c800c7322d711f1816f5c00e1215b4d7c001c9b6892556d11/data"),
+    ),
+    responses(
+        (status = 200, description = "Metadata updated", body = StatusMessage),
+        (status = 400, description = "Missing version in resource path"),
+        (status = 404, description = "Repository not found")
+    )
+)]
 pub async fn update_metadata(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;

--- a/oxen-rust/src/server/src/controllers/namespaces.rs
+++ b/oxen-rust/src/server/src/controllers/namespaces.rs
@@ -5,7 +5,19 @@ use liboxen::namespaces;
 use liboxen::view::{ListNamespacesResponse, NamespaceResponse, NamespaceView, StatusMessage};
 
 use actix_web::{HttpRequest, HttpResponse, Result};
+use utoipa;
 
+/// List namespaces
+#[utoipa::path(
+    get,
+    path = "/api/namespaces",
+    operation_id = "list_namespaces",
+    tag = "Namespaces",
+    security( ("api_key" = []) ),
+    responses(
+        (status = 200, description = "List of namespaces", body = ListNamespacesResponse),
+    )
+)]
 pub async fn index(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
 
@@ -22,6 +34,22 @@ pub async fn index(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     Ok(HttpResponse::Ok().json(view))
 }
 
+/// Get namespace
+#[utoipa::path(
+    get,
+    path = "/api/namespaces/{namespace}",
+    operation_id = "get_namespace",
+    tag = "Namespaces",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Name of the namespace"),
+    ),
+    responses(
+        (status = 200, description = "Namespace details", body = NamespaceResponse),
+        (status = 400, description = "Missing namespace parameter"),
+        (status = 404, description = "Namespace not found"),
+    )
+)]
 pub async fn show(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace: Option<&str> = req.match_info().get("namespace");

--- a/oxen-rust/src/server/src/controllers/revisions.rs
+++ b/oxen-rust/src/server/src/controllers/revisions.rs
@@ -7,7 +7,25 @@ use actix_web::{HttpRequest, HttpResponse, Result};
 use liboxen::view::{ParseResourceResponse, StatusMessage};
 
 use log;
+use utoipa;
 
+#[utoipa::path(
+    get,
+    path = "/api/repos/{namespace}/{repo_name}/dir/{resource}",
+    operation_id = "get_dir",
+    tag = "Entries",
+    security( ("api_key" = []) ),
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository"),
+        ("repo_name" = String, Path, description = "Name of the repository"),
+        ("resource" = String, Path, description = "Path to the directory (including branch/commit info)"),
+    ),
+    responses(
+        (status = 200, description = "Directory structure resolved", body = ParseResourceResponse),
+        (status = 404, description = "Directory or repository not found"),
+        (status = 400, description = "Invalid resource string")
+    )
+)]
 pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;

--- a/oxen-rust/src/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/files.rs
@@ -334,7 +334,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
         ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745")
     ),
     request_body(
-        content = Vec<String>, 
+        content = Vec<String>,
         description = "List of paths to remove from the workspace staging area",
         example = json!(["images/train/dog_1.jpg", "annotations/incorrect.xml"])
     ),
@@ -403,7 +403,7 @@ pub async fn rm_files(
         ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745")
     ),
     request_body(
-        content = Vec<String>, 
+        content = Vec<String>,
         description = "List of paths to restore/unstage from the workspace staging area",
         example = json!(["images/train/revert_me.jpg", "data/config.json"])
     ),

--- a/oxen-rust/src/server/src/main.rs
+++ b/oxen-rust/src/server/src/main.rs
@@ -94,7 +94,6 @@ const SUPPORT: &str = "
         // Namespaces
         crate::controllers::namespaces::index,
         crate::controllers::namespaces::show,
-
         // Repositories
         crate::controllers::repositories::index,
         crate::controllers::repositories::show,
@@ -104,8 +103,7 @@ const SUPPORT: &str = "
         crate::controllers::repositories::update_size,
         crate::controllers::repositories::get_size,
         crate::controllers::repositories::transfer_namespace,
-        
-        // Workspaces  
+        // Workspaces
         crate::controllers::workspaces::get_or_create,
         crate::controllers::workspaces::get,
         crate::controllers::workspaces::create,
@@ -115,16 +113,14 @@ const SUPPORT: &str = "
         crate::controllers::workspaces::delete,
         crate::controllers::workspaces::mergeability,
         crate::controllers::workspaces::commit,
-        
-        // Files (Workspace) 
+        // Files (Workspace)
         crate::controllers::workspaces::files::get,
         crate::controllers::workspaces::files::add,
         crate::controllers::workspaces::files::add_version_files,
         crate::controllers::workspaces::files::delete,
         crate::controllers::workspaces::files::rm_files,
         crate::controllers::workspaces::files::rm_files_from_staged,
-        
-        // Branches 
+        // Branches
         crate::controllers::branches::index,
         crate::controllers::branches::show,
         crate::controllers::branches::create,
@@ -136,7 +132,6 @@ const SUPPORT: &str = "
         crate::controllers::branches::unlock,
         crate::controllers::branches::is_locked,
         crate::controllers::branches::list_entry_versions,
-
         // Commits
         crate::controllers::commits::index,
         crate::controllers::commits::history,
@@ -155,11 +150,9 @@ const SUPPORT: &str = "
         crate::controllers::commits::root_commit,
         crate::controllers::commits::upload,
         crate::controllers::commits::complete,
-
         // Merge
         crate::controllers::merger::show,
         crate::controllers::merger::merge,
-        
         // Diff
         crate::controllers::diff::commits,
         crate::controllers::diff::entries,
@@ -171,51 +164,46 @@ const SUPPORT: &str = "
         crate::controllers::diff::get_df_diff,
         crate::controllers::diff::delete_df_diff,
         crate::controllers::diff::get_derived_df,
-
         // Fork
         crate::controllers::fork::fork,
         crate::controllers::fork::get_status,
-
-        // Files (Repository) 
+        // Files (Repository)
         crate::controllers::file::get,
         crate::controllers::file::put,
         crate::controllers::file::upload_zip,
         crate::controllers::file::import,
-
         // DataFrames
         crate::controllers::data_frames::get,
         crate::controllers::data_frames::index,
         crate::controllers::data_frames::from_directory,
-
-        // Directories 
+        // Directories
         crate::controllers::dir::get,
-        
-        // Metadata 
+        // Metadata
         crate::controllers::metadata::file,
         crate::controllers::metadata::update_metadata,
     ),
     components(
         // TODO: I'm not sure if these are all necessary to include
         schemas(
-            // Misc 
+            // Misc
             StatusMessage,
             ParseResourceResponse,
             ImgResize,
-            // Namespaces Schemas 
+            // Namespaces Schemas
             ListNamespacesResponse,
             NamespaceResponse,
             NamespaceView,
-            // Repository Schemas 
+            // Repository Schemas
             ListRepositoryResponse, RepositoryResponse, RepositoryView,
-            RepositoryCreationResponse, RepositoryCreationView, RepositoryDataTypesResponse, 
-            RepositoryDataTypesView, RepositoryListView, RepositoryStatsResponse, 
+            RepositoryCreationResponse, RepositoryCreationView, RepositoryDataTypesResponse,
+            RepositoryDataTypesView, RepositoryListView, RepositoryStatsResponse,
             RepositoryStatsView, DataTypeView, DataTypeCount,
             RepoNew, User,
-            // Commit Schemas 
-            CommitResponse, ListCommitResponse, PaginatedCommits, RootCommitResponse, 
-            MerkleHashesResponse, MerkleHashes, ListCommitEntryResponse, Commit, 
-            CommitStatsResponse, CommitStats, CommitTreeValidationResponse, 
-            // Workspace Schemas 
+            // Commit Schemas
+            CommitResponse, ListCommitResponse, PaginatedCommits, RootCommitResponse,
+            MerkleHashesResponse, MerkleHashes, ListCommitEntryResponse, Commit,
+            CommitStatsResponse, CommitStats, CommitTreeValidationResponse,
+            // Workspace Schemas
             ListWorkspaceResponseView, NewWorkspace, WorkspaceResponse, MergeableResponse,
             // Merge Schemas
             MergeSuccessResponse, MergeResult, Mergeable, MergeConflictFile,
@@ -225,17 +213,17 @@ const SUPPORT: &str = "
             TabularCompareBody, TabularCompareTargetBody,
             // Fork Schemas
             ForkRequest, ForkStartResponse, ForkStatus,
-            // File/Entry Schemas 
+            // File/Entry Schemas
             CommitEntryVersion, ResourceVersion, PaginatedEntryVersions, PaginatedEntryVersionsResponse,            FilePathsResponse, ErrorFilesResponse, ErrorFileInfo, FileWithHash,
             // Upload & Request Bodies
             crate::controllers::workspaces::files::FileUpload,
             crate::controllers::file::FileUploadBody,
             crate::controllers::file::ZipUploadBody,
             crate::controllers::file::ImportFileBody,
-            FromDirectoryRequest, 
-            // Metadata Schemas 
+            FromDirectoryRequest,
+            // Metadata Schemas
             EMetadataEntryResponseView,
-            GenericMetadata, MetadataDir, MetadataText, MetadataImage, 
+            GenericMetadata, MetadataDir, MetadataText, MetadataImage,
             MetadataVideo, MetadataAudio, MetadataTabular,
         ),
     ),

--- a/oxen-rust/src/server/src/main.rs
+++ b/oxen-rust/src/server/src/main.rs
@@ -400,7 +400,7 @@ async fn main() -> std::io::Result<()> {
                             ))
                             .service(
                                 SwaggerUi::new("/swagger-ui/{_:.*}")
-                                    .url("/api/_spec/openapi.json", openapi.clone()),
+                                    .url("/api/_spec/oxen_server_openapi.json", openapi.clone()),
                             )
                             .service(web::scope("/api/repos").configure(routes::config))
                             .default_service(web::route().to(controllers::not_found::index))

--- a/oxen-rust/src/server/src/params/df_opts_query.rs
+++ b/oxen-rust/src/server/src/params/df_opts_query.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 use actix_web::web;
 use liboxen::opts::DFOpts;
 use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema, IntoParams)]
 pub struct DFOptsQuery {
     pub columns: Option<String>,
     pub delimiter: Option<String>,

--- a/oxen-rust/src/server/src/params/name_param.rs
+++ b/oxen-rust/src/server/src/params/name_param.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
+use utoipa::IntoParams;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct NameParam {
     pub name: Option<String>,
 }

--- a/oxen-rust/src/server/src/params/page_num_query.rs
+++ b/oxen-rust/src/server/src/params/page_num_query.rs
@@ -1,12 +1,13 @@
 use serde::Deserialize;
+use utoipa::IntoParams;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct PageNumQuery {
     pub page: Option<usize>,
     pub page_size: Option<usize>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct PageNumVersionQuery {
     pub page: Option<usize>,
     pub page_size: Option<usize>,


### PR DESCRIPTION
Adds utoipa annotations to the majority of our view modules and controller functions

This PR shouldn't change the functionality of the code whatsoever. It solely adds these annotations and the corresponding main module in server/main.rs to display the new docs.

The generated OpenAPI Spec can be found at localhost:3000/api/_spec/openapi.json. Utoipa also comes integrated with SwaggerUI, which you can use to view the API in a decorated format at localhost:3000/swagger-ui 

To view the changes as they'd be displayed on the actual oxen.ai website, build the oxenhub locally with the corresponding PR there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many new REST endpoints for branches, commits (including chunked uploads), diffs, data-frames, repositories, workspaces, forks, merges, metadata, and workspace file operations; added pagination totals and extra response fields (e.g., workspace/fork progress, repository stats).

* **Documentation**
  * Full OpenAPI/Swagger integration with generated schemas, annotated request/response types, inline examples and an interactive Swagger UI to explore the API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->