### PR TITLE
Gs/add video thumbnails

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install system dependencies (Linux)
         run: |
           sudo apt-get update
-          apt install -y clang libavcodec-dev libavformat-dev libavutil-dev pkg-config
+          sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev pkg-config
 
       - name: Cargo Check
         run: |

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -34,6 +34,11 @@ jobs:
             oxen-rust
             oxen-python
 
+      - name: Install system dependencies (Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev pkg-config
+
       - name: Cargo Check
         run: |
           cd ${{ github.workspace }}/oxen-rust

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install system dependencies (Linux)
         run: |
           sudo apt-get update
-          sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev pkg-config
+          sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev pkg-config
 
       - name: Cargo Check
         run: |

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install system dependencies (Linux)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev pkg-config
+          sudo apt-get install -y nasm libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev pkg-config
 
       - name: Cargo Check
         run: |

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install system dependencies (Linux)
         run: |
           sudo apt-get update
-          sudo apt-get install -y nasm libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev pkg-config
+          apt install -y clang libavcodec-dev libavformat-dev libavutil-dev pkg-config
 
       - name: Cargo Check
         run: |

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install system dependencies (Linux)
         run: |
           sudo apt-get update
-          sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev pkg-config
+          sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev pkg-config
 
       - name: Cargo Check
         run: |

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -134,12 +134,7 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           cd ${{ github.workspace }}\oxen-rust
-          .\target\debug\oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
-          echo "=== After adding user ==="
-          dir
-          echo "=== Checking target\debug\ directory ==="
-          dir .\target\debug\
-          copy .\target\debug\user_config.toml .\data\test\config\user_config.toml
+          Set-Content -Path .\data\test\config\user_config.toml -Value "name = `"Ox`"`nemail = `"ox@oxen.ai`""
 
       - name: Run oxen-rust tests (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -75,6 +75,17 @@ jobs:
           brew install ffmpeg imagemagick redis
           brew services start redis
 
+      - name: Install dependencies (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev pkg-config
+
+      - name: Install dependencies (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          choco install ffmpeg -y
+
       - name: Install nextest runner
         uses: taiki-e/install-action@nextest
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -82,7 +82,7 @@ jobs:
         if: matrix.platform == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev pkg-config
+          sudo apt-get install -y nasm libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev pkg-config
 
       - name: Install dependencies (Windows)
         if: matrix.platform == 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -75,10 +75,14 @@ jobs:
         if: matrix.platform == 'macos'
         run: |
           brew update
-          brew install ffmpeg@7 imagemagick redis pkg-config
+          brew install redis pkg-config
           brew services start redis
+          
+          # NOTE: This adds a lot of bloat and takes a long time to build.
+          #       we have ffmpeg disabled by default in the CI pipeline
           # Set PKG_CONFIG_PATH so pkg-config can find FFmpeg libraries
-          echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          # brew install ffmpeg@7 imagemagick
+          # echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
       - name: Install dependencies (Linux)
         if: matrix.platform == 'linux'
@@ -86,52 +90,32 @@ jobs:
           sudo apt-get update
           sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev pkg-config
 
-      - name: Install dependencies (Windows)
-        if: matrix.platform == 'windows'
-        run: |
-          echo "=== Before installing dependencies ==="
-          Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{Label="Used(GB)";Expression={[math]::Round($_.Used/1GB,2)}}, @{Label="Free(GB)";Expression={[math]::Round($_.Free/1GB,2)}}, @{Label="Total(GB)";Expression={[math]::Round(($_.Used+$_.Free)/1GB,2)}}
+      # NOTE: This adds a lot of bloat to the Windows image and takes a long time to build.
+      #       we have ffmpeg disabled by default in the CI pipeline
+      # - name: Install dependencies (Windows)
+      #   if: matrix.platform == 'windows'
+      #   run: |
+      #     # Install clang (via llvm) and pkg-config via Chocolatey
+      #     choco install -y llvm pkgconfiglite
           
-          # Install clang (via llvm) and pkg-config via Chocolatey
-          choco install -y llvm pkgconfiglite
+      #     # Install vcpkg for FFmpeg static development libraries (libavcodec, libavformat, libavutil, libavfilter, libavdevice)
+      #     # Using x64-windows-static-md for static libraries with dynamic MSVC runtime (better compatibility)
+      #     git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+      #     cd C:\vcpkg
+      #     .\bootstrap-vcpkg.bat
           
-          # Install vcpkg for FFmpeg static development libraries (libavcodec, libavformat, libavutil, libavfilter, libavdevice)
-          # Using x64-windows-static-md for static libraries with dynamic MSVC runtime (better compatibility)
-          git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
-          cd C:\vcpkg
-          .\bootstrap-vcpkg.bat
+      #     # Install FFmpeg (includes libavutil, libavcodec, libavformat, libavfilter, libavdevice)
+      #     # FFmpeg installation provides libavutil.pc and other .pc files needed by pkg-config
+      #     .\vcpkg.exe install ffmpeg:x64-windows-static-md
           
-          # Install FFmpeg (includes libavutil, libavcodec, libavformat, libavfilter, libavdevice)
-          # FFmpeg installation provides libavutil.pc and other .pc files needed by pkg-config
-          .\vcpkg.exe install ffmpeg:x64-windows-static-md
+      #     # Set VCPKG_ROOT for cargo to find FFmpeg libraries
+      #     echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
           
-          # Set VCPKG_ROOT for cargo to find FFmpeg libraries
-          echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
-          
-          # Set PKG_CONFIG_PATH so pkg-config can find libavutil.pc and other FFmpeg .pc files
-          # vcpkg installs pkg-config files in the installed/<triplet>/lib/pkgconfig directory
-          # This must be set before cargo build runs, as ffmpeg-sys-next uses pkg-config during build
-          $pkgConfigPath = "C:\vcpkg\installed\x64-windows-static-md\lib\pkgconfig"
-          echo "PKG_CONFIG_PATH=$pkgConfigPath" >> $env:GITHUB_ENV
-          
-          # Debug: Print contents of PKG_CONFIG_PATH directory
-          echo "=== PKG_CONFIG_PATH directory contents ==="
-          if (Test-Path $pkgConfigPath) {
-            echo "Directory exists: $pkgConfigPath"
-            Get-ChildItem -Path $pkgConfigPath -Filter "*.pc" | ForEach-Object {
-              echo "  - $($_.Name)"
-            }
-            echo "Total .pc files found: $((Get-ChildItem -Path $pkgConfigPath -Filter '*.pc').Count)"
-          } else {
-            echo "WARNING: PKG_CONFIG_PATH directory does not exist: $pkgConfigPath"
-            echo "Searching for .pc files in vcpkg installed directory..."
-            Get-ChildItem -Path "C:\vcpkg\installed" -Recurse -Filter "*.pc" -ErrorAction SilentlyContinue | Select-Object -First 10 | ForEach-Object {
-              echo "  Found: $($_.FullName)"
-            }
-          }
-          
-          echo "=== After installing dependencies ==="
-          Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{Label="Used(GB)";Expression={[math]::Round($_.Used/1GB,2)}}, @{Label="Free(GB)";Expression={[math]::Round($_.Free/1GB,2)}}, @{Label="Total(GB)";Expression={[math]::Round(($_.Used+$_.Free)/1GB,2)}}
+      #     # Set PKG_CONFIG_PATH so pkg-config can find libavutil.pc and other FFmpeg .pc files
+      #     # vcpkg installs pkg-config files in the installed/<triplet>/lib/pkgconfig directory
+      #     # This must be set before cargo build runs, as ffmpeg-sys-next uses pkg-config during build
+      #     $pkgConfigPath = "C:\vcpkg\installed\x64-windows-static-md\lib\pkgconfig"
+      #     echo "PKG_CONFIG_PATH=$pkgConfigPath" >> $env:GITHUB_ENV
 
       - name: Install nextest runner
         uses: taiki-e/install-action@nextest
@@ -166,7 +150,8 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           cd ${{ github.workspace }}\oxen-rust
-          Set-Content -Path .\data\test\config\user_config.toml -Value "name = `"Ox`"`nemail = `"ox@oxen.ai`""
+          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          copy user_config.toml data\test\config\user_config.toml
 
       - name: Run oxen-rust tests (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -137,7 +137,9 @@ jobs:
           .\target\debug\oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
           echo "=== After adding user ==="
           dir
-          copy user_config.toml data\test\config\user_config.toml
+          echo "=== Checking target\debug\ directory ==="
+          dir .\target\debug\
+          copy .\target\debug\user_config.toml .\data\test\config\user_config.toml
 
       - name: Run oxen-rust tests (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -149,8 +149,22 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           cd ${{ github.workspace }}\oxen-rust
-          Start-Process -FilePath "${{ github.workspace }}\oxen-rust\target\debug\oxen-server.exe" -WindowStyle Hidden -ArgumentList "start"
+          # Start server and redirect output to log files so we can see what's happening
+          $serverLog = "${{ github.workspace }}\oxen-rust\server.log"
+          $serverErr = "${{ github.workspace }}\oxen-rust\server.err"
+          Start-Process -FilePath "${{ github.workspace }}\oxen-rust\target\debug\oxen-server.exe" -WindowStyle Hidden -ArgumentList "start" -RedirectStandardOutput $serverLog -RedirectStandardError $serverErr
+          # Wait a moment for server to start, then show logs
+          Start-Sleep -Seconds 2
+          Write-Host "=== Server Output ==="
+          Get-Content $serverLog -ErrorAction SilentlyContinue
+          Write-Host "=== Server Errors ==="
+          Get-Content $serverErr -ErrorAction SilentlyContinue
           cargo nextest run --profile ci
+          # Show logs again after tests in case there were errors
+          Write-Host "=== Server Output (after tests) ==="
+          Get-Content $serverLog -ErrorAction SilentlyContinue
+          Write-Host "=== Server Errors (after tests) ==="
+          Get-Content $serverErr -ErrorAction SilentlyContinue
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -28,7 +28,10 @@ jobs:
 
           # Remove unnecessary tools and files to free up space
           sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/share/powershell
           sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
 
           # Clean apt cache
@@ -84,6 +87,9 @@ jobs:
       - name: Install dependencies (Windows)
         if: matrix.platform == 'windows'
         run: |
+          echo "=== Before installing dependencies ==="
+          Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{Label="Used(GB)";Expression={[math]::Round($_.Used/1GB,2)}}, @{Label="Free(GB)";Expression={[math]::Round($_.Free/1GB,2)}}, @{Label="Total(GB)";Expression={[math]::Round(($_.Used+$_.Free)/1GB,2)}}
+          
           # Install vcpkg for FFmpeg development libraries
           git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
           cd C:\vcpkg
@@ -91,6 +97,9 @@ jobs:
           .\vcpkg.exe install ffmpeg:x64-windows
           # Set VCPKG_ROOT for cargo to find FFmpeg libraries
           echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
+          
+          echo "=== After installing dependencies ==="
+          Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{Label="Used(GB)";Expression={[math]::Round($_.Used/1GB,2)}}, @{Label="Free(GB)";Expression={[math]::Round($_.Free/1GB,2)}}, @{Label="Total(GB)";Expression={[math]::Round(($_.Used+$_.Free)/1GB,2)}}
 
       - name: Install nextest runner
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -92,11 +92,15 @@ jobs:
           echo "=== Before installing dependencies ==="
           Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{Label="Used(GB)";Expression={[math]::Round($_.Used/1GB,2)}}, @{Label="Free(GB)";Expression={[math]::Round($_.Free/1GB,2)}}, @{Label="Total(GB)";Expression={[math]::Round(($_.Used+$_.Free)/1GB,2)}}
           
-          # Install vcpkg for FFmpeg development libraries
+          # Install clang (via llvm) and pkg-config via Chocolatey
+          choco install -y llvm pkgconfiglite
+          
+          # Install vcpkg for FFmpeg static development libraries (libavcodec, libavformat, libavutil, libavfilter, libavdevice)
+          # Using x64-windows-static-md for static libraries with dynamic MSVC runtime (better compatibility)
           git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
           cd C:\vcpkg
           .\bootstrap-vcpkg.bat
-          .\vcpkg.exe install ffmpeg:x64-windows
+          .\vcpkg.exe install ffmpeg:x64-windows-static-md
           # Set VCPKG_ROOT for cargo to find FFmpeg libraries
           echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
           
@@ -149,22 +153,8 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           cd ${{ github.workspace }}\oxen-rust
-          # Start server and redirect output to log files so we can see what's happening
-          $serverLog = "${{ github.workspace }}\oxen-rust\server.log"
-          $serverErr = "${{ github.workspace }}\oxen-rust\server.err"
-          Start-Process -FilePath "${{ github.workspace }}\oxen-rust\target\debug\oxen-server.exe" -WindowStyle Hidden -ArgumentList "start" -RedirectStandardOutput $serverLog -RedirectStandardError $serverErr
-          # Wait a moment for server to start, then show logs
-          Start-Sleep -Seconds 2
-          Write-Host "=== Server Output ==="
-          Get-Content $serverLog -ErrorAction SilentlyContinue
-          Write-Host "=== Server Errors ==="
-          Get-Content $serverErr -ErrorAction SilentlyContinue
+          Start-Process -FilePath "${{ github.workspace }}\oxen-rust\target\debug\oxen-server.exe" -WindowStyle Hidden -ArgumentList "start"
           cargo nextest run --profile ci
-          # Show logs again after tests in case there were errors
-          Write-Host "=== Server Output (after tests) ==="
-          Get-Content $serverLog -ErrorAction SilentlyContinue
-          Write-Host "=== Server Errors (after tests) ==="
-          Get-Content $serverErr -ErrorAction SilentlyContinue
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -103,6 +103,11 @@ jobs:
           cd ${{ github.workspace }}\oxen-rust
           mkdir .\data\test\runs
 
+      - name: Set FFMPEG_STATIC for Windows
+        if: matrix.platform == 'windows'
+        run: |
+          echo "FFMPEG_STATIC=1" >> $env:GITHUB_ENV
+
       - name: Build oxen-rust
         run: |
           cd ${{ github.workspace }}/oxen-rust

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -77,12 +77,14 @@ jobs:
           brew update
           brew install ffmpeg@7 imagemagick redis pkg-config
           brew services start redis
+          # Set PKG_CONFIG_PATH so pkg-config can find FFmpeg libraries
+          echo "PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
       - name: Install dependencies (Linux)
         if: matrix.platform == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y nasm libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev pkg-config
+          sudo apt install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev pkg-config
 
       - name: Install dependencies (Windows)
         if: matrix.platform == 'windows'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -75,7 +75,7 @@ jobs:
         if: matrix.platform == 'macos'
         run: |
           brew update
-          brew install ffmpeg@7 imagemagick redis
+          brew install ffmpeg@7 imagemagick redis pkg-config
           brew services start redis
 
       - name: Install dependencies (Linux)

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -75,7 +75,7 @@ jobs:
         if: matrix.platform == 'macos'
         run: |
           brew update
-          brew install ffmpeg imagemagick redis
+          brew install ffmpeg@7 imagemagick redis
           brew services start redis
 
       - name: Install dependencies (Linux)

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -84,7 +84,13 @@ jobs:
       - name: Install dependencies (Windows)
         if: matrix.platform == 'windows'
         run: |
-          choco install ffmpeg -y
+          # Install vcpkg for FFmpeg development libraries
+          git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+          cd C:\vcpkg
+          .\bootstrap-vcpkg.bat
+          .\vcpkg.exe install ffmpeg:x64-windows
+          # Set VCPKG_ROOT for cargo to find FFmpeg libraries
+          echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
 
       - name: Install nextest runner
         uses: taiki-e/install-action@nextest
@@ -102,11 +108,6 @@ jobs:
         run: |
           cd ${{ github.workspace }}\oxen-rust
           mkdir .\data\test\runs
-
-      - name: Set FFMPEG_STATIC for Windows
-        if: matrix.platform == 'windows'
-        run: |
-          echo "FFMPEG_STATIC=1" >> $env:GITHUB_ENV
 
       - name: Build oxen-rust
         run: |

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -100,9 +100,35 @@ jobs:
           git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
           cd C:\vcpkg
           .\bootstrap-vcpkg.bat
+          
+          # Install FFmpeg (includes libavutil, libavcodec, libavformat, libavfilter, libavdevice)
+          # FFmpeg installation provides libavutil.pc and other .pc files needed by pkg-config
           .\vcpkg.exe install ffmpeg:x64-windows-static-md
+          
           # Set VCPKG_ROOT for cargo to find FFmpeg libraries
           echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
+          
+          # Set PKG_CONFIG_PATH so pkg-config can find libavutil.pc and other FFmpeg .pc files
+          # vcpkg installs pkg-config files in the installed/<triplet>/lib/pkgconfig directory
+          # This must be set before cargo build runs, as ffmpeg-sys-next uses pkg-config during build
+          $pkgConfigPath = "C:\vcpkg\installed\x64-windows-static-md\lib\pkgconfig"
+          echo "PKG_CONFIG_PATH=$pkgConfigPath" >> $env:GITHUB_ENV
+          
+          # Debug: Print contents of PKG_CONFIG_PATH directory
+          echo "=== PKG_CONFIG_PATH directory contents ==="
+          if (Test-Path $pkgConfigPath) {
+            echo "Directory exists: $pkgConfigPath"
+            Get-ChildItem -Path $pkgConfigPath -Filter "*.pc" | ForEach-Object {
+              echo "  - $($_.Name)"
+            }
+            echo "Total .pc files found: $((Get-ChildItem -Path $pkgConfigPath -Filter '*.pc').Count)"
+          } else {
+            echo "WARNING: PKG_CONFIG_PATH directory does not exist: $pkgConfigPath"
+            echo "Searching for .pc files in vcpkg installed directory..."
+            Get-ChildItem -Path "C:\vcpkg\installed" -Recurse -Filter "*.pc" -ErrorAction SilentlyContinue | Select-Object -First 10 | ForEach-Object {
+              echo "  Found: $($_.FullName)"
+            }
+          }
           
           echo "=== After installing dependencies ==="
           Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{Label="Used(GB)";Expression={[math]::Round($_.Used/1GB,2)}}, @{Label="Free(GB)";Expression={[math]::Round($_.Free/1GB,2)}}, @{Label="Total(GB)";Expression={[math]::Round(($_.Used+$_.Free)/1GB,2)}}

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -135,6 +135,8 @@ jobs:
         run: |
           cd ${{ github.workspace }}\oxen-rust
           .\target\debug\oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          echo "=== After adding user ==="
+          dir
           copy user_config.toml data\test\config\user_config.toml
 
       - name: Run oxen-rust tests (Linux/macOS)

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -104,7 +104,9 @@ jobs:
             openssl-devel \
             cmake \
             clang \
-            rubygems
+            rubygems \
+            ffmpeg-devel \
+            pkg-config
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -77,10 +77,13 @@ jobs:
       - name: Install dependencies
         run: |
           choco install -y cmake llvm uv rustup.install
-
-      - name: Set FFMPEG_STATIC for Windows
-        run: |
-          echo "FFMPEG_STATIC=1" >> $env:GITHUB_ENV
+          # Install vcpkg for FFmpeg development libraries
+          git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+          cd C:\vcpkg
+          .\bootstrap-vcpkg.bat
+          .\vcpkg.exe install ffmpeg:x64-windows
+          # Set VCPKG_ROOT for cargo to find FFmpeg libraries
+          echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
 
       - name: Build oxen binaries
         run: |

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -78,6 +78,10 @@ jobs:
         run: |
           choco install -y cmake llvm uv rustup.install
 
+      - name: Set FFMPEG_STATIC for Windows
+        run: |
+          echo "FFMPEG_STATIC=1" >> $env:GITHUB_ENV
+
       - name: Build oxen binaries
         run: |
           refreshenv

--- a/oxen-python/Cargo.lock
+++ b/oxen-python/Cargo.lock
@@ -1132,6 +1132,24 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -2503,6 +2521,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ez-ffmpeg"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8af0a973c7624368d8964ef9114ce7f4b418fe884ef5f65a600952f786a51"
+dependencies = [
+ "core-foundation 0.10.1",
+ "crossbeam",
+ "crossbeam-channel",
+ "ffmpeg-next",
+ "ffmpeg-sys-next",
+ "libc",
+ "log",
+ "objc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2599,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ffmpeg-next"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
+dependencies = [
+ "bitflags 2.10.0",
+ "ffmpeg-sys-next",
+ "libc",
+]
+
+[[package]]
+name = "ffmpeg-sys-next"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
+dependencies = [
+ "bindgen 0.70.1",
+ "cc",
+ "libc",
+ "num_cpus",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3773,6 +3833,7 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
+ "ez-ffmpeg",
  "fd-lock",
  "filetime",
  "flate2",
@@ -3834,10 +3895,11 @@ dependencies = [
  "url",
  "urlencoding",
  "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
  "walkdir",
  "xxhash-rust",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -4043,6 +4105,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4410,6 +4481,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "object"
@@ -6182,6 +6262,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.110",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7681,7 +7795,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -7695,7 +7809,25 @@ checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "actix-web",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip 3.0.0",
 ]
 
 [[package]]
@@ -8507,6 +8639,20 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.12.1",
+ "memchr",
+ "zopfli",
 ]
 
 [[package]]

--- a/oxen-python/Cargo.lock
+++ b/oxen-python/Cargo.lock
@@ -1132,24 +1132,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -1806,26 +1788,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "web-sys",
 ]
 
 [[package]]
@@ -2605,31 +2567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ffmpeg-next"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
-dependencies = [
- "bitflags 2.10.0",
- "ffmpeg-sys-next",
- "libc",
-]
-
-[[package]]
-name = "ffmpeg-sys-next"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
-dependencies = [
- "bindgen 0.70.1",
- "cc",
- "libc",
- "num_cpus",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,12 +2583,6 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -3894,7 +3825,6 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
- "thumbnails",
  "time",
  "tokio",
  "tokio-console",
@@ -4138,22 +4068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
-
-[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4330,21 +4244,6 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
 ]
 
 [[package]]
@@ -4753,47 +4652,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pdfium-render"
-version = "0.8.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6553f6604a52b3203db7b4e9d51eb4dd193cf455af9e56d40cab6575b547b679"
-dependencies = [
- "bitflags 2.10.0",
- "bytemuck",
- "bytes",
- "chrono",
- "console_error_panic_hook",
- "console_log",
- "image",
- "itertools 0.14.0",
- "js-sys",
- "libloading",
- "log",
- "maybe-owned",
- "once_cell",
- "utf16string",
- "vecmath",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap 2.12.1",
-]
 
 [[package]]
 name = "phf"
@@ -4855,12 +4717,6 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
-
-[[package]]
-name = "piston-float"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
 
 [[package]]
 name = "pkg-config"
@@ -6017,12 +5873,6 @@ checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.10.0",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -7239,22 +7089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thumbnails"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252ed8a0ffd9ed2d28e06cf629c7d7fe6e58375f344e7f2a73d7a6879e0958d0"
-dependencies = [
- "anyhow",
- "image",
- "ndarray",
- "pdfium-render",
- "tempfile",
- "tree_magic_mini",
- "video-rs",
- "zip 2.4.2",
-]
-
-[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7752,17 +7586,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_magic_mini"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
-dependencies = [
- "memchr",
- "nom 8.0.0",
- "petgraph",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7876,15 +7699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf16string"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b62a1e85e12d5d712bf47a85f426b73d303e2d00a90de5f3004df3596e9d216"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7991,31 +7805,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vecmath"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
-dependencies = [
- "piston-float",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "video-rs"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859aad7261bac267f90f9635ec9addba3b4bcb4bbb2edb03fec3e6b765657bee"
-dependencies = [
- "ffmpeg-next",
- "ndarray",
- "tracing",
- "url",
-]
 
 [[package]]
 name = "walkdir"

--- a/oxen-python/Cargo.lock
+++ b/oxen-python/Cargo.lock
@@ -1809,6 +1809,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,23 +2541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ez-ffmpeg"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b9c0f3a1253fd7c2c0520efab42f715000c68ba531530e70018dad03e6f307"
-dependencies = [
- "core-foundation 0.10.1",
- "crossbeam",
- "crossbeam-channel",
- "ffmpeg-next",
- "ffmpeg-sys-next",
- "libc",
- "log",
- "objc",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2646,12 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -3833,7 +3842,6 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
- "ez-ffmpeg",
  "fd-lock",
  "filetime",
  "flate2",
@@ -3886,6 +3894,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
+ "thumbnails",
  "time",
  "tokio",
  "tokio-console",
@@ -4108,15 +4117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4136,6 +4136,22 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -4317,6 +4333,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4481,15 +4512,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
 
 [[package]]
 name = "object"
@@ -4731,10 +4753,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdfium-render"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6553f6604a52b3203db7b4e9d51eb4dd193cf455af9e56d40cab6575b547b679"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "console_error_panic_hook",
+ "console_log",
+ "image",
+ "itertools 0.14.0",
+ "js-sys",
+ "libloading",
+ "log",
+ "maybe-owned",
+ "once_cell",
+ "utf16string",
+ "vecmath",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.12.1",
+]
 
 [[package]]
 name = "phf"
@@ -4796,6 +4855,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "piston-float"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
 
 [[package]]
 name = "pkg-config"
@@ -5952,6 +6017,12 @@ checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.10.0",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -7168,6 +7239,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "thumbnails"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252ed8a0ffd9ed2d28e06cf629c7d7fe6e58375f344e7f2a73d7a6879e0958d0"
+dependencies = [
+ "anyhow",
+ "image",
+ "ndarray",
+ "pdfium-render",
+ "tempfile",
+ "tree_magic_mini",
+ "video-rs",
+ "zip 2.4.2",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7665,6 +7752,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7778,6 +7876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf16string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b62a1e85e12d5d712bf47a85f426b73d303e2d00a90de5f3004df3596e9d216"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7884,10 +7991,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vecmath"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
+dependencies = [
+ "piston-float",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "video-rs"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859aad7261bac267f90f9635ec9addba3b4bcb4bbb2edb03fec3e6b765657bee"
+dependencies = [
+ "ffmpeg-next",
+ "ndarray",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "walkdir"

--- a/oxen-python/Cargo.lock
+++ b/oxen-python/Cargo.lock
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",
@@ -1143,16 +1143,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.110",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.72.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",
@@ -2521,6 +2521,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ez-ffmpeg"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b9c0f3a1253fd7c2c0520efab42f715000c68ba531530e70018dad03e6f307"
+dependencies = [
+ "core-foundation 0.10.1",
+ "crossbeam",
+ "crossbeam-channel",
+ "ffmpeg-next",
+ "ffmpeg-sys-next",
+ "libc",
+ "log",
+ "objc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "8.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d658424d233cbd993a972dd73a66ca733acd12a494c68995c9ac32ae1fe65b40"
+checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
 dependencies = [
  "bitflags 2.10.0",
  "ffmpeg-sys-next",
@@ -2597,11 +2614,11 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "8.0.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bca20aa4ee774fe384c2490096c122b0b23cf524a9910add0686691003d797b"
+checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen 0.70.1",
  "cc",
  "libc",
  "num_cpus",
@@ -3816,8 +3833,8 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
+ "ez-ffmpeg",
  "fd-lock",
- "ffmpeg-next",
  "filetime",
  "flate2",
  "fs_extra",
@@ -4088,6 +4105,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4455,6 +4481,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "object"

--- a/oxen-python/Cargo.lock
+++ b/oxen-python/Cargo.lock
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",
@@ -1143,16 +1143,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.110",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",
@@ -2521,23 +2521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ez-ffmpeg"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8af0a973c7624368d8964ef9114ce7f4b418fe884ef5f65a600952f786a51"
-dependencies = [
- "core-foundation 0.10.1",
- "crossbeam",
- "crossbeam-channel",
- "ffmpeg-next",
- "ffmpeg-sys-next",
- "libc",
- "log",
- "objc",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "7.1.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
+checksum = "d658424d233cbd993a972dd73a66ca733acd12a494c68995c9ac32ae1fe65b40"
 dependencies = [
  "bitflags 2.10.0",
  "ffmpeg-sys-next",
@@ -2614,11 +2597,11 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "7.1.3"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
+checksum = "9bca20aa4ee774fe384c2490096c122b0b23cf524a9910add0686691003d797b"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen 0.72.1",
  "cc",
  "libc",
  "num_cpus",
@@ -3833,8 +3816,8 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
- "ez-ffmpeg",
  "fd-lock",
+ "ffmpeg-next",
  "filetime",
  "flate2",
  "fs_extra",
@@ -4105,15 +4088,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -4481,15 +4455,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
 
 [[package]]
 name = "object"

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -40,8 +40,8 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
+ "ez-ffmpeg",
  "fd-lock",
- "ffmpeg-next",
  "filetime",
  "flate2",
  "fs_extra",
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.72.1"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
@@ -1268,7 +1268,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.104",
 ]
@@ -2641,6 +2641,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ez-ffmpeg"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b9c0f3a1253fd7c2c0520efab42f715000c68ba531530e70018dad03e6f307"
+dependencies = [
+ "core-foundation 0.10.1",
+ "crossbeam",
+ "crossbeam-channel",
+ "ffmpeg-next",
+ "ffmpeg-sys-next",
+ "libc",
+ "log",
+ "objc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "8.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d658424d233cbd993a972dd73a66ca733acd12a494c68995c9ac32ae1fe65b40"
+checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
 dependencies = [
  "bitflags 2.9.1",
  "ffmpeg-sys-next",
@@ -2697,11 +2714,11 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "8.0.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bca20aa4ee774fe384c2490096c122b0b23cf524a9910add0686691003d797b"
+checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen 0.70.1",
  "cc",
  "libc",
  "num_cpus",
@@ -3947,8 +3964,8 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
+ "ez-ffmpeg",
  "fd-lock",
- "ffmpeg-next",
  "filetime",
  "flate2",
  "fs_extra",
@@ -4224,6 +4241,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4557,6 +4583,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "object"

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
+ "ez-ffmpeg",
  "fd-lock",
  "filetime",
  "flate2",
@@ -1246,6 +1247,24 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2622,6 +2641,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ez-ffmpeg"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8af0a973c7624368d8964ef9114ce7f4b418fe884ef5f65a600952f786a51"
+dependencies = [
+ "core-foundation 0.10.1",
+ "crossbeam",
+ "crossbeam-channel",
+ "ffmpeg-next",
+ "ffmpeg-sys-next",
+ "libc",
+ "log",
+ "objc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,6 +2699,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ffmpeg-next"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
+dependencies = [
+ "bitflags 2.9.1",
+ "ffmpeg-sys-next",
+ "libc",
+]
+
+[[package]]
+name = "ffmpeg-sys-next"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
+dependencies = [
+ "bindgen 0.70.1",
+ "cc",
+ "libc",
+ "num_cpus",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3903,6 +3964,7 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
+ "ez-ffmpeg",
  "fd-lock",
  "filetime",
  "flate2",
@@ -3989,7 +4051,7 @@ version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "bzip2-sys",
  "cc",
  "glob",
@@ -4179,6 +4241,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4514,6 +4585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,6 +4791,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "url",
+ "utoipa",
  "uuid",
 ]
 

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -42,6 +42,8 @@ dependencies = [
  "env_logger",
  "ez-ffmpeg",
  "fd-lock",
+ "ffmpeg-next",
+ "ffmpeg-sys-next",
  "filetime",
  "flate2",
  "fs_extra",

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "env_logger",
  "fd-lock",
  "ffmpeg-next",
- "ffmpeg-sys-next",
  "filetime",
  "flate2",
  "fs_extra",

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "env_logger",
  "fd-lock",
  "ffmpeg-next",
+ "ffmpeg-sys-next",
  "filetime",
  "flate2",
  "fs_extra",

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -40,8 +40,8 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
- "ez-ffmpeg",
  "fd-lock",
+ "ffmpeg-next",
  "filetime",
  "flate2",
  "fs_extra",
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
@@ -1268,7 +1268,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.104",
 ]
@@ -2641,23 +2641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ez-ffmpeg"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8af0a973c7624368d8964ef9114ce7f4b418fe884ef5f65a600952f786a51"
-dependencies = [
- "core-foundation 0.10.1",
- "crossbeam",
- "crossbeam-channel",
- "ffmpeg-next",
- "ffmpeg-sys-next",
- "libc",
- "log",
- "objc",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "7.1.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
+checksum = "d658424d233cbd993a972dd73a66ca733acd12a494c68995c9ac32ae1fe65b40"
 dependencies = [
  "bitflags 2.9.1",
  "ffmpeg-sys-next",
@@ -2714,11 +2697,11 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "7.1.3"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
+checksum = "9bca20aa4ee774fe384c2490096c122b0b23cf524a9910add0686691003d797b"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen 0.72.1",
  "cc",
  "libc",
  "num_cpus",
@@ -3964,8 +3947,8 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
- "ez-ffmpeg",
  "fd-lock",
+ "ffmpeg-next",
  "filetime",
  "flate2",
  "fs_extra",
@@ -4241,15 +4224,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -4583,15 +4557,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
 
 [[package]]
 name = "object"

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -40,7 +40,6 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
- "ez-ffmpeg",
  "fd-lock",
  "filetime",
  "flate2",
@@ -99,6 +98,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
+ "thumbnails",
  "time",
  "tokio",
  "tokio-console",
@@ -1138,7 +1138,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom",
+ "nom 7.1.3",
  "num-rational",
  "v_frame",
 ]
@@ -1593,7 +1593,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1983,6 +1983,26 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
 ]
 
 [[package]]
@@ -2641,23 +2661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ez-ffmpeg"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b9c0f3a1253fd7c2c0520efab42f715000c68ba531530e70018dad03e6f307"
-dependencies = [
- "core-foundation 0.10.1",
- "crossbeam",
- "crossbeam-channel",
- "ffmpeg-next",
- "ffmpeg-sys-next",
- "libc",
- "log",
- "objc",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2740,12 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -3143,7 +3152,7 @@ dependencies = [
  "base64 0.21.7",
  "byteorder",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -3964,7 +3973,6 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
- "ez-ffmpeg",
  "fd-lock",
  "filetime",
  "flate2",
@@ -4018,6 +4026,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
+ "thumbnails",
  "time",
  "tokio",
  "tokio-console",
@@ -4244,15 +4253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4266,6 +4266,22 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -4428,6 +4444,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,6 +4472,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4583,15 +4623,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
 
 [[package]]
 name = "object"
@@ -4872,6 +4903,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdfium-render"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6553f6604a52b3203db7b4e9d51eb4dd193cf455af9e56d40cab6575b547b679"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "console_error_panic_hook",
+ "console_log",
+ "image",
+ "itertools 0.14.0",
+ "js-sys",
+ "libloading",
+ "log",
+ "maybe-owned",
+ "once_cell",
+ "utf16string",
+ "vecmath",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4886,6 +4943,17 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.4",
+ "indexmap 2.10.0",
+]
 
 [[package]]
 name = "phf"
@@ -4947,6 +5015,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "piston-float"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
 
 [[package]]
 name = "pkg-config"
@@ -5974,6 +6048,12 @@ checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -7258,6 +7338,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "thumbnails"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252ed8a0ffd9ed2d28e06cf629c7d7fe6e58375f344e7f2a73d7a6879e0958d0"
+dependencies = [
+ "anyhow",
+ "image",
+ "ndarray",
+ "pdfium-render",
+ "tempfile",
+ "tree_magic_mini",
+ "video-rs",
+ "zip 2.4.2",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7678,6 +7774,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7782,6 +7889,15 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf16string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b62a1e85e12d5d712bf47a85f426b73d303e2d00a90de5f3004df3596e9d216"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "utf8_iter"
@@ -7896,6 +8012,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vecmath"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
+dependencies = [
+ "piston-float",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7906,6 +8031,18 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "video-rs"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859aad7261bac267f90f9635ec9addba3b4bcb4bbb2edb03fec3e6b765657bee"
+dependencies = [
+ "ffmpeg-next",
+ "ndarray",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "walkdir"

--- a/oxen-rust/Cargo.lock
+++ b/oxen-rust/Cargo.lock
@@ -42,8 +42,6 @@ dependencies = [
  "env_logger",
  "ez-ffmpeg",
  "fd-lock",
- "ffmpeg-next",
- "ffmpeg-sys-next",
  "filetime",
  "flate2",
  "fs_extra",

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -63,6 +63,9 @@ dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.11.3"
 ez-ffmpeg = "*"
+# Force a new-enough ffmpeg-next & ffmpeg-sys-next and let them build FFmpeg
+ffmpeg-next = { version = "7", features = ["build"] }
+ffmpeg-sys-next = { version = "7", features = ["build"] }
 fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -19,6 +19,7 @@ categories = [
 [features]
 default = ["duckdb/bundled"]
 docs = ["duckdb"]
+ffmpeg = ["thumbnails"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -62,7 +63,7 @@ dirs = "5.0.1"
 dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.11.3"
-thumbnails = "0.2.1"
+thumbnails = { version = "0.2.1", optional = true }
 fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -62,7 +62,7 @@ dirs = "5.0.1"
 dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.11.3"
-ez-ffmpeg = "0.5.6"
+ffmpeg-next = "8.0.0"
 fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -62,7 +62,7 @@ dirs = "5.0.1"
 dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.11.3"
-ffmpeg-next = "8.0.0"
+ez-ffmpeg = "*"
 fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -62,10 +62,10 @@ dirs = "5.0.1"
 dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.11.3"
-ez-ffmpeg = "*"
+ez-ffmpeg = {version="*", features = ["static"] }
 # Force a new-enough ffmpeg-next & ffmpeg-sys-next and let them build FFmpeg
-ffmpeg-next = { version = "7", features = ["build"] }
-ffmpeg-sys-next = { version = "7", features = ["build"] }
+ffmpeg-next = { version = "7.1.0", features = ["build"] }
+ffmpeg-sys-next = { version = "7.1.0", features = ["build"] }
 fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -195,11 +195,5 @@ name = "benchmark"
 path = "src/benches/benchmark.rs"
 harness = false
 
-# Windows-specific dependency configuration to build FFmpeg from source
-[target.'cfg(windows)'.dependencies]
-ffmpeg-next = { version = "8.0.0", default-features = false, features = ["build"] }
-ffmpeg-sys-next = { version = "8.0.0", default-features = false, features = ["build"] }
-
-
 [package.metadata.cargo-machete]
 ignored = ["astral-tokio-tar", "libduckdb-sys"]

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -62,7 +62,7 @@ dirs = "5.0.1"
 dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.11.3"
-ez-ffmpeg = {version="0.6.0" }
+thumbnails = "0.2.1"
 fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -62,7 +62,7 @@ dirs = "5.0.1"
 dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.11.3"
-# ffmpeg-next = { version = "6.0.0", features = ["codec", "format"] }
+ez-ffmpeg = "0.5.6"
 fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -62,10 +62,7 @@ dirs = "5.0.1"
 dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.11.3"
-ez-ffmpeg = {version="*", features = ["static"] }
-# Force a new-enough ffmpeg-next & ffmpeg-sys-next and let them build FFmpeg
-ffmpeg-next = { version = "7.1.0", features = ["build"] }
-ffmpeg-sys-next = { version = "7.1.0", features = ["build"] }
+ez-ffmpeg = {version="0.6.0" }
 fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/Cargo.toml
+++ b/oxen-rust/Cargo.toml
@@ -195,5 +195,11 @@ name = "benchmark"
 path = "src/benches/benchmark.rs"
 harness = false
 
+# Windows-specific dependency configuration to build FFmpeg from source
+[target.'cfg(windows)'.dependencies]
+ffmpeg-next = { version = "8.0.0", default-features = false, features = ["build"] }
+ffmpeg-sys-next = { version = "8.0.0", default-features = false, features = ["build"] }
+
+
 [package.metadata.cargo-machete]
 ignored = ["astral-tokio-tar", "libduckdb-sys"]

--- a/oxen-rust/Dockerfile
+++ b/oxen-rust/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update \
 
 WORKDIR /usr/src/oxen-server
 COPY . .
-RUN cargo build --release
+RUN cargo build --release --features ffmpeg
 
 # Minimal image to run the binary (without Rust toolchain)
 FROM debian:bookworm-slim AS runtime

--- a/oxen-rust/README.md
+++ b/oxen-rust/README.md
@@ -12,11 +12,6 @@ The documentation for the Oxen.ai tool chain can be found [here](https://docs.ox
 
 # ✅ TODO
 
-- [ ] Hugging face compatible APIs
-  - [ ] Upload model to hub
-  - [ ] Download model with `transformers` library
-  - [ ] Upload dataset to hub
-  - [ ] Download dataset with `datasets` library
 - [ ] Configurable storage backends
   - [x] Local filesystem
   - [ ] S3
@@ -361,3 +356,12 @@ cargo bench -- --save-baseline bench
 ```
 
 Which would then store the benchmark under `target/criterion/add`
+
+## Enable ffmpeg
+
+To enable thumbnailing for videos, you will have to build with ffmpeg enabled
+
+```
+brew install ffmpeg@7
+cargo build --features ffmpeg
+```

--- a/oxen-rust/src/lib/Cargo.toml
+++ b/oxen-rust/src/lib/Cargo.toml
@@ -52,8 +52,8 @@ duckdb = { package = "duckdb", version = "=1.1.1", default-features = false, opt
     "serde_json",
 ] }
 env_logger = "0.11.3"
+ez-ffmpeg = "0.5.6"
 parking_lot = "0.12.1"
-# ffmpeg-next = { version = "6.0.0", features = ["codec", "format"] }
 fd-lock = "4.0.1"
 filetime = "0.2.16"
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-ng"] }

--- a/oxen-rust/src/lib/Cargo.toml
+++ b/oxen-rust/src/lib/Cargo.toml
@@ -52,7 +52,7 @@ duckdb = { package = "duckdb", version = "=1.1.1", default-features = false, opt
     "serde_json",
 ] }
 env_logger = "0.11.3"
-ez-ffmpeg = "*"
+thumbnails = "0.2.1"
 parking_lot = "0.12.1"
 fd-lock = "4.0.1"
 filetime = "0.2.16"

--- a/oxen-rust/src/lib/Cargo.toml
+++ b/oxen-rust/src/lib/Cargo.toml
@@ -19,6 +19,7 @@ categories = [
 [features]
 default = ["duckdb/bundled"]
 docs = ["duckdb"]
+ffmpeg = ["thumbnails"]
 
 [dependencies]
 actix-web = { version = "4", features = ["rustls"] }
@@ -52,7 +53,7 @@ duckdb = { package = "duckdb", version = "=1.1.1", default-features = false, opt
     "serde_json",
 ] }
 env_logger = "0.11.3"
-thumbnails = "0.2.1"
+thumbnails = { version = "0.2.1", optional = true }
 parking_lot = "0.12.1"
 fd-lock = "4.0.1"
 filetime = "0.2.16"

--- a/oxen-rust/src/lib/Cargo.toml
+++ b/oxen-rust/src/lib/Cargo.toml
@@ -52,7 +52,7 @@ duckdb = { package = "duckdb", version = "=1.1.1", default-features = false, opt
     "serde_json",
 ] }
 env_logger = "0.11.3"
-ffmpeg-next = "8.0.0"
+ez-ffmpeg = "*"
 parking_lot = "0.12.1"
 fd-lock = "4.0.1"
 filetime = "0.2.16"

--- a/oxen-rust/src/lib/Cargo.toml
+++ b/oxen-rust/src/lib/Cargo.toml
@@ -52,7 +52,7 @@ duckdb = { package = "duckdb", version = "=1.1.1", default-features = false, opt
     "serde_json",
 ] }
 env_logger = "0.11.3"
-ez-ffmpeg = "0.5.6"
+ffmpeg-next = "8.0.0"
 parking_lot = "0.12.1"
 fd-lock = "4.0.1"
 filetime = "0.2.16"

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -73,28 +73,22 @@ pub async fn get_file_with_params(
 
     let client = client::new_for_url(&url)?;
 
-    // Build query string if parameters are provided
-    let url_with_params =
-        if thumbnail.is_some() || width.is_some() || height.is_some() || timestamp.is_some() {
-            let mut query_parts = Vec::new();
-            if let Some(thumb) = thumbnail {
-                query_parts.push(format!("thumbnail={thumb}"));
-            }
-            if let Some(w) = width {
-                query_parts.push(format!("width={w}"));
-            }
-            if let Some(h) = height {
-                query_parts.push(format!("height={h}"));
-            }
-            if let Some(ts) = timestamp {
-                query_parts.push(format!("timestamp={ts}"));
-            }
-            format!("{}?{}", url, query_parts.join("&"))
-        } else {
-            url.to_string()
-        };
+    // Build query parameters only for Some(...) values
+    let mut query_params: Vec<(&str, String)> = Vec::new();
+    if let Some(thumb) = thumbnail {
+        query_params.push(("thumbnail", thumb.to_string()));
+    }
+    if let Some(w) = width {
+        query_params.push(("width", w.to_string()));
+    }
+    if let Some(h) = height {
+        query_params.push(("height", h.to_string()));
+    }
+    if let Some(ts) = timestamp {
+        query_params.push(("timestamp", ts.to_string()));
+    }
 
-    let req = client.get(&url_with_params);
+    let req = client.get(&url).query(&query_params);
 
     let res = req.send().await?;
 

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -69,7 +69,7 @@ pub async fn get_file_with_params(
     let branch = branch.as_ref();
     let path_ref = file_path.as_ref();
     let file_path = path_ref.to_str().ok_or_else(|| {
-        OxenError::basic_str(format!("Invalid UTF-8 in file path: {:?}", path_ref))
+        OxenError::basic_str(format!("Invalid UTF-8 in file path: {path_ref:?}"))
     })?;
     let uri = format!("/file/{branch}/{file_path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -67,7 +67,10 @@ pub async fn get_file_with_params(
     timestamp: Option<f64>,
 ) -> Result<Bytes, OxenError> {
     let branch = branch.as_ref();
-    let file_path = file_path.as_ref().to_str().unwrap();
+    let path_ref = file_path.as_ref();
+    let file_path = path_ref.to_str().ok_or_else(|| {
+        OxenError::basic_str(format!("Invalid UTF-8 in file path: {:?}", path_ref))
+    })?;
     let uri = format!("/file/{branch}/{file_path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -68,9 +68,9 @@ pub async fn get_file_with_params(
 ) -> Result<Bytes, OxenError> {
     let branch = branch.as_ref();
     let path_ref = file_path.as_ref();
-    let file_path = path_ref.to_str().ok_or_else(|| {
-        OxenError::basic_str(format!("Invalid UTF-8 in file path: {path_ref:?}"))
-    })?;
+    let file_path = path_ref
+        .to_str()
+        .ok_or_else(|| OxenError::basic_str(format!("Invalid UTF-8 in file path: {path_ref:?}")))?;
     let uri = format!("/file/{branch}/{file_path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 

--- a/oxen-rust/src/lib/src/api/client/file.rs
+++ b/oxen-rust/src/lib/src/api/client/file.rs
@@ -385,6 +385,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "ffmpeg")]
     async fn test_upload_video_and_get_thumbnail() -> Result<(), OxenError> {
         test::run_empty_configured_remote_repo_test(|_local_repo, remote_repo| async move {
             let branch_name = DEFAULT_BRANCH_NAME;

--- a/oxen-rust/src/lib/src/api/client/workspaces/files.rs
+++ b/oxen-rust/src/lib/src/api/client/workspaces/files.rs
@@ -1250,6 +1250,7 @@ mod tests {
     use std::path::PathBuf;
 
     use std::path::Path;
+    use tempfile::TempDir;
     use uuid;
 
     #[tokio::test]
@@ -2077,7 +2078,10 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
 
             let bounding_box_path = PathBuf::from("README.md");
-            let output_path = PathBuf::from("output.md");
+
+            // Create a temporary directory for the output file
+            let temp_dir = TempDir::new()?;
+            let output_path = temp_dir.path().join("output.md");
 
             // Download the bounding box from the base repo to a new path
             api::client::workspaces::files::download(
@@ -2090,6 +2094,7 @@ mod tests {
 
             assert!(output_path.exists());
 
+            // TempDir will automatically clean up when it goes out of scope
             Ok(remote_repo)
         })
         .await

--- a/oxen-rust/src/lib/src/core/v_latest/add.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/add.rs
@@ -978,9 +978,7 @@ pub fn get_status_and_add_file(
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
 ) -> Result<(), OxenError> {
     let relative_path = util::fs::path_relative_to_dir(dst_path, &repo.path)?;
-    if let Some(parent) = dst_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
+
     let file_name = dst_path.file_name().unwrap().to_string_lossy();
     let maybe_dir_node = None;
     let file_status =
@@ -1020,10 +1018,6 @@ pub fn stage_file_with_hash(
     let head_commit = &workspace.commit;
 
     let relative_path = util::fs::path_relative_to_dir(dst_path, base_repo.path.clone())?;
-    if let Some(parent) = dst_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
     let metadata = util::fs::metadata(data_path)?;
     let mtime = FileTime::from_last_modification_time(&metadata);
     let maybe_file_node =

--- a/oxen-rust/src/lib/src/error.rs
+++ b/oxen-rust/src/lib/src/error.rs
@@ -97,6 +97,7 @@ pub enum OxenError {
 
     // Metadata
     ImageMetadataParseError(StringError),
+    ThumbnailingNotEnabled(StringError),
 
     // SQL
     SQLParseError(StringError),
@@ -146,7 +147,9 @@ pub enum OxenError {
 impl fmt::Display for OxenError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            OxenError::OxenUpdateRequired(err) | OxenError::Basic(err) => write!(f, "{err}"),
+            OxenError::OxenUpdateRequired(err)
+            | OxenError::Basic(err)
+            | OxenError::ThumbnailingNotEnabled(err) => write!(f, "{err}"),
             _ => {
                 write!(f, "{self:?}")
             }
@@ -157,6 +160,10 @@ impl fmt::Display for OxenError {
 impl OxenError {
     pub fn basic_str(s: impl AsRef<str>) -> Self {
         OxenError::Basic(StringError::from(s.as_ref()))
+    }
+
+    pub fn thumbnailing_not_enabled(s: impl AsRef<str>) -> Self {
+        OxenError::ThumbnailingNotEnabled(StringError::from(s.as_ref()))
     }
 
     pub fn authentication(s: impl AsRef<str>) -> Self {

--- a/oxen-rust/src/lib/src/model/metadata/metadata_video.rs
+++ b/oxen-rust/src/lib/src/model/metadata/metadata_video.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct MetadataVideo {
@@ -11,6 +11,18 @@ pub struct MetadataVideoImpl {
     pub num_seconds: f64,
     pub width: usize,
     pub height: usize,
+}
+
+#[derive(Deserialize, Debug, IntoParams, ToSchema)]
+pub struct VideoThumbnail {
+    #[schema(example = 320)]
+    pub width: Option<u32>,
+    #[schema(example = 240)]
+    pub height: Option<u32>,
+    #[schema(example = 1.0)]
+    pub timestamp: Option<f64>,
+    #[schema(example = true)]
+    pub thumbnail: Option<bool>,
 }
 
 impl MetadataVideo {

--- a/oxen-rust/src/lib/src/model/repository/local_repository.rs
+++ b/oxen-rust/src/lib/src/model/repository/local_repository.rs
@@ -487,7 +487,7 @@ mod tests {
     use crate::error::OxenError;
     use crate::model::{LocalRepository, RepoNew};
     use crate::test;
-    use std::path::PathBuf;
+    use tempfile::TempDir;
 
     #[test]
     fn test_get_dirname_from_url() -> Result<(), OxenError> {
@@ -536,7 +536,8 @@ mod tests {
     // Do we want to require that?
     #[test]
     fn test_add_workspace() -> Result<(), OxenError> {
-        let repo_path = PathBuf::from("repo_path");
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path().to_path_buf();
         let mut repo = LocalRepository::new(repo_path)?;
 
         let sample_name = "sample";
@@ -553,7 +554,8 @@ mod tests {
 
     #[test]
     fn test_cannot_add_repeat_workspace() -> Result<(), OxenError> {
-        let repo_path = PathBuf::from("repo_path");
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path().to_path_buf();
         let mut repo = LocalRepository::new(repo_path)?;
 
         let sample_name = "sample";
@@ -568,7 +570,8 @@ mod tests {
 
     #[test]
     fn test_delete_workspace() -> Result<(), OxenError> {
-        let repo_path = PathBuf::from("repo_path");
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path().to_path_buf();
         let mut repo = LocalRepository::new(repo_path)?;
 
         let sample_name = "sample";

--- a/oxen-rust/src/lib/src/repositories/metadata/video.rs
+++ b/oxen-rust/src/lib/src/repositories/metadata/video.rs
@@ -26,8 +26,14 @@ pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataVideo, OxenError> 
             let video_tracks: Vec<&Mp4Track> = video
                 .tracks()
                 .values()
-                .filter(|t| t.track_type().unwrap() == TrackType::Video)
-                .collect();
+                .filter_map(|t| match t.track_type() {
+                    Ok(TrackType::Video) => Some(Ok(t)),
+                    Ok(_) => None,
+                    Err(e) => Some(Err(OxenError::basic_str(format!(
+                        "Could not get track type: {e:?}"
+                    )))),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
 
             let video = video_tracks
                 .first()

--- a/oxen-rust/src/lib/src/util/fs.rs
+++ b/oxen-rust/src/lib/src/util/fs.rs
@@ -36,7 +36,7 @@ use crate::opts::CountLinesOpts;
 use crate::storage::version_store::VersionStore;
 use crate::view::health::DiskUsage;
 use crate::{constants, util};
-use ffmpeg_next as ffmpeg;
+use ez_ffmpeg::{FfmpegContext, FfmpegScheduler, Input, Output};
 use filetime::FileTime;
 use image::{ImageFormat, ImageReader};
 
@@ -1730,7 +1730,7 @@ pub fn resize_cache_image_version_store(
     Ok(())
 }
 
-/// Generate a video thumbnail using ffmpeg-next library.
+/// Generate a video thumbnail using ez-ffmpeg library.
 /// This function extracts a frame from the video at the specified timestamp
 /// and saves it as an image thumbnail.
 fn generate_video_thumbnail_version_store(
@@ -1768,154 +1768,49 @@ fn generate_video_thumbnail_version_store(
         (None, None) => (320, 240),
     };
 
-    // Initialize FFmpeg
-    ffmpeg::init().map_err(|e| {
-        OxenError::basic_str(format!(
-            "Failed to initialize FFmpeg: {e}. Make sure ffmpeg is installed."
-        ))
-    })?;
-
-    // Open input video
-    let mut ictx = ffmpeg::format::input(version_path_str)
-        .map_err(|e| OxenError::basic_str(format!("Failed to open video file: {e}")))?;
-
-    // Find the best video stream
-    let input = ictx
-        .streams()
-        .best(ffmpeg::media::Type::Video)
-        .ok_or_else(|| OxenError::basic_str("No video stream found in file"))?;
-
-    let video_stream_index = input.index();
-    let time_base = input.time_base();
-
-    // Create decoder context
-    let context_decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())
-        .map_err(|e| OxenError::basic_str(format!("Failed to create decoder context: {e}")))?;
-    let mut decoder = context_decoder
-        .decoder()
-        .video()
-        .map_err(|e| OxenError::basic_str(format!("Failed to create video decoder: {e}")))?;
-
-    // Get original dimensions
-    let original_width = decoder.width();
-    let original_height = decoder.height();
-
-    let original_format = decoder.format();
-
-    // Calculate output dimensions maintaining aspect ratio if needed
-    let (final_width, final_height) = if output_width == 0 {
-        // Height specified, calculate width
-        let aspect_ratio = original_width as f64 / original_height as f64;
-        ((output_height as f64 * aspect_ratio) as u32, output_height)
+    // Build scale filter string
+    let scale_filter = if output_width == 0 {
+        // Height specified, maintain aspect ratio
+        format!("scale=-1:{output_height}")
     } else if output_height == 0 {
-        // Width specified, calculate height
-        let aspect_ratio = original_height as f64 / original_width as f64;
-        (output_width, (output_width as f64 * aspect_ratio) as u32)
+        // Width specified, maintain aspect ratio
+        format!("scale={output_width}:-1")
     } else {
-        (output_width, output_height)
+        format!("scale={output_width}:{output_height}")
     };
 
-    // Set up scaler to convert to RGB24 and resize
-    let mut scaler = ffmpeg::software::scaling::Context::get(
-        original_format,
-        original_width,
-        original_height,
-        ffmpeg::format::Pixel::RGB24,
-        final_width,
-        final_height,
-        ffmpeg::software::scaling::Flags::BILINEAR,
-    )
-    .map_err(|e| OxenError::basic_str(format!("Failed to create scaler: {e}")))?;
+    // Build FFmpeg context to extract frame at timestamp
+    // Convert timestamp from seconds to microseconds
+    let timestamp_us = (timestamp * 1_000_000.0) as i64;
+    // Set recording duration to a small value to capture just one frame
+    let capture_duration_us = 1_000_000i64; // 1 second
 
-    // Seek to the specified timestamp
-    // Convert timestamp to the stream's time base
-    let timestamp_pts =
-        (timestamp / time_base.denominator() as f64 * time_base.numerator() as f64) as i64;
-    ictx.seek(timestamp_pts, timestamp_pts..timestamp_pts + 1)
-        .map_err(|e| OxenError::basic_str(format!("Failed to seek to timestamp: {e}")))?;
+    let thumbnail_path_str = thumbnail_path
+        .to_str()
+        .ok_or_else(|| OxenError::basic_str("Invalid thumbnail path"))?;
 
-    // Decode frames until we get one
-    let mut frame = ffmpeg::frame::Video::empty();
-    let mut rgb_frame = ffmpeg::frame::Video::empty();
-    let mut frame_found = false;
+    // Build the context with input seeking, filter, and output
+    let context = FfmpegContext::builder()
+        .input(
+            Input::from(version_path_str)
+                .set_start_time_us(timestamp_us)
+                .set_recording_time_us(capture_duration_us),
+        )
+        .filter_desc(scale_filter.as_str())
+        .output(Output::from(thumbnail_path_str).set_max_video_frames(1))
+        .build()
+        .map_err(|e| {
+            OxenError::basic_str(format!(
+                "Failed to build FFmpeg context: {e}. Make sure ffmpeg is installed."
+            ))
+        })?;
 
-    for (stream, packet) in ictx.packets() {
-        if stream.index() == video_stream_index {
-            decoder.send_packet(&packet).map_err(|e| {
-                OxenError::basic_str(format!("Failed to send packet to decoder: {e}"))
-            })?;
-
-            if decoder.receive_frame(&mut frame).is_ok() {
-                // Scale the frame to RGB24 and desired dimensions
-                scaler
-                    .run(&frame, &mut rgb_frame)
-                    .map_err(|e| OxenError::basic_str(format!("Failed to scale frame: {e}")))?;
-
-                frame_found = true;
-            }
-        }
-        if frame_found {
-            break;
-        }
-    }
-
-    // Flush decoder
-    decoder.send_eof().ok();
-    if !frame_found && decoder.receive_frame(&mut frame).is_ok() {
-        scaler
-            .run(&frame, &mut rgb_frame)
-            .map_err(|e| OxenError::basic_str(format!("Failed to scale frame: {e}")))?;
-        frame_found = true;
-    }
-
-    if !frame_found {
-        return Err(OxenError::basic_str("Failed to extract frame from video"));
-    }
-
-    // Save the frame as an image using the image crate
-    // FFmpeg frames may have padding bytes at the end of each row for alignment.
-    // We need to copy each row individually, skipping padding, to create a contiguous buffer.
-    let width = rgb_frame.width() as usize;
-    let height = rgb_frame.height() as usize;
-    let stride = rgb_frame.stride(0); // Get the stride (may include padding)
-    let bytes_per_pixel = 3; // RGB24 = 3 bytes per pixel
-    let row_size = width * bytes_per_pixel;
-
-    // Create a contiguous buffer without padding
-    let mut image_data = Vec::with_capacity(width * height * bytes_per_pixel);
-
-    // Copy each row individually, skipping padding
-    // We use unsafe only to create properly bounded row slices, then use safe copy operations
-    unsafe {
-        let data_ptr = rgb_frame.data(0).as_ptr();
-        let total_buffer_size = stride * height;
-
-        // Create a slice covering the entire frame buffer
-        let frame_buffer = std::slice::from_raw_parts(data_ptr, total_buffer_size);
-
-        // Copy each row, skipping padding bytes
-        for row_idx in 0..height {
-            let row_start = row_idx * stride;
-            let row_end = row_start + row_size;
-            image_data.extend_from_slice(&frame_buffer[row_start..row_end]);
-        }
-    }
-
-    // Create image from the contiguous RGB data
-    let img = image::RgbImage::from_raw(width as u32, height as u32, image_data)
-        .ok_or_else(|| OxenError::basic_str("Failed to create image from frame data"))?;
-
-    // Determine format from extension
-    let format = match thumbnail_path.extension().and_then(|s| s.to_str()) {
-        Some("jpg") | Some("jpeg") => ImageFormat::Jpeg,
-        Some("png") => ImageFormat::Png,
-        Some("webp") => ImageFormat::WebP,
-        _ => ImageFormat::Jpeg, // Default to JPEG
-    };
-
-    // Save the image
-    img.save_with_format(thumbnail_path, format)
-        .map_err(|e| OxenError::basic_str(format!("Failed to save thumbnail image: {e}")))?;
+    // Execute FFmpeg to extract the frame
+    FfmpegScheduler::new(context)
+        .start()
+        .map_err(|e| OxenError::basic_str(format!("Failed to start FFmpeg: {e}")))?
+        .wait()
+        .map_err(|e| OxenError::basic_str(format!("Failed to extract frame: {e}")))?;
 
     log::debug!("saved thumbnail {thumbnail_path:?}");
     Ok(())

--- a/oxen-rust/src/server/Cargo.toml
+++ b/oxen-rust/src/server/Cargo.toml
@@ -40,6 +40,7 @@ tar = "0.4.44"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.16", features = ["io-util"] }
+utoipa = { version = "5", features = ["time"] }
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/oxen-rust/src/server/src/controllers/file.rs
+++ b/oxen-rust/src/server/src/controllers/file.rs
@@ -8,6 +8,7 @@ use liboxen::model::commit::NewCommitBody;
 use liboxen::model::file::{FileContents, FileNew, TempFileNew, TempFilePathNew};
 use liboxen::model::merkle_tree::node::EMerkleTreeNode;
 use liboxen::model::metadata::metadata_image::ImgResize;
+use liboxen::model::metadata::metadata_video::VideoThumbnail;
 use liboxen::model::{Commit, User};
 use liboxen::repositories::{self, branches};
 use liboxen::util;
@@ -90,6 +91,18 @@ pub struct ImportFileBody {
     pub headers: Option<Value>,
 }
 
+/// Combined query parameters for file operations (image resize and video thumbnail)
+/// Since both ImgResize and VideoThumbnail share width/height fields, we combine them here
+#[derive(Deserialize, Debug)]
+pub struct FileQueryParams {
+    // Shared parameters (can be used for both image resize and video thumbnail)
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    // Video thumbnail specific parameters
+    pub timestamp: Option<f64>,
+    pub thumbnail: Option<bool>,
+}
+
 /// Download File
 #[utoipa::path(
     get,
@@ -100,7 +113,10 @@ pub struct ImportFileBody {
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "Voice-Data"),
         ("resource" = String, Path, description = "Path to the file (including branch/commit info)", example = "main/audio/moo.wav"),
-        ImgResize
+        ("width" = Option<u32>, Query, description = "Width for image resize or video thumbnail", example = 320),
+        ("height" = Option<u32>, Query, description = "Height for image resize or video thumbnail", example = 240),
+        ("timestamp" = Option<f64>, Query, description = "Timestamp in seconds to extract video thumbnail from (default: 1.0)", example = 1.0),
+        ("thumbnail" = Option<bool>, Query, description = "Set to true to generate a video thumbnail instead of returning the full video", example = true)
     ),
     responses(
         (status = 200, description = "File content stream", content_type = "application/octet-stream", body = Vec<u8>),
@@ -109,7 +125,7 @@ pub struct ImportFileBody {
 )]
 pub async fn get(
     req: HttpRequest,
-    query: web::Query<ImgResize>,
+    query: web::Query<FileQueryParams>,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -157,17 +173,21 @@ pub async fn get(
     let last_commit_id = entry.last_commit_id().to_string();
     let version_path = version_store.get_version_path(&hash_str)?;
 
-    // TODO: refactor out of here and check for type,
-    // but seeing if it works to resize the image and cache it to disk if we have a resize query
-    let img_resize = query.into_inner();
-    if (img_resize.width.is_some() || img_resize.height.is_some())
+    let query_params = query.into_inner();
+
+    // Handle image resize
+    if (query_params.width.is_some() || query_params.height.is_some())
         && mime_type.starts_with("image/")
     {
+        let img_resize = ImgResize {
+            width: query_params.width,
+            height: query_params.height,
+        };
         log::debug!("img_resize {img_resize:?}");
 
         let resized_path = util::fs::handle_image_resize(
             Arc::clone(&version_store),
-            hash_str,
+            hash_str.clone(),
             &path,
             &version_path,
             img_resize,
@@ -183,9 +203,39 @@ pub async fn get(
             .content_type(mime_type)
             .insert_header(("oxen-revision-id", last_commit_id.as_str()))
             .streaming(stream));
-    } else {
-        log::debug!("did not hit the resize cache");
     }
+
+    // Handle video thumbnail - requires thumbnail=true parameter
+    if query_params.thumbnail == Some(true) && mime_type.starts_with("video/") {
+        let video_thumbnail = VideoThumbnail {
+            width: query_params.width,
+            height: query_params.height,
+            timestamp: query_params.timestamp,
+            thumbnail: query_params.thumbnail,
+        };
+        log::debug!("video_thumbnail {video_thumbnail:?}");
+
+        let thumbnail_path = util::fs::handle_video_thumbnail(
+            Arc::clone(&version_store),
+            hash_str,
+            &path,
+            &version_path,
+            video_thumbnail,
+        )?;
+        log::debug!("In the thumbnail cache! {thumbnail_path:?}");
+
+        // Generate stream for the thumbnail (always JPEG)
+        let file = File::open(&thumbnail_path).await?;
+        let reader = BufReader::new(file);
+        let stream = ReaderStream::new(reader);
+
+        return Ok(HttpResponse::Ok()
+            .content_type("image/jpeg")
+            .insert_header(("oxen-revision-id", last_commit_id.as_str()))
+            .streaming(stream));
+    }
+
+    log::debug!("did not hit the resize or thumbnail cache");
 
     // Stream the file
     let stream = version_store.get_version_stream(&hash_str).await?;

--- a/oxen-rust/src/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/files.rs
@@ -7,6 +7,7 @@ use liboxen::core::staged::with_staged_db_manager;
 use liboxen::error::OxenError;
 use liboxen::model::merkle_tree::node::EMerkleTreeNode;
 use liboxen::model::metadata::metadata_image::ImgResize;
+use liboxen::model::metadata::metadata_video::VideoThumbnail;
 use liboxen::model::LocalRepository;
 use liboxen::model::Workspace;
 use liboxen::repositories;
@@ -22,6 +23,7 @@ use actix_web::Error;
 use actix_web::{web, HttpRequest, HttpResponse};
 use flate2::read::GzDecoder;
 use futures_util::TryStreamExt as _;
+use serde::Deserialize;
 use std::io::Read as StdRead;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -36,6 +38,17 @@ pub struct FileUpload {
     pub file: Vec<u8>,
 }
 
+/// Combined query parameters for workspace file operations (image resize and video thumbnail)
+#[derive(Deserialize, Debug)]
+pub struct WorkspaceFileQueryParams {
+    // Shared parameters (can be used for both image resize and video thumbnail)
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    // Video thumbnail specific parameters
+    pub timestamp: Option<f64>,
+    pub thumbnail: Option<bool>,
+}
+
 /// Get workspace file
 #[utoipa::path(
     get,
@@ -46,7 +59,10 @@ pub struct FileUpload {
         ("repo_name" = String, Path, description = "The name of the repository", example = "ImageNet-1k"),
         ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745"),
         ("path" = String, Path, description = "The path to the file in the workspace", example = "images/train/dog_1.jpg"),
-        ImgResize
+        ("width" = Option<u32>, Query, description = "Width for image resize or video thumbnail", example = 320),
+        ("height" = Option<u32>, Query, description = "Height for image resize or video thumbnail", example = 240),
+        ("timestamp" = Option<f64>, Query, description = "Timestamp in seconds to extract video thumbnail from (default: 1.0)", example = 1.0),
+        ("thumbnail" = Option<bool>, Query, description = "Set to true to generate a video thumbnail instead of returning the full video", example = true)
     ),
     responses(
         (status = 200, description = "File content returned as a stream", 
@@ -62,7 +78,7 @@ pub struct FileUpload {
 )]
 pub async fn get(
     req: HttpRequest,
-    query: web::Query<ImgResize>,
+    query: web::Query<WorkspaceFileQueryParams>,
 ) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
@@ -116,16 +132,21 @@ pub async fn get(
     let version_path = version_store.get_version_path(&hash_str)?;
     log::debug!("got workspace file version path {:?}", &version_path);
 
-    // TODO: This probably isn't the best place for the resize logic
-    let img_resize = query.into_inner();
-    if (img_resize.width.is_some() || img_resize.height.is_some())
+    let query_params = query.into_inner();
+
+    // Handle image resize
+    if (query_params.width.is_some() || query_params.height.is_some())
         && mime_type.starts_with("image/")
     {
+        let img_resize = ImgResize {
+            width: query_params.width,
+            height: query_params.height,
+        };
         log::debug!("img_resize {img_resize:?}");
 
         let resized_path = util::fs::handle_image_resize(
             Arc::clone(&version_store),
-            hash_str,
+            hash_str.clone(),
             &PathBuf::from(path),
             &version_path,
             img_resize,
@@ -141,9 +162,39 @@ pub async fn get(
             .content_type(mime_type)
             .insert_header(("oxen-revision-id", last_commit_id.as_str()))
             .streaming(stream));
-    } else {
-        log::debug!("did not hit the resize cache");
     }
+
+    // Handle video thumbnail - requires thumbnail=true parameter
+    if query_params.thumbnail == Some(true) && mime_type.starts_with("video/") {
+        let video_thumbnail = VideoThumbnail {
+            width: query_params.width,
+            height: query_params.height,
+            timestamp: query_params.timestamp,
+            thumbnail: query_params.thumbnail,
+        };
+        log::debug!("video_thumbnail {video_thumbnail:?}");
+
+        let thumbnail_path = util::fs::handle_video_thumbnail(
+            Arc::clone(&version_store),
+            hash_str,
+            &PathBuf::from(path),
+            &version_path,
+            video_thumbnail,
+        )?;
+        log::debug!("In the thumbnail cache! {thumbnail_path:?}");
+
+        // Generate stream for the thumbnail (always JPEG)
+        let file = File::open(&thumbnail_path).await?;
+        let reader = BufReader::new(file);
+        let stream = ReaderStream::new(reader);
+
+        return Ok(HttpResponse::Ok()
+            .content_type("image/jpeg")
+            .insert_header(("oxen-revision-id", last_commit_id.as_str()))
+            .streaming(stream));
+    }
+
+    log::debug!("did not hit the resize or thumbnail cache");
 
     // Stream the file
     let stream = version_store.get_version_stream(&hash_str).await?;

--- a/oxen-rust/src/server/src/controllers/workspaces/files.rs
+++ b/oxen-rust/src/server/src/controllers/workspaces/files.rs
@@ -61,12 +61,11 @@ pub struct WorkspaceFileQueryParams {
         ("path" = String, Path, description = "The path to the file in the workspace", example = "images/train/dog_1.jpg"),
         ("width" = Option<u32>, Query, description = "Width for image resize or video thumbnail", example = 320),
         ("height" = Option<u32>, Query, description = "Height for image resize or video thumbnail", example = 240),
-        ("timestamp" = Option<f64>, Query, description = "Timestamp in seconds to extract video thumbnail from (default: 1.0)", example = 1.0),
+        ("timestamp" = Option<f64>, Query, description = "Timestamp in seconds to extract video thumbnail from", example = 1.0),
         ("thumbnail" = Option<bool>, Query, description = "Set to true to generate a video thumbnail instead of returning the full video", example = true)
     ),
     responses(
-        (status = 200, description = "File content returned as a stream", 
-            content_type = "application/octet-stream", 
+        (status = 200, description = "File content returned as a stream. Content-Type varies: matches the file's MIME type for regular files and image resizes, or 'image/jpeg' for video thumbnails",
             body = Vec<u8>,
             headers(
                 ("oxen-revision-id" = String, description = "The commit ID of the file version")
@@ -169,7 +168,7 @@ pub async fn get(
         let video_thumbnail = VideoThumbnail {
             width: query_params.width,
             height: query_params.height,
-            timestamp: query_params.timestamp,
+            timestamp: query_params.timestamp.or(Some(1.0)),
             thumbnail: query_params.thumbnail,
         };
         log::debug!("video_thumbnail {video_thumbnail:?}");

--- a/oxen-rust/src/server/src/errors.rs
+++ b/oxen-rust/src/server/src/errors.rs
@@ -485,6 +485,19 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::InternalServerError().json(error_json)
                     }
+                    OxenError::ThumbnailingNotEnabled(error) => {
+                        log::error!("Thumbnailing not enabled: {error}");
+                        let error_json = json!({
+                            "error": {
+                                "type": "thumbnailing_not_enabled",
+                                "title": "Thumbnailing Not Enabled",
+                                "detail": format!("{}", error),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_INTERNAL_SERVER_ERROR,
+                        });
+                        HttpResponse::InternalServerError().json(error_json)
+                    }
                     OxenError::Basic(error) => {
                         let error_json = json!({
                             "error": {


### PR DESCRIPTION
Adding thumbnail logic for videos. To test out, upload a video to a repo, and run:

```bash
wget --header="Accept: image/jpeg" \
     --header="Authorization: Bearer YOUR_API_KEY" \
     "http://localhost:3000/api/repos/{namespace}/{repo_name}/file/{branch}/{video_path}?thumbnail=true&width=640&height=480" \
     -O thumbnail.jpg
```

<img width="1512" height="795" alt="Screenshot 2025-12-08 at 12 49 01 PM" src="https://github.com/user-attachments/assets/a99999da-7616-4db3-9ddf-1b96c42900e8" />

Implements ENG-507

Also fixes a few other bugs

* fixes ENG-531 .unwrap() on video metadata
* fixes ENG-526 empty directories when running tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional video thumbnail generation (width/height/timestamp) and image resizing via download query parameters; opt-in feature flag.

* **Bug Fixes**
  * Safer video-track handling and explicit error when thumbnailing is disabled.
  * Removed some automatic parent-directory creation.

* **Chores**
  * CI/release workflows now install media dev libraries and platform-specific setup to support optional FFmpeg; release builds enable the feature flag.

* **Tests**
  * End-to-end tests for video upload and thumbnail retrieval; tests use temporary directories.

* **Documentation**
  * Added "Enable ffmpeg" build instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->