### PR TITLE
adding a unit test for modifying a schema and fixing the push pull pipeline

### DIFF
--- a/oxen-rust/src/lib/src/core/v_latest/index/restore.rs
+++ b/oxen-rust/src/lib/src/core/v_latest/index/restore.rs
@@ -282,7 +282,6 @@ pub fn should_restore_file(
 ) -> Result<bool, OxenError> {
     let path = path.as_ref();
     let working_path = repo.path.join(path);
-
     // Check to see if the file has been modified if it exists
     if working_path.exists() {
         // Check metadata for changes first
@@ -291,6 +290,7 @@ pub fn should_restore_file(
 
         // If there are modifications compared to the base node, we should not restore the file
         if let Some(base_node) = base_node {
+            // First, check the modified times
             let node_modified_nanoseconds = std::time::SystemTime::UNIX_EPOCH
                 + std::time::Duration::from_secs(base_node.last_modified_seconds() as u64)
                 + std::time::Duration::from_nanos(base_node.last_modified_nanoseconds() as u64);
@@ -302,11 +302,27 @@ pub fn should_restore_file(
                 return Ok(true);
             }
 
-            // If modified times are different, check hashes
-            let hash = MerkleHash::new(util::hasher::u128_hash_file_contents(&working_path)?);
+            // Second, check the combined hashes
+            let file_hash = util::hasher::u128_hash_file_contents(&working_path)?;
+            let file_combined_hash = {
+                let mime_type = util::fs::file_mime_type(path);
+                let data_type = util::fs::datatype_from_mimetype(path, mime_type.as_str());
 
-            let base_node_hash = base_node.hash();
-            if hash != *base_node_hash {
+                let file_metadata = repositories::metadata::get_file_metadata(path, &data_type)?;
+                let file_metadata_hash = util::hasher::maybe_get_metadata_hash(&file_metadata)?;
+
+                let combined_hash = util::hasher::get_combined_hash(file_metadata_hash, file_hash)?;
+                MerkleHash::new(combined_hash)
+            };
+
+            let node_combined_hash = file_node.combined_hash();
+            if file_combined_hash != *node_combined_hash {
+                return Ok(true);
+            }
+
+            let base_hash = base_node.combined_hash();
+
+            if file_combined_hash != *base_hash {
                 return Ok(false);
             }
         } else {
@@ -322,9 +338,21 @@ pub fn should_restore_file(
                 return Ok(true);
             }
 
-            // If modified times are different, check hashes
-            let hash = MerkleHash::new(util::hasher::u128_hash_file_contents(&working_path)?);
-            if hash != *file_node.hash() {
+            // Second, check the combined hashes
+            let file_hash = util::hasher::u128_hash_file_contents(&working_path)?;
+            let file_combined_hash = {
+                let mime_type = util::fs::file_mime_type(path);
+                let data_type = util::fs::datatype_from_mimetype(path, mime_type.as_str());
+
+                let file_metadata = repositories::metadata::get_file_metadata(path, &data_type)?;
+                let file_metadata_hash = util::hasher::maybe_get_metadata_hash(&file_metadata)?;
+
+                let combined_hash = util::hasher::get_combined_hash(file_metadata_hash, file_hash)?;
+                MerkleHash::new(combined_hash)
+            };
+
+            let node_combined_hash = file_node.combined_hash();
+            if file_combined_hash != *node_combined_hash {
                 return Ok(false);
             }
         }

--- a/oxen-rust/src/lib/src/model/partial_node.rs
+++ b/oxen-rust/src/lib/src/model/partial_node.rs
@@ -2,6 +2,8 @@ use crate::model::MerkleHash;
 use crate::util;
 use filetime::FileTime;
 
+// TODO: Either deprecate this struct, or update it to include schema
+
 // Reduced form of the FileNode, used to save space
 #[derive(Eq, Hash, PartialEq, Debug, Clone)]
 pub struct PartialNode {

--- a/oxen-rust/src/lib/src/repositories/data_frames/schemas.rs
+++ b/oxen-rust/src/lib/src/repositories/data_frames/schemas.rs
@@ -788,4 +788,146 @@ mod tests {
         })
         .await
     }
+
+    #[tokio::test]
+    async fn test_schemas_merge_fast_forward_pull() -> Result<(), OxenError> {
+        test::run_select_data_sync_remote("README.md", |_local_repo, remote_repo| async move {
+            let remote_repo_copy = remote_repo.clone();
+            test::run_empty_dir_test_async(|repo_dir_a| async move {
+                let repo_dir_a = repo_dir_a.join("repo_a");
+                let cloned_repo_a =
+                    repositories::clone_url(&remote_repo.remote.url, &repo_dir_a).await?;
+
+                test::run_empty_dir_test_async(|repo_dir_b| async move {
+                    println!("=== Starting test: Two users pushing to remote ===");
+                    println!("User A: Will add schema metadata to dataframe");
+                    println!("User B: Will edit README");
+
+                    // Write a data frame to data.csv
+                    let data_filename = Path::new("data.csv");
+                    let data_path = cloned_repo_a.path.join(data_filename);
+                    let column_name = "name";
+                    let data_content = "name,age\nJohn,30\nJane,25";
+                    util::fs::write_to_path(&data_path, data_content)?;
+                    repositories::add(&cloned_repo_a, &data_path).await?;
+                    repositories::commit(&cloned_repo_a, "User A adding data.csv")?;
+                    // Push to the remote so User B can pull
+                    repositories::push(&cloned_repo_a).await?;
+
+                    // Clone repo to User B before we edit the schema metadata
+                    let repo_dir_b = repo_dir_b.join("repo_b");
+                    let cloned_repo_b =
+                        repositories::clone_url(&remote_repo.remote.url, &repo_dir_b).await?;
+
+                    // User A: Add schema metadata to the data.csv dataframe
+                    println!("User A: Adding schema metadata...");
+                    // Add schema metadata
+                    let column_metadata = json!({
+                        "my_custom": "name_column_metadata"
+                    });
+                    repositories::data_frames::schemas::add_column_metadata(
+                        &cloned_repo_a,
+                        &data_filename,
+                        column_name,
+                        &column_metadata,
+                    )?;
+                    repositories::commit(&cloned_repo_a, "User A adding schema metadata")?;
+                    println!("User A: Pushing schema metadata...");
+                    repositories::push(&cloned_repo_a).await?;
+                    println!("User A pushed ✅ 1");
+
+                    // Make sure the schema metadata is in the schema
+                    let commit = repositories::commits::head_commit(&cloned_repo_a)?;
+                    let schema = repositories::data_frames::schemas::get_by_path(
+                        &cloned_repo_a,
+                        &commit,
+                        &data_filename,
+                    )?
+                    .expect("Schema should exist");
+                    println!("User A: Schema: {schema:?}");
+
+                    // Save the number of commits in User A
+                    let num_commits_a = repositories::commits::list(&cloned_repo_a)?.len();
+                    println!("User A: Number of commits: {num_commits_a}");
+                    let commits = repositories::commits::list(&cloned_repo_a)?;
+                    for commit in &commits {
+                        println!("User A: GOT COMMIT {commit}");
+                    }
+                    println!("================================================");
+
+                    // User B: Edit the README (but don't push yet)
+                    println!("User B: Editing README...");
+                    let readme_path = cloned_repo_b.path.join("README.md");
+                    let readme_content = "Updated README by User B";
+                    util::fs::write_to_path(&readme_path, readme_content)?;
+                    repositories::add(&cloned_repo_b, &readme_path).await?;
+                    repositories::commit(&cloned_repo_b, "User B editing README")?;
+
+                    // User B should have all the commits from User A
+                    let commits = repositories::commits::list(&cloned_repo_b)?;
+                    for commit in &commits {
+                        println!("User B: GOT COMMIT BEFORE {commit}");
+                    }
+                    println!("================================================");
+
+                    // User B tries to push - should fail because remote is ahead
+                    println!("User B: Attempting to push README changes (should fail because remote is ahead)...");
+                    let push_result = repositories::push(&cloned_repo_b).await;
+                    assert!(push_result.is_err(), "Push should fail when remote is ahead");
+                    println!("User B push failed ✅ 3 (as expected - remote is ahead)");
+
+                    // User B pulls - should succeed with fast-forward merge (no conflicts)
+                    println!("User B: Pulling changes...");
+                    repositories::pull(&cloned_repo_b).await?;
+                    println!("User B pulled ✅ 4");
+
+                    // User B should have all the commits from User A
+                    let commits = repositories::commits::list(&cloned_repo_b)?;
+                    for commit in &commits {
+                        println!("User B: GOT COMMIT AFTER {commit}");
+                    }
+                    println!("================================================");
+                    // assert_eq!(commits.len(), num_commits_a);
+
+                    // Verify User B has both changes locally:
+                    // 1. The README should still have User B's changes
+                    let readme_content_after_pull = util::fs::read_from_path(&readme_path)?;
+                    assert_eq!(
+                        readme_content_after_pull, readme_content,
+                        "README should still have User B's changes"
+                    );
+
+                    // 2. The schema should have User A's metadata
+                    let commit = repositories::commits::head_commit(&cloned_repo_b)?;
+                    println!("User B: CHECKING COMMIT {commit}");
+                    let schema = repositories::data_frames::schemas::get_by_path(
+                        &cloned_repo_b,
+                        &commit,
+                        &data_filename,
+                    )?
+                    .expect("Schema should exist");
+                    println!("User B: Schema: {schema:?}");
+                    let name_field = schema.fields.iter()
+                        .find(|field| field.name == column_name)
+                        .expect("Schema should have a 'name' field");
+                    assert_eq!(
+                        name_field.metadata, Some(column_metadata.clone()),
+                        "Schema should have User A's metadata on the 'name' field"
+                    );
+
+                    // User B pushes - should succeed now after pulling
+                    println!("User B: Pushing README changes (should succeed after pull)...");
+                    repositories::push(&cloned_repo_b).await?;
+                    println!("User B pushed ✅ 5");
+
+                    Ok(())
+                })
+                .await?;
+                Ok(())
+            })
+            .await?;
+            Ok(remote_repo_copy)
+        })
+        .await
+    }
 }

--- a/oxen-rust/src/lib/src/repositories/data_frames/schemas.rs
+++ b/oxen-rust/src/lib/src/repositories/data_frames/schemas.rs
@@ -827,7 +827,7 @@ mod tests {
                     });
                     repositories::data_frames::schemas::add_column_metadata(
                         &cloned_repo_a,
-                        &data_filename,
+                        data_filename,
                         column_name,
                         &column_metadata,
                     )?;
@@ -841,7 +841,7 @@ mod tests {
                     let schema = repositories::data_frames::schemas::get_by_path(
                         &cloned_repo_a,
                         &commit,
-                        &data_filename,
+                        data_filename,
                     )?
                     .expect("Schema should exist");
                     println!("User A: Schema: {schema:?}");
@@ -903,7 +903,7 @@ mod tests {
                     let schema = repositories::data_frames::schemas::get_by_path(
                         &cloned_repo_b,
                         &commit,
-                        &data_filename,
+                        data_filename,
                     )?
                     .expect("Schema should exist");
                     println!("User B: Schema: {schema:?}");


### PR DESCRIPTION
Use case:

The dataframe metadata gets updated on the remote, and a change is made on local, need to sync changes locally (when it is just metadata changes)

```
# User A
oxen init
oxen add data.csv README.md
oxen commit -m "adding two files"
oxen push origin main

# User B Clones Repo
oxen clone <remote>

# User A
oxen schemas add data.csv ...
oxen commit -m "add schema metadata"
oxen push origin main

# User B
echo "Changing README" > README.md
oxen add README.md
oxen commit -m "changing readme"
oxen push # SHOULD FAIL
oxen pull # SHOULD SUCCEED, AND UPDATE METADATA
oxen push # SHOULD SUCCEED
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test validating schema metadata persistence across fast-forward pulls and multi-client syncs.

* **Enhancements**
  * Merge/restore decisions now consider combined file+metadata checks, improving correctness of restores.
  * After successful restores, tabular files automatically re-apply per-field and per-schema metadata.

* **Chores**
  * Added a TODO note indicating potential future schema-related cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->