### PR TITLE
Deduplicate commit message

### DIFF
--- a/oxen-rust/src/cli/src/cmd/push.rs
+++ b/oxen-rust/src/cli/src/cmd/push.rs
@@ -76,7 +76,7 @@ impl RunCmd for PushCmd {
         } else if let Some(branch) = current_branch {
             branch.name
         } else {
-            return Err(OxenError::basic_str("Cannot push from non-existant branch"));
+            return Err(OxenError::basic_str("Cannot push from non-existent branch"));
         };
 
         let opts = PushOpts {

--- a/oxen-rust/src/cli/src/cmd/push.rs
+++ b/oxen-rust/src/cli/src/cmd/push.rs
@@ -76,9 +76,7 @@ impl RunCmd for PushCmd {
         } else if let Some(branch) = current_branch {
             branch.name
         } else {
-            return Err(OxenError::basic_str(
-                "Error: Cannot push from non-existant branch",
-            ));
+            return Err(OxenError::basic_str("Cannot push from non-existant branch"));
         };
 
         let opts = PushOpts {
@@ -114,10 +112,7 @@ impl RunCmd for PushCmd {
                     let msg = format!("{branch}\nMake sure you are on the correct branch and have committed your changes.");
                     Err(OxenError::basic_str(msg))
                 }
-                Err(e) => {
-                    println!("Error pushing: {e}");
-                    Err(e)
-                }
+                Err(e) => Err(e),
             }
         }
     }

--- a/oxen-rust/src/lib/src/core/v_latest/push.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/push.rs
@@ -152,7 +152,7 @@ async fn push_to_existing_branch(
             } else {
                 //we're behind
                 let err_str = format!(
-                    "Branch {} is behind {} must pull.\n\nRun `oxen pull` to update your local branch",
+                    "Branch {} is behind remote commit {}.\nRun `oxen pull` to update your local branch",
                     remote_branch.name, remote_branch.commit_id
                 );
                 return Err(OxenError::basic_str(err_str));


### PR DESCRIPTION
This is in response to a Linear issue where it apparently wasn't clear to a user why they couldn't push to a repo. They weren't getting a message that their repo was behind when they made a commit to it with a workspace remotely.

When I test it now, I do get that error message and it's clear what to do, so I think this was probably deprecated with the push refactor. However, I did notice that the printed error message was duplicated, so this corrects that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typo and clarified error when pushing from a non-existent branch.
  * Improved message when a local branch is behind the remote to include the specific commit ID.
  * Removed redundant/duplicate error output so failed pushes report errors cleanly without extra prints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->