### PR TITLE
Correct status message issue with moved dirs

### DIFF
--- a/oxen-rust/src/lib/src/model/staged_data.rs
+++ b/oxen-rust/src/lib/src/model/staged_data.rs
@@ -331,6 +331,7 @@ impl StagedData {
 
                 if !dir_row.is_empty() {
                     dirs.push(dir_row.clone());
+                    dir_row.clear();
                 }
             }
         }


### PR DESCRIPTION
This is a fix for a visual bug with status where moving a file and then calling oxen status would result in duplicate entries in the status output. It was caused because we weren't clearing the vec when gathering outputs to display the staged data

To reproduce on main:

1. In an empty repo, add and commit file in a dir (dir/a).
2. Use `mv` to rename the file (a -> b). Use `oxen add` on the new file (b), and then `oxen rm` on the original file (a)
3. `oxen status` will now have a visual bug where (dir/b) is added twice.

Don't believe I've seen this on any scenarios besides moving files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where staged directory entries were incorrectly carried over between processing iterations, which could cause duplicate or stale data to appear.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->