### PR TITLE
Api 85/oxen node panic

### DIFF
--- a/oxen-rust/src/cli/src/cmd/node.rs
+++ b/oxen-rust/src/cli/src/cmd/node.rs
@@ -31,18 +31,18 @@ impl RunCmd for NodeCmd {
                 Arg::new("node")
                     .long("node")
                     .short('n')
-                    .conflicts_with("file")
-                    .required_unless_present("file")
+                    .conflicts_with("path")
+                    .required_unless_present("path")
                     .help("Node hash to inspect"),
             )
-            // add --file flag
+            // add --path flag
             .arg(
-                Arg::new("file")
-                    .long("file")
-                    .short('f')
+                Arg::new("path")
+                    .long("path")
+                    .short('p')
                     .conflicts_with("node")
                     .required_unless_present("node")
-                    .help("File path to inspect"),
+                    .help("Path to the node to inspect"),
             )
             // add --revision flag
             .arg(
@@ -57,17 +57,18 @@ impl RunCmd for NodeCmd {
         // Find the repository
         let repository = LocalRepository::from_current_dir()?;
 
-        // if the --file flag is set, we need to get the node for the file
-        if let Some(file) = args.get_one::<String>("file") {
+        // if the --path flag is set, get the node by path in the specified revision
+        if let Some(path) = args.get_one::<String>("path") {
             let commit = if let Some(revision) = args.get_one::<String>("revision") {
                 repositories::revisions::get(&repository, revision)?.unwrap()
             } else {
                 repositories::commits::head_commit(&repository)?
             };
-            let Some(node) = repositories::entries::get_file(&repository, &commit, file)? else {
+            let Some(node) = repositories::tree::get_node_by_path(&repository, &commit, path)?
+            else {
                 return Err(OxenError::basic_str(format!(
-                    "Error: file {:?} not found in commit {:?}",
-                    file, commit.id
+                    "Error: path {:?} not found in commit {:?}",
+                    path, commit.id
                 )));
             };
 

--- a/oxen-rust/src/cli/src/cmd/node.rs
+++ b/oxen-rust/src/cli/src/cmd/node.rs
@@ -60,7 +60,8 @@ impl RunCmd for NodeCmd {
         // if the --path flag is set, get the node by path in the specified revision
         if let Some(path) = args.get_one::<String>("path") {
             let commit = if let Some(revision) = args.get_one::<String>("revision") {
-                repositories::revisions::get(&repository, revision)?.unwrap()
+                repositories::revisions::get(&repository, revision)?
+                    .ok_or_else(|| OxenError::basic_str(format!("Revision {revision} not found")))?
             } else {
                 repositories::commits::head_commit(&repository)?
             };

--- a/oxen-rust/src/cli/src/cmd/node.rs
+++ b/oxen-rust/src/cli/src/cmd/node.rs
@@ -4,6 +4,8 @@ use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
+use std::path::Path;
+
 use crate::cmd::RunCmd;
 pub const NAME: &str = "node";
 pub struct NodeCmd;
@@ -65,6 +67,7 @@ impl RunCmd for NodeCmd {
             } else {
                 repositories::commits::head_commit(&repository)?
             };
+            let path = Path::new(path);
             let Some(node) = repositories::tree::get_node_by_path(&repository, &commit, path)?
             else {
                 return Err(OxenError::basic_str(format!(
@@ -74,6 +77,12 @@ impl RunCmd for NodeCmd {
             };
 
             println!("{node:?}");
+            if args.get_flag("verbose") {
+                println!("{} children", node.children.len());
+                for child in node.children {
+                    println!("{child:?}");
+                }
+            }
             return Ok(());
 
         // otherwise, get the node based on the node hash


### PR DESCRIPTION
This is a correction for a small issue with `oxen node`. Previously, running this command with no arguments would cause a panic, rather than being aborted by CLap or returning an error. That's now fixed, and you can also now use `oxen node --path` to lookup dir nodes by path, instead of just file nodes

To reproduce the error on main:

1. Run `oxen node` with no arguments. It will panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI adds a dedicated --path (-p) option to locate nodes by repository path.

* **Bug Fixes**
  * Replaces the old file flag with --path and enforces mutual exclusivity with the node identifier.
  * Clearer, explicit errors when a revision, path, or node identifier cannot be found.
  * Command now requires either a path or node; verbose output still shows node children when requested.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->