### PR TITLE
Fix oxen restore --staged for non-glob paths

### DIFF
--- a/oxen-rust/src/lib/src/core/v_latest/index/restore.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/index/restore.rs
@@ -83,8 +83,10 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
 fn restore_staged(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), OxenError> {
     log::debug!("restore::restore_staged: start");
     let db_path = util::fs::oxen_hidden_dir(&repo.path).join(STAGED_DIR);
+    let repo_path = repo.path.clone();
     if let Some(db) = open_staged_db(&db_path)? {
         for path in &opts.paths {
+            let path = util::fs::path_relative_to_dir(path, &repo_path)?;
             let mut batch = WriteBatch::default();
 
             // Remove specific staged entry or entries under a directory


### PR DESCRIPTION
It seems my restore refactor might have broken restore --staged for non-glob paths. This PR makes the glob module return   relative paths for `oxen restore --staged` by always feeding paths into `search_staged_db` when the stage flag is set on glob opts.

To test:
1. Do `oxen restore --staged` with different paths. All of them should now behave as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved error handling and clearer control flow for path expansion (glob vs non-glob).
  * Safer UTF-8 handling for file paths with explicit error messages instead of panics.
  * Simplified debug output to report path counts.

* **Bug Fixes**
  * Restore targets are resolved relative to the repository root for correct staged matching.
  * Searches that require a local repository now return explicit errors if no repo is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->