### PR TITLE
ENG-194 // Fix df.size() in python

### DIFF
--- a/oxen-python/src/py_workspace_data_frame.rs
+++ b/oxen-python/src/py_workspace_data_frame.rs
@@ -109,7 +109,7 @@ impl PyWorkspaceDataFrame {
         let df = _get(&self.workspace.repo.repo, &self.workspace.id, &self.path)?;
         let size = &df.view.size;
         let width = size.width;
-        let height = size.height;
+        let height = df.view.pagination.total_entries;
         self._first_page = df;
         Ok((width, height))
     }


### PR DESCRIPTION
We don't have any partial/queried df view provided in python. So it's safe to just return the total_entries of the df for `.size()` instead of the view height

linear: https://linear.app/oxenai/issue/ENG-194/python-remote-data-frame-size-is-page-size-not-data-frame-size