### PR TITLE
Default to unauthenticated client if auth_config.toml not found

### DIFF
--- a/oxen-rust/src/lib/src/api/client.rs
+++ b/oxen-rust/src/lib/src/api/client.rs
@@ -161,7 +161,7 @@ pub async fn parse_json_body(url: &str, res: reqwest::Response) -> Result<String
             Ok(config) => config,
             Err(err) => {
                 log::debug!("remote::client::new_for_host error getting config: {err}");
-                return Err(OxenError::auth_token_not_set());
+                return Err(OxenError::must_supply_valid_api_key());
             }
         };
     }
@@ -237,7 +237,7 @@ fn parse_status_and_message(
                     Ok(_) => {}
                     Err(err) => {
                         log::debug!("remote::client::new_for_host error getting config: {err}");
-                        return Err(OxenError::auth_token_not_set());
+                        return Err(OxenError::must_supply_valid_api_key());
                     }
                 };
             }

--- a/oxen-rust/src/lib/src/api/client.rs
+++ b/oxen-rust/src/lib/src/api/client.rs
@@ -232,6 +232,16 @@ fn parse_status_and_message(
         }
         http::STATUS_ERROR => {
             log::debug!("Status error: {status}");
+            if status == reqwest::StatusCode::FORBIDDEN {
+                match AuthConfig::get() {
+                    Ok(_) => {}
+                    Err(err) => {
+                        log::debug!("remote::client::new_for_host error getting config: {err}");
+                        return Err(OxenError::auth_token_not_set());
+                    }
+                };
+            }
+
             if let Some(msg) = response_msg_override {
                 if let Some(response_type) = response_type {
                     if response.desc_or_msg() == response_type {

--- a/oxen-rust/src/lib/src/api/client.rs
+++ b/oxen-rust/src/lib/src/api/client.rs
@@ -97,7 +97,11 @@ fn builder_for_host<S: AsRef<str>>(
     let config = match AuthConfig::get() {
         Ok(config) => config,
         Err(e) => {
-            log::debug!("remote::client::new_for_host error getting config: {}. No auth token found for host {}", e, host.as_ref());
+            log::debug!(
+                "Error getting config: {}. No auth token found for host {}",
+                e,
+                host.as_ref()
+            );
             return builder;
         }
     };
@@ -107,7 +111,7 @@ fn builder_for_host<S: AsRef<str>>(
         let mut auth_value = match header::HeaderValue::from_str(auth_header.as_str()) {
             Ok(header) => header,
             Err(e) => {
-                log::debug!("remote::client::new invalid header value: {e}");
+                log::debug!("Invalid header value: {e}");
                 return Err(OxenError::basic_str(
                     "Error setting request auth. Please check your Oxen config.",
                 ));
@@ -160,7 +164,7 @@ pub async fn parse_json_body(url: &str, res: reqwest::Response) -> Result<String
         let _ = match AuthConfig::get() {
             Ok(config) => config,
             Err(err) => {
-                log::debug!("remote::client::new_for_host error getting config: {err}");
+                log::debug!("Error getting config: {err}");
                 return Err(OxenError::must_supply_valid_api_key());
             }
         };
@@ -170,7 +174,7 @@ pub async fn parse_json_body(url: &str, res: reqwest::Response) -> Result<String
 }
 
 /// Used to override error message when parsing json body
-pub async fn parse_json_body_with_err_msg(
+async fn parse_json_body_with_err_msg(
     url: &str,
     res: reqwest::Response,
     response_type: Option<&str>,

--- a/oxen-rust/src/lib/src/api/client.rs
+++ b/oxen-rust/src/lib/src/api/client.rs
@@ -232,15 +232,6 @@ fn parse_status_and_message(
         }
         http::STATUS_ERROR => {
             log::debug!("Status error: {status}");
-            if status == reqwest::StatusCode::FORBIDDEN {
-                match AuthConfig::get() {
-                    Ok(_) => {}
-                    Err(err) => {
-                        log::debug!("remote::client::new_for_host error getting config: {err}");
-                        return Err(OxenError::must_supply_valid_api_key());
-                    }
-                };
-            }
 
             if let Some(msg) = response_msg_override {
                 if let Some(response_type) = response_type {

--- a/oxen-rust/src/lib/src/config/auth_config.rs
+++ b/oxen-rust/src/lib/src/config/auth_config.rs
@@ -71,7 +71,7 @@ impl AuthConfig {
                 config_file,
                 std::env::current_dir().unwrap()
             );
-            Err(OxenError::auth_token_not_set())
+            Err(OxenError::must_supply_valid_api_key())
         }
     }
 

--- a/oxen-rust/src/lib/src/error.rs
+++ b/oxen-rust/src/lib/src/error.rs
@@ -290,10 +290,6 @@ impl OxenError {
         OxenError::user_config_not_found(EMAIL_AND_NAME_NOT_FOUND.to_string().into())
     }
 
-    pub fn auth_token_not_set() -> OxenError {
-        OxenError::basic_str(AUTH_TOKEN_NOT_FOUND)
-    }
-
     pub fn remote_repo_not_found(url: impl AsRef<str>) -> OxenError {
         let err = format!("Remote repository does not exist {}", url.as_ref());
         OxenError::basic_str(err)


### PR DESCRIPTION
This solves an issue where you couldn't connect to any host, even unauthenticated ones, if auth_config.toml did not exist.

In current main, if auth_config.toml exists but there's no auth token for a host, the client code can still return a client with no authorization. This PR matches that behavior for if auth_config.toml doesn't exist.

To test:
1. Move or rename `~/.config/oxen/auth_config.toml`
2. Use `oxen create-remote --host localhost:3000 --name ox/no-auth --scheme http` to create a new remote. This won't work in current main, but does with this PR

You can also consider connecting to other unauthenticated hosts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client now proceeds gracefully when no authentication config is found, allowing unauthenticated requests instead of failing.
  * Improved logging and clearer error messages for malformed or missing authorization headers.
  * 403 Forbidden responses now prompt supplying a valid API key, improving recovery guidance for auth failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->