### PR TITLE
Remove AsRef generics to reduce compilation time & binary size

### DIFF
--- a/crates/cli/src/cmd/branch.rs
+++ b/crates/cli/src/cmd/branch.rs
@@ -196,8 +196,8 @@ impl BranchCmd {
     ) -> Result<(), OxenError> {
         let (scheme, host) = get_scheme_and_host_from_repo(repo)?;
 
-        check_remote_version_blocking(scheme.clone(), host.clone()).await?;
-        check_remote_version(scheme, host).await?;
+        check_remote_version_blocking(&scheme, &host).await?;
+        check_remote_version(&scheme, &host).await?;
 
         let remote = repo
             .get_remote(remote_name)
@@ -219,7 +219,7 @@ impl BranchCmd {
     ) -> Result<(), OxenError> {
         let (scheme, host) = get_scheme_and_host_from_repo(repo)?;
 
-        check_remote_version(scheme, host).await?;
+        check_remote_version(&scheme, &host).await?;
 
         api::client::branches::delete_remote(repo, remote_name, branch_name).await?;
         Ok(())

--- a/crates/cli/src/cmd/checkout.rs
+++ b/crates/cli/src/cmd/checkout.rs
@@ -3,6 +3,7 @@ use clap::{Arg, Command};
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
+use std::path::Path;
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "checkout";
@@ -96,12 +97,12 @@ impl CheckoutCmd {
         repo: &LocalRepository,
         path: &str,
     ) -> Result<(), OxenError> {
-        repositories::checkout::checkout_theirs(repo, path).await?;
+        repositories::checkout::checkout_theirs(repo, Path::new(path)).await?;
         Ok(())
     }
 
     pub async fn checkout_ours(&self, repo: &LocalRepository, path: &str) -> Result<(), OxenError> {
-        repositories::checkout::checkout_ours(repo, path).await?;
+        repositories::checkout::checkout_ours(repo, Path::new(path)).await?;
         Ok(())
     }
 

--- a/crates/cli/src/cmd/checkout.rs
+++ b/crates/cli/src/cmd/checkout.rs
@@ -52,7 +52,7 @@ impl RunCmd for CheckoutCmd {
         } else if args.get_flag("ours") {
             let Some(name) = args.get_one::<String>("name") else {
                 return Err(OxenError::basic_str(
-                    "Err: Usage `oxen checkout --ours <name>`",
+                    "Err: Usage `oxen checkout --ours <name>`".to_string(),
                 ));
             };
 
@@ -60,7 +60,7 @@ impl RunCmd for CheckoutCmd {
         } else if args.get_flag("theirs") {
             let Some(name) = args.get_one::<String>("name") else {
                 return Err(OxenError::basic_str(
-                    "Err: Usage `oxen checkout --theirs <name>`",
+                    "Err: Usage `oxen checkout --theirs <name>`".to_string(),
                 ));
             };
 

--- a/crates/cli/src/cmd/clone.rs
+++ b/crates/cli/src/cmd/clone.rs
@@ -147,7 +147,7 @@ impl RunCmd for CloneCmd {
                 StorageOpts::default()
             }
             unsupported_backend => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Unsupported async storage type: {unsupported_backend}"
                 )));
             }
@@ -171,8 +171,8 @@ impl RunCmd for CloneCmd {
         let (scheme, host) = api::client::get_scheme_and_host_from_url(&opts.url)?;
 
         // TODO: Do I need to worry about this for remote repo?
-        check_remote_version_blocking(scheme.clone(), host.clone()).await?;
-        check_remote_version(scheme, host).await?;
+        check_remote_version_blocking(&scheme, &host).await?;
+        check_remote_version(&scheme, &host).await?;
 
         repositories::clone(&opts).await?;
 

--- a/crates/cli/src/cmd/clone.rs
+++ b/crates/cli/src/cmd/clone.rs
@@ -114,14 +114,14 @@ impl RunCmd for CloneCmd {
                     || path.components().any(|c| matches!(c, Component::ParentDir))
                 {
                     return Err(OxenError::basic_str(
-                        "Invalid destination: absolute paths or '..' not allowed",
+                        "Invalid destination: absolute paths or '..' not allowed".to_string(),
                     ));
                 }
 
                 let joined = current_dir.join(path);
                 if !joined.starts_with(&current_dir) {
                     return Err(OxenError::basic_str(
-                        "Invalid destination: path escapes base directory",
+                        "Invalid destination: path escapes base directory".to_string(),
                     ));
                 }
                 joined
@@ -147,7 +147,7 @@ impl RunCmd for CloneCmd {
                 StorageOpts::default()
             }
             unsupported_backend => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Unsupported async storage type: {unsupported_backend}"
                 )));
             }

--- a/crates/cli/src/cmd/commit.rs
+++ b/crates/cli/src/cmd/commit.rs
@@ -134,7 +134,7 @@ fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, 
         .status()?;
 
     if !status.success() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Editor '{editor}' exited with non-zero status."
         )));
     }

--- a/crates/cli/src/cmd/commit.rs
+++ b/crates/cli/src/cmd/commit.rs
@@ -96,7 +96,8 @@ fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, 
              To set your preferred editor, run:\n    \
              oxen config --editor <EDITOR>\n\n\
              Or manually add the following to ~/.config/oxen/user_config.toml:\n    \
-             editor = \"vim\"",
+             editor = \"vim\""
+                .to_string(),
         )
     })?;
 
@@ -125,7 +126,7 @@ fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, 
     let parts: Vec<&str> = editor.split_whitespace().collect();
     if parts.is_empty() {
         return Err(OxenError::basic_str(
-            "Must supply valid editor path, not an empty/whitespace-only string.",
+            "Must supply valid editor path, not an empty/whitespace-only string.".to_string(),
         ));
     }
     let status = std::process::Command::new(parts[0])
@@ -134,7 +135,7 @@ fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, 
         .status()?;
 
     if !status.success() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Editor '{editor}' exited with non-zero status."
         )));
     }
@@ -152,7 +153,7 @@ fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, 
 
     if message.is_empty() {
         return Err(OxenError::basic_str(
-            "Aborting commit due to empty commit message.",
+            "Aborting commit due to empty commit message.".to_string(),
         ));
     }
 

--- a/crates/cli/src/cmd/config.rs
+++ b/crates/cli/src/cmd/config.rs
@@ -143,7 +143,8 @@ impl RunCmd for ConfigCmd {
                 .get_one::<String>("storage-backend")
                 .ok_or_else(|| {
                     OxenError::basic_str(
-                        "storage-backend must be specified when storage-backend-path is provided",
+                        "storage-backend must be specified when storage-backend-path is provided"
+                            .to_string(),
                     )
                 })?
                 .to_string();
@@ -165,7 +166,7 @@ impl ConfigCmd {
         if host.contains("://") {
             Ok(url::Url::parse(host)?
                 .host_str()
-                .ok_or_else(|| OxenError::basic_str("Unable to parse host."))?
+                .ok_or_else(|| OxenError::basic_str("Unable to parse host.".to_string()))?
                 .to_string())
         } else {
             Ok(host.to_string())

--- a/crates/cli/src/cmd/create_remote.rs
+++ b/crates/cli/src/cmd/create_remote.rs
@@ -86,7 +86,7 @@ impl RunCmd for CreateRemoteCmd {
         // Parse Args
         let Some(namespace_name) = args.get_one::<String>("name") else {
             return Err(OxenError::basic_str(
-                "Must supply a namespace/name for the remote repository.",
+                "Must supply a namespace/name for the remote repository.".to_string(),
             ));
         };
 
@@ -115,7 +115,7 @@ impl RunCmd for CreateRemoteCmd {
         let parts: Vec<&str> = namespace_name.split('/').collect();
         if parts.len() != 2 {
             return Err(OxenError::basic_str(
-                "Invalid name format. Must be namespace/name",
+                "Invalid name format. Must be namespace/name".to_string(),
             ));
         }
 

--- a/crates/cli/src/cmd/db.rs
+++ b/crates/cli/src/cmd/db.rs
@@ -52,7 +52,7 @@ impl RunCmd for DbCmd {
             })?;
         } else {
             return Err(OxenError::basic_str(
-                "No db subcommand provided. Run `oxen db --help` for usage.",
+                "No db subcommand provided. Run `oxen db --help` for usage.".to_string(),
             ));
         }
 

--- a/crates/cli/src/cmd/db/count.rs
+++ b/crates/cli/src/cmd/db/count.rs
@@ -27,7 +27,7 @@ impl RunCmd for DbCountCmd {
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
         // Parse Args
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str("Must supply path"));
+            return Err(OxenError::basic_str("Must supply path".to_string()));
         };
 
         let count = command::db::count(&PathBuf::from(path))?;

--- a/crates/cli/src/cmd/db/count.rs
+++ b/crates/cli/src/cmd/db/count.rs
@@ -30,7 +30,7 @@ impl RunCmd for DbCountCmd {
             return Err(OxenError::basic_str("Must supply path"));
         };
 
-        let count = command::db::count(PathBuf::from(path))?;
+        let count = command::db::count(&PathBuf::from(path))?;
 
         println!("There are {count} entries in the database");
 

--- a/crates/cli/src/cmd/db/get.rs
+++ b/crates/cli/src/cmd/db/get.rs
@@ -31,10 +31,10 @@ impl RunCmd for DbGetCmd {
         // Parse Args
         let error = "Usage: oxen db get <PATH> <KEY>";
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str(error));
+            return Err(OxenError::basic_str(error.to_string()));
         };
         let Some(key) = args.get_one::<String>("KEY") else {
-            return Err(OxenError::basic_str(error));
+            return Err(OxenError::basic_str(error.to_string()));
         };
 
         let dtype = args.get_one::<String>("dtype").map(|x| x.as_str());

--- a/crates/cli/src/cmd/db/get.rs
+++ b/crates/cli/src/cmd/db/get.rs
@@ -38,7 +38,7 @@ impl RunCmd for DbGetCmd {
         };
 
         let dtype = args.get_one::<String>("dtype").map(|x| x.as_str());
-        let value = command::db::get(path, key, dtype)?;
+        let value = command::db::get(std::path::Path::new(path), key, dtype)?;
         println!("{value}");
 
         Ok(())

--- a/crates/cli/src/cmd/db/list.rs
+++ b/crates/cli/src/cmd/db/list.rs
@@ -33,7 +33,7 @@ impl RunCmd for DbListCmd {
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
         // Parse Args
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str("Must supply path"));
+            return Err(OxenError::basic_str("Must supply path".to_string()));
         };
 
         let limit = args

--- a/crates/cli/src/cmd/db/list.rs
+++ b/crates/cli/src/cmd/db/list.rs
@@ -40,7 +40,7 @@ impl RunCmd for DbListCmd {
             .get_one::<String>("limit")
             .map(|x| x.parse::<usize>().expect("limit must be valid size"));
 
-        command::db::list(PathBuf::from(path), limit)?;
+        command::db::list(&PathBuf::from(path), limit)?;
 
         Ok(())
     }

--- a/crates/cli/src/cmd/delete_remote.rs
+++ b/crates/cli/src/cmd/delete_remote.rs
@@ -53,7 +53,7 @@ impl RunCmd for DeleteRemoteCmd {
         // Parse Args
         let Some(namespace_name) = args.get_one::<String>("name") else {
             return Err(OxenError::basic_str(
-                "Must supply a namespace/name for the remote repository.",
+                "Must supply a namespace/name for the remote repository.".to_string(),
             ));
         };
         // Default the host to the oxen.ai hub
@@ -88,7 +88,7 @@ impl RunCmd for DeleteRemoteCmd {
                     return Ok(());
                 }
                 Err(e) => {
-                    return Err(OxenError::basic_str(&format!(
+                    return Err(OxenError::basic_str(format!(
                         "Error confirming deletion: {e}"
                     )));
                 }

--- a/crates/cli/src/cmd/delete_remote.rs
+++ b/crates/cli/src/cmd/delete_remote.rs
@@ -88,7 +88,7 @@ impl RunCmd for DeleteRemoteCmd {
                     return Ok(());
                 }
                 Err(e) => {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(OxenError::basic_str(&format!(
                         "Error confirming deletion: {e}"
                     )));
                 }

--- a/crates/cli/src/cmd/df.rs
+++ b/crates/cli/src/cmd/df.rs
@@ -249,7 +249,9 @@ impl RunCmd for DFCmd {
         // Parse Args
         let mut opts = DFCmd::parse_df_args(args)?;
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str("Must supply a DataFrame to process."));
+            return Err(OxenError::basic_str(
+                "Must supply a DataFrame to process.".to_string(),
+            ));
         };
         opts.path = Some(PathBuf::from(path));
 

--- a/crates/cli/src/cmd/df.rs
+++ b/crates/cli/src/cmd/df.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command, arg};
@@ -255,13 +255,13 @@ impl RunCmd for DFCmd {
 
         if let Some(revision) = args.get_one::<String>("revision") {
             let repo = LocalRepository::from_current_dir()?;
-            command::df::df_revision(&repo, path, revision, opts).await?;
+            command::df::df_revision(&repo, Path::new(path), revision, opts).await?;
         } else if args.get_flag("schema") || args.get_flag("schema-flat") {
             let flatten = args.get_flag("schema-flat");
-            let result = command::df::schema(path, flatten, opts)?;
+            let result = command::df::schema(Path::new(path), flatten, opts)?;
             println!("{result}");
         } else {
-            command::df(path, opts).await?;
+            command::df(Path::new(path), opts).await?;
         }
 
         Ok(())

--- a/crates/cli/src/cmd/diff.rs
+++ b/crates/cli/src/cmd/diff.rs
@@ -21,12 +21,12 @@ pub struct DiffCmd;
 
 fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
     write!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(&format!("Could not write to pager: {e}")))
+        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
 }
 
 fn writeln_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
     writeln!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(&format!("Could not write to pager: {e}")))
+        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
 }
 
 #[async_trait]

--- a/crates/cli/src/cmd/diff.rs
+++ b/crates/cli/src/cmd/diff.rs
@@ -21,12 +21,12 @@ pub struct DiffCmd;
 
 fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
     write!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
+        .map_err(|e| OxenError::basic_str(&format!("Could not write to pager: {e}")))
 }
 
 fn writeln_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
     writeln!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
+        .map_err(|e| OxenError::basic_str(&format!("Could not write to pager: {e}")))
 }
 
 #[async_trait]
@@ -339,7 +339,7 @@ impl DiffCmd {
                 match result {
                     DiffResult::Tabular(result) => {
                         let mut df = result.contents.clone();
-                        tabular::write_df(&mut df, file_path.clone())?;
+                        tabular::write_df(&mut df, &file_path.clone())?;
                     }
                     DiffResult::Text(_) => {
                         println!("Saving to disk not supported for text output");

--- a/crates/cli/src/cmd/download.rs
+++ b/crates/cli/src/cmd/download.rs
@@ -95,7 +95,7 @@ impl RunCmd for DownloadCmd {
             .map(String::from)
             .unwrap_or(DEFAULT_SCHEME.to_string());
 
-        check_remote_version_blocking(scheme.clone(), host.clone()).await?;
+        check_remote_version_blocking(&scheme, &host).await?;
 
         // Check if the first path is a valid remote repo
         let remote_repo =

--- a/crates/cli/src/cmd/download.rs
+++ b/crates/cli/src/cmd/download.rs
@@ -67,7 +67,7 @@ impl RunCmd for DownloadCmd {
         // Check that the id format is namespace/repo-name
         if id.chars().filter(|&c| c == '/').count() != 1 {
             return Err(OxenError::basic_str(
-                "Invalid repository ID format. Must be namespace/repo-name",
+                "Invalid repository ID format. Must be namespace/repo-name".to_string(),
             ));
         }
         let paths: Vec<PathBuf> = args
@@ -76,7 +76,9 @@ impl RunCmd for DownloadCmd {
             .map(PathBuf::from)
             .collect();
         if paths.is_empty() {
-            return Err(OxenError::basic_str("Must supply a path to download."));
+            return Err(OxenError::basic_str(
+                "Must supply a path to download.".to_string(),
+            ));
         }
         let dst = args
             .get_one::<String>("output")

--- a/crates/cli/src/cmd/embeddings/index.rs
+++ b/crates/cli/src/cmd/embeddings/index.rs
@@ -43,12 +43,12 @@ impl RunCmd for EmbeddingsIndexCmd {
 
         let err_msg = "Must supply a path to the data frame.";
         let Some(path) = path else {
-            return Err(OxenError::basic_str(err_msg));
+            return Err(OxenError::basic_str(err_msg.to_string()));
         };
 
         let err_msg = "Must supply a column name.";
         let Some(column) = column else {
-            return Err(OxenError::basic_str(err_msg));
+            return Err(OxenError::basic_str(err_msg.to_string()));
         };
 
         let use_background_thread = args.get_flag("use-background-thread");
@@ -75,7 +75,9 @@ impl RunCmd for EmbeddingsIndexCmd {
                 use_background_thread,
             )
         } else {
-            Err(OxenError::basic_str("Data frame is already indexed."))
+            Err(OxenError::basic_str(
+                "Data frame is already indexed.".to_string(),
+            ))
         }
     }
 }

--- a/crates/cli/src/cmd/embeddings/index.rs
+++ b/crates/cli/src/cmd/embeddings/index.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
+use std::path::Path;
 
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
@@ -56,18 +57,20 @@ impl RunCmd for EmbeddingsIndexCmd {
         let commit = repositories::commits::head_commit(&repository)?;
         if !repositories::workspaces::data_frames::is_queryable_data_frame_indexed(
             &repository,
-            path,
+            Path::new(path),
             &commit,
         )? {
             // If not, proceed to create a new workspace and index the data frame.
             // create the workspace id from the file path + commit id
             let workspace_id = format!("{}-{}", path, commit.id);
             let workspace =
-                repositories::workspaces::create(&repository, &commit, workspace_id, false)?;
-            repositories::workspaces::data_frames::index(&repository, &workspace, path).await?;
+                repositories::workspaces::create(&repository, &commit, &workspace_id, false)?;
+            repositories::workspaces::data_frames::index(&repository, &workspace, Path::new(path))
+                .await?;
+
             repositories::workspaces::data_frames::embeddings::index(
                 &workspace,
-                path,
+                Path::new(path),
                 column,
                 use_background_thread,
             )

--- a/crates/cli/src/cmd/embeddings/query.rs
+++ b/crates/cli/src/cmd/embeddings/query.rs
@@ -110,7 +110,7 @@ impl RunCmd for EmbeddingsQueryCmd {
         let commit = repositories::commits::head_commit(&repository)?;
         let workspace_id = format!("{}-{}", path, commit.id);
         let Some(workspace) = repositories::workspaces::get(&repository, &workspace_id)? else {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Workspace not found: {workspace_id}"
             )));
         };
@@ -126,7 +126,7 @@ impl RunCmd for EmbeddingsQueryCmd {
         };
 
         println!("Writing to {output}");
-        tabular::write_df(&mut df, output)?;
+        tabular::write_df(&mut df, std::path::Path::new(output))?;
 
         Ok(())
     }

--- a/crates/cli/src/cmd/embeddings/query.rs
+++ b/crates/cli/src/cmd/embeddings/query.rs
@@ -68,16 +68,18 @@ impl RunCmd for EmbeddingsQueryCmd {
 
         let Some(path) = path else {
             return Err(OxenError::basic_str(
-                "Must supply a path to the data frame.",
+                "Must supply a path to the data frame.".to_string(),
             ));
         };
 
         let Some(column) = column else {
-            return Err(OxenError::basic_str("Must supply a column name."));
+            return Err(OxenError::basic_str(
+                "Must supply a column name.".to_string(),
+            ));
         };
 
         let Some(query) = args.get_one::<String>("query") else {
-            return Err(OxenError::basic_str("Must supply a query."));
+            return Err(OxenError::basic_str("Must supply a query.".to_string()));
         };
 
         let page_size = args
@@ -102,7 +104,7 @@ impl RunCmd for EmbeddingsQueryCmd {
 
         if opts.parse_query().is_err() {
             return Err(OxenError::basic_str(
-                "Query must be in the format key=value",
+                "Query must be in the format key=value".to_string(),
             ));
         }
 
@@ -110,7 +112,7 @@ impl RunCmd for EmbeddingsQueryCmd {
         let commit = repositories::commits::head_commit(&repository)?;
         let workspace_id = format!("{}-{}", path, commit.id);
         let Some(workspace) = repositories::workspaces::get(&repository, &workspace_id)? else {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Workspace not found: {workspace_id}"
             )));
         };

--- a/crates/cli/src/cmd/fetch.rs
+++ b/crates/cli/src/cmd/fetch.rs
@@ -36,7 +36,7 @@ impl RunCmd for FetchCmd {
         let (scheme, host) = get_scheme_and_host_from_repo(&repository)?;
 
         check_repo_migration_needed(&repository)?;
-        check_remote_version_blocking(scheme.clone(), host.clone()).await?;
+        check_remote_version_blocking(&scheme, &host).await?;
         let mut fetch_opts = FetchOpts::new();
         let subtrees = repository.subtree_paths();
         fetch_opts.subtree_paths = subtrees;

--- a/crates/cli/src/cmd/info.rs
+++ b/crates/cli/src/cmd/info.rs
@@ -43,7 +43,7 @@ impl RunCmd for InfoCmd {
         let revision = args.get_one::<String>("revision").map(String::from);
 
         if path.is_none() {
-            return Err(OxenError::basic_str("Must supply path."));
+            return Err(OxenError::basic_str("Must supply path.".to_string()));
         }
 
         let path = path.unwrap();

--- a/crates/cli/src/cmd/init.rs
+++ b/crates/cli/src/cmd/init.rs
@@ -87,7 +87,8 @@ impl RunCmd for InitCmd {
         if backend.is_none() && (storage_backend_path.is_some() || storage_backend_bucket.is_some())
         {
             return Err(OxenError::basic_str(
-                "storage-backend must be specified when storage-backend-path or storage-backend-bucket is provided",
+                "storage-backend must be specified when storage-backend-path or storage-backend-bucket is provided".to_string(),
+
             ));
         }
 

--- a/crates/cli/src/cmd/init.rs
+++ b/crates/cli/src/cmd/init.rs
@@ -97,10 +97,10 @@ impl RunCmd for InitCmd {
         // Make sure the remote version is compatible
         let (scheme, host) = get_scheme_and_host_or_default()?;
 
-        check_remote_version(scheme, host).await?;
+        check_remote_version(&scheme, &host).await?;
 
         // Initialize the repository
-        let directory = util::fs::canonicalize(PathBuf::from(&path))?;
+        let directory = util::fs::canonicalize(&PathBuf::from(&path))?;
         repositories::init::init_with_version_and_storage_opts(
             &directory,
             oxen_version,

--- a/crates/cli/src/cmd/log.rs
+++ b/crates/cli/src/cmd/log.rs
@@ -15,7 +15,7 @@ pub struct LogCmd;
 
 fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
     writeln!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(&format!("Could not write to pager: {e}")))
+        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
 }
 
 #[async_trait]

--- a/crates/cli/src/cmd/log.rs
+++ b/crates/cli/src/cmd/log.rs
@@ -15,7 +15,7 @@ pub struct LogCmd;
 
 fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
     writeln!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
+        .map_err(|e| OxenError::basic_str(&format!("Could not write to pager: {e}")))
 }
 
 #[async_trait]

--- a/crates/cli/src/cmd/ls.rs
+++ b/crates/cli/src/cmd/ls.rs
@@ -62,7 +62,7 @@ impl RunCmd for LsCmd {
             repositories::commits::head_commit(&repo)?
         } else {
             let Some(commit) = repositories::commits::get_by_id(&repo, commit_id)? else {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Commit {commit_id} not found"
                 )));
             };

--- a/crates/cli/src/cmd/ls.rs
+++ b/crates/cli/src/cmd/ls.rs
@@ -62,7 +62,7 @@ impl RunCmd for LsCmd {
             repositories::commits::head_commit(&repo)?
         } else {
             let Some(commit) = repositories::commits::get_by_id(&repo, commit_id)? else {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Commit {commit_id} not found"
                 )));
             };
@@ -78,7 +78,7 @@ impl RunCmd for LsCmd {
         let remote_status = api::client::workspaces::changes::list(
             &remote_repo,
             workspace_identifier,
-            directory.clone(),
+            &directory.clone(),
             page_num,
             page_size,
         )

--- a/crates/cli/src/cmd/merge.rs
+++ b/crates/cli/src/cmd/merge.rs
@@ -35,7 +35,8 @@ impl RunCmd for MergeCmd {
         // Don't allow in remote mode
         if repository.is_remote_mode() {
             return Err(OxenError::basic_str(
-                "Error: Command 'oxen merge' not implemented for remote mode repositories",
+                "Error: Command 'oxen merge' not implemented for remote mode repositories"
+                    .to_string(),
             ));
         }
 
@@ -44,13 +45,13 @@ impl RunCmd for MergeCmd {
             current
         } else {
             return Err(OxenError::basic_str(
-                "Error: Cannot use 'oxen merge' in an empty repository",
+                "Error: Cannot use 'oxen merge' in an empty repository".to_string(),
             ));
         };
 
         if current.name == *branch {
             return Err(OxenError::basic_str(
-                "Error: Cannot merge into current branch",
+                "Error: Cannot merge into current branch".to_string(),
             ));
         }
 

--- a/crates/cli/src/cmd/migrate.rs
+++ b/crates/cli/src/cmd/migrate.rs
@@ -64,7 +64,7 @@ impl RunCmd for MigrateCmd {
         {
             let migration = migrations
                 .get(migration)
-                .ok_or(OxenError::basic_str(format!(
+                .ok_or(OxenError::basic_str(&format!(
                     "Unknown migration: {migration}"
                 )))?;
             let path_str = sub_matches.get_one::<String>("PATH").expect("required");
@@ -82,7 +82,7 @@ impl RunCmd for MigrateCmd {
             } else if direction == "down" {
                 migration.down(path, all)?;
             } else {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Unknown direction: {direction}"
                 )));
             }

--- a/crates/cli/src/cmd/migrate.rs
+++ b/crates/cli/src/cmd/migrate.rs
@@ -64,7 +64,7 @@ impl RunCmd for MigrateCmd {
         {
             let migration = migrations
                 .get(migration)
-                .ok_or(OxenError::basic_str(&format!(
+                .ok_or(OxenError::basic_str(format!(
                     "Unknown migration: {migration}"
                 )))?;
             let path_str = sub_matches.get_one::<String>("PATH").expect("required");
@@ -82,7 +82,7 @@ impl RunCmd for MigrateCmd {
             } else if direction == "down" {
                 migration.down(path, all)?;
             } else {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Unknown direction: {direction}"
                 )));
             }

--- a/crates/cli/src/cmd/node.rs
+++ b/crates/cli/src/cmd/node.rs
@@ -86,7 +86,7 @@ impl RunCmd for NodeCmd {
         } else if let Some(node_hash) = args.get_one::<String>("node") {
             let node_hash = node_hash.parse()?;
             let Some(node) = repositories::tree::get_node_by_id(&repository, &node_hash)? else {
-                return Err(OxenError::resource_not_found(&format!(
+                return Err(OxenError::resource_not_found(format!(
                     "Node {node_hash} not found in repo"
                 )));
             };
@@ -99,7 +99,9 @@ impl RunCmd for NodeCmd {
                 }
             }
         } else {
-            return Err(OxenError::basic_str("Must supply file path or node hash"));
+            return Err(OxenError::basic_str(
+                "Must supply file path or node hash".to_string(),
+            ));
         }
 
         Ok(())

--- a/crates/cli/src/cmd/node.rs
+++ b/crates/cli/src/cmd/node.rs
@@ -86,7 +86,7 @@ impl RunCmd for NodeCmd {
         } else if let Some(node_hash) = args.get_one::<String>("node") {
             let node_hash = node_hash.parse()?;
             let Some(node) = repositories::tree::get_node_by_id(&repository, &node_hash)? else {
-                return Err(OxenError::resource_not_found(format!(
+                return Err(OxenError::resource_not_found(&format!(
                     "Node {node_hash} not found in repo"
                 )));
             };

--- a/crates/cli/src/cmd/pack.rs
+++ b/crates/cli/src/cmd/pack.rs
@@ -64,7 +64,9 @@ impl RunCmd for PackCmd {
             .expect("Chunk size must be a valid integer.");
 
         if _paths.len() != 1 {
-            return Err(OxenError::basic_str("Must supply exactly one file"));
+            return Err(OxenError::basic_str(
+                "Must supply exactly one file".to_string(),
+            ));
         }
         Ok(())
     }

--- a/crates/cli/src/cmd/pull.rs
+++ b/crates/cli/src/cmd/pull.rs
@@ -70,8 +70,8 @@ impl RunCmd for PullCmd {
         let (scheme, host) = get_scheme_and_host_from_repo(&repo)?;
 
         check_repo_migration_needed(&repo)?;
-        check_remote_version_blocking(scheme.clone(), host.clone()).await?;
-        check_remote_version(scheme, host).await?;
+        check_remote_version_blocking(&scheme, &host).await?;
+        check_remote_version(&scheme, &host).await?;
 
         let mut fetch_opts = FetchOpts::new();
         fetch_opts.remote = remote.to_owned();

--- a/crates/cli/src/cmd/push.rs
+++ b/crates/cli/src/cmd/push.rs
@@ -99,7 +99,7 @@ impl RunCmd for PushCmd {
         if opts.delete {
             let (scheme, host) = get_scheme_and_host_from_repo(&repo)?;
 
-            check_remote_version(scheme, host).await?;
+            check_remote_version(&scheme, &host).await?;
 
             api::client::branches::delete_remote(&repo, &opts.remote, &opts.branch).await?;
             println!("Deleted remote branch: {}/{}", opts.remote, opts.branch);
@@ -111,8 +111,8 @@ impl RunCmd for PushCmd {
             let (scheme, host) = get_scheme_and_host_from_repo(&repo)?;
 
             check_repo_migration_needed(&repo)?;
-            check_remote_version_blocking(scheme.clone(), host.clone()).await?;
-            check_remote_version(scheme, host).await?;
+            check_remote_version_blocking(&scheme, &host).await?;
+            check_remote_version(&scheme, &host).await?;
 
             repositories::push::push_remote_branch(&repo, &opts).await?;
             Ok(())

--- a/crates/cli/src/cmd/remote_mode/commit.rs
+++ b/crates/cli/src/cmd/remote_mode/commit.rs
@@ -36,7 +36,7 @@ impl RunCmd for RemoteModeCommitCmd {
         // Parse Args
         let Some(message) = args.get_one::<String>("message") else {
             return Err(OxenError::basic_str(
-                "Err: Usage `oxen workspace commit -w <workspace_id> -m <message>`",
+                "Err: Usage `oxen workspace commit -w <workspace_id> -m <message>`".to_string(),
             ));
         };
 

--- a/crates/cli/src/cmd/remote_mode/status.rs
+++ b/crates/cli/src/cmd/remote_mode/status.rs
@@ -63,7 +63,7 @@ impl RunCmd for RemoteModeStatusCmd {
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
         let current_dir = std::env::current_dir().map_err(OxenError::from)?;
         let repo_dir = util::fs::get_repo_root_from_current_dir()
-            .ok_or_else(|| OxenError::local_repo_not_found(&current_dir))?;
+            .ok_or_else(|| OxenError::local_repo_not_found(current_dir))?;
         let repository = LocalRepository::from_dir(&repo_dir)?;
 
         let workspace_id = if repository.is_remote_mode() {
@@ -71,7 +71,7 @@ impl RunCmd for RemoteModeStatusCmd {
         } else {
             // TODO: New error type
             return Err(OxenError::basic_str(
-                "New err type, can't do rmeote mode command outside remote mode repo",
+                "New err type, can't do rmeote mode command outside remote mode repo".to_string(),
             ));
         };
 

--- a/crates/cli/src/cmd/remote_mode/status.rs
+++ b/crates/cli/src/cmd/remote_mode/status.rs
@@ -105,8 +105,8 @@ impl RunCmd for RemoteModeStatusCmd {
 
         let (scheme, host) = get_scheme_and_host_from_repo(&repository)?;
 
-        check_remote_version_blocking(scheme.clone(), host.clone()).await?;
-        check_remote_version(scheme, host).await?;
+        check_remote_version_blocking(&scheme, &host).await?;
+        check_remote_version(&scheme, &host).await?;
 
         // TODO: Implement path-based workspace status
         let directory = PathBuf::from(".");

--- a/crates/cli/src/cmd/save.rs
+++ b/crates/cli/src/cmd/save.rs
@@ -41,7 +41,7 @@ impl RunCmd for SaveCmd {
         let output_path = Path::new(output_str);
         let repo_path = Path::new(repo_str);
         let repo_dir = util::fs::get_repo_root(repo_path)
-            .ok_or_else(|| OxenError::local_repo_not_found(repo_path))?;
+            .ok_or_else(|| OxenError::local_repo_not_found(repo_path.to_path_buf()))?;
         let repo = LocalRepository::from_dir(&repo_dir)?;
 
         repositories::save(&repo, output_path)?;

--- a/crates/cli/src/cmd/schemas.rs
+++ b/crates/cli/src/cmd/schemas.rs
@@ -72,8 +72,12 @@ impl RunCmd for SchemasCmd {
             let repository = LocalRepository::from_current_dir()?;
             let staged = args.get_flag("staged");
             let verbose = !args.get_flag("flatten"); // default to verbose
-            let val =
-                repositories::data_frames::schemas::show(&repository, schema_ref, staged, verbose)?;
+            let val = repositories::data_frames::schemas::show(
+                &repository,
+                std::path::Path::new(schema_ref),
+                staged,
+                verbose,
+            )?;
             println!("{val}");
         } else {
             // Fall back to list schemas

--- a/crates/cli/src/cmd/schemas/add.rs
+++ b/crates/cli/src/cmd/schemas/add.rs
@@ -80,7 +80,7 @@ impl RunCmd for SchemasAddCmd {
         if let Some(column) = column {
             if let Some(render) = render {
                 let render_json = self.generate_render_json(render)?;
-                match self.schema_add_column_metadata(&repository, path, column, render_json) {
+                match self.schema_add_column_metadata(&repository, path, column, &render_json) {
                     Ok(_) => {}
                     Err(err) => {
                         eprintln!("{err}")
@@ -116,16 +116,15 @@ impl SchemasAddCmd {
     fn schema_add_column_metadata(
         &self,
         repository: &LocalRepository,
-        path: impl AsRef<Path>,
-        column: impl AsRef<str>,
-        metadata: impl AsRef<str>,
+        path: &Path,
+        column: &str,
+        metadata: &str,
     ) -> Result<(), OxenError> {
         // make sure metadata is valid json, return oxen error if not
-        let metadata: serde_json::Value = serde_json::from_str(metadata.as_ref()).map_err(|e| {
-            OxenError::basic_str(format!(
+        let metadata: serde_json::Value = serde_json::from_str(metadata).map_err(|e| {
+            OxenError::basic_str(&format!(
                 "Metadata must be valid JSON: '{}'\n{}",
-                metadata.as_ref(),
-                e
+                metadata, e
             ))
         })?;
 
@@ -141,14 +140,13 @@ impl SchemasAddCmd {
     fn schema_add_metadata(
         &self,
         repository: &LocalRepository,
-        path: impl AsRef<Path>,
-        metadata: impl AsRef<str>,
+        path: &Path,
+        metadata: &str,
     ) -> Result<(), OxenError> {
-        let metadata: serde_json::Value = serde_json::from_str(metadata.as_ref()).map_err(|e| {
-            OxenError::basic_str(format!(
+        let metadata: serde_json::Value = serde_json::from_str(metadata).map_err(|e| {
+            OxenError::basic_str(&format!(
                 "Metadata must be valid JSON: '{}'\n{}",
-                metadata.as_ref(),
-                e
+                metadata, e
             ))
         })?;
 
@@ -161,8 +159,7 @@ impl SchemasAddCmd {
         Ok(())
     }
 
-    fn generate_render_json(&self, render_type: impl AsRef<str>) -> Result<String, OxenError> {
-        let render_type = render_type.as_ref();
+    fn generate_render_json(&self, render_type: &str) -> Result<String, OxenError> {
         let valid_render_types: HashSet<&str> = ["image", "link", "video"].into_iter().collect();
         if valid_render_types.contains(render_type) {
             let json = serde_json::json!({
@@ -175,7 +172,7 @@ impl SchemasAddCmd {
 
             Ok(serde_json::to_string(&json)?)
         } else {
-            Err(OxenError::basic_str(format!(
+            Err(OxenError::basic_str(&format!(
                 "Invalid render type: {render_type}"
             )))
         }

--- a/crates/cli/src/cmd/schemas/add.rs
+++ b/crates/cli/src/cmd/schemas/add.rs
@@ -63,13 +63,13 @@ impl RunCmd for SchemasAddCmd {
         let err_msg = "Must supply a file path, column name and either -m for metadata or -t for data type\n\n  oxen schemas add file.csv -c 'col1' -t 'str'\n";
 
         let Some(path) = &path else {
-            return Err(OxenError::basic_str(err_msg));
+            return Err(OxenError::basic_str(err_msg.to_string()));
         };
 
         // If there is a render flag without a column, return an error
         if render.is_some() && column.is_none() {
             return Err(OxenError::basic_str(
-                "Must supply a column name with the -c flag when using --render.",
+                "Must supply a column name with the -c flag when using --render.".to_string(),
             ));
         }
 
@@ -122,7 +122,7 @@ impl SchemasAddCmd {
     ) -> Result<(), OxenError> {
         // make sure metadata is valid json, return oxen error if not
         let metadata: serde_json::Value = serde_json::from_str(metadata).map_err(|e| {
-            OxenError::basic_str(&format!(
+            OxenError::basic_str(format!(
                 "Metadata must be valid JSON: '{}'\n{}",
                 metadata, e
             ))
@@ -144,7 +144,7 @@ impl SchemasAddCmd {
         metadata: &str,
     ) -> Result<(), OxenError> {
         let metadata: serde_json::Value = serde_json::from_str(metadata).map_err(|e| {
-            OxenError::basic_str(&format!(
+            OxenError::basic_str(format!(
                 "Metadata must be valid JSON: '{}'\n{}",
                 metadata, e
             ))
@@ -172,7 +172,7 @@ impl SchemasAddCmd {
 
             Ok(serde_json::to_string(&json)?)
         } else {
-            Err(OxenError::basic_str(&format!(
+            Err(OxenError::basic_str(format!(
                 "Invalid render type: {render_type}"
             )))
         }

--- a/crates/cli/src/cmd/schemas/rm.rs
+++ b/crates/cli/src/cmd/schemas/rm.rs
@@ -40,7 +40,11 @@ impl RunCmd for SchemasRmCmd {
         };
 
         let staged = args.get_flag("staged");
-        repositories::data_frames::schemas::rm(&repository, schema_ref, staged)?;
+        repositories::data_frames::schemas::rm(
+            &repository,
+            std::path::Path::new(schema_ref),
+            staged,
+        )?;
 
         Ok(())
     }

--- a/crates/cli/src/cmd/schemas/rm.rs
+++ b/crates/cli/src/cmd/schemas/rm.rs
@@ -35,7 +35,7 @@ impl RunCmd for SchemasRmCmd {
 
         let Some(schema_ref) = args.get_one::<String>("NAME_OR_HASH") else {
             return Err(OxenError::basic_str(
-                "Must supply a name, hash, or path of the schema you want to remove.",
+                "Must supply a name, hash, or path of the schema you want to remove.".to_string(),
             ));
         };
 

--- a/crates/cli/src/cmd/schemas/show.rs
+++ b/crates/cli/src/cmd/schemas/show.rs
@@ -48,7 +48,12 @@ impl RunCmd for SchemasShowCmd {
         let verbose = args.get_flag("verbose");
         let staged = args.get_flag("staged");
 
-        let result = repositories::data_frames::schemas::show(&repository, path, staged, verbose)?;
+        let result = repositories::data_frames::schemas::show(
+            &repository,
+            std::path::Path::new(path),
+            staged,
+            verbose,
+        )?;
         println!("{result}");
 
         Ok(())

--- a/crates/cli/src/cmd/schemas/show.rs
+++ b/crates/cli/src/cmd/schemas/show.rs
@@ -42,7 +42,7 @@ impl RunCmd for SchemasShowCmd {
 
         let Some(path) = args.get_one::<String>("PATH") else {
             return Err(OxenError::basic_str(
-                "Must supply a path of the schema you want to show.",
+                "Must supply a path of the schema you want to show.".to_string(),
             ));
         };
         let verbose = args.get_flag("verbose");

--- a/crates/cli/src/cmd/tree.rs
+++ b/crates/cli/src/cmd/tree.rs
@@ -95,7 +95,7 @@ impl TreeCmd {
         let node_hash = node.parse()?;
         // REFACTOR: Get through repositories::tree
         let tree = CommitMerkleTree::read_node(repo, &node_hash, true)?
-            .ok_or_else(|| OxenError::resource_not_found(&format!("Node {node_hash} not found")))?;
+            .ok_or_else(|| OxenError::resource_not_found(format!("Node {node_hash} not found")))?;
         CommitMerkleTree::print_node_depth(&tree, depth);
 
         Ok(())
@@ -114,9 +114,9 @@ impl TreeCmd {
                 println!("Working with subtrees: {subtrees:?}");
                 println!("Depth: {depth}");
                 println!("Loading first tree...");
-                let first = subtrees
-                    .first()
-                    .ok_or_else(|| OxenError::basic_str("No subtree paths configured"))?;
+                let first = subtrees.first().ok_or_else(|| {
+                    OxenError::basic_str("No subtree paths configured".to_string())
+                })?;
                 repositories::tree::print_tree_depth_subtree(repo, commit, depth, first)?;
             }
             (_, _) => {

--- a/crates/cli/src/cmd/tree.rs
+++ b/crates/cli/src/cmd/tree.rs
@@ -95,7 +95,7 @@ impl TreeCmd {
         let node_hash = node.parse()?;
         // REFACTOR: Get through repositories::tree
         let tree = CommitMerkleTree::read_node(repo, &node_hash, true)?
-            .ok_or_else(|| OxenError::resource_not_found(format!("Node {node_hash} not found")))?;
+            .ok_or_else(|| OxenError::resource_not_found(&format!("Node {node_hash} not found")))?;
         CommitMerkleTree::print_node_depth(&tree, depth);
 
         Ok(())
@@ -121,7 +121,7 @@ impl TreeCmd {
             }
             (_, _) => {
                 if let Some(path) = path {
-                    repositories::tree::print_tree_path(repo, commit, path)?;
+                    repositories::tree::print_tree_path(repo, commit, std::path::Path::new(path))?;
                 } else {
                     repositories::tree::print_tree_depth(repo, commit, depth)?;
                 }

--- a/crates/cli/src/cmd/upload.rs
+++ b/crates/cli/src/cmd/upload.rs
@@ -110,7 +110,7 @@ impl RunCmd for UploadCmd {
             ));
         }
 
-        check_remote_version_blocking(&opts.scheme, opts.clone().host).await?;
+        check_remote_version_blocking(&opts.scheme, &opts.host).await?;
 
         // Check if the first path is a valid remote repo
         let name = paths[0].to_string_lossy();

--- a/crates/cli/src/cmd/upload.rs
+++ b/crates/cli/src/cmd/upload.rs
@@ -106,7 +106,7 @@ impl RunCmd for UploadCmd {
         let paths = &opts.paths;
         if paths.is_empty() {
             return Err(OxenError::basic_str(
-                "Must supply repository and a file to upload.",
+                "Must supply repository and a file to upload.".to_string(),
             ));
         }
 

--- a/crates/cli/src/cmd/workspace/add.rs
+++ b/crates/cli/src/cmd/workspace/add.rs
@@ -77,7 +77,7 @@ impl RunCmd for WorkspaceAddCmd {
                         (name, directory.as_str())
                     } else {
                         return Err(OxenError::basic_str(
-                            "Either workspace-id or workspace-name must be provided.",
+                            "Either workspace-id or workspace-name must be provided.".to_string(),
                         ));
                     }
                 }
@@ -95,7 +95,7 @@ impl RunCmd for WorkspaceAddCmd {
         // If no paths left after filtering, return early
         if paths.is_empty() {
             return Err(OxenError::basic_str(
-                "No files to add after filtering with .oxenignore.",
+                "No files to add after filtering with .oxenignore.".to_string(),
             ));
         }
 

--- a/crates/cli/src/cmd/workspace/add.rs
+++ b/crates/cli/src/cmd/workspace/add.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use clap::{Arg, ArgGroup, ArgMatches, Command};
@@ -102,7 +102,7 @@ impl RunCmd for WorkspaceAddCmd {
         api::client::workspaces::files::add(
             &remote_repo,
             workspace_identifier,
-            directory,
+            Path::new(directory),
             paths,
             &None,
         )

--- a/crates/cli/src/cmd/workspace/clear.rs
+++ b/crates/cli/src/cmd/workspace/clear.rs
@@ -54,7 +54,7 @@ impl RunCmd for WorkspaceClearCmd {
                 return Ok(());
             }
             Err(e) => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Error confirming deletion: {e}"
                 )));
             }

--- a/crates/cli/src/cmd/workspace/clear.rs
+++ b/crates/cli/src/cmd/workspace/clear.rs
@@ -54,7 +54,7 @@ impl RunCmd for WorkspaceClearCmd {
                 return Ok(());
             }
             Err(e) => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Error confirming deletion: {e}"
                 )));
             }

--- a/crates/cli/src/cmd/workspace/commit.rs
+++ b/crates/cli/src/cmd/workspace/commit.rs
@@ -57,7 +57,7 @@ impl RunCmd for WorkspaceCommitCmd {
         // Parse Args
         let Some(message) = args.get_one::<String>("message") else {
             return Err(OxenError::basic_str(
-                "Err: Usage `oxen workspace commit -w <workspace_id> -m <message>`",
+                "Err: Usage `oxen workspace commit -w <workspace_id> -m <message>`".to_string(),
             ));
         };
 
@@ -76,7 +76,7 @@ impl RunCmd for WorkspaceCommitCmd {
                         name
                     } else {
                         return Err(OxenError::basic_str(
-                            "Either workspace-id or workspace-name must be provided.",
+                            "Either workspace-id or workspace-name must be provided.".to_string(),
                         ));
                     }
                 }
@@ -93,7 +93,8 @@ impl RunCmd for WorkspaceCommitCmd {
                     Some(branch) => branch.name,
                     None => {
                         return Err(OxenError::basic_str(
-                            "No current branch. Use --branch to specify a target branch to commit the workspace to.",
+                            "No current branch. Use --branch to specify a target branch to commit the workspace to.".to_string(),
+
                         ));
                     }
                 }

--- a/crates/cli/src/cmd/workspace/create.rs
+++ b/crates/cli/src/cmd/workspace/create.rs
@@ -47,7 +47,7 @@ impl RunCmd for WorkspaceCreateCmd {
                     Some(branch) => branch.name,
                     None => {
                         return Err(OxenError::basic_str(
-                            "No current branch. Use --branch to specify a branch name.",
+                            "No current branch. Use --branch to specify a branch name.".to_string(),
                         ));
                     }
                 }

--- a/crates/cli/src/cmd/workspace/delete.rs
+++ b/crates/cli/src/cmd/workspace/delete.rs
@@ -51,7 +51,7 @@ impl RunCmd for WorkspaceDeleteCmd {
                     name
                 } else {
                     return Err(OxenError::basic_str(
-                        "Either workspace-id or workspace-name must be provided.",
+                        "Either workspace-id or workspace-name must be provided.".to_string(),
                     ));
                 }
             }

--- a/crates/cli/src/cmd/workspace/delete.rs
+++ b/crates/cli/src/cmd/workspace/delete.rs
@@ -58,7 +58,7 @@ impl RunCmd for WorkspaceDeleteCmd {
         };
 
         // Now call the delete API using the resolved workspace id.
-        api::client::workspaces::delete(&remote_repo, &workspace_identifier).await?;
+        api::client::workspaces::delete(&remote_repo, workspace_identifier).await?;
         println!("Workspace '{workspace_identifier}' deleted successfully");
         Ok(())
     }

--- a/crates/cli/src/cmd/workspace/df/get.rs
+++ b/crates/cli/src/cmd/workspace/df/get.rs
@@ -99,8 +99,8 @@ impl RunCmd for WorkspaceDFGetCmd {
             println!("Downloading data frame to {output:?}");
             api::client::workspaces::data_frames::download(
                 &remote_repo,
-                &workspace_id,
-                &path,
+                workspace_id,
+                std::path::Path::new(path),
                 &opts,
             )
             .await?;
@@ -110,8 +110,13 @@ impl RunCmd for WorkspaceDFGetCmd {
         }
 
         let start = std::time::Instant::now();
-        match api::client::workspaces::data_frames::get(&remote_repo, &workspace_id, &path, &opts)
-            .await
+        match api::client::workspaces::data_frames::get(
+            &remote_repo,
+            workspace_id,
+            std::path::Path::new(path),
+            &opts,
+        )
+        .await
         {
             Ok(response) => {
                 if let Some(data_frame) = response.data_frame {
@@ -120,7 +125,7 @@ impl RunCmd for WorkspaceDFGetCmd {
                     println!("{df:?}");
                     println!("Query took: {:?}", start.elapsed());
                 } else {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(OxenError::basic_str(&format!(
                         "No data frame found. Index the data frame before querying.\n\n  oxen workspace df index {path} -w {workspace_id}\n"
                     )));
                 }

--- a/crates/cli/src/cmd/workspace/df/get.rs
+++ b/crates/cli/src/cmd/workspace/df/get.rs
@@ -84,11 +84,13 @@ impl RunCmd for WorkspaceDFGetCmd {
         // Parse Args
         let Some(path) = args.get_one::<String>("path") else {
             return Err(OxenError::basic_str(
-                "Must supply a path to the data frame you want to get.",
+                "Must supply a path to the data frame you want to get.".to_string(),
             ));
         };
         let Some(workspace_id) = args.get_one::<String>("workspace-id") else {
-            return Err(OxenError::basic_str("Must supply a workspace id."));
+            return Err(OxenError::basic_str(
+                "Must supply a workspace id.".to_string(),
+            ));
         };
 
         let repository = LocalRepository::from_current_dir()?;
@@ -125,7 +127,7 @@ impl RunCmd for WorkspaceDFGetCmd {
                     println!("{df:?}");
                     println!("Query took: {:?}", start.elapsed());
                 } else {
-                    return Err(OxenError::basic_str(&format!(
+                    return Err(OxenError::basic_str(format!(
                         "No data frame found. Index the data frame before querying.\n\n  oxen workspace df index {path} -w {workspace_id}\n"
                     )));
                 }

--- a/crates/cli/src/cmd/workspace/df/index.rs
+++ b/crates/cli/src/cmd/workspace/df/index.rs
@@ -72,15 +72,20 @@ impl RunCmd for WorkspaceDFIndexCmd {
 
         let df = api::client::workspaces::data_frames::get(
             &remote_repo,
-            &workspace_id,
-            &path,
+            workspace_id,
+            std::path::Path::new(path),
             &DFOpts::empty(),
         )
         .await?;
 
         if !df.is_indexed {
             let start = Instant::now();
-            api::client::workspaces::data_frames::index(&remote_repo, workspace_id, &path).await?;
+            api::client::workspaces::data_frames::index(
+                &remote_repo,
+                workspace_id,
+                std::path::Path::new(path),
+            )
+            .await?;
             println!("{:?} indexed in {:?}", path, start.elapsed());
         } else {
             log::debug!("Data frame is already indexed.");

--- a/crates/cli/src/cmd/workspace/df/index.rs
+++ b/crates/cli/src/cmd/workspace/df/index.rs
@@ -56,12 +56,14 @@ impl RunCmd for WorkspaceDFIndexCmd {
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
         // Parse Args
         let Some(workspace_id) = args.get_one::<String>("workspace-id") else {
-            return Err(OxenError::basic_str("Must supply a workspace id."));
+            return Err(OxenError::basic_str(
+                "Must supply a workspace id.".to_string(),
+            ));
         };
 
         let Some(path) = args.get_one::<String>("path") else {
             return Err(OxenError::basic_str(
-                "Must supply a path to the data frame you want to index.",
+                "Must supply a path to the data frame you want to index.".to_string(),
             ));
         };
 
@@ -94,7 +96,7 @@ impl RunCmd for WorkspaceDFIndexCmd {
         if args.get_flag("embeddings") {
             let Some(column) = args.get_one::<String>("column") else {
                 return Err(OxenError::basic_str(
-                    "Must supply a column to index for embeddings.",
+                    "Must supply a column to index for embeddings.".to_string(),
                 ));
             };
             let use_background_thread = args.get_flag("use-background-thread");

--- a/crates/cli/src/cmd/workspace/diff.rs
+++ b/crates/cli/src/cmd/workspace/diff.rs
@@ -42,7 +42,9 @@ impl RunCmd for WorkspaceDiffCmd {
         } else if let Some(id) = args.get_one::<String>("workspace-id") {
             Some(id.to_string())
         } else {
-            return Err(OxenError::basic_str("Must supply a workspace id."));
+            return Err(OxenError::basic_str(
+                "Must supply a workspace id.".to_string(),
+            ));
         }
         .unwrap();
 

--- a/crates/cli/src/cmd/workspace/download.rs
+++ b/crates/cli/src/cmd/workspace/download.rs
@@ -115,5 +115,5 @@ fn workspace_not_found(message: &str) -> OxenError {
     //       CLI error rendering needs to be updated so we can use error variants properly & have precise
     //       error message formatting control.
     // OxenError::WorkspaceNotFound(Box::new(StringError::new(format!("Workspace {message} does not exist"))))
-    OxenError::basic_str(format!("Workspace {message} does not exist"))
+    OxenError::basic_str(&format!("Workspace {message} does not exist"))
 }

--- a/crates/cli/src/cmd/workspace/download.rs
+++ b/crates/cli/src/cmd/workspace/download.rs
@@ -55,9 +55,10 @@ impl RunCmd for WorkspaceDownloadCmd {
 
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
         // Parse Args
-        let file_path = args
-            .get_one::<String>("file")
-            .map_or_else(|| Err(OxenError::basic_str("Must supply --file (-f)")), Ok)?;
+        let file_path = args.get_one::<String>("file").map_or_else(
+            || Err(OxenError::basic_str("Must supply --file (-f)".to_string())),
+            Ok,
+        )?;
 
         let workspace_name = args.get_one::<String>("workspace-name");
         let workspace_id = args.get_one::<String>("workspace-id");
@@ -86,7 +87,7 @@ impl RunCmd for WorkspaceDownloadCmd {
             }
             // This should never be reached due to clap's required_unless_present
             _ => Err(OxenError::basic_str(
-                "Either --workspace-id or --workspace-name must be provided.",
+                "Either --workspace-id or --workspace-name must be provided.".to_string(),
             ))?,
         };
 
@@ -100,7 +101,7 @@ impl RunCmd for WorkspaceDownloadCmd {
         {
             Ok(_) => Ok(()),
             Err(OxenError::PathDoesNotExist(_)) => Err(OxenError::resource_not_found(
-                "File not found in workspace staged DB or base repo",
+                "File not found in workspace staged DB or base repo".to_string(),
             )),
             unexpected_error => unexpected_error,
         }
@@ -115,5 +116,5 @@ fn workspace_not_found(message: &str) -> OxenError {
     //       CLI error rendering needs to be updated so we can use error variants properly & have precise
     //       error message formatting control.
     // OxenError::WorkspaceNotFound(Box::new(StringError::new(format!("Workspace {message} does not exist"))))
-    OxenError::basic_str(&format!("Workspace {message} does not exist"))
+    OxenError::basic_str(format!("Workspace {message} does not exist"))
 }

--- a/crates/cli/src/cmd/workspace/rm.rs
+++ b/crates/cli/src/cmd/workspace/rm.rs
@@ -80,7 +80,7 @@ impl RunCmd for WorkspaceRmCmd {
                         name
                     } else {
                         return Err(OxenError::basic_str(
-                            "Either workspace-id or workspace-name must be provided.",
+                            "Either workspace-id or workspace-name must be provided.".to_string(),
                         ));
                     }
                 }
@@ -98,7 +98,7 @@ impl RunCmd for WorkspaceRmCmd {
         // If no paths left after filtering, return early
         if paths.is_empty() {
             return Err(OxenError::basic_str(
-                "No files to remove after filtering with .oxenignore.",
+                "No files to remove after filtering with .oxenignore.".to_string(),
             ));
         }
 

--- a/crates/cli/src/cmd/workspace/status.rs
+++ b/crates/cli/src/cmd/workspace/status.rs
@@ -153,8 +153,8 @@ impl RunCmd for WorkspaceStatusCmd {
 
         let (scheme, host) = get_scheme_and_host_from_repo(&repository)?;
 
-        check_remote_version_blocking(scheme.clone(), host.clone()).await?;
-        check_remote_version(scheme, host).await?;
+        check_remote_version_blocking(&scheme, &host).await?;
+        check_remote_version(&scheme, &host).await?;
 
         let directory = directory.unwrap_or(PathBuf::from("."));
 
@@ -173,7 +173,7 @@ impl WorkspaceStatusCmd {
     pub(crate) async fn status(
         remote_repo: &RemoteRepository,
         workspace_id: &str,
-        directory: impl AsRef<Path>,
+        directory: &Path,
         opts: &StagedDataOpts,
     ) -> Result<StagedData, OxenError> {
         let page_size = opts.limit;
@@ -215,6 +215,7 @@ mod tests {
     use super::*;
     use liboxen::api;
     use liboxen::error::OxenError;
+    use std::path::Path;
 
     #[tokio::test]
     async fn test_workspace_status_by_name() -> Result<(), OxenError> {
@@ -232,18 +233,20 @@ mod tests {
 
             // Create a named workspace
             api::client::workspaces::create_with_name(&remote_repo, "main", w_id, w_name).await?;
-            let status = WorkspaceStatusCmd::status(&remote_repo, w_id, ".", &opts).await?;
+            let status =
+                WorkspaceStatusCmd::status(&remote_repo, w_id, Path::new("."), &opts).await?;
             assert_eq!(status.staged_files.len(), 0);
 
             // add a file to it and ensure that we can retrieve status via name
             api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 w_name,
-                "",
-                liboxen::test::test_img_file(),
+                Path::new(""),
+                &liboxen::test::test_img_file(),
             )
             .await?;
-            let status = WorkspaceStatusCmd::status(&remote_repo, w_name, ".", &opts).await?;
+            let status =
+                WorkspaceStatusCmd::status(&remote_repo, w_name, Path::new("."), &opts).await?;
             assert_eq!(status.staged_files.len(), 1);
 
             Ok(remote_repo)

--- a/crates/cli/src/cmd/workspace/status.rs
+++ b/crates/cli/src/cmd/workspace/status.rs
@@ -117,7 +117,7 @@ impl RunCmd for WorkspaceStatusCmd {
                     name
                 } else {
                     return Err(OxenError::basic_str(
-                        "Either workspace-id or workspace-name must be provided.",
+                        "Either workspace-id or workspace-name must be provided.".to_string(),
                     ));
                 }
             }
@@ -147,7 +147,7 @@ impl RunCmd for WorkspaceStatusCmd {
 
         let current_dir = std::env::current_dir().map_err(OxenError::from)?;
         let repo_dir = util::fs::get_repo_root_from_current_dir()
-            .ok_or_else(|| OxenError::local_repo_not_found(&current_dir))?;
+            .ok_or_else(|| OxenError::local_repo_not_found(current_dir))?;
 
         let repository = LocalRepository::from_dir(&repo_dir)?;
 

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -38,12 +38,9 @@ pub fn get_scheme_and_host_from_repo(
     get_scheme_and_host_or_default()
 }
 
-pub async fn check_remote_version(
-    scheme: impl AsRef<str>,
-    host: impl AsRef<str>,
-) -> Result<(), OxenError> {
+pub async fn check_remote_version(scheme: &str, host: &str) -> Result<(), OxenError> {
     // Do the version check in the dispatch because it's only really the CLI that needs to do it
-    match api::client::oxen_version::get_remote_version(scheme.as_ref(), host.as_ref()).await {
+    match api::client::oxen_version::get_remote_version(scheme, host).await {
         Ok(remote_version) => {
             let local_version: &str = constants::OXEN_VERSION;
 
@@ -60,11 +57,8 @@ pub async fn check_remote_version(
     Ok(())
 }
 
-pub async fn check_remote_version_blocking(
-    scheme: impl AsRef<str>,
-    host: impl AsRef<str>,
-) -> Result<(), OxenError> {
-    match api::client::oxen_version::get_min_oxen_version(scheme.as_ref(), host.as_ref()).await {
+pub async fn check_remote_version_blocking(scheme: &str, host: &str) -> Result<(), OxenError> {
+    match api::client::oxen_version::get_min_oxen_version(scheme, host).await {
         Ok(remote_version) => {
             let local_version: &str = constants::OXEN_VERSION;
             let min_oxen_version = OxenVersion::from_str(&remote_version)?;

--- a/crates/lib/benches/add.rs
+++ b/crates/lib/benches/add.rs
@@ -165,14 +165,14 @@ pub fn add_benchmark(c: &mut Criterion) {
                         .await
                         .unwrap();
 
-                    let _ = util::fs::remove_dir_all(repo.path.join(".oxen/staging"));
+                    let _ = util::fs::remove_dir_all(&repo.path.join(".oxen/staging"));
                 })
             },
         );
     }
     group.finish();
 
-    util::fs::remove_dir_all(base_dir).unwrap();
+    util::fs::remove_dir_all(&base_dir).unwrap();
 }
 
 criterion_group!(benches, add_benchmark);

--- a/crates/lib/benches/download.rs
+++ b/crates/lib/benches/download.rs
@@ -200,7 +200,7 @@ pub fn download_benchmark(c: &mut Criterion) {
     }
     group.finish();
 
-    util::fs::remove_dir_all(base_dir).unwrap();
+    util::fs::remove_dir_all(&base_dir).unwrap();
 }
 
 criterion_group!(benches, download_benchmark);

--- a/crates/lib/benches/fetch.rs
+++ b/crates/lib/benches/fetch.rs
@@ -204,7 +204,7 @@ pub fn fetch_benchmark(c: &mut Criterion) {
     }
     group.finish();
 
-    util::fs::remove_dir_all(base_dir).unwrap();
+    util::fs::remove_dir_all(&base_dir).unwrap();
 }
 
 criterion_group!(benches, fetch_benchmark);

--- a/crates/lib/benches/push.rs
+++ b/crates/lib/benches/push.rs
@@ -184,8 +184,8 @@ pub fn push_benchmark(c: &mut Criterion) {
 
                         let repo_new = RepoNew::from_namespace_name_host(
                             DEFAULT_NAMESPACE,
-                            iter_dirname,
-                            test_host(),
+                            &iter_dirname,
+                            &test_host(),
                             None,
                         );
 
@@ -229,7 +229,7 @@ pub fn push_benchmark(c: &mut Criterion) {
     }
     group.finish();
 
-    util::fs::remove_dir_all(base_dir).unwrap();
+    util::fs::remove_dir_all(&base_dir).unwrap();
 }
 
 criterion_group!(benches, push_benchmark);

--- a/crates/lib/benches/workspace_add.rs
+++ b/crates/lib/benches/workspace_add.rs
@@ -202,7 +202,7 @@ pub fn workspace_add_benchmark(c: &mut Criterion) {
                 let workspace = rt
                     .block_on(api::client::workspaces::create(
                         &remote_repo,
-                        &branch_name,
+                        branch_name,
                         &workspace_id,
                     ))
                     .unwrap();
@@ -210,8 +210,8 @@ pub fn workspace_add_benchmark(c: &mut Criterion) {
                 b.to_async(&rt).iter(|| async {
                     api::client::workspaces::files::add(
                         &remote_repo,
-                        &workspace.id.as_str(),
-                        "",
+                        workspace.id.as_str(),
+                        Path::new(""),
                         files.clone(),
                         &None,
                     )
@@ -227,7 +227,7 @@ pub fn workspace_add_benchmark(c: &mut Criterion) {
     }
     group.finish();
 
-    util::fs::remove_dir_all(base_dir).unwrap();
+    util::fs::remove_dir_all(&base_dir).unwrap();
 }
 
 criterion_group!(benches, workspace_add_benchmark);

--- a/crates/lib/src/api/client.rs
+++ b/crates/lib/src/api/client.rs
@@ -135,7 +135,7 @@ fn builder_for_host(host: &str, should_add_user_agent: bool) -> Result<ClientBui
             Err(e) => {
                 log::debug!("Invalid header value: {e}");
                 return Err(OxenError::basic_str(
-                    "Error setting request auth. Please check your Oxen config.",
+                    "Error setting request auth. Please check your Oxen config.".to_string(),
                 ));
             }
         };
@@ -215,7 +215,7 @@ async fn parse_json_body_with_err_msg(
         ),
         Err(err) => {
             log::debug!("Err: {err}");
-            Err(OxenError::basic_str(&format!(
+            Err(OxenError::basic_str(format!(
                 "Could not deserialize response from [{url}]\n{status}"
             )))
         }
@@ -234,7 +234,7 @@ fn parse_status_and_message(
         http::STATUS_SUCCESS => {
             log::debug!("Status success: {status}");
             if !status.is_success() {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Err status [{}] from url {} [{}]",
                     status,
                     url,
@@ -246,7 +246,7 @@ fn parse_status_and_message(
         }
         http::STATUS_WARNING => {
             log::debug!("Status warning: {status}");
-            Err(OxenError::basic_str(&format!(
+            Err(OxenError::basic_str(format!(
                 "Remote Warning: {}",
                 response.desc_or_msg()
             )))
@@ -258,12 +258,12 @@ fn parse_status_and_message(
                 && let Some(response_type) = response_type
                 && response.desc_or_msg() == response_type
             {
-                return Err(OxenError::basic_str(msg));
+                return Err(OxenError::basic_str(msg.to_string()));
             }
 
-            Err(OxenError::basic_str(&response.full_err_msg()))
+            Err(OxenError::basic_str(response.full_err_msg()))
         }
-        status => Err(OxenError::basic_str(&format!("Unknown status [{status}]"))),
+        status => Err(OxenError::basic_str(format!("Unknown status [{status}]"))),
     }
 }
 

--- a/crates/lib/src/api/client.rs
+++ b/crates/lib/src/api/client.rs
@@ -53,15 +53,15 @@ pub fn get_scheme_and_host_from_url(url: &str) -> Result<(String, String), OxenE
 // new one for each request so we can take advantage of keep-alive
 pub fn new_for_url(url: &str) -> Result<Client, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(url)?;
-    new_for_host(host, true)
+    new_for_host(&host, true)
 }
 
 pub fn new_for_url_no_user_agent(url: &str) -> Result<Client, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(url)?;
-    new_for_host(host, false)
+    new_for_host(&host, false)
 }
 
-fn new_for_host(host: String, should_add_user_agent: bool) -> Result<Client, OxenError> {
+fn new_for_host(host: &str, should_add_user_agent: bool) -> Result<Client, OxenError> {
     match builder_for_host(host, should_add_user_agent)?
         .timeout(time::Duration::from_secs(constants::timeout()))
         .build()
@@ -73,20 +73,20 @@ fn new_for_host(host: String, should_add_user_agent: bool) -> Result<Client, Oxe
 
 pub fn new_for_remote_repo(remote_repo: &RemoteRepository) -> Result<Client, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(remote_repo.url())?;
-    new_for_host(host, true)
+    new_for_host(&host, true)
 }
 
 pub fn builder_for_remote_repo(remote_repo: &RemoteRepository) -> Result<ClientBuilder, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(remote_repo.url())?;
-    builder_for_host(host, true)
+    builder_for_host(&host, true)
 }
 
 pub fn builder_for_url(url: &str) -> Result<ClientBuilder, OxenError> {
     let (_scheme, host) = get_scheme_and_host_from_url(url)?;
-    builder_for_host(host, true)
+    builder_for_host(&host, true)
 }
 
-fn builder_for_host(host: String, should_add_user_agent: bool) -> Result<ClientBuilder, OxenError> {
+fn builder_for_host(host: &str, should_add_user_agent: bool) -> Result<ClientBuilder, OxenError> {
     let mut builder = Client::builder();
     if should_add_user_agent {
         let config = RuntimeConfig::get()?;
@@ -94,7 +94,7 @@ fn builder_for_host(host: String, should_add_user_agent: bool) -> Result<ClientB
     }
 
     // Bump max retries for this oxen-server host from 2 to 3. Exponential backoff is used by default.
-    let retry_policy = retry::for_host(host.clone())
+    let retry_policy = retry::for_host(host.to_owned())
         .max_retries_per_request(3)
         .classify_fn(|req_rep| {
             // Still retry on low-level network errors
@@ -127,8 +127,8 @@ fn builder_for_host(host: String, should_add_user_agent: bool) -> Result<ClientB
             return Ok(builder);
         }
     };
-    if let Some(auth_token) = config.auth_token_for_host(host.as_str()) {
-        log::trace!("Setting auth token for host: {}", host);
+    if let Some(auth_token) = config.auth_token_for_host(host) {
+        log::debug!("Setting auth token for host: {}", host);
         let auth_header = format!("Bearer {auth_token}");
         let mut auth_value = match header::HeaderValue::from_str(auth_header.as_str()) {
             Ok(header) => header,
@@ -215,7 +215,7 @@ async fn parse_json_body_with_err_msg(
         ),
         Err(err) => {
             log::debug!("Err: {err}");
-            Err(OxenError::basic_str(format!(
+            Err(OxenError::basic_str(&format!(
                 "Could not deserialize response from [{url}]\n{status}"
             )))
         }
@@ -234,7 +234,7 @@ fn parse_status_and_message(
         http::STATUS_SUCCESS => {
             log::debug!("Status success: {status}");
             if !status.is_success() {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Err status [{}] from url {} [{}]",
                     status,
                     url,
@@ -246,7 +246,7 @@ fn parse_status_and_message(
         }
         http::STATUS_WARNING => {
             log::debug!("Status warning: {status}");
-            Err(OxenError::basic_str(format!(
+            Err(OxenError::basic_str(&format!(
                 "Remote Warning: {}",
                 response.desc_or_msg()
             )))
@@ -261,9 +261,9 @@ fn parse_status_and_message(
                 return Err(OxenError::basic_str(msg));
             }
 
-            Err(OxenError::basic_str(response.full_err_msg()))
+            Err(OxenError::basic_str(&response.full_err_msg()))
         }
-        status => Err(OxenError::basic_str(format!("Unknown status [{status}]"))),
+        status => Err(OxenError::basic_str(&format!("Unknown status [{status}]"))),
     }
 }
 

--- a/crates/lib/src/api/client/branches.rs
+++ b/crates/lib/src/api/client/branches.rs
@@ -13,9 +13,8 @@ use std::path::Path;
 
 pub async fn get_by_name(
     repository: &RemoteRepository,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
 ) -> Result<Option<Branch>, OxenError> {
-    let branch_name = branch_name.as_ref();
     let uri = format!("/branches/{branch_name}");
     let url = api::endpoint::url_from_repo(repository, &uri)?;
 
@@ -34,12 +33,9 @@ pub async fn get_by_name(
 /// Create a new branch from an existing branch
 pub async fn create_from_branch(
     repository: &RemoteRepository,
-    new_name: impl AsRef<str>,
-    from_name: impl AsRef<str>,
+    new_name: &str,
+    from_name: &str,
 ) -> Result<Branch, OxenError> {
-    let new_name = new_name.as_ref();
-    let from_name = from_name.as_ref();
-
     let url = api::endpoint::url_from_repo(repository, "/branches")?;
     log::debug!("branches::create_from_branch {url}");
 
@@ -59,11 +55,9 @@ pub async fn create_from_branch(
 /// The commit must already exist on the remote
 pub async fn create_from_commit(
     repository: &RemoteRepository,
-    new_name: impl AsRef<str>,
+    new_name: &str,
     commit: &Commit,
 ) -> Result<Branch, OxenError> {
-    let new_name = new_name.as_ref();
-
     let url = api::endpoint::url_from_repo(repository, "/branches")?;
     log::debug!("branches::create_from_commit {url}");
 
@@ -81,12 +75,9 @@ pub async fn create_from_commit(
 
 pub async fn create_from_commit_id(
     repository: &RemoteRepository,
-    new_name: impl AsRef<str>,
-    commit_id: impl AsRef<str>,
+    new_name: &str,
+    commit_id: &str,
 ) -> Result<Branch, OxenError> {
-    let new_name = new_name.as_ref();
-    let commit_id = commit_id.as_ref();
-
     let url = api::endpoint::url_from_repo(repository, "/branches")?;
     log::debug!("branches::create_from_commit_id {url}");
 
@@ -116,10 +107,9 @@ pub async fn list(repository: &RemoteRepository) -> Result<Vec<Branch>, OxenErro
 /// Update a remote branch to point to a new commit
 pub async fn update(
     repository: &RemoteRepository,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
     commit: &Commit,
 ) -> Result<Branch, OxenError> {
-    let branch_name = branch_name.as_ref();
     let uri = format!("/branches/{branch_name}");
     let url = api::endpoint::url_from_repo(repository, &uri)?;
     log::debug!("api::client::branches::update url: {url}");
@@ -159,14 +149,14 @@ pub async fn maybe_create_merge(
 /// # Delete a remote branch
 pub async fn delete_remote(
     repo: &LocalRepository,
-    remote: impl AsRef<str>,
-    branch_name: impl AsRef<str>,
+    remote: &str,
+    branch_name: &str,
 ) -> Result<Branch, OxenError> {
     let remote = repo
-        .get_remote(&remote)
+        .get_remote(remote)
         .ok_or_else(|| OxenError::remote_not_set(remote))?;
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
-    let branch = api::client::branches::get_by_name(&remote_repo, &branch_name)
+    let branch = api::client::branches::get_by_name(&remote_repo, branch_name)
         .await?
         .ok_or_else(|| OxenError::remote_branch_not_found(branch_name))?;
     api::client::branches::delete(&remote_repo, &branch.name).await?;
@@ -256,8 +246,8 @@ mod tests {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
             // add and commit a file
             let new_file = local_repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&local_repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&local_repo, &new_file).await?;
             repositories::commit(&local_repo, "Added a new file")?;
 
             // set proper remote
@@ -282,8 +272,8 @@ mod tests {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
             // add and commit a file
             let new_file = local_repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&local_repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&local_repo, &new_file).await?;
             repositories::commit(&local_repo, "Added a new file")?;
 
             // set proper remote
@@ -311,8 +301,8 @@ mod tests {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
             // add and commit a file
             let new_file = local_repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&local_repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&local_repo, &new_file).await?;
             repositories::commit(&local_repo, "Added a new file")?;
 
             // set proper remote
@@ -340,8 +330,8 @@ mod tests {
             // Create and push the main branch
             // add a file
             let new_file = local_repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&local_repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&local_repo, &new_file).await?;
             repositories::commit(&local_repo, "Added a new file")?;
 
             // Set proper remote
@@ -381,8 +371,8 @@ mod tests {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
             // add and commit a file
             let new_file = local_repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&local_repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&local_repo, &new_file).await?;
             repositories::commit(&local_repo, "Added a new file")?;
 
             // set proper remote
@@ -421,8 +411,8 @@ mod tests {
         test::run_empty_local_repo_test_async(|repo| async move {
             // add and commit a file
             let new_file = repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&repo, &new_file).await?;
             repositories::commit(&repo, "Added a new file")?;
 
             // Create and checkout branch
@@ -539,8 +529,8 @@ mod tests {
         test::run_select_data_repo_test_no_commits_async("labels", |repo| async move {
             // add and commit a file
             let new_file = repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&repo, &new_file).await?;
             repositories::commit(&repo, "Added a new file")?;
 
             let branch_name = "my-branch";
@@ -561,8 +551,8 @@ mod tests {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             // add and commit a file
             let new_file = repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&repo, &new_file).await?;
             repositories::commit(&repo, "Added a new file")?;
 
             let branch_name = "my-branch";
@@ -583,8 +573,8 @@ mod tests {
         test::run_select_data_repo_test_no_commits_async("labels", |repo| async move {
             // add and commit a file
             let new_file = repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&repo, &new_file).await?;
             repositories::commit(&repo, "Added a new file")?;
 
             let og_branches = repositories::branches::list(&repo)?;
@@ -595,11 +585,11 @@ mod tests {
 
             // Add another commit on this branch
             let labels_path = repo.path.join("labels.txt");
-            repositories::add(&repo, labels_path).await?;
+            repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "adding initial labels file")?;
 
             // Checkout main again
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             // Should not be able to delete `my-branch` because it is ahead of `main`
             if repositories::branches::delete(&repo, branch_name).is_ok() {
@@ -622,8 +612,8 @@ mod tests {
         test::run_select_data_repo_test_no_commits_async("labels", |repo| async move {
             // add and commit a file
             let new_file = repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&repo, &new_file).await?;
             repositories::commit(&repo, "Added a new file")?;
 
             let og_branches = repositories::branches::list(&repo)?;
@@ -634,11 +624,11 @@ mod tests {
 
             // Add another commit on this branch
             let labels_path = repo.path.join("labels.txt");
-            repositories::add(&repo, labels_path).await?;
+            repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "adding initial labels file")?;
 
             // Checkout main again
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             // Force delete
             repositories::branches::force_delete(&repo, branch_name)?;

--- a/crates/lib/src/api/client/commits.rs
+++ b/crates/lib/src/api/client/commits.rs
@@ -40,9 +40,8 @@ pub struct ChunkParams {
 
 pub async fn get_by_id(
     repository: &RemoteRepository,
-    commit_id: impl AsRef<str>,
+    commit_id: &str,
 ) -> Result<Option<Commit>, OxenError> {
-    let commit_id = commit_id.as_ref();
     let uri = format!("/commits/{commit_id}");
     let url = api::endpoint::url_from_repo(repository, &uri)?;
     log::debug!("remote::commits::get_by_id {url}");
@@ -58,7 +57,7 @@ pub async fn get_by_id(
     let response: Result<CommitResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(j_res) => Ok(Some(j_res.commit)),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "get_commit_by_id() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -67,12 +66,10 @@ pub async fn get_by_id(
 /// List commits for a file
 pub async fn list_commits_for_path(
     remote_repo: &RemoteRepository,
-    revision: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    revision: &str,
+    path: &Path,
     page_opts: &PaginateOpts,
 ) -> Result<PaginatedCommits, OxenError> {
-    let revision = revision.as_ref();
-    let path = path.as_ref();
     let path_str = path.to_string_lossy();
     let uri = format!(
         "/commits/history/{revision}/{path_str}?page={}&page_size={}",
@@ -85,7 +82,7 @@ pub async fn list_commits_for_path(
     let response: Result<PaginatedCommits, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(j_res) => Ok(j_res),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "list_commits_for_file() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -158,7 +155,7 @@ pub async fn list_missing_hashes(
                 .cloned()
                 .collect())
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::tree::list_missing_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -187,7 +184,7 @@ pub async fn list_missing_files(
     let response: Result<ListCommitEntryResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response.entries),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::commits::list_missing_files() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -211,7 +208,7 @@ pub async fn mark_commits_as_synced(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(_response) => Ok(()),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::tree::list_missing_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -275,12 +272,12 @@ pub async fn list_commit_history_paginated(
             let response: Result<PaginatedCommits, serde_json::Error> = serde_json::from_str(&body);
             match response {
                 Ok(j_res) => Ok(j_res),
-                Err(err) => Err(OxenError::basic_str(format!(
+                Err(err) => Err(OxenError::basic_str(&format!(
                     "list_commit_history() Could not deserialize response [{err}]\n{body}"
                 ))),
             }
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "list_commit_history() Request failed: {err}"
         ))),
     }
@@ -302,12 +299,12 @@ async fn list_all_commits_paginated(
             let response: Result<PaginatedCommits, serde_json::Error> = serde_json::from_str(&body);
             match response {
                 Ok(j_res) => Ok(j_res),
-                Err(err) => Err(OxenError::basic_str(format!(
+                Err(err) => Err(OxenError::basic_str(&format!(
                     "list_commit_history() Could not deserialize response [{err}]\n{body}"
                 ))),
             }
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "list_commit_history() Request failed: {err}"
         ))),
     }
@@ -327,7 +324,7 @@ pub async fn root_commit_maybe(
         let response: Result<RootCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(j_res) => Ok(j_res.commit),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "root_commit() Could not deserialize response [{err}]\n{body}"
             ))),
         }
@@ -339,38 +336,33 @@ pub async fn root_commit_maybe(
 pub async fn download_dir_hashes_from_commit(
     remote_repo: &RemoteRepository,
     commit_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<PathBuf, OxenError> {
     let uri = format!("/commits/{commit_id}/download_dir_hashes_db");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("calling download_dir_hashes_from_commit for commit {commit_id}");
-    download_dir_hashes_from_url(url, path).await
+    download_dir_hashes_from_url(&url, path).await
 }
 
 pub async fn download_base_head_dir_hashes(
     remote_repo: &RemoteRepository,
     base_commit_id: &str,
     head_commit_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<PathBuf, OxenError> {
     let uri = format!("/commits/{base_commit_id}..{head_commit_id}/download_dir_hashes_db");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!(
         "calling download_base_head_dir_hashes for commits {base_commit_id}..{head_commit_id}"
     );
-    download_dir_hashes_from_url(url, path).await
+    download_dir_hashes_from_url(&url, path).await
 }
 
-pub async fn download_dir_hashes_from_url(
-    url: impl AsRef<str>,
-    path: impl AsRef<Path>,
-) -> Result<PathBuf, OxenError> {
-    let url = url.as_ref();
+pub async fn download_dir_hashes_from_url(url: &str, path: &Path) -> Result<PathBuf, OxenError> {
     log::debug!("{} downloading from {}", current_function!(), url);
     let client = client::new_for_url(url)?;
     match client.get(url).send().await {
         Ok(res) => {
-            let path = path.as_ref();
             let reader = res
                 .bytes_stream()
                 .map_err(futures::io::Error::other)
@@ -433,7 +425,7 @@ pub async fn download_dir_hashes_from_url(
         }
         Err(err) => {
             let error = format!("Error fetching commit db: {err}");
-            Err(OxenError::basic_str(error))
+            Err(OxenError::basic_str(&error))
         }
     }
 }
@@ -441,7 +433,7 @@ pub async fn download_dir_hashes_from_url(
 pub async fn download_dir_hashes_db_to_path(
     remote_repo: &RemoteRepository,
     commit_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<PathBuf, OxenError> {
     let uri = format!("/commits/{commit_id}/commit_db");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
@@ -450,7 +442,6 @@ pub async fn download_dir_hashes_db_to_path(
     let client = client::new_for_url(&url)?;
     match client.get(url).send().await {
         Ok(res) => {
-            let path = path.as_ref();
             let reader = res
                 .bytes_stream()
                 .map_err(futures::io::Error::other)
@@ -497,7 +488,7 @@ pub async fn download_dir_hashes_db_to_path(
             log::debug!("renaming {tmp_path:?} to {full_unpacked_path:?}");
 
             util::fs::rename(
-                tmp_path.join(HISTORY_DIR).join(commit_id),
+                &tmp_path.join(HISTORY_DIR).join(commit_id),
                 &full_unpacked_path,
             )?;
 
@@ -507,7 +498,7 @@ pub async fn download_dir_hashes_db_to_path(
         }
         Err(err) => {
             let error = format!("Error fetching commit db: {err}");
-            Err(OxenError::basic_str(error))
+            Err(OxenError::basic_str(&error))
         }
     }
 }
@@ -525,7 +516,7 @@ pub async fn get_remote_parent(
         let response: Result<ListCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(j_res) => Ok(j_res.commits),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "get_remote_parent() Could not deserialize response [{err}]\n{body}"
             ))),
         }
@@ -538,10 +529,9 @@ pub async fn post_push_complete(
     remote_repo: &RemoteRepository,
     branch: &Branch,
     // we need to pass in the commit id because we might be pushing multiple commits from the same branch
-    commit_id: impl AsRef<str>,
+    commit_id: &str,
 ) -> Result<(), OxenError> {
     use serde_json::json;
-    let commit_id = commit_id.as_ref();
     let uri = format!("/commits/{commit_id}/complete");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("post_push_complete: {url}");
@@ -559,7 +549,7 @@ pub async fn post_push_complete(
         let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "post_push_complete() Could not deserialize response [{err}]\n{body}"
             ))),
         }
@@ -586,7 +576,7 @@ pub async fn bulk_post_push_complete(
         let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "bulk_post_push_complete() Could not deserialize response [{err}]\n{body}"
             ))),
         }
@@ -612,7 +602,7 @@ pub async fn get_commits_with_unsynced_dbs(
         let response: Result<ListCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(commit_response) => Ok(commit_response.commits),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "get_commits_with_unsynced_dbs() Could not deserialize response [{err}]\n{body}"
             ))),
         }
@@ -638,7 +628,7 @@ pub async fn get_commits_with_unsynced_entries(
         let response: Result<ListCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(commit_response) => Ok(commit_response.commits),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "get_commits_with_unsynced_entries() Could not deserialize response [{err}]\n{body}"
             ))),
         }
@@ -794,7 +784,7 @@ pub async fn bulk_create_commit_obj_on_server(
         let response: Result<ListCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(response) => Ok(response),
-            Err(_) => Err(OxenError::basic_str(format!(
+            Err(_) => Err(OxenError::basic_str(&format!(
                 "bulk_create_commit_obj_on_server Err deserializing \n\n{body}"
             ))),
         }
@@ -885,7 +875,7 @@ async fn upload_single_tarball_to_server_with_client(
             bar.inc(size);
             Ok(response)
         }
-        Err(_) => Err(OxenError::basic_str(format!(
+        Err(_) => Err(OxenError::basic_str(&format!(
             "upload_single_tarball_to_server Err deserializing \n\n{body}"
         ))),
     }
@@ -982,7 +972,7 @@ pub async fn upload_data_chunk_to_server_with_retry(
         }
     }
 
-    Err(OxenError::basic_str(format!(
+    Err(OxenError::basic_str(&format!(
         "Upload chunk retry failed. {last_error}"
     )))
 }
@@ -1038,7 +1028,7 @@ async fn upload_data_chunk_to_server(
     let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "upload_data_chunk_to_server Err deserializing: {err}"
         ))),
     }
@@ -1264,7 +1254,7 @@ mod tests {
 
             // Add and commit a new file
             let file_path = local_repo.path.join("test.txt");
-            let file_path = test::write_txt_file_to_path(file_path, "image,label\n1,2\n3,4\n5,6")?;
+            let file_path = test::write_txt_file_to_path(&file_path, "image,label\n1,2\n3,4\n5,6")?;
             repositories::add(&local_repo, &file_path).await?;
             let commit = repositories::commit(&local_repo, "test")?;
             let missing_commit_nodes =

--- a/crates/lib/src/api/client/commits.rs
+++ b/crates/lib/src/api/client/commits.rs
@@ -57,7 +57,7 @@ pub async fn get_by_id(
     let response: Result<CommitResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(j_res) => Ok(Some(j_res.commit)),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "get_commit_by_id() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -82,7 +82,7 @@ pub async fn list_commits_for_path(
     let response: Result<PaginatedCommits, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(j_res) => Ok(j_res),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "list_commits_for_file() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -155,7 +155,7 @@ pub async fn list_missing_hashes(
                 .cloned()
                 .collect())
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::tree::list_missing_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -184,7 +184,7 @@ pub async fn list_missing_files(
     let response: Result<ListCommitEntryResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response.entries),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::commits::list_missing_files() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -208,7 +208,7 @@ pub async fn mark_commits_as_synced(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(_response) => Ok(()),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::tree::list_missing_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -272,12 +272,12 @@ pub async fn list_commit_history_paginated(
             let response: Result<PaginatedCommits, serde_json::Error> = serde_json::from_str(&body);
             match response {
                 Ok(j_res) => Ok(j_res),
-                Err(err) => Err(OxenError::basic_str(&format!(
+                Err(err) => Err(OxenError::basic_str(format!(
                     "list_commit_history() Could not deserialize response [{err}]\n{body}"
                 ))),
             }
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "list_commit_history() Request failed: {err}"
         ))),
     }
@@ -299,12 +299,12 @@ async fn list_all_commits_paginated(
             let response: Result<PaginatedCommits, serde_json::Error> = serde_json::from_str(&body);
             match response {
                 Ok(j_res) => Ok(j_res),
-                Err(err) => Err(OxenError::basic_str(&format!(
+                Err(err) => Err(OxenError::basic_str(format!(
                     "list_commit_history() Could not deserialize response [{err}]\n{body}"
                 ))),
             }
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "list_commit_history() Request failed: {err}"
         ))),
     }
@@ -324,12 +324,14 @@ pub async fn root_commit_maybe(
         let response: Result<RootCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(j_res) => Ok(j_res.commit),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "root_commit() Could not deserialize response [{err}]\n{body}"
             ))),
         }
     } else {
-        Err(OxenError::basic_str("root_commit() Request failed"))
+        Err(OxenError::basic_str(
+            "root_commit() Request failed".to_string(),
+        ))
     }
 }
 
@@ -425,7 +427,7 @@ pub async fn download_dir_hashes_from_url(url: &str, path: &Path) -> Result<Path
         }
         Err(err) => {
             let error = format!("Error fetching commit db: {err}");
-            Err(OxenError::basic_str(&error))
+            Err(OxenError::basic_str(error))
         }
     }
 }
@@ -498,7 +500,7 @@ pub async fn download_dir_hashes_db_to_path(
         }
         Err(err) => {
             let error = format!("Error fetching commit db: {err}");
-            Err(OxenError::basic_str(&error))
+            Err(OxenError::basic_str(error))
         }
     }
 }
@@ -516,12 +518,14 @@ pub async fn get_remote_parent(
         let response: Result<ListCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(j_res) => Ok(j_res.commits),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "get_remote_parent() Could not deserialize response [{err}]\n{body}"
             ))),
         }
     } else {
-        Err(OxenError::basic_str("get_remote_parent() Request failed"))
+        Err(OxenError::basic_str(
+            "get_remote_parent() Request failed".to_string(),
+        ))
     }
 }
 
@@ -549,12 +553,14 @@ pub async fn post_push_complete(
         let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "post_push_complete() Could not deserialize response [{err}]\n{body}"
             ))),
         }
     } else {
-        Err(OxenError::basic_str("post_push_complete() Request failed"))
+        Err(OxenError::basic_str(
+            "post_push_complete() Request failed".to_string(),
+        ))
     }
 }
 
@@ -576,13 +582,13 @@ pub async fn bulk_post_push_complete(
         let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "bulk_post_push_complete() Could not deserialize response [{err}]\n{body}"
             ))),
         }
     } else {
         Err(OxenError::basic_str(
-            "bulk_post_push_complete() Request failed",
+            "bulk_post_push_complete() Request failed".to_string(),
         ))
     }
 }
@@ -602,13 +608,13 @@ pub async fn get_commits_with_unsynced_dbs(
         let response: Result<ListCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(commit_response) => Ok(commit_response.commits),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "get_commits_with_unsynced_dbs() Could not deserialize response [{err}]\n{body}"
             ))),
         }
     } else {
         Err(OxenError::basic_str(
-            "get_commits_with_unsynced_dbs() Request failed",
+            "get_commits_with_unsynced_dbs() Request failed".to_string(),
         ))
     }
 }
@@ -628,13 +634,13 @@ pub async fn get_commits_with_unsynced_entries(
         let response: Result<ListCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(commit_response) => Ok(commit_response.commits),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "get_commits_with_unsynced_entries() Could not deserialize response [{err}]\n{body}"
             ))),
         }
     } else {
         Err(OxenError::basic_str(
-            "get_commits_with_unsynced_entries() Request failed",
+            "get_commits_with_unsynced_entries() Request failed".to_string(),
         ))
     }
 }
@@ -784,13 +790,13 @@ pub async fn bulk_create_commit_obj_on_server(
         let response: Result<ListCommitResponse, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(response) => Ok(response),
-            Err(_) => Err(OxenError::basic_str(&format!(
+            Err(_) => Err(OxenError::basic_str(format!(
                 "bulk_create_commit_obj_on_server Err deserializing \n\n{body}"
             ))),
         }
     } else {
         Err(OxenError::basic_str(
-            "bulk_create_commit_obj_on_server error sending data from file",
+            "bulk_create_commit_obj_on_server error sending data from file".to_string(),
         ))
     }
 }
@@ -854,7 +860,7 @@ pub async fn upload_single_tarball_to_server_with_client_with_retry(
         }
     }
 
-    Err(OxenError::basic_str("Upload retry failed."))
+    Err(OxenError::basic_str("Upload retry failed.".to_string()))
 }
 
 async fn upload_single_tarball_to_server_with_client(
@@ -875,7 +881,7 @@ async fn upload_single_tarball_to_server_with_client(
             bar.inc(size);
             Ok(response)
         }
-        Err(_) => Err(OxenError::basic_str(&format!(
+        Err(_) => Err(OxenError::basic_str(format!(
             "upload_single_tarball_to_server Err deserializing \n\n{body}"
         ))),
     }
@@ -972,7 +978,7 @@ pub async fn upload_data_chunk_to_server_with_retry(
         }
     }
 
-    Err(OxenError::basic_str(&format!(
+    Err(OxenError::basic_str(format!(
         "Upload chunk retry failed. {last_error}"
     )))
 }
@@ -1028,7 +1034,7 @@ async fn upload_data_chunk_to_server(
     let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "upload_data_chunk_to_server Err deserializing: {err}"
         ))),
     }

--- a/crates/lib/src/api/client/compare.rs
+++ b/crates/lib/src/api/client/compare.rs
@@ -52,7 +52,7 @@ pub async fn create_compare(
     let response: Result<CompareTabularResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(tabular_compare) => Ok(tabular_compare.dfs),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "create_compare() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -97,7 +97,7 @@ pub async fn update_compare(
             serde_json::from_str(&body);
         match response {
             Ok(tabular_compare) => Ok(tabular_compare.dfs),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "update_compare() Could not deserialize response [{err}]\n{body}"
             ))),
         }
@@ -122,7 +122,7 @@ pub async fn get_derived_compare_df(
         serde_json::from_str(&body);
     match response {
         Ok(df) => Ok(df.data_frame.view),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "get_derived_compare_df() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -144,7 +144,7 @@ pub async fn commits(
     let response: Result<CompareCommitsResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(commits) => Ok(commits.compare.commits),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "commits() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -166,7 +166,7 @@ pub async fn dir_tree(
     let response: Result<DirTreeDiffResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(dir_tree) => Ok(dir_tree.dirs),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "commits() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -188,7 +188,7 @@ pub async fn entries(
     let response: Result<CompareEntriesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(entries) => Ok(entries.compare),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "commits() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -223,8 +223,8 @@ mod tests {
                 // Write a file
                 let file_path = format!("file_{i}.txt");
                 test::write_txt_file_to_path(
-                    local_repo.path.join(file_path),
-                    format!("File content {i}"),
+                    &local_repo.path.join(file_path),
+                    &format!("File content {i}"),
                 )?;
                 repositories::add(&local_repo, &local_repo.path).await?;
 
@@ -406,7 +406,7 @@ mod tests {
                 // Create the directory
                 util::fs::create_dir_all(full_path.parent().unwrap())?;
 
-                test::write_txt_file_to_path(full_path, format!("File content {i}"))?;
+                test::write_txt_file_to_path(&full_path, &format!("File content {i}"))?;
                 repositories::add(&local_repo, &local_repo.path).await?;
 
                 let commit_message = format!("Commit {i}");
@@ -451,8 +451,8 @@ mod tests {
             let left_path = "left.csv";
             let right_path = "right.csv";
 
-            test::write_txt_file_to_path(local_repo.path.join(left_path), csv1)?;
-            test::write_txt_file_to_path(local_repo.path.join(right_path), csv2)?;
+            test::write_txt_file_to_path(&local_repo.path.join(left_path), csv1)?;
+            test::write_txt_file_to_path(&local_repo.path.join(right_path), csv2)?;
 
             repositories::add(&local_repo, &local_repo.path).await?;
 
@@ -552,8 +552,8 @@ mod tests {
             let left_path = "left.csv";
             let right_path = "right.csv";
 
-            test::write_txt_file_to_path(local_repo.path.join(left_path), csv1)?;
-            test::write_txt_file_to_path(local_repo.path.join(right_path), csv2)?;
+            test::write_txt_file_to_path(&local_repo.path.join(left_path), csv1)?;
+            test::write_txt_file_to_path(&local_repo.path.join(right_path), csv2)?;
 
             repositories::add(&local_repo, &local_repo.path).await?;
 
@@ -640,7 +640,7 @@ mod tests {
             let csv1 = "a,b,c,d\n1,2,3,4\n4,5,6,7";
             // let csv2 = "a,b,c,d\n1,2,3,4\n4,5,6,8\n0,1,9,2";
 
-            test::write_txt_file_to_path(local_repo.path.join(left_path), csv1)?;
+            test::write_txt_file_to_path(&local_repo.path.join(left_path), csv1)?;
 
             repositories::add(&local_repo, &local_repo.path).await?;
             repositories::commit(&local_repo, "committing files")?;

--- a/crates/lib/src/api/client/compare.rs
+++ b/crates/lib/src/api/client/compare.rs
@@ -52,7 +52,7 @@ pub async fn create_compare(
     let response: Result<CompareTabularResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(tabular_compare) => Ok(tabular_compare.dfs),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "create_compare() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -97,12 +97,14 @@ pub async fn update_compare(
             serde_json::from_str(&body);
         match response {
             Ok(tabular_compare) => Ok(tabular_compare.dfs),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "update_compare() Could not deserialize response [{err}]\n{body}"
             ))),
         }
     } else {
-        Err(OxenError::basic_str("update_compare() Request failed"))
+        Err(OxenError::basic_str(
+            "update_compare() Request failed".to_string(),
+        ))
     }
 }
 
@@ -122,7 +124,7 @@ pub async fn get_derived_compare_df(
         serde_json::from_str(&body);
     match response {
         Ok(df) => Ok(df.data_frame.view),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "get_derived_compare_df() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -144,7 +146,7 @@ pub async fn commits(
     let response: Result<CompareCommitsResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(commits) => Ok(commits.compare.commits),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "commits() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -166,7 +168,7 @@ pub async fn dir_tree(
     let response: Result<DirTreeDiffResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(dir_tree) => Ok(dir_tree.dirs),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "commits() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -188,7 +190,7 @@ pub async fn entries(
     let response: Result<CompareEntriesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(entries) => Ok(entries.compare),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "commits() Could not deserialize response [{err}]\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/data_frames.rs
+++ b/crates/lib/src/api/client/data_frames.rs
@@ -13,7 +13,7 @@ use crate::view::{JsonDataFrameViewResponse, StatusMessage};
 pub async fn get(
     remote_repo: &RemoteRepository,
     commit_or_branch: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
     opts: DFOpts,
 ) -> Result<JsonDataFrameViewResponse, OxenError> {
     let path_str = util::fs::to_unix_str(path);
@@ -32,7 +32,7 @@ pub async fn get(
             log::debug!("got JsonDataFrameViewResponse: {val:?}");
             Ok(val)
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -41,9 +41,9 @@ pub async fn get(
 pub async fn index(
     remote_repo: &RemoteRepository,
     commit_or_branch: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<StatusMessage, OxenError> {
-    let path_str = path.as_ref().to_str().unwrap();
+    let path_str = path.to_str().unwrap();
     let uri = format!("/data_frames/index/{commit_or_branch}/{path_str}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -58,7 +58,7 @@ pub async fn index(
             log::debug!("got StatusMessage: {val:?}");
             Ok(val)
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -67,7 +67,7 @@ pub async fn index(
 pub async fn from_directory(
     remote_repo: &RemoteRepository,
     commit_or_branch: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
     request: FromDirectoryRequest,
 ) -> Result<CommitResponse, OxenError> {
     let path_str = util::fs::to_unix_str(path);
@@ -93,7 +93,7 @@ pub async fn from_directory(
             log::debug!("got CommitResponse: {val:?}");
             Ok(val)
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -102,6 +102,7 @@ pub async fn from_directory(
 #[cfg(test)]
 mod tests {
 
+    use std::path::Path;
     use std::path::PathBuf;
 
     use crate::api;
@@ -127,7 +128,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_200k_csv();
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             repositories::add(&local_repo, &csv_file).await?;
             repositories::commit(&local_repo, "add test.csv")?;
@@ -168,14 +169,14 @@ mod tests {
 
             repositories::data_frames::schemas::add_column_metadata(
                 &local_repo,
-                schema_ref,
+                Path::new(schema_ref),
                 &column_name,
                 &column_metadata,
             )?;
 
             repositories::data_frames::schemas::add_schema_metadata(
                 &local_repo,
-                schema_ref,
+                Path::new(schema_ref),
                 &schema_metadata,
             )?;
 
@@ -198,7 +199,7 @@ mod tests {
             let df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                PathBuf::from("large_files").join("test.csv"),
+                &PathBuf::from("large_files").join("test.csv"),
                 opts,
             )
             .await?;
@@ -243,7 +244,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_200k_csv();
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             repositories::add(&local_repo, &csv_file).await?;
             repositories::commit(&local_repo, "add test.csv")?;
@@ -264,7 +265,7 @@ mod tests {
             let df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                PathBuf::from("large_files").join("test.csv"),
+                &PathBuf::from("large_files").join("test.csv"),
                 opts,
             )
             .await?;
@@ -291,7 +292,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_200k_csv();
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             repositories::add(&local_repo, &csv_file).await?;
             repositories::commit(&local_repo, "add test.csv")?;
@@ -313,7 +314,7 @@ mod tests {
             let df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "large_files/test.csv",
+                Path::new("large_files/test.csv"),
                 opts,
             )
             .await?;
@@ -345,7 +346,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_200k_csv();
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             repositories::add(&local_repo, &csv_file).await?;
             repositories::commit(&local_repo, "add test.csv")?;
@@ -364,7 +365,7 @@ mod tests {
             api::client::data_frames::index(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "large_files/test.csv",
+                Path::new("large_files/test.csv"),
             )
             .await?;
 
@@ -377,7 +378,7 @@ mod tests {
             let df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                PathBuf::from("large_files").join("test.csv"),
+                &PathBuf::from("large_files").join("test.csv"),
                 opts,
             )
             .await?;
@@ -406,7 +407,7 @@ mod tests {
             let df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                PathBuf::from("large_files").join("test.csv"),
+                &PathBuf::from("large_files").join("test.csv"),
                 opts,
             )
             .await?;
@@ -436,7 +437,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_csv_file_with_name("mixed_data_types.csv");
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             // Add the file
             repositories::add(&local_repo, &csv_file).await?;
@@ -455,9 +456,13 @@ mod tests {
 
             // Cannot get schema that does not exist
             let opts = DFOpts::empty();
-            let result =
-                api::client::data_frames::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref, opts)
-                    .await;
+            let result = api::client::data_frames::get(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                Path::new(schema_ref),
+                opts,
+            )
+            .await;
             assert!(result.is_err());
 
             // Push the repo
@@ -486,12 +491,12 @@ mod tests {
             );
             repositories::data_frames::schemas::add_schema_metadata(
                 &local_repo,
-                schema_ref,
+                Path::new(schema_ref),
                 &schema_metadata,
             )?;
             repositories::data_frames::schemas::add_column_metadata(
                 &local_repo,
-                schema_ref,
+                Path::new(schema_ref),
                 &column_name,
                 &column_metadata,
             )?;
@@ -500,8 +505,13 @@ mod tests {
 
             // Cannot get schema that does not exist
             let opts = DFOpts::empty();
-            let result =
-                api::client::data_frames::get(&remote_repo, branch_name, schema_ref, opts).await;
+            let result = api::client::data_frames::get(
+                &remote_repo,
+                branch_name,
+                Path::new(schema_ref),
+                opts,
+            )
+            .await;
             assert!(result.is_err());
 
             // Push the repo
@@ -509,8 +519,13 @@ mod tests {
 
             // List the one schema
             let opts = DFOpts::empty();
-            let results =
-                api::client::data_frames::get(&remote_repo, branch_name, schema_ref, opts).await;
+            let results = api::client::data_frames::get(
+                &remote_repo,
+                branch_name,
+                Path::new(schema_ref),
+                opts,
+            )
+            .await;
             assert!(results.is_ok());
 
             let result = results.unwrap();
@@ -547,7 +562,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let test_file = large_dir.join("test.parquet");
             let from_file = test::test_1k_parquet();
-            util::fs::copy(from_file, &test_file)?;
+            util::fs::copy(&from_file, &test_file)?;
 
             repositories::add(&local_repo, &test_file).await?;
             repositories::commit(&local_repo, "add test.parquet")?;
@@ -568,7 +583,7 @@ mod tests {
             let df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "data/test.parquet",
+                Path::new("data/test.parquet"),
                 opts,
             )
             .await?;
@@ -613,7 +628,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let test_file = large_dir.join("test.parquet");
             let from_file = test::test_1k_parquet();
-            util::fs::copy(from_file, &test_file)?;
+            util::fs::copy(&from_file, &test_file)?;
 
             repositories::add(&local_repo, &test_file).await?;
             repositories::commit(&local_repo, "add test.parquet")?;
@@ -636,7 +651,7 @@ mod tests {
             let df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "data/test.parquet",
+                Path::new("data/test.parquet"),
                 opts,
             )
             .await?;
@@ -676,7 +691,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let test_file = large_dir.join("test.parquet");
             let from_file = test::test_1k_parquet();
-            util::fs::copy(from_file, &test_file)?;
+            util::fs::copy(&from_file, &test_file)?;
 
             repositories::add(&local_repo, &test_file).await?;
             repositories::commit(&local_repo, "add test.parquet")?;
@@ -698,7 +713,7 @@ mod tests {
             let df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "data/test.parquet",
+                Path::new("data/test.parquet"),
                 opts,
             )
             .await?;
@@ -783,7 +798,7 @@ mod tests {
             let response = api::client::data_frames::from_directory(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "test_files",
+                Path::new("test_files"),
                 request,
             )
             .await?;
@@ -791,7 +806,7 @@ mod tests {
             let files = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "file_listing.parquet",
+                Path::new("file_listing.parquet"),
                 DFOpts::empty(),
             )
             .await?;
@@ -850,9 +865,9 @@ mod tests {
 
             // Create minimal valid JPEG files (or use test fixtures)
             // Here using a placeholder - in real test you'd use actual image data
-            util::fs::copy(test::test_img_file_with_name("cat_1.jpg"), &image1)?;
-            util::fs::copy(test::test_img_file_with_name("cat_rgba.png"), &image2)?;
-            util::fs::copy(test::test_img_file_with_name("dog_1.jpg"), &image3)?;
+            util::fs::copy(&test::test_img_file_with_name("cat_1.jpg"), &image1)?;
+            util::fs::copy(&test::test_img_file_with_name("cat_rgba.png"), &image2)?;
+            util::fs::copy(&test::test_img_file_with_name("dog_1.jpg"), &image3)?;
 
             // Add and commit the files
             repositories::add(&local_repo, &test_dir).await?;
@@ -882,7 +897,7 @@ mod tests {
             let response = api::client::data_frames::from_directory(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "test_images",
+                Path::new("test_images"),
                 request,
             )
             .await?;
@@ -891,7 +906,7 @@ mod tests {
             let files = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "image_listing.parquet",
+                Path::new("image_listing.parquet"),
                 DFOpts::empty(),
             )
             .await?;
@@ -945,7 +960,7 @@ mod tests {
             let image1 = test_dir.join("image1.jpg");
             let text1 = test_dir.join("file1.txt");
 
-            util::fs::copy(test::test_img_file_with_name("cat_1.jpg"), &image1)?;
+            util::fs::copy(&test::test_img_file_with_name("cat_1.jpg"), &image1)?;
             std::fs::write(&text1, "content1")?;
 
             // Add and commit the files
@@ -976,7 +991,7 @@ mod tests {
             let _response = api::client::data_frames::from_directory(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "test_mixed",
+                Path::new("test_mixed"),
                 request,
             )
             .await?;
@@ -985,7 +1000,7 @@ mod tests {
             let files = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "mixed_listing.parquet",
+                Path::new("mixed_listing.parquet"),
                 DFOpts::empty(),
             )
             .await?;

--- a/crates/lib/src/api/client/data_frames.rs
+++ b/crates/lib/src/api/client/data_frames.rs
@@ -32,7 +32,7 @@ pub async fn get(
             log::debug!("got JsonDataFrameViewResponse: {val:?}");
             Ok(val)
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -58,7 +58,7 @@ pub async fn index(
             log::debug!("got StatusMessage: {val:?}");
             Ok(val)
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -93,7 +93,7 @@ pub async fn from_directory(
             log::debug!("got CommitResponse: {val:?}");
             Ok(val)
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/diff.rs
+++ b/crates/lib/src/api/client/diff.rs
@@ -9,13 +9,11 @@ use crate::view::compare::{CompareEntries, CompareEntryResponse};
 
 pub async fn list_diff_entries(
     remote_repo: &RemoteRepository,
-    base: impl AsRef<str>,
-    head: impl AsRef<str>,
+    base: &str,
+    head: &str,
     page: usize,
     page_size: usize,
 ) -> Result<CompareEntries, OxenError> {
-    let base = base.as_ref();
-    let head = head.as_ref();
     let uri = format!("/compare/entries/{base}..{head}?page={page}&page_size={page_size}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -25,7 +23,7 @@ pub async fn list_diff_entries(
     let response: Result<CompareEntriesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.compare),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::diff::list_diff_entries error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -33,13 +31,10 @@ pub async fn list_diff_entries(
 
 pub async fn diff_entries(
     remote_repo: &RemoteRepository,
-    base: impl AsRef<str>,
-    head: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    base: &str,
+    head: &str,
+    path: &Path,
 ) -> Result<DiffEntry, OxenError> {
-    let base = base.as_ref();
-    let head = head.as_ref();
-    let path = path.as_ref();
     let uri = format!("/compare/file/{base}..{head}/{}", path.to_string_lossy());
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -49,7 +44,7 @@ pub async fn diff_entries(
     let response: Result<CompareEntryResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.compare),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::diff::diff_entries error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -131,7 +126,7 @@ mod tests {
             let compare = api::client::diff::diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 &PathBuf::from("images").join("cat_2.jpg"),
             )
             .await?;
@@ -213,7 +208,7 @@ mod tests {
             let compare = api::client::diff::diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 &PathBuf::from("images").join("cat_1.jpg"),
             )
             .await?;
@@ -277,8 +272,8 @@ mod tests {
             repositories::branches::create_checkout(&repo, branch_name)?;
 
             // Modify and commit the dataframe
-            let repo_filepath = test::append_line_txt_file(repo_filepath, "answer the question,what is the color of the sky?,blue,trivia")?;
-            let repo_filepath = test::append_line_txt_file(repo_filepath, "answer the question,what is the color of the ocean?,blue-ish green sometimes,trivia")?;
+            let repo_filepath = test::append_line_txt_file(&repo_filepath, "answer the question,what is the color of the sky?,blue,trivia")?;
+            let repo_filepath = test::append_line_txt_file(&repo_filepath, "answer the question,what is the color of the ocean?,blue-ish green sometimes,trivia")?;
 
             repositories::add(&repo, &repo_filepath).await?;
             repositories::commit(&repo, "Modifying the csv")?;
@@ -299,7 +294,7 @@ mod tests {
             let compare = api::client::diff::diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 &PathBuf::from("llm_fine_tune.csv"),
             )
             .await?;
@@ -398,7 +393,7 @@ mod tests {
 
             // Modify and commit the dataframe
             let repo_filepath = test::write_txt_file_to_path(
-                repo_filepath,
+                &repo_filepath,
                 r"instruction,context,response,category
 answer the question,what is the capital of france?,paris,geography
 answer the question,who was the 44th president of the united states?,barack obama,politics
@@ -427,7 +422,7 @@ define the word,what does the word 'the' mean?,it is a stopword.,language
             let compare = api::client::diff::diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 &PathBuf::from("llm_fine_tune.csv"),
             )
             .await?;
@@ -537,7 +532,7 @@ define the word,what does the word 'the' mean?,it is a stopword.,language
 
             // Modify and commit the dataframe
             let repo_filepath = test::write_txt_file_to_path(
-                repo_filepath,
+                &repo_filepath,
                 r#"instruction,context,response
 answer the question,what is the capital of france?,paris
 answer the question,who was the 44th president of the united states?,barack obama
@@ -567,7 +562,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 &PathBuf::from("llm_fine_tune.csv"),
             )
             .await?;
@@ -801,7 +796,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::list_diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 0,
                 100,
             )
@@ -906,7 +901,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::list_diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 0,
                 100,
             )
@@ -1001,7 +996,7 @@ who won the game?,The packers beat up on the bears,packers
             let repo_filepath = cats_dir.join(test_file.file_name().unwrap());
             util::fs::remove_file(&repo_filepath)?;
 
-            let rm_opts = RmOpts::from_path(Path::new("images").join("cats").join("cat_2.jpg"));
+            let rm_opts = RmOpts::from_path(&Path::new("images").join("cats").join("cat_2.jpg"));
             repositories::rm(&repo, &rm_opts)?;
             repositories::commit(&repo, "Remove and modify some cats")?;
 
@@ -1021,7 +1016,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::list_diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 0,
                 100,
             )
@@ -1270,7 +1265,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::list_diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 0,
                 100,
             )
@@ -1365,7 +1360,7 @@ who won the game?,The packers beat up on the bears,packers
                 util::fs::copy(&test_file, &repo_filepath)?;
             }
 
-            repositories::add(&repo, dogs_dir).await?;
+            repositories::add(&repo, &dogs_dir).await?;
             repositories::commit(&repo, "Adding dog images 🐕")?;
 
             // Set the proper remote
@@ -1384,7 +1379,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::list_diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 0,
                 100,
             )
@@ -1497,7 +1492,7 @@ who won the game?,The packers beat up on the bears,packers
                 util::fs::copy(&test_file, &repo_filepath)?;
             }
 
-            repositories::add(&repo, dogs_dir).await?;
+            repositories::add(&repo, &dogs_dir).await?;
             repositories::commit(&repo, "Adding dog images")?;
 
             // Add dwight vince to the cats dir
@@ -1505,7 +1500,7 @@ who won the game?,The packers beat up on the bears,packers
             let repo_filepath = cats_dir.join(test_file.file_name().unwrap());
             util::fs::copy(&test_file, &repo_filepath)?;
 
-            repositories::add(&repo, cats_dir).await?;
+            repositories::add(&repo, &cats_dir).await?;
             repositories::commit(&repo, "Adding dwight/vince image to cats")?;
 
             // Set the proper remote
@@ -1524,7 +1519,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::list_diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 0,
                 100,
             )
@@ -1749,7 +1744,7 @@ who won the game?,The packers beat up on the bears,packers
                 util::fs::remove_file(&repo_filepath)?;
             }
 
-            let mut rm_opts = RmOpts::from_path("images");
+            let mut rm_opts = RmOpts::from_path(Path::new("images"));
             rm_opts.recursive = true;
             repositories::rm(&repo, &rm_opts)?;
             repositories::commit(&repo, "Removing cat images")?;
@@ -1770,7 +1765,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::list_diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 0,
                 100,
             )
@@ -1858,7 +1853,7 @@ who won the game?,The packers beat up on the bears,packers
             // Remove one of the dogs
             let repo_filepath = PathBuf::from("images").join("dog_1.jpg");
 
-            let rm_opts = RmOpts::from_path(repo_filepath);
+            let rm_opts = RmOpts::from_path(&repo_filepath);
             repositories::rm(&repo, &rm_opts)?;
             repositories::commit(&repo, "Removing dog")?;
 
@@ -1881,7 +1876,7 @@ who won the game?,The packers beat up on the bears,packers
             let compare = api::client::diff::list_diff_entries(
                 &remote_repo,
                 &og_branch.name,
-                &branch_name,
+                branch_name,
                 0,
                 100,
             )

--- a/crates/lib/src/api/client/diff.rs
+++ b/crates/lib/src/api/client/diff.rs
@@ -23,7 +23,7 @@ pub async fn list_diff_entries(
     let response: Result<CompareEntriesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.compare),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::diff::list_diff_entries error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -44,7 +44,7 @@ pub async fn diff_entries(
     let response: Result<CompareEntryResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.compare),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::diff::diff_entries error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/dir.rs
+++ b/crates/lib/src/api/client/dir.rs
@@ -37,7 +37,7 @@ pub async fn list(
     let response: Result<PaginatedDirEntries, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::dir::list_dir error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -54,15 +54,15 @@ pub async fn file_counts(
         Some(dir_entry) => match dir_entry {
             EMetadataEntry::MetadataEntry(metadata_entry) => match metadata_entry.metadata {
                 Some(GenericMetadata::MetadataDir(metadata)) => Ok(metadata),
-                _ => Err(OxenError::basic_str(&format!(
+                _ => Err(OxenError::basic_str(format!(
                     "No metadata on directory found at {path_str}"
                 ))),
             },
             EMetadataEntry::WorkspaceMetadataEntry(_) => Err(OxenError::basic_str(
-                "Workspace metadata entry is not implemented",
+                "Workspace metadata entry is not implemented".to_string(),
             )),
         },
-        None => Err(OxenError::basic_str(&format!(
+        None => Err(OxenError::basic_str(format!(
             "No directory found at {path_str}"
         ))),
     }
@@ -84,7 +84,7 @@ pub async fn get_dir(
         serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::dir::get_dir error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/dir.rs
+++ b/crates/lib/src/api/client/dir.rs
@@ -22,13 +22,12 @@ pub async fn list_root(remote_repo: &RemoteRepository) -> Result<PaginatedDirEnt
 
 pub async fn list(
     remote_repo: &RemoteRepository,
-    revision: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    revision: &str,
+    path: &Path,
     page: usize,
     page_size: usize,
 ) -> Result<PaginatedDirEntries, OxenError> {
-    let revision = revision.as_ref();
-    let path = path.as_ref().to_string_lossy();
+    let path = path.to_string_lossy();
     let uri = format!("/dir/{revision}/{path}?page={page}&page_size={page_size}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -38,7 +37,7 @@ pub async fn list(
     let response: Result<PaginatedDirEntries, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::dir::list_dir error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -46,16 +45,16 @@ pub async fn list(
 
 pub async fn file_counts(
     remote_repo: &RemoteRepository,
-    revision: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    revision: &str,
+    path: &Path,
 ) -> Result<MetadataDir, OxenError> {
-    let path_str = path.as_ref().to_string_lossy();
-    let response = list(remote_repo, revision, &path, 1, 1).await?;
+    let path_str = path.to_string_lossy();
+    let response = list(remote_repo, revision, path, 1, 1).await?;
     match response.dir {
         Some(dir_entry) => match dir_entry {
             EMetadataEntry::MetadataEntry(metadata_entry) => match metadata_entry.metadata {
                 Some(GenericMetadata::MetadataDir(metadata)) => Ok(metadata),
-                _ => Err(OxenError::basic_str(format!(
+                _ => Err(OxenError::basic_str(&format!(
                     "No metadata on directory found at {path_str}"
                 ))),
             },
@@ -63,7 +62,7 @@ pub async fn file_counts(
                 "Workspace metadata entry is not implemented",
             )),
         },
-        None => Err(OxenError::basic_str(format!(
+        None => Err(OxenError::basic_str(&format!(
             "No directory found at {path_str}"
         ))),
     }
@@ -71,11 +70,10 @@ pub async fn file_counts(
 
 pub async fn get_dir(
     remote_repo: &RemoteRepository,
-    revision: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    revision: &str,
+    path: &Path,
 ) -> Result<PaginatedDirEntriesResponse, OxenError> {
-    let path_str = path.as_ref().to_string_lossy();
-    let revision = revision.as_ref();
+    let path_str = path.to_string_lossy();
     let uri = format!("/dir/{revision}/{path_str}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -86,7 +84,7 @@ pub async fn get_dir(
         serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::dir::get_dir error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -136,7 +134,7 @@ mod tests {
             let file_path = local_repo.path.join(file_name);
             let file_content = "Hello, World!";
             util::fs::write_to_path(&file_path, file_content)?;
-            repositories::add(&local_repo, file_path).await?;
+            repositories::add(&local_repo, &file_path).await?;
 
             // Commit it
             let first_commit = repositories::commit(&local_repo, "Add file.txt")?;
@@ -383,7 +381,8 @@ mod tests {
             repositories::push(&local_repo).await?;
 
             let dir_response =
-                api::client::dir::get_dir(&remote_repo, DEFAULT_BRANCH_NAME, "dir=dir").await?;
+                api::client::dir::get_dir(&remote_repo, DEFAULT_BRANCH_NAME, Path::new("dir=dir"))
+                    .await?;
             assert_eq!(dir_response.status.status, "success");
 
             // Assert the directory is present and named "dir=dir"
@@ -431,7 +430,7 @@ mod tests {
                 .to_string();
 
             let workspace =
-                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_id)
+                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                     .await?;
             assert_eq!(workspace.id, workspace_id);
 
@@ -441,20 +440,20 @@ mod tests {
 
             let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
-                &workspace_id,
-                directory_name.clone(),
+                workspace_id,
+                Path::new(&directory_name),
                 &full_path,
             )
             .await;
 
             let file_path = test::test_bounding_box_csv();
             let full_path = local_repo.path.join(file_path);
-            util::fs::write(&full_path, "name,age\nAlice,30\nBob,25\n")?;
+            util::fs::write(&full_path, "name,age\nAlice,30\nBob,25\n".as_bytes())?;
 
             let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
-                &workspace_id,
-                directory_name,
+                workspace_id,
+                Path::new(&directory_name),
                 &full_path,
             )
             .await;
@@ -464,7 +463,8 @@ mod tests {
                 .unwrap()
                 .to_string();
             let response =
-                api::client::dir::get_dir(&remote_repo, workspace_id, train_path).await?;
+                api::client::dir::get_dir(&remote_repo, workspace_id, Path::new(&train_path))
+                    .await?;
 
             for entry in response.entries.entries.iter() {
                 if let EMetadataEntry::WorkspaceMetadataEntry(ws_entry) = entry {

--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -30,13 +30,11 @@ use tokio::io::AsyncWriteExt;
 /// Returns the metadata given a file path
 pub async fn get_entry(
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    remote_path: &Path,
+    revision: &str,
 ) -> Result<Option<EMetadataEntry>, OxenError> {
-    let remote_path = remote_path.as_ref();
-
     let Some(response) =
-        api::client::metadata::get_file(remote_repo, &revision, &remote_path).await?
+        api::client::metadata::get_file(remote_repo, revision, remote_path).await?
     else {
         return Ok(None);
     };
@@ -45,12 +43,11 @@ pub async fn get_entry(
 
 pub async fn list_entries_with_type(
     remote_repo: &RemoteRepository,
-    path: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    path: &Path,
+    revision: &str,
     data_type: &EntryDataType,
 ) -> Result<Vec<MetadataEntry>, OxenError> {
-    let path = path.as_ref().to_string_lossy();
-    let revision = revision.as_ref();
+    let path = path.to_string_lossy();
     let uri = if path.is_empty() || path == "/" {
         format!("/{data_type}/{revision}")
     } else {
@@ -99,14 +96,8 @@ pub async fn upload_entries(
         api::client::workspaces::create(remote_repo, &branch_name, &workspace_id).await?;
     assert_eq!(workspace.id, workspace_id);
 
-    api::client::workspaces::files::add(
-        remote_repo,
-        &workspace_id,
-        &opts.dst.to_string_lossy(),
-        file_paths,
-        &None,
-    )
-    .await?;
+    api::client::workspaces::files::add(remote_repo, &workspace_id, &opts.dst, file_paths, &None)
+        .await?;
 
     log::debug!("Committing on {branch_name}");
 
@@ -129,14 +120,13 @@ pub async fn upload_entries(
 /// and get the size before downloading
 pub async fn download_entry(
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    remote_path: &Path,
+    local_path: &Path,
+    revision: &str,
 ) -> Result<(), OxenError> {
-    let remote_path = remote_path.as_ref();
     let download_path = util::fs::remove_leading_slash(remote_path);
 
-    let entry = get_entry(remote_repo, download_path.clone(), &revision).await?;
+    let entry = get_entry(remote_repo, &download_path.clone(), revision).await?;
 
     let entry = match entry {
         Some(EMetadataEntry::MetadataEntry(entry)) => entry,
@@ -146,26 +136,26 @@ pub async fn download_entry(
             ));
         }
         None => {
-            return Err(OxenError::path_does_not_exist(download_path));
+            return Err(OxenError::path_does_not_exist(&download_path));
         }
     };
 
     let remote_file_name = download_path.file_name();
-    let mut local_path = local_path.as_ref().to_path_buf();
+    let mut local_path = local_path.to_path_buf();
 
     // Following the similar logic as cp or scp
 
     // * if the dst parent is a file, we error because cannot copy to a file subdirectory
     if let Some(parent) = local_path.parent() {
         if parent.is_file() {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "{parent:?} is not a directory"
             )));
         }
 
         // * if the dst parent does not exist, we error because cannot copy a directory to a non-existent location
         if !parent.exists() && parent != Path::new("") {
-            return Err(OxenError::basic_str(format!("{parent:?} does not exist")));
+            return Err(OxenError::basic_str(&format!("{parent:?} does not exist")));
         }
     }
 
@@ -182,9 +172,9 @@ pub async fn download_entry(
     }
 
     if entry.is_dir {
-        repositories::download::download_dir(remote_repo, &entry, download_path, &local_path).await
+        repositories::download::download_dir(remote_repo, &entry, &download_path, &local_path).await
     } else {
-        download_file(remote_repo, &entry, download_path, local_path, revision).await
+        download_file(remote_repo, &entry, &download_path, &local_path, revision).await
     }
 }
 
@@ -193,12 +183,11 @@ pub async fn download_entries_to_repo(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
     paths_to_download: &[(PathBuf, PathBuf)],
-    revision: impl AsRef<str>,
+    revision: &str,
 ) -> Result<(), OxenError> {
-    let revision = revision.as_ref();
     for (local_path, remote_path) in paths_to_download.iter() {
         // TODO: Refactor to get the entries for all paths in one API call
-        let entry = get_entry(remote_repo, remote_path, &revision).await?;
+        let entry = get_entry(remote_repo, remote_path, revision).await?;
         let entry = match entry {
             Some(EMetadataEntry::MetadataEntry(entry)) => entry,
             Some(EMetadataEntry::WorkspaceMetadataEntry(_entry)) => {
@@ -214,7 +203,7 @@ pub async fn download_entries_to_repo(
         // * if the dst parent is a file, we error because cannot copy to a file subdirectory
         if let Some(parent) = local_path.parent() {
             if parent.is_file() {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "{parent:?} is not a directory"
                 )));
             }
@@ -229,18 +218,18 @@ pub async fn download_entries_to_repo(
                 local_repo,
                 remote_repo,
                 &entry,
-                &remote_path,
-                &local_path,
+                remote_path,
+                local_path,
             )
             .await?
         } else {
             // Download file contents to working directory
-            download_file(remote_repo, &entry, &remote_path, &local_path, revision).await?;
+            download_file(remote_repo, &entry, remote_path, local_path, revision).await?;
 
             // Save contents to version store
             let version_store = local_repo.version_store()?;
             let file = std::fs::read(local_path).map_err(|e| {
-                OxenError::basic_str(format!("Failed to read file '{remote_path:?}': {e}"))
+                OxenError::basic_str(&format!("Failed to read file '{remote_path:?}': {e}"))
             })?;
             let hash = util::hasher::hash_buffer(&file);
             version_store
@@ -255,19 +244,12 @@ pub async fn download_entries_to_repo(
 pub async fn download_file(
     remote_repo: &RemoteRepository,
     entry: &MetadataEntry,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    remote_path: &Path,
+    local_path: &Path,
+    revision: &str,
 ) -> Result<(), OxenError> {
     if entry.size > AVG_CHUNK_SIZE {
-        download_large_entry(
-            remote_repo,
-            &remote_path,
-            &local_path,
-            &revision,
-            entry.size,
-        )
-        .await
+        download_large_entry(remote_repo, remote_path, local_path, revision, entry.size).await
     } else {
         download_small_entry(remote_repo, remote_path, local_path, revision).await
     }
@@ -275,12 +257,11 @@ pub async fn download_file(
 
 pub async fn download_small_entry(
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
-    dest: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    remote_path: &Path,
+    dest: &Path,
+    revision: &str,
 ) -> Result<(), OxenError> {
-    let path = remote_path.as_ref().to_string_lossy();
-    let revision = revision.as_ref();
+    let path = remote_path.to_string_lossy();
     let uri = format!("/file/{revision}/{path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     // log::debug!("url: {url:?}");
@@ -295,7 +276,6 @@ pub async fn download_small_entry(
     match status {
         reqwest::StatusCode::OK => {
             // Copy to file
-            let dest = dest.as_ref();
             // Create parent directories if they don't exist
             if let Some(parent) = dest.parent() {
                 util::fs::create_dir_all(parent)?;
@@ -306,7 +286,7 @@ pub async fn download_small_entry(
             let mut stream = response.bytes_stream();
             while let Some(chunk_result) = stream.next().await {
                 let chunk = chunk_result
-                    .map_err(|e| OxenError::basic_str(format!("Failed to read chunk: {e}")))?;
+                    .map_err(|e| OxenError::basic_str(&format!("Failed to read chunk: {e}")))?;
                 dest_file.write_all(&chunk).await?;
             }
 
@@ -317,7 +297,7 @@ pub async fn download_small_entry(
         reqwest::StatusCode::UNAUTHORIZED => Err(OxenError::must_supply_valid_api_key()),
         _ => {
             let err = format!("Could not download entry status: {status}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -326,7 +306,7 @@ pub async fn download_small_entry(
 pub async fn pull_large_entry(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
+    remote_path: &Path,
     entry: &Entry,
 ) -> Result<(), OxenError> {
     // Read chunks
@@ -336,8 +316,6 @@ pub async fn pull_large_entry(
     let hash = entry.hash();
     let revision = entry.commit_id();
     let version_store = repo.version_store()?;
-
-    let remote_path = remote_path.as_ref();
 
     log::debug!("Trying to download file {remote_path:?}");
 
@@ -432,9 +410,9 @@ pub async fn pull_large_entry(
 async fn try_pull_entry_chunk(
     version_store: Arc<dyn VersionStore>,
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
+    remote_path: &Path,
     hash: &str,
-    revision: impl AsRef<str>,
+    revision: &str,
     chunk_start: u64,
     chunk_size: u64,
 ) -> Result<u64, OxenError> {
@@ -443,18 +421,19 @@ async fn try_pull_entry_chunk(
         match pull_entry_chunk(
             Arc::clone(&version_store),
             remote_repo,
-            &remote_path,
+            remote_path,
             hash,
-            &revision,
+            revision,
             chunk_start,
             chunk_size,
         )
         .await
         {
             Ok(_status) => {
-                log::debug!("Downloaded chunk {:?}", remote_path.as_ref());
+                log::debug!("Downloaded chunk {:?}", remote_path);
                 return Ok(chunk_size);
             }
+
             Err(err) => {
                 // Don't retry non-transient errors
                 if err.is_auth_error() || err.is_not_found() {
@@ -478,18 +457,17 @@ async fn try_pull_entry_chunk(
 async fn pull_entry_chunk(
     version_store: Arc<dyn VersionStore>,
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
+    remote_path: &Path,
     hash: &str,
-    revision: impl AsRef<str>,
+    revision: &str,
     chunk_start: u64,
     chunk_size: u64,
 ) -> Result<reqwest::StatusCode, OxenError> {
-    let remote_path = remote_path.as_ref();
     log::debug!("{} {:?}", current_function!(), remote_path);
 
     let uri = format!(
         "/chunk/{}/{}?chunk_start={}&chunk_size={}",
-        revision.as_ref(),
+        revision,
         remote_path.to_string_lossy(),
         chunk_start,
         chunk_size
@@ -524,7 +502,7 @@ async fn pull_entry_chunk(
         reqwest::StatusCode::UNAUTHORIZED => Err(OxenError::must_supply_valid_api_key()),
         _ => {
             let err = format!("Could not download entry status: {status}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -532,9 +510,9 @@ async fn pull_entry_chunk(
 /// Download a file from the remote repository in parallel chunks
 pub async fn download_large_entry(
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    remote_path: &Path,
+    local_path: &Path,
+    revision: &str,
     num_bytes: u64,
 ) -> Result<(), OxenError> {
     // Read chunks
@@ -544,9 +522,7 @@ pub async fn download_large_entry(
     let mut chunk_size = chunk_size;
 
     // Write files to ~/.oxen/tmp/HASH/chunk_0..N
-    let remote_path = remote_path.as_ref();
-    let local_path = local_path.as_ref();
-    let hash = util::hasher::hash_str(format!("{remote_path:?}_{local_path:?}"));
+    let hash = util::hasher::hash_str(&format!("{remote_path:?}_{local_path:?}"));
 
     let home_dir = util::fs::oxen_tmp_dir()?;
 
@@ -581,7 +557,7 @@ pub async fn download_large_entry(
             remote_repo.clone(),
             remote_path.to_path_buf(),
             tmp_file,
-            revision.as_ref().to_string(),
+            revision.to_string(),
             chunk_start,
             chunk_size,
         ));
@@ -659,7 +635,7 @@ pub async fn download_large_entry(
                 match combined_file.write_all(&buffer) {
                     Ok(_) => {
                         log::debug!("Unpack successful! {local_path:?}");
-                        util::fs::remove_file(tmp_file)?;
+                        util::fs::remove_file(&tmp_file)?;
                     }
                     Err(err) => {
                         log::error!("Could not write all data to disk {err:?}");
@@ -676,7 +652,7 @@ pub async fn download_large_entry(
 
     if should_cleanup {
         log::error!("Cleaning up tmp dir {tmp_dir:?}");
-        util::fs::remove_dir_all(tmp_dir)?;
+        util::fs::remove_dir_all(&tmp_dir)?;
         return Err(OxenError::basic_str("Could not write all data to disk"));
     }
 
@@ -685,9 +661,9 @@ pub async fn download_large_entry(
 
 async fn try_download_entry_chunk(
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    remote_path: &Path,
+    local_path: &Path,
+    revision: &str,
     chunk_start: u64,
     chunk_size: u64,
 ) -> Result<u64, OxenError> {
@@ -695,18 +671,19 @@ async fn try_download_entry_chunk(
     while try_num < constants::NUM_HTTP_RETRIES {
         match download_entry_chunk(
             remote_repo,
-            &remote_path,
-            &local_path,
-            &revision,
+            remote_path,
+            local_path,
+            revision,
             chunk_start,
             chunk_size,
         )
         .await
         {
             Ok(_status) => {
-                log::debug!("Downloaded chunk {:?}", local_path.as_ref());
+                log::debug!("Downloaded chunk {:?}", local_path);
                 return Ok(chunk_size);
             }
+
             Err(err) => {
                 // Don't retry non-transient errors
                 if err.is_auth_error() || err.is_not_found() {
@@ -729,14 +706,12 @@ async fn try_download_entry_chunk(
 /// Downloads a chunk of a file
 async fn download_entry_chunk(
     remote_repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    remote_path: &Path,
+    local_path: &Path,
+    revision: &str,
     chunk_start: u64,
     chunk_size: u64,
 ) -> Result<reqwest::StatusCode, OxenError> {
-    let remote_path = remote_path.as_ref();
-    let local_path = local_path.as_ref();
     log::debug!(
         "{} {:?} -> {:?}",
         current_function!(),
@@ -746,7 +721,7 @@ async fn download_entry_chunk(
 
     let uri = format!(
         "/chunk/{}/{}?chunk_start={}&chunk_size={}",
-        revision.as_ref(),
+        revision,
         remote_path.to_string_lossy(),
         chunk_start,
         chunk_size
@@ -785,7 +760,7 @@ async fn download_entry_chunk(
         reqwest::StatusCode::UNAUTHORIZED => Err(OxenError::must_supply_valid_api_key()),
         _ => {
             let err = format!("Could not download entry status: {status}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -799,7 +774,7 @@ pub async fn download_data_from_version_paths(
     let mut num_retries = 0;
 
     while num_retries < total_retries {
-        match try_download_data_from_version_paths(remote_repo, content_ids, &dst).await {
+        match try_download_data_from_version_paths(remote_repo, content_ids, dst).await {
             Ok(val) => return Ok(val),
             Err(OxenError::Authentication(val)) => return Err(OxenError::Authentication(val)),
             Err(err) => {
@@ -817,15 +792,14 @@ pub async fn download_data_from_version_paths(
         content_ids.len(),
         total_retries
     );
-    Err(OxenError::basic_str(err))
+    Err(OxenError::basic_str(&err))
 }
 
 pub async fn try_download_data_from_version_paths(
     remote_repo: &RemoteRepository,
     content_ids: &[(String, PathBuf)], // tuple of content id and entry path
-    dst: impl AsRef<Path>,
+    dst: &Path,
 ) -> Result<u64, OxenError> {
-    let dst = dst.as_ref();
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
     for (content_id, _path) in content_ids.iter() {
         let line = format!("{content_id}\n");
@@ -859,7 +833,7 @@ pub async fn try_download_data_from_version_paths(
                 Ok(file) => file,
                 Err(err) => {
                     let err = format!("Could not unwrap file {entry_path:?} -> {err:?}");
-                    return Err(OxenError::basic_str(err));
+                    return Err(OxenError::basic_str(&err));
                 }
             };
 
@@ -877,7 +851,7 @@ pub async fn try_download_data_from_version_paths(
                 }
                 Err(err) => {
                     let err = format!("Could not unpack file {entry_path:?} -> {err:?}");
-                    return Err(OxenError::basic_str(err));
+                    return Err(OxenError::basic_str(&err));
                 }
             }
 
@@ -890,7 +864,7 @@ pub async fn try_download_data_from_version_paths(
     } else {
         let err =
             format!("api::entries::download_data_from_version_paths Err request failed: {url}");
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }
 
@@ -931,7 +905,7 @@ mod tests {
             // List the entries
             let entries = api::client::entries::list_entries_with_type(
                 &remote_repo,
-                "",
+                Path::new(""),
                 revision,
                 &EntryDataType::Tabular,
             )
@@ -955,7 +929,7 @@ mod tests {
             // List the entries
             let entries = api::client::entries::list_entries_with_type(
                 &remote_repo,
-                "",
+                Path::new(""),
                 revision,
                 &EntryDataType::Tabular,
             )
@@ -1086,7 +1060,7 @@ mod tests {
             let remote_path = Path::new("annotations");
             let local_path = local_repo.path.join("data");
             let revision = DEFAULT_BRANCH_NAME;
-            api::client::entries::download_entry(&remote_repo, &remote_path, &local_path, revision)
+            api::client::entries::download_entry(&remote_repo, remote_path, &local_path, revision)
                 .await?;
             assert!(local_path.exists());
             assert!(local_path.join("annotations").join("README.md").exists());

--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -67,7 +67,7 @@ pub async fn upload_entries(
     opts: &UploadOpts,
 ) -> Result<(), OxenError> {
     if opts.paths.is_empty() {
-        return Err(OxenError::basic_str("No files to upload"));
+        return Err(OxenError::basic_str("No files to upload".to_string()));
     }
 
     // Filter down to only files
@@ -132,11 +132,11 @@ pub async fn download_entry(
         Some(EMetadataEntry::MetadataEntry(entry)) => entry,
         Some(EMetadataEntry::WorkspaceMetadataEntry(_entry)) => {
             return Err(OxenError::basic_str(
-                "Workspace entries are not supported for download",
+                "Workspace entries are not supported for download".to_string(),
             ));
         }
         None => {
-            return Err(OxenError::path_does_not_exist(&download_path));
+            return Err(OxenError::path_does_not_exist(download_path));
         }
     };
 
@@ -148,14 +148,14 @@ pub async fn download_entry(
     // * if the dst parent is a file, we error because cannot copy to a file subdirectory
     if let Some(parent) = local_path.parent() {
         if parent.is_file() {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "{parent:?} is not a directory"
             )));
         }
 
         // * if the dst parent does not exist, we error because cannot copy a directory to a non-existent location
         if !parent.exists() && parent != Path::new("") {
-            return Err(OxenError::basic_str(&format!("{parent:?} does not exist")));
+            return Err(OxenError::basic_str(format!("{parent:?} does not exist")));
         }
     }
 
@@ -192,18 +192,18 @@ pub async fn download_entries_to_repo(
             Some(EMetadataEntry::MetadataEntry(entry)) => entry,
             Some(EMetadataEntry::WorkspaceMetadataEntry(_entry)) => {
                 return Err(OxenError::basic_str(
-                    "Workspace entries are not supported for download",
+                    "Workspace entries are not supported for download".to_string(),
                 ));
             }
             None => {
-                return Err(OxenError::path_does_not_exist(remote_path));
+                return Err(OxenError::path_does_not_exist(remote_path.to_path_buf()));
             }
         };
 
         // * if the dst parent is a file, we error because cannot copy to a file subdirectory
         if let Some(parent) = local_path.parent() {
             if parent.is_file() {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "{parent:?} is not a directory"
                 )));
             }
@@ -229,7 +229,7 @@ pub async fn download_entries_to_repo(
             // Save contents to version store
             let version_store = local_repo.version_store()?;
             let file = std::fs::read(local_path).map_err(|e| {
-                OxenError::basic_str(&format!("Failed to read file '{remote_path:?}': {e}"))
+                OxenError::basic_str(format!("Failed to read file '{remote_path:?}': {e}"))
             })?;
             let hash = util::hasher::hash_buffer(&file);
             version_store
@@ -270,7 +270,7 @@ pub async fn download_small_entry(
         .get(&url)
         .send()
         .await
-        .map_err(|_| OxenError::resource_not_found(&url))?;
+        .map_err(|_| OxenError::resource_not_found(url))?;
 
     let status = response.status();
     match status {
@@ -286,18 +286,20 @@ pub async fn download_small_entry(
             let mut stream = response.bytes_stream();
             while let Some(chunk_result) = stream.next().await {
                 let chunk = chunk_result
-                    .map_err(|e| OxenError::basic_str(&format!("Failed to read chunk: {e}")))?;
+                    .map_err(|e| OxenError::basic_str(format!("Failed to read chunk: {e}")))?;
                 dest_file.write_all(&chunk).await?;
             }
 
             dest_file.flush().await?;
             Ok(())
         }
-        reqwest::StatusCode::NOT_FOUND => Err(OxenError::path_does_not_exist(remote_path)),
+        reqwest::StatusCode::NOT_FOUND => {
+            Err(OxenError::path_does_not_exist(remote_path.to_path_buf()))
+        }
         reqwest::StatusCode::UNAUTHORIZED => Err(OxenError::must_supply_valid_api_key()),
         _ => {
             let err = format!("Could not download entry status: {status}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -348,7 +350,7 @@ pub async fn pull_large_entry(
 
     // Try to download the first chunk and return error if it fails
     if tasks.is_empty() {
-        return Err(OxenError::basic_str("No chunks to download"));
+        return Err(OxenError::basic_str("No chunks to download".to_string()));
     }
     let item = tasks.remove(0);
     let (version_store, remote_repo, remote_path, hash, revision, chunk_start, chunk_size) = item;
@@ -450,7 +452,9 @@ async fn try_pull_entry_chunk(
             }
         }
     }
-    Err(OxenError::basic_str("Retry download chunk failed"))
+    Err(OxenError::basic_str(
+        "Retry download chunk failed".to_string(),
+    ))
 }
 
 /// Downloads a chunk of a file
@@ -498,11 +502,13 @@ async fn pull_entry_chunk(
                 .await?;
             Ok(status)
         }
-        reqwest::StatusCode::NOT_FOUND => Err(OxenError::path_does_not_exist(remote_path)),
+        reqwest::StatusCode::NOT_FOUND => {
+            Err(OxenError::path_does_not_exist(remote_path.to_path_buf()))
+        }
         reqwest::StatusCode::UNAUTHORIZED => Err(OxenError::must_supply_valid_api_key()),
         _ => {
             let err = format!("Could not download entry status: {status}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -565,7 +571,7 @@ pub async fn download_large_entry(
 
     // Try to download the first chunk and return error if it fails
     if tasks.is_empty() {
-        return Err(OxenError::basic_str("No chunks to download"));
+        return Err(OxenError::basic_str("No chunks to download".to_string()));
     }
     let item = tasks.remove(0);
     let (remote_repo, remote_path, tmp_file, revision, chunk_start, chunk_size) = item;
@@ -653,7 +659,9 @@ pub async fn download_large_entry(
     if should_cleanup {
         log::error!("Cleaning up tmp dir {tmp_dir:?}");
         util::fs::remove_dir_all(&tmp_dir)?;
-        return Err(OxenError::basic_str("Could not write all data to disk"));
+        return Err(OxenError::basic_str(
+            "Could not write all data to disk".to_string(),
+        ));
     }
 
     Ok(())
@@ -700,7 +708,9 @@ async fn try_download_entry_chunk(
             }
         }
     }
-    Err(OxenError::basic_str("Retry download chunk failed"))
+    Err(OxenError::basic_str(
+        "Retry download chunk failed".to_string(),
+    ))
 }
 
 /// Downloads a chunk of a file
@@ -756,11 +766,13 @@ async fn download_entry_chunk(
             std::io::copy(&mut content, &mut dest)?;
             Ok(status)
         }
-        reqwest::StatusCode::NOT_FOUND => Err(OxenError::path_does_not_exist(remote_path)),
+        reqwest::StatusCode::NOT_FOUND => {
+            Err(OxenError::path_does_not_exist(remote_path.to_path_buf()))
+        }
         reqwest::StatusCode::UNAUTHORIZED => Err(OxenError::must_supply_valid_api_key()),
         _ => {
             let err = format!("Could not download entry status: {status}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -792,7 +804,7 @@ pub async fn download_data_from_version_paths(
         content_ids.len(),
         total_retries
     );
-    Err(OxenError::basic_str(&err))
+    Err(OxenError::basic_str(err))
 }
 
 pub async fn try_download_data_from_version_paths(
@@ -833,7 +845,7 @@ pub async fn try_download_data_from_version_paths(
                 Ok(file) => file,
                 Err(err) => {
                     let err = format!("Could not unwrap file {entry_path:?} -> {err:?}");
-                    return Err(OxenError::basic_str(&err));
+                    return Err(OxenError::basic_str(err));
                 }
             };
 
@@ -851,7 +863,7 @@ pub async fn try_download_data_from_version_paths(
                 }
                 Err(err) => {
                     let err = format!("Could not unpack file {entry_path:?} -> {err:?}");
-                    return Err(OxenError::basic_str(&err));
+                    return Err(OxenError::basic_str(err));
                 }
             }
 
@@ -864,7 +876,7 @@ pub async fn try_download_data_from_version_paths(
     } else {
         let err =
             format!("api::entries::download_data_from_version_paths Err request failed: {url}");
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 

--- a/crates/lib/src/api/client/export.rs
+++ b/crates/lib/src/api/client/export.rs
@@ -27,10 +27,10 @@ pub async fn download_dir_as_zip(
             if status == reqwest::StatusCode::UNAUTHORIZED {
                 let e = "Err: unauthorized request to download data".to_string();
                 log::error!("{e}");
-                return Err(OxenError::authentication(&e));
+                return Err(OxenError::authentication(e));
             }
 
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "download_dir_as_zip failed with status {status} for {url}"
             )));
         }
@@ -45,7 +45,7 @@ pub async fn download_dir_as_zip(
             Ok(s) => s,
             Err(e) => {
                 let _ = tokio::fs::remove_file(local_path).await;
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Failed to download ZIP to {local_path:?}: {e}"
                 )));
             }
@@ -56,7 +56,7 @@ pub async fn download_dir_as_zip(
         Ok(size)
     } else {
         let err = format!("try_download_dir_as_zip failed to send request {url}");
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 

--- a/crates/lib/src/api/client/export.rs
+++ b/crates/lib/src/api/client/export.rs
@@ -10,13 +10,12 @@ use crate::model::RemoteRepository;
 
 pub async fn download_dir_as_zip(
     remote_repo: &RemoteRepository,
-    revision: impl AsRef<str>,
-    directory: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
+    revision: &str,
+    directory: &Path,
+    local_path: &Path,
 ) -> Result<u64, OxenError> {
-    let revision = revision.as_ref().to_string();
-    let directory = directory.as_ref().to_string_lossy().to_string();
-    let local_path = local_path.as_ref();
+    let revision = revision.to_string();
+    let directory = directory.to_string_lossy().to_string();
     let uri = format!("/export/download/{revision}/{directory}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -28,10 +27,10 @@ pub async fn download_dir_as_zip(
             if status == reqwest::StatusCode::UNAUTHORIZED {
                 let e = "Err: unauthorized request to download data".to_string();
                 log::error!("{e}");
-                return Err(OxenError::authentication(e));
+                return Err(OxenError::authentication(&e));
             }
 
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "download_dir_as_zip failed with status {status} for {url}"
             )));
         }
@@ -46,7 +45,7 @@ pub async fn download_dir_as_zip(
             Ok(s) => s,
             Err(e) => {
                 let _ = tokio::fs::remove_file(local_path).await;
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Failed to download ZIP to {local_path:?}: {e}"
                 )));
             }
@@ -57,7 +56,7 @@ pub async fn download_dir_as_zip(
         Ok(size)
     } else {
         let err = format!("try_download_dir_as_zip failed to send request {url}");
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }
 
@@ -72,6 +71,7 @@ mod tests {
 
     use std::io::Read;
 
+    use std::path::Path;
     use std::path::PathBuf;
     use zip::ZipArchive;
 
@@ -88,7 +88,7 @@ mod tests {
             let _size = api::client::export::download_dir_as_zip(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                remote_dir,
+                Path::new(remote_dir),
                 &zip_local_path,
             )
             .await?;

--- a/crates/lib/src/api/client/file.rs
+++ b/crates/lib/src/api/client/file.rs
@@ -109,9 +109,9 @@ pub async fn get_file_with_params(
     timestamp: Option<f64>,
 ) -> Result<Bytes, OxenError> {
     let path_ref = file_path;
-    let file_path = path_ref.to_str().ok_or_else(|| {
-        OxenError::basic_str(&format!("Invalid UTF-8 in file path: {path_ref:?}"))
-    })?;
+    let file_path = path_ref
+        .to_str()
+        .ok_or_else(|| OxenError::basic_str(format!("Invalid UTF-8 in file path: {path_ref:?}")))?;
     let uri = format!("/file/{branch}/{file_path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -140,8 +140,8 @@ pub async fn get_file_with_params(
     let mut stream = res.bytes_stream();
     let mut buffer = BytesMut::new();
     while let Some(chunk_result) = stream.next().await {
-        let chunk = chunk_result
-            .map_err(|e| OxenError::basic_str(&format!("Failed to read chunk: {e}")))?;
+        let chunk =
+            chunk_result.map_err(|e| OxenError::basic_str(format!("Failed to read chunk: {e}")))?;
         buffer.extend_from_slice(&chunk);
     }
 

--- a/crates/lib/src/api/client/file.rs
+++ b/crates/lib/src/api/client/file.rs
@@ -12,14 +12,12 @@ use std::path::Path;
 
 pub async fn put_file(
     remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    directory: impl AsRef<str>,
-    file_path: impl AsRef<Path>,
-    file_name: Option<impl AsRef<str>>,
+    branch: &str,
+    directory: &str,
+    file_path: &Path,
+    file_name: Option<&str>,
     commit_body: Option<NewCommitBody>,
 ) -> Result<CommitResponse, OxenError> {
-    let branch = branch.as_ref();
-    let directory = directory.as_ref();
     put_multipart_file(
         remote_repo,
         format!("/file/{branch}/{directory}"),
@@ -94,8 +92,8 @@ fn apply_commit_body(mut form: Form, commit_body: Option<NewCommitBody>) -> Form
 
 pub async fn get_file(
     remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    file_path: impl AsRef<Path>,
+    branch: &str,
+    file_path: &Path,
 ) -> Result<Bytes, OxenError> {
     get_file_with_params(remote_repo, branch, file_path, None, None, None, None).await
 }
@@ -103,18 +101,17 @@ pub async fn get_file(
 /// Get a file with optional query parameters (for thumbnails, image resizing, etc.)
 pub async fn get_file_with_params(
     remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    file_path: impl AsRef<Path>,
+    branch: &str,
+    file_path: &Path,
     thumbnail: Option<bool>,
     width: Option<u32>,
     height: Option<u32>,
     timestamp: Option<f64>,
 ) -> Result<Bytes, OxenError> {
-    let branch = branch.as_ref();
-    let path_ref = file_path.as_ref();
-    let file_path = path_ref
-        .to_str()
-        .ok_or_else(|| OxenError::basic_str(format!("Invalid UTF-8 in file path: {path_ref:?}")))?;
+    let path_ref = file_path;
+    let file_path = path_ref.to_str().ok_or_else(|| {
+        OxenError::basic_str(&format!("Invalid UTF-8 in file path: {path_ref:?}"))
+    })?;
     let uri = format!("/file/{branch}/{file_path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -143,8 +140,8 @@ pub async fn get_file_with_params(
     let mut stream = res.bytes_stream();
     let mut buffer = BytesMut::new();
     while let Some(chunk_result) = stream.next().await {
-        let chunk =
-            chunk_result.map_err(|e| OxenError::basic_str(format!("Failed to read chunk: {e}")))?;
+        let chunk = chunk_result
+            .map_err(|e| OxenError::basic_str(&format!("Failed to read chunk: {e}")))?;
         buffer.extend_from_slice(&chunk);
     }
 
@@ -154,8 +151,8 @@ pub async fn get_file_with_params(
 /// Get a video thumbnail
 pub async fn get_file_thumbnail(
     remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    file_path: impl AsRef<Path>,
+    branch: &str,
+    file_path: &Path,
     width: Option<u32>,
     height: Option<u32>,
     timestamp: Option<f64>,
@@ -175,15 +172,11 @@ pub async fn get_file_thumbnail(
 /// Move/rename a file in place (mv in a temp workspace and commit)
 pub async fn mv_file(
     remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    source_path: impl AsRef<Path>,
-    new_path: impl AsRef<Path>,
+    branch: &str,
+    source_path: &Path,
+    new_path: &Path,
     commit_body: Option<NewCommitBody>,
 ) -> Result<CommitResponse, OxenError> {
-    let branch = branch.as_ref();
-    let source_path = source_path.as_ref();
-    let new_path = new_path.as_ref();
-
     let source_path_str = source_path.to_string_lossy().to_string();
     let new_path_str = new_path.to_string_lossy().to_string();
 
@@ -218,13 +211,10 @@ pub async fn mv_file(
 /// Delete a file in place (rm from a temp workspace and commit)
 pub async fn delete_file(
     remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    file_path: impl AsRef<Path>,
+    branch: &str,
+    file_path: &Path,
     commit_body: Option<NewCommitBody>,
 ) -> Result<CommitResponse, OxenError> {
-    let branch = branch.as_ref();
-    let file_path = file_path.as_ref();
-
     let file_path = file_path.to_string_lossy().to_string();
 
     let uri = format!("/file/{branch}/{file_path}");
@@ -402,7 +392,7 @@ mod tests {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
             let branch_name = "main";
             let file_path = test::test_bounding_box_csv();
-            let bytes = api::client::file::get_file(&remote_repo, branch_name, file_path).await;
+            let bytes = api::client::file::get_file(&remote_repo, branch_name, &file_path).await;
 
             assert!(bytes.is_ok());
             assert!(!bytes.unwrap().is_empty());
@@ -429,7 +419,7 @@ mod tests {
             // Delete the file on the remote repo
             let _commit_response = api::client::file::delete_file(
                 &remote_repo,
-                &branch_name,
+                branch_name,
                 &file_path,
                 Some(commit_body),
             )
@@ -479,7 +469,7 @@ mod tests {
             let delete_response = api::client::file::delete_file(
                 &remote_repo,
                 branch_name,
-                &file_to_delete,
+                Path::new(file_to_delete),
                 Some(delete_commit_body),
             )
             .await?;
@@ -526,8 +516,8 @@ mod tests {
             let mv_response = api::client::file::mv_file(
                 &remote_repo,
                 branch_name,
-                source_path,
-                new_path,
+                Path::new(source_path),
+                Path::new(new_path),
                 Some(mv_commit_body),
             )
             .await?;
@@ -581,7 +571,7 @@ mod tests {
                 .into_owned();
 
             let workspace =
-                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_id)
+                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                     .await?;
             assert_eq!(workspace.id, workspace_id);
 
@@ -592,12 +582,14 @@ mod tests {
             let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace.id,
-                directory_name,
+                Path::new(&directory_name),
                 &full_path,
             )
             .await;
 
-            let bytes = api::client::file::get_file(&remote_repo, workspace_id, file_path).await;
+            let bytes =
+                api::client::file::get_file(&remote_repo, workspace_id, Path::new(&file_path))
+                    .await;
 
             assert!(bytes.is_ok());
             assert!(!bytes.as_ref().unwrap().is_empty());

--- a/crates/lib/src/api/client/import.rs
+++ b/crates/lib/src/api/client/import.rs
@@ -19,7 +19,7 @@ pub async fn upload_zip(
     let zip_data = std::fs::read(zip_path)?;
     let file_name = zip_path
         .file_name()
-        .ok_or_else(|| OxenError::basic_str("Invalid ZIP file path"))?
+        .ok_or_else(|| OxenError::basic_str("Invalid ZIP file path".to_string()))?
         .to_string_lossy();
 
     // Create the URL for workspace ZIP upload endpoint
@@ -45,7 +45,7 @@ pub async fn upload_zip(
 
     // Parse the response
     let response: crate::view::CommitResponse = serde_json::from_str(&body)
-        .map_err(|e| OxenError::basic_str(&format!("Failed to parse response: {e}")))?;
+        .map_err(|e| OxenError::basic_str(format!("Failed to parse response: {e}")))?;
 
     Ok(response.commit)
 }

--- a/crates/lib/src/api/client/import.rs
+++ b/crates/lib/src/api/client/import.rs
@@ -8,19 +8,13 @@ use std::path::Path;
 /// Upload a ZIP file that gets extracted into the workspace directory
 pub async fn upload_zip(
     remote_repo: &RemoteRepository,
-    branch_name: impl AsRef<str>,
-    directory: impl AsRef<str>,
-    zip_path: impl AsRef<Path>,
-    name: impl AsRef<str>,
-    email: impl AsRef<str>,
-    commit_message: Option<impl AsRef<str>>,
+    branch_name: &str,
+    directory: &str,
+    zip_path: &Path,
+    name: &str,
+    email: &str,
+    commit_message: Option<&str>,
 ) -> Result<crate::model::Commit, OxenError> {
-    let branch_name = branch_name.as_ref();
-    let directory = directory.as_ref();
-    let zip_path = zip_path.as_ref();
-    let name = name.as_ref();
-    let email = email.as_ref();
-
     // Read the ZIP file
     let zip_data = std::fs::read(zip_path)?;
     let file_name = zip_path
@@ -41,7 +35,7 @@ pub async fn upload_zip(
         .text("resource_path", directory.to_string());
 
     if let Some(msg) = commit_message {
-        form = form.text("commit_message", msg.as_ref().to_string());
+        form = form.text("commit_message", msg.to_string());
     }
 
     // Send the request
@@ -51,7 +45,7 @@ pub async fn upload_zip(
 
     // Parse the response
     let response: crate::view::CommitResponse = serde_json::from_str(&body)
-        .map_err(|e| OxenError::basic_str(format!("Failed to parse response: {e}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("Failed to parse response: {e}")))?;
 
     Ok(response.commit)
 }
@@ -65,6 +59,7 @@ mod tests {
     use crate::error::OxenError;
 
     use crate::api;
+    use std::path::Path;
 
     use std::io::Write;
 
@@ -109,8 +104,12 @@ mod tests {
             let commit = result.unwrap();
             assert!(commit.message.contains("Upload test ZIP"));
 
-            let bytes =
-                api::client::file::get_file(&remote_repo, branch_name, "images/image1.png").await;
+            let bytes = api::client::file::get_file(
+                &remote_repo,
+                branch_name,
+                Path::new("images/image1.png"),
+            )
+            .await;
 
             assert!(bytes.is_ok());
             assert!(!bytes.as_ref().unwrap().is_empty());
@@ -161,8 +160,12 @@ mod tests {
             let commit = result.unwrap();
             assert!(commit.message.contains("Upload test ZIP in empty repo"));
 
-            let bytes =
-                api::client::file::get_file(&remote_repo, branch_name, "images/image1.png").await;
+            let bytes = api::client::file::get_file(
+                &remote_repo,
+                branch_name,
+                Path::new("images/image1.png"),
+            )
+            .await;
 
             assert!(bytes.is_ok());
             assert_eq!(
@@ -170,8 +173,12 @@ mod tests {
                 &Bytes::from_static(b"fake png data 1")
             );
 
-            let bytes_2 =
-                api::client::file::get_file(&remote_repo, branch_name, "images/image2.png").await;
+            let bytes_2 = api::client::file::get_file(
+                &remote_repo,
+                branch_name,
+                Path::new("images/image2.png"),
+            )
+            .await;
 
             assert!(bytes_2.is_ok());
             assert_eq!(

--- a/crates/lib/src/api/client/metadata.rs
+++ b/crates/lib/src/api/client/metadata.rs
@@ -14,11 +14,10 @@ use std::path::Path;
 /// Get the metadata about a resource from the remote.
 pub async fn get_file(
     remote_repo: &RemoteRepository,
-    revision: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    revision: &str,
+    path: &Path,
 ) -> Result<Option<EMetadataEntryResponseView>, OxenError> {
-    let path = path.as_ref().to_string_lossy();
-    let revision = revision.as_ref();
+    let path = path.to_string_lossy();
     let uri = format!("/meta/{revision}/{path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -58,7 +57,7 @@ mod tests {
             let entry = tree.get_by_path(&path)?;
             assert!(entry.is_some());
 
-            let entry = api::client::metadata::get_file(&remote_repo, revision, path)
+            let entry = api::client::metadata::get_file(&remote_repo, revision, &path)
                 .await?
                 .unwrap()
                 .entry;
@@ -88,7 +87,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_dir_entry() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
-            let path = "train";
+            let path = Path::new("train");
             let revision = DEFAULT_BRANCH_NAME;
             let entry = api::client::metadata::get_file(&remote_repo, revision, path)
                 .await?
@@ -153,12 +152,12 @@ mod tests {
             repositories::push(&local_repo).await?;
 
             let meta: EMetadataEntryResponseView =
-                api::client::metadata::get_file(&remote_repo, main_branch, &path)
+                api::client::metadata::get_file(&remote_repo, main_branch, path)
                     .await?
                     .unwrap();
 
             let second_meta: EMetadataEntryResponseView =
-                api::client::metadata::get_file(&remote_repo, second_branch, &path)
+                api::client::metadata::get_file(&remote_repo, second_branch, path)
                     .await?
                     .unwrap();
 
@@ -176,12 +175,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_file_with_workspace() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
-            let file_path = "annotations/train/file.txt";
+            let file_path = Path::new("annotations/train/file.txt");
             let workspace_id = "test_workspace_id";
-            let directory_name = "annotations/train";
+            let directory_name = Path::new("annotations/train");
 
             let workspace =
-                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_id)
+                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                     .await?;
             assert_eq!(workspace.id, workspace_id);
 
@@ -191,7 +190,7 @@ mod tests {
 
             let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
-                &workspace_id,
+                workspace_id,
                 directory_name,
                 &full_path,
             )
@@ -214,18 +213,18 @@ mod tests {
 
             let file_path = test::test_bounding_box_csv();
             let full_path = local_repo.path.join(file_path.clone());
-            util::fs::write(&full_path, "name,age\nAlice,30\nBob,25\n")?;
+            util::fs::write(&full_path, "name,age\nAlice,30\nBob,25\n".as_bytes())?;
 
             let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
-                &workspace_id,
+                workspace_id,
                 directory_name,
                 &full_path,
             )
             .await;
 
             let meta: EMetadataEntryResponseView =
-                api::client::metadata::get_file(&remote_repo, workspace_id, file_path.clone())
+                api::client::metadata::get_file(&remote_repo, workspace_id, &file_path)
                     .await?
                     .unwrap();
 

--- a/crates/lib/src/api/client/oxen_version.rs
+++ b/crates/lib/src/api/client/oxen_version.rs
@@ -15,7 +15,7 @@ pub async fn get_remote_version(scheme: &str, host: &str) -> Result<String, Oxen
     let response: StatusMessage = serde_json::from_str(&body)?;
     response
         .oxen_version
-        .ok_or_else(|| OxenError::basic_str("Remote server did not return a version"))
+        .ok_or_else(|| OxenError::basic_str("Remote server did not return a version".to_string()))
 }
 
 pub async fn get_min_oxen_version(scheme: &str, host: &str) -> Result<String, OxenError> {

--- a/crates/lib/src/api/client/prune.rs
+++ b/crates/lib/src/api/client/prune.rs
@@ -65,7 +65,7 @@ pub async fn prune(remote_repo: &RemoteRepository, dry_run: bool) -> Result<Prun
                 }
                 Err(err) => {
                     log::error!("Failed to parse PruneResponse from body: {body}");
-                    Err(OxenError::basic_str(&format!(
+                    Err(OxenError::basic_str(format!(
                         "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     )))
                 }
@@ -73,7 +73,7 @@ pub async fn prune(remote_repo: &RemoteRepository, dry_run: bool) -> Result<Prun
         }
         Err(err) => {
             let err = format!("Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }

--- a/crates/lib/src/api/client/prune.rs
+++ b/crates/lib/src/api/client/prune.rs
@@ -65,7 +65,7 @@ pub async fn prune(remote_repo: &RemoteRepository, dry_run: bool) -> Result<Prun
                 }
                 Err(err) => {
                     log::error!("Failed to parse PruneResponse from body: {body}");
-                    Err(OxenError::basic_str(format!(
+                    Err(OxenError::basic_str(&format!(
                         "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     )))
                 }
@@ -73,7 +73,7 @@ pub async fn prune(remote_repo: &RemoteRepository, dry_run: bool) -> Result<Prun
         }
         Err(err) => {
             let err = format!("Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }

--- a/crates/lib/src/api/client/repositories.rs
+++ b/crates/lib/src/api/client/repositories.rs
@@ -49,41 +49,38 @@ pub async fn get_by_remote_repo(repo: &RemoteRepository) -> Result<RemoteReposit
 }
 
 /// Attempts to find a repo by name on the remote "origin". For example ox/CatDog
-pub async fn get_by_name_default(name: impl AsRef<str>) -> Result<RemoteRepository, OxenError> {
+pub async fn get_by_name_default(name: &str) -> Result<RemoteRepository, OxenError> {
     get_by_name_host_and_remote(name, DEFAULT_HOST, DEFAULT_SCHEME, DEFAULT_REMOTE_NAME).await
 }
 
 pub async fn get_by_name_and_host(
-    name: impl AsRef<str>,
-    host: impl AsRef<str>,
-    scheme: impl AsRef<str>,
+    name: &str,
+    host: &str,
+    scheme: &str,
 ) -> Result<RemoteRepository, OxenError> {
     get_by_name_host_and_remote(name, host, scheme, DEFAULT_REMOTE_NAME).await
 }
 
 pub async fn get_by_name_host_and_scheme(
-    name: impl AsRef<str>,
-    host: impl AsRef<str>,
-    scheme: impl AsRef<str>,
+    name: &str,
+    host: &str,
+    scheme: &str,
 ) -> Result<RemoteRepository, OxenError> {
-    let name = name.as_ref();
-    let url = api::endpoint::remote_url_from_name_and_scheme(host.as_ref(), name, scheme.as_ref());
+    let url = api::endpoint::remote_url_from_name_and_scheme(host, name, scheme);
     log::debug!("get_by_name_host_and_scheme({name}) remote url: {url}");
     get_by_url(&url).await
 }
 
 pub async fn get_by_name_host_and_remote(
-    name: impl AsRef<str>,
-    host: impl AsRef<str>,
-    scheme: impl AsRef<str>,
-    remote: impl AsRef<str>,
+    name: &str,
+    host: &str,
+    scheme: &str,
+    remote: &str,
 ) -> Result<RemoteRepository, OxenError> {
-    let name = name.as_ref();
-    let scheme = scheme.as_ref();
-    let url = api::endpoint::remote_url_from_name_and_scheme(host.as_ref(), name, scheme);
+    let url = api::endpoint::remote_url_from_name_and_scheme(host, name, scheme);
     log::debug!("get_by_name_host_and_remote({name}) remote url: {url}");
     let remote = Remote {
-        name: String::from(remote.as_ref()),
+        name: String::from(remote),
         url,
     };
     get_by_remote(&remote).await
@@ -124,7 +121,7 @@ pub async fn get_by_remote(remote: &Remote) -> Result<RemoteRepository, OxenErro
         Ok(j_res) => Ok(RemoteRepository::from_view(&j_res.repository, remote)),
         Err(err) => {
             log::debug!("Err: {err}");
-            Err(OxenError::basic_str(format!(
+            Err(OxenError::basic_str(&format!(
                 "get_by_remote Could not deserialize repository [{url}]"
             )))
         }
@@ -154,7 +151,7 @@ pub async fn get_repo_data_by_remote(
                 Ok(j_res) => Ok(Some(j_res.repository)),
                 Err(err) => {
                     log::debug!("Err: {err}");
-                    Err(OxenError::basic_str(format!(
+                    Err(OxenError::basic_str(&format!(
                         "api::repositories::get_repo_data_by_remote() Could not deserialize repository [{url}]"
                     )))
                 }
@@ -162,7 +159,7 @@ pub async fn get_repo_data_by_remote(
         }
         Err(err) => {
             log::error!("Failed to get remote url {url}\n{err:?}");
-            Err(OxenError::basic_str(format!(
+            Err(OxenError::basic_str(&format!(
                 "api::repositories::get_repo_data_by_remote() Request failed at url {url}"
             )))
         }
@@ -208,7 +205,7 @@ pub async fn create_empty(repo: RepoNew) -> Result<RemoteRepository, OxenError> 
             let err = format!(
                 "Create repository could not connect to {url}. Make sure you have the correct server and that it is running."
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -216,7 +213,7 @@ pub async fn create_empty(repo: RepoNew) -> Result<RemoteRepository, OxenError> 
 pub async fn create(repo_new: RepoNew) -> Result<RemoteRepository, OxenError> {
     let host = repo_new.host();
     let scheme = repo_new.scheme();
-    let url = api::endpoint::url_from_host_and_scheme(&host, "", scheme);
+    let url = api::endpoint::url_from_host_and_scheme(&host, "", &scheme);
 
     // convert repo_new to json with serde
     log::debug!("Create remote: {url}\n{repo_new:?}");
@@ -247,14 +244,14 @@ pub async fn create(repo_new: RepoNew) -> Result<RemoteRepository, OxenError> {
                     "Could not create or find repository [{}]: {err}\n{body}",
                     repo_new.repo_id()
                 );
-                Err(OxenError::basic_str(err))
+                Err(OxenError::basic_str(&err))
             }
         }
     } else {
         let err = format!(
             "Create repository could not connect to {url}. Make sure you have the correct server and that it is running."
         );
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }
 
@@ -266,7 +263,7 @@ pub async fn create_repo_with_files(
 ) -> Result<RemoteRepository, OxenError> {
     let host = repo_new.host();
     let scheme = repo_new.scheme();
-    let url = api::endpoint::url_from_host_and_scheme(&host, "", scheme);
+    let url = api::endpoint::url_from_host_and_scheme(&host, "", &scheme);
 
     let new_repo_json = json!({
         "name": repo_new.name,
@@ -314,7 +311,7 @@ pub async fn create_repo_with_files(
                 "Could not create or find repository [{}]: {err}\n{body}",
                 repo_new.repo_id()
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -355,7 +352,7 @@ pub async fn create_from_local(
                 "Could not create or find repository [{}]: {err}\n{body}",
                 repo_new.repo_id()
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -369,7 +366,7 @@ pub async fn delete(repository: &RemoteRepository) -> Result<StatusMessage, Oxen
         let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(val) => Ok(val),
-            Err(_) => Err(OxenError::basic_str(format!(
+            Err(_) => Err(OxenError::basic_str(&format!(
                 "Could not delete repository \n\n{body}"
             ))),
         }
@@ -387,7 +384,7 @@ pub async fn delete_from_url(url: String) -> Result<StatusMessage, OxenError> {
         let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(val) => Ok(val),
-            Err(_) => Err(OxenError::basic_str(format!(
+            Err(_) => Err(OxenError::basic_str(&format!(
                 "Could not delete repository \n\n{body}"
             ))),
         }
@@ -436,7 +433,7 @@ pub async fn transfer_namespace(
             }
             Err(err) => {
                 let err = format!("Could not transfer repository: {err}\n{body}");
-                Err(OxenError::basic_str(err))
+                Err(OxenError::basic_str(&err))
             }
         }
     } else {
@@ -580,6 +577,7 @@ async fn action_hook(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
     use std::path::PathBuf;
 
     use tokio::time::sleep;
@@ -675,7 +673,7 @@ mod tests {
             let namespace = constants::DEFAULT_NAMESPACE;
             let name = local_repo.dirname();
             let repo_new =
-                RepoNew::from_namespace_name_host(namespace, &name, test::test_host(), None);
+                RepoNew::from_namespace_name_host(namespace, &name, &test::test_host(), None);
             let repository =
                 api::client::repositories::create_from_local(&local_repo, repo_new).await?;
             println!("got repository: {repository:?}");
@@ -750,7 +748,7 @@ mod tests {
             };
 
             let mut repo_new =
-                RepoNew::from_namespace_name_host(namespace, &name, test::test_host(), None);
+                RepoNew::from_namespace_name_host(namespace, &name, &test::test_host(), None);
             repo_new.scheme = Some("http".to_string());
 
             let repository = api::client::repositories::create_repo_with_files(
@@ -764,17 +762,27 @@ mod tests {
             assert_eq!(repository.name, name);
 
             // List the files in the repo
-            let readme =
-                api::client::entries::get_entry(&repository, "README", DEFAULT_BRANCH_NAME)
-                    .await?
-                    .unwrap();
-            let csv = api::client::entries::get_entry(&repository, "data.csv", DEFAULT_BRANCH_NAME)
-                .await?
-                .unwrap();
-            let png =
-                api::client::entries::get_entry(&repository, "image.png", DEFAULT_BRANCH_NAME)
-                    .await?
-                    .unwrap();
+            let readme = api::client::entries::get_entry(
+                &repository,
+                Path::new("README"),
+                DEFAULT_BRANCH_NAME,
+            )
+            .await?
+            .unwrap();
+            let csv = api::client::entries::get_entry(
+                &repository,
+                Path::new("data.csv"),
+                DEFAULT_BRANCH_NAME,
+            )
+            .await?
+            .unwrap();
+            let png = api::client::entries::get_entry(
+                &repository,
+                Path::new("image.png"),
+                DEFAULT_BRANCH_NAME,
+            )
+            .await?
+            .unwrap();
 
             assert_eq!(readme.filename(), "README");
             assert_eq!(csv.filename(), "data.csv");

--- a/crates/lib/src/api/client/repositories.rs
+++ b/crates/lib/src/api/client/repositories.rs
@@ -110,7 +110,7 @@ pub async fn get_by_remote(remote: &Remote) -> Result<RemoteRepository, OxenErro
     let res = client.get(&url).send().await?;
     log::debug!("get_by_remote status: {}", res.status());
     if 404 == res.status() {
-        return Err(OxenError::remote_repo_not_found(&remote.url));
+        return Err(OxenError::remote_repo_not_found(remote.url.clone()));
     }
 
     let body = client::parse_json_body(&url, res).await?;
@@ -121,7 +121,7 @@ pub async fn get_by_remote(remote: &Remote) -> Result<RemoteRepository, OxenErro
         Ok(j_res) => Ok(RemoteRepository::from_view(&j_res.repository, remote)),
         Err(err) => {
             log::debug!("Err: {err}");
-            Err(OxenError::basic_str(&format!(
+            Err(OxenError::basic_str(format!(
                 "get_by_remote Could not deserialize repository [{url}]"
             )))
         }
@@ -151,7 +151,7 @@ pub async fn get_repo_data_by_remote(
                 Ok(j_res) => Ok(Some(j_res.repository)),
                 Err(err) => {
                     log::debug!("Err: {err}");
-                    Err(OxenError::basic_str(&format!(
+                    Err(OxenError::basic_str(format!(
                         "api::repositories::get_repo_data_by_remote() Could not deserialize repository [{url}]"
                     )))
                 }
@@ -159,7 +159,7 @@ pub async fn get_repo_data_by_remote(
         }
         Err(err) => {
             log::error!("Failed to get remote url {url}\n{err:?}");
-            Err(OxenError::basic_str(&format!(
+            Err(OxenError::basic_str(format!(
                 "api::repositories::get_repo_data_by_remote() Request failed at url {url}"
             )))
         }
@@ -205,7 +205,7 @@ pub async fn create_empty(repo: RepoNew) -> Result<RemoteRepository, OxenError> 
             let err = format!(
                 "Create repository could not connect to {url}. Make sure you have the correct server and that it is running."
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -244,14 +244,14 @@ pub async fn create(repo_new: RepoNew) -> Result<RemoteRepository, OxenError> {
                     "Could not create or find repository [{}]: {err}\n{body}",
                     repo_new.repo_id()
                 );
-                Err(OxenError::basic_str(&err))
+                Err(OxenError::basic_str(err))
             }
         }
     } else {
         let err = format!(
             "Create repository could not connect to {url}. Make sure you have the correct server and that it is running."
         );
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 
@@ -311,7 +311,7 @@ pub async fn create_repo_with_files(
                 "Could not create or find repository [{}]: {err}\n{body}",
                 repo_new.repo_id()
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -352,7 +352,7 @@ pub async fn create_from_local(
                 "Could not create or find repository [{}]: {err}\n{body}",
                 repo_new.repo_id()
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -366,13 +366,13 @@ pub async fn delete(repository: &RemoteRepository) -> Result<StatusMessage, Oxen
         let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(val) => Ok(val),
-            Err(_) => Err(OxenError::basic_str(&format!(
+            Err(_) => Err(OxenError::basic_str(format!(
                 "Could not delete repository \n\n{body}"
             ))),
         }
     } else {
         Err(OxenError::basic_str(
-            "api::repositories::delete() Request failed",
+            "api::repositories::delete() Request failed".to_string(),
         ))
     }
 }
@@ -384,13 +384,13 @@ pub async fn delete_from_url(url: String) -> Result<StatusMessage, OxenError> {
         let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
         match response {
             Ok(val) => Ok(val),
-            Err(_) => Err(OxenError::basic_str(&format!(
+            Err(_) => Err(OxenError::basic_str(format!(
                 "Could not delete repository \n\n{body}"
             ))),
         }
     } else {
         Err(OxenError::basic_str(
-            "api::repositories::delete() Request failed",
+            "api::repositories::delete() Request failed".to_string(),
         ))
     }
 }
@@ -433,12 +433,12 @@ pub async fn transfer_namespace(
             }
             Err(err) => {
                 let err = format!("Could not transfer repository: {err}\n{body}");
-                Err(OxenError::basic_str(&err))
+                Err(OxenError::basic_str(err))
             }
         }
     } else {
         Err(OxenError::basic_str(
-            "api::repositories::transfer_namespace() Request failed",
+            "api::repositories::transfer_namespace() Request failed".to_string(),
         ))
     }
 }
@@ -570,7 +570,7 @@ async fn action_hook(
         Ok(_) => Ok(()),
         _ => {
             let err = "api::repositories::action_hook() Request failed";
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(err.to_string()))
         }
     }
 }

--- a/crates/lib/src/api/client/revisions.rs
+++ b/crates/lib/src/api/client/revisions.rs
@@ -6,9 +6,8 @@ use crate::view::ParseResourceResponse;
 
 pub async fn get(
     repository: &RemoteRepository,
-    revision: impl AsRef<str>,
+    revision: &str,
 ) -> Result<Option<ParsedResource>, OxenError> {
-    let revision = revision.as_ref();
     let uri = format!("/revisions/{revision}");
     let url = api::endpoint::url_from_repo(repository, &uri)?;
     log::debug!("api::client::revisions::get {url}");
@@ -24,7 +23,7 @@ pub async fn get(
     let response: Result<ParseResourceResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(j_res) => Ok(Some(j_res.resource)),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::revisions::get() Could not deserialize response [{err}]\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/revisions.rs
+++ b/crates/lib/src/api/client/revisions.rs
@@ -23,7 +23,7 @@ pub async fn get(
     let response: Result<ParseResourceResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(j_res) => Ok(Some(j_res.resource)),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::revisions::get() Could not deserialize response [{err}]\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/schemas.rs
+++ b/crates/lib/src/api/client/schemas.rs
@@ -14,10 +14,8 @@ use crate::view::schema::SchemaWithPath;
 
 pub async fn list(
     remote_repo: &RemoteRepository,
-    revision: impl AsRef<str>,
+    revision: &str,
 ) -> Result<Vec<SchemaWithPath>, OxenError> {
-    let revision = revision.as_ref();
-
     let uri = format!("/schemas/{revision}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -33,26 +31,23 @@ pub async fn list(
                     log::debug!("got ListSchemaResponse: {val:?}");
                     Ok(val.schemas)
                 }
-                Err(err) => Err(OxenError::basic_str(format!(
+                Err(err) => Err(OxenError::basic_str(&format!(
                     "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
 
 pub async fn get(
     remote_repo: &RemoteRepository,
-    revision: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    revision: &str,
+    path: &Path,
 ) -> Result<Option<SchemaWithPath>, OxenError> {
-    let revision = revision.as_ref();
-    let path = path.as_ref();
-
     let uri = format!("/schemas/{revision}/{}", path.to_string_lossy());
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -72,14 +67,14 @@ pub async fn get(
                         Ok(None)
                     }
                 }
-                Err(err) => Err(OxenError::basic_str(format!(
+                Err(err) => Err(OxenError::basic_str(&format!(
                     "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -96,6 +91,7 @@ mod tests {
     use crate::test;
     use crate::util;
 
+    use std::path::Path;
     use std::path::PathBuf;
 
     use serde_json::json;
@@ -117,7 +113,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_csv_file_with_name("mixed_data_types.csv");
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             repositories::add(&local_repo, &csv_file).await?;
             repositories::commit(&local_repo, "add test.csv")?;
@@ -160,7 +156,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_csv_file_with_name("mixed_data_types.csv");
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             // Add the file
             repositories::add(&local_repo, &csv_file).await?;
@@ -189,12 +185,12 @@ mod tests {
             );
             repositories::data_frames::schemas::add_schema_metadata(
                 &local_repo,
-                schema_ref,
+                Path::new(schema_ref),
                 &schema_metadata,
             )?;
             repositories::data_frames::schemas::add_column_metadata(
                 &local_repo,
-                schema_ref,
+                Path::new(schema_ref),
                 &column_name,
                 &column_metadata,
             )?;
@@ -210,7 +206,8 @@ mod tests {
 
             // Cannot get schema that does not exist
             let result =
-                api::client::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref).await;
+                api::client::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, Path::new(schema_ref))
+                    .await;
             assert!(result.is_err());
 
             // Push the repo
@@ -218,7 +215,8 @@ mod tests {
 
             // List the one schema
             let schema =
-                api::client::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref).await?;
+                api::client::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, Path::new(schema_ref))
+                    .await?;
 
             assert!(schema.is_some());
             let schema = schema.unwrap().schema;
@@ -253,7 +251,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_csv_file_with_name("mixed_data_types.csv");
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             // Add the file
             repositories::add(&local_repo, &csv_file).await?;
@@ -273,7 +271,8 @@ mod tests {
 
             // Cannot get schema that does not exist
             let result =
-                api::client::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref).await;
+                api::client::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, Path::new(schema_ref))
+                    .await;
             assert!(result.is_err());
 
             // Push the repo
@@ -300,12 +299,12 @@ mod tests {
             );
             repositories::data_frames::schemas::add_schema_metadata(
                 &local_repo,
-                schema_ref,
+                Path::new(schema_ref),
                 &schema_metadata,
             )?;
             repositories::data_frames::schemas::add_column_metadata(
                 &local_repo,
-                schema_ref,
+                Path::new(schema_ref),
                 &column_name,
                 &column_metadata,
             )?;
@@ -316,7 +315,8 @@ mod tests {
             repositories::push(&local_repo).await?;
 
             // List the one schema
-            let schema = api::client::schemas::get(&remote_repo, branch_name, schema_ref).await?;
+            let schema =
+                api::client::schemas::get(&remote_repo, branch_name, Path::new(schema_ref)).await?;
 
             assert!(schema.is_some());
             let schema = schema.unwrap().schema;

--- a/crates/lib/src/api/client/schemas.rs
+++ b/crates/lib/src/api/client/schemas.rs
@@ -31,14 +31,14 @@ pub async fn list(
                     log::debug!("got ListSchemaResponse: {val:?}");
                     Ok(val.schemas)
                 }
-                Err(err) => Err(OxenError::basic_str(&format!(
+                Err(err) => Err(OxenError::basic_str(format!(
                     "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -67,14 +67,14 @@ pub async fn get(
                         Ok(None)
                     }
                 }
-                Err(err) => Err(OxenError::basic_str(&format!(
+                Err(err) => Err(OxenError::basic_str(format!(
                     "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }

--- a/crates/lib/src/api/client/stats.rs
+++ b/crates/lib/src/api/client/stats.rs
@@ -25,14 +25,14 @@ pub async fn get(remote_repo: &RemoteRepository) -> Result<RepositoryStatsView, 
                     log::debug!("got RepositoryStatsResponse: {val:?}");
                     Ok(val.repository)
                 }
-                Err(err) => Err(OxenError::basic_str(&format!(
+                Err(err) => Err(OxenError::basic_str(format!(
                     "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }

--- a/crates/lib/src/api/client/stats.rs
+++ b/crates/lib/src/api/client/stats.rs
@@ -25,14 +25,14 @@ pub async fn get(remote_repo: &RemoteRepository) -> Result<RepositoryStatsView, 
                     log::debug!("got RepositoryStatsResponse: {val:?}");
                     Ok(val.repository)
                 }
-                Err(err) => Err(OxenError::basic_str(format!(
+                Err(err) => Err(OxenError::basic_str(&format!(
                     "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -57,7 +57,7 @@ mod tests {
             util::fs::create_dir_all(&large_dir)?;
             let csv_file = large_dir.join("test.csv");
             let from_file = test::test_csv_file_with_name("mixed_data_types.csv");
-            util::fs::copy(from_file, &csv_file)?;
+            util::fs::copy(&from_file, &csv_file)?;
 
             repositories::add(&local_repo, &csv_file).await?;
             repositories::commit(&local_repo, "add test.csv")?;

--- a/crates/lib/src/api/client/tree.rs
+++ b/crates/lib/src/api/client/tree.rs
@@ -44,7 +44,7 @@ pub async fn has_node(
     let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(_) => Ok(true),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::tree::get_by_id() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -201,10 +201,9 @@ pub async fn download_tree_from(
 
 pub async fn get_node_hash_by_path(
     remote_repo: &RemoteRepository,
-    commit_id: impl AsRef<str>,
+    commit_id: &str,
     path: PathBuf,
 ) -> Result<MerkleHash, OxenError> {
-    let commit_id = commit_id.as_ref();
     let path_str = path.to_string_lossy();
     let uri = format!("/tree/nodes/resource/{commit_id}/{path_str}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
@@ -219,17 +218,16 @@ pub async fn get_node_hash_by_path(
 pub async fn download_tree_from_path(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    commit_id: impl AsRef<str>,
-    path: impl AsRef<str>,
+    commit_id: &str,
+    path: &str,
     is_dir: bool,
 ) -> Result<MerkleTreeNode, OxenError> {
     let download_tree_opts = DownloadTreeOpts {
-        subtree_paths: path.as_ref().into(),
+        subtree_paths: path.into(),
         depth: if is_dir { -1 } else { 0 },
         is_download: true,
     };
-    let path: PathBuf = path.as_ref().into();
-    let commit_id = commit_id.as_ref();
+    let path: PathBuf = path.into();
     let uri = append_download_tree_opts_to_uri(
         format!("/tree/download/{commit_id}"),
         &download_tree_opts,
@@ -259,10 +257,9 @@ pub async fn download_tree_from_path(
 pub async fn download_trees_from(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    commit_id: impl AsRef<str>,
+    commit_id: &str,
     fetch_opts: &FetchOpts,
 ) -> Result<(), OxenError> {
-    let commit_id = commit_id.as_ref();
     let uri = append_fetch_opts_to_uri(format!("/tree/download/{commit_id}"), fetch_opts);
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -332,12 +329,10 @@ fn append_subtree_paths_and_depth_to_uri(
 pub async fn download_trees_between(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    base_id: impl AsRef<str>,
-    head_id: impl AsRef<str>,
+    base_id: &str,
+    head_id: &str,
     fetch_opts: &FetchOpts,
 ) -> Result<(), OxenError> {
-    let base_id = base_id.as_ref();
-    let head_id = head_id.as_ref();
     let base_head = format!("{base_id}..{head_id}");
     let uri = append_fetch_opts_to_uri(format!("/tree/download/{base_head}"), fetch_opts);
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
@@ -351,12 +346,7 @@ pub async fn download_trees_between(
     Ok(())
 }
 
-async fn node_download_request(
-    local_repo: &LocalRepository,
-    url: impl AsRef<str>,
-) -> Result<(), OxenError> {
-    let url = url.as_ref();
-
+async fn node_download_request(local_repo: &LocalRepository, url: &str) -> Result<(), OxenError> {
     let client = client::builder_for_url(url)?
         .timeout(time::Duration::from_secs(12000))
         .build()?;
@@ -390,7 +380,7 @@ async fn node_download_request(
         log::debug!("Succesfully unpacked tar to temp dir");
 
         // Copy to the repo
-        util::fs::copy_dir_all(&temp_dir, &full_unpacked_path)?;
+        util::fs::copy_dir_all(temp_dir.path(), &full_unpacked_path)?;
     } else {
         // Else, unpack directly to the repo
         archive.unpack(&full_unpacked_path).await?;
@@ -412,7 +402,7 @@ pub async fn list_missing_node_hashes(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response.hashes),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::tree::list_missing_node_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -430,7 +420,7 @@ pub async fn list_missing_file_hashes(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response.hashes),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::tree::list_missing_file_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -457,7 +447,7 @@ pub async fn list_missing_file_hashes_from_commits(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response.hashes),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::tree::list_missing_file_hashes_from_commits() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -481,7 +471,7 @@ pub async fn mark_nodes_as_synced(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(_response) => Ok(()),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::tree::list_missing_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -535,10 +525,10 @@ mod tests {
             let dir_count = entries
                 .filter_map(|entry| match entry {
                     Ok(e) => {
-                        if let Ok(file_type) = e.file_type() {
-                            if file_type.is_dir() {
-                                return Some(1);
-                            }
+                        if let Ok(file_type) = e.file_type()
+                            && file_type.is_dir()
+                        {
+                            return Some(1);
                         }
                         None
                     }
@@ -562,10 +552,10 @@ mod tests {
             let dir_count = entries
                 .filter_map(|entry| match entry {
                     Ok(e) => {
-                        if let Ok(file_type) = e.file_type() {
-                            if file_type.is_dir() {
-                                return Some(1);
-                            }
+                        if let Ok(file_type) = e.file_type()
+                            && file_type.is_dir()
+                        {
+                            return Some(1);
                         }
                         None
                     }
@@ -604,10 +594,10 @@ mod tests {
             let dir_count = entries
                 .filter_map(|entry| match entry {
                     Ok(e) => {
-                        if let Ok(file_type) = e.file_type() {
-                            if file_type.is_dir() {
-                                return Some(1);
-                            }
+                        if let Ok(file_type) = e.file_type()
+                            && file_type.is_dir()
+                        {
+                            return Some(1);
                         }
                         None
                     }
@@ -642,10 +632,10 @@ mod tests {
             let dir_count = entries
                 .filter_map(|entry| match entry {
                     Ok(e) => {
-                        if let Ok(file_type) = e.file_type() {
-                            if file_type.is_dir() {
-                                return Some(1);
-                            }
+                        if let Ok(file_type) = e.file_type()
+                            && file_type.is_dir()
+                        {
+                            return Some(1);
                         }
                         None
                     }
@@ -678,7 +668,7 @@ mod tests {
 
             // Add and commit a new file
             let file_path = local_repo.path.join("test.txt");
-            let file_path = test::write_txt_file_to_path(file_path, "image,label\n1,2\n3,4\n5,6")?;
+            let file_path = test::write_txt_file_to_path(&file_path, "image,label\n1,2\n3,4\n5,6")?;
             repositories::add(&local_repo, &file_path).await?;
             let commit = repositories::commit(&local_repo, "test")?;
             let commit_hash = commit.id.parse()?;

--- a/crates/lib/src/api/client/tree.rs
+++ b/crates/lib/src/api/client/tree.rs
@@ -44,7 +44,7 @@ pub async fn has_node(
     let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(_) => Ok(true),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::tree::get_by_id() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -245,7 +245,7 @@ pub async fn download_tree_from_path(
     } else {
         let parent_path = path
             .parent()
-            .ok_or_else(|| OxenError::basic_str("Parent path not found"))?;
+            .ok_or_else(|| OxenError::basic_str("Parent path not found".to_string()))?;
         let hash = get_node_hash_by_path(remote_repo, commit_id, parent_path.to_path_buf()).await?;
         let file_node = CommitMerkleTree::read_node(local_repo, &hash, true)?.unwrap();
 
@@ -402,7 +402,7 @@ pub async fn list_missing_node_hashes(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response.hashes),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::tree::list_missing_node_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -420,7 +420,7 @@ pub async fn list_missing_file_hashes(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response.hashes),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::tree::list_missing_file_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -447,7 +447,7 @@ pub async fn list_missing_file_hashes_from_commits(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response.hashes),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::tree::list_missing_file_hashes_from_commits() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -471,7 +471,7 @@ pub async fn mark_nodes_as_synced(
     let response: Result<MerkleHashesResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(_response) => Ok(()),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::tree::list_missing_hashes() Could not deserialize response [{err}]\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -77,7 +77,7 @@ pub async fn get(
     let response: Result<VersionFileResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(version_file) => Ok(Some(version_file.version)),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::versions::get() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -97,7 +97,7 @@ pub async fn clean(
         serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::client::versions::clean() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -107,13 +107,13 @@ pub async fn clean(
 /// Returns the `MultipartLargeFileUpload` struct for the created upload
 pub async fn parallel_large_file_upload(
     remote_repo: &RemoteRepository,
-    file_path: impl AsRef<Path>,
-    dst_dir: Option<impl AsRef<Path>>, // dst_dir is provided for workspace add workflow
+    file_path: &Path,
+    dst_dir: Option<&Path>, // dst_dir is provided for workspace add workflow
     workspace_id: Option<String>,
     entry: Option<Entry>,                 // entry is provided for push workflow
     progress: Option<&Arc<PushProgress>>, // for push workflow
 ) -> Result<MultipartLargeFileUpload, OxenError> {
-    log::debug!("multipart_large_file_upload path: {:?}", file_path.as_ref());
+    log::debug!("multipart_large_file_upload path: {:?}", file_path);
 
     let mut upload =
         create_multipart_large_file_upload(remote_repo, file_path, dst_dir, entry).await?;
@@ -141,13 +141,10 @@ pub async fn parallel_large_file_upload(
 /// Returns the `MultipartLargeFileUpload` struct for the created upload
 async fn create_multipart_large_file_upload(
     remote_repo: &RemoteRepository,
-    file_path: impl AsRef<Path>,
-    dst_dir: Option<impl AsRef<Path>>,
+    file_path: &Path,
+    dst_dir: Option<&Path>,
     entry: Option<Entry>,
 ) -> Result<MultipartLargeFileUpload, OxenError> {
-    let file_path = file_path.as_ref();
-    let dst_dir = dst_dir.as_ref();
-
     let (file_size, hash) = match entry {
         Some(entry) => (entry.num_bytes(), entry.hash()),
         None => {
@@ -169,7 +166,7 @@ async fn create_multipart_large_file_upload(
         hash: hash.to_string(),
         file_name: file_path.file_name().unwrap().to_string_lossy().to_string(),
         size: file_size,
-        dst_dir: dst_dir.map(|d| d.as_ref().to_path_buf()),
+        dst_dir: dst_dir.map(|d| d.to_path_buf()),
     };
 
     let body = serde_json::to_string(&body)?;
@@ -183,7 +180,7 @@ async fn create_multipart_large_file_upload(
 
     Ok(MultipartLargeFileUpload {
         local_path: file_path.to_path_buf(),
-        dst_dir: dst_dir.map(|d| d.as_ref().to_path_buf()),
+        dst_dir: dst_dir.map(|d| d.to_path_buf()),
         hash: hash.parse()?,
         size: file_size,
         status: MultipartLargeFileUploadStatus::Pending,
@@ -219,7 +216,7 @@ pub async fn download_data_from_version_paths(
         hashes.len(),
         total_retries
     );
-    Err(OxenError::basic_str(err))
+    Err(OxenError::basic_str(&err))
 }
 
 pub async fn try_download_data_from_version_paths(
@@ -260,13 +257,13 @@ pub async fn try_download_data_from_version_paths(
                 Ok(file) => file,
                 Err(err) => {
                     let err = format!("Could not unwrap file -> {err:?}");
-                    return Err(OxenError::basic_str(err));
+                    return Err(OxenError::basic_str(&err));
                 }
             };
 
             let file_hash = file
                 .path()
-                .map_err(|e| OxenError::basic_str(format!("Failed to get entry path: {e}")))?
+                .map_err(|e| OxenError::basic_str(&format!("Failed to get entry path: {e}")))?
                 .to_string_lossy()
                 .to_string();
 
@@ -287,7 +284,7 @@ pub async fn try_download_data_from_version_paths(
                 Err(err) => {
                     let err =
                         format!("Could not store file {file_hash} to version store -> {err:?}");
-                    return Err(OxenError::basic_str(err));
+                    return Err(OxenError::basic_str(&err));
                 }
             }
         }
@@ -296,7 +293,7 @@ pub async fn try_download_data_from_version_paths(
     } else {
         let err =
             format!("api::entries::download_data_from_version_paths Err request failed: {url}");
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }
 
@@ -332,19 +329,19 @@ async fn upload_chunks(
                         .clone()
                         .acquire_owned()
                         .await
-                        .map_err(|err| OxenError::basic_str(format!("Error acquiring semaphore: {err}")))?;
+                        .map_err(|err| OxenError::basic_str(&format!("Error acquiring semaphore: {err}")))?;
                     let mut chunk = upload_chunk(&client, &remote_repo, &upload, start, chunk_size).await;
                     let mut i = 0;
                     if parallel_failures > 0 {
                         while let Err(ul_err) = chunk {
                             if i >= max_retries {
-                                return Err(OxenError::basic_str(format!(
+                                return Err(OxenError::basic_str(&format!(
                                     "Failed after too many retries ({max_retries}): {ul_err}"
                                 )));
                             }
 
                             let parallel_failure_permit = parallel_failures_semaphore.clone().try_acquire_owned().map_err(|err| {
-                                OxenError::basic_str(format!(
+                                OxenError::basic_str(&format!(
                                     "Failed too many failures in parallel ({parallel_failures}): {ul_err} ({err})"
                                 ))
                             })?;
@@ -359,7 +356,7 @@ async fn upload_chunks(
                     }
                     drop(permit);
                     chunk
-                    .map_err(|e| OxenError::basic_str(format!("Upload error {e}")))
+                    .map_err(|e| OxenError::basic_str(&format!("Upload error {e}")))
                     .map(|chunk| (chunk_number, chunk, chunk_size))
                 }));
     }
@@ -379,7 +376,7 @@ async fn upload_chunks(
                 return Err(py_err);
             }
             Err(err) => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Error occurred while uploading: {err}"
                 )));
             }
@@ -429,7 +426,7 @@ async fn upload_chunk(
             name.to_string(),
             value
                 .to_str()
-                .map_err(|e| OxenError::basic_str(format!("Invalid header value: {e}")))?
+                .map_err(|e| OxenError::basic_str(&format!("Invalid header value: {e}")))?
                 .to_owned(),
         );
     }
@@ -501,7 +498,7 @@ pub async fn multipart_batch_upload_with_retry(
     if files_to_retry.is_empty() {
         Ok(())
     } else {
-        Err(OxenError::basic_str(format!(
+        Err(OxenError::basic_str(&format!(
             "Failed to upload files: {files_to_retry:#?}"
         )))
     }
@@ -635,11 +632,13 @@ pub(crate) async fn workspace_multipart_batch_upload_versions(
             }
 
             let Some(_file_name) = path.file_name() else {
-                return Err(OxenError::basic_str(format!("Invalid file path: {path:?}")));
+                return Err(OxenError::basic_str(&format!(
+                    "Invalid file path: {path:?}"
+                )));
             };
 
             let file = std::fs::read(&path).map_err(|e| {
-                OxenError::basic_str(format!("Failed to read file '{path:?}': {e}"))
+                OxenError::basic_str(&format!("Failed to read file '{path:?}': {e}"))
             })?;
 
             let hash = hasher::hash_buffer(&file);
@@ -782,7 +781,7 @@ pub(crate) async fn workspace_multipart_batch_upload_parts_with_retry(
     }
 
     if !files_to_retry.is_empty() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Failed to upload version files after {max_retries} retries"
         )));
     }
@@ -821,10 +820,10 @@ mod tests {
             // Just testing upload, not adding to workspace
             let workspace_id = None;
             let dst_dir: Option<PathBuf> = None;
-            let result = api::client::versions::parallel_large_file_upload(
+            let result = &api::client::versions::parallel_large_file_upload(
                 &remote_repo,
-                path,
-                dst_dir,
+                &path,
+                dst_dir.as_deref(),
                 workspace_id,
                 None,
                 None,
@@ -832,7 +831,8 @@ mod tests {
             .await;
             assert!(result.is_ok());
 
-            let version = api::client::versions::get(&remote_repo, result.unwrap().hash).await?;
+            let version =
+                api::client::versions::get(&remote_repo, result.as_ref().unwrap().hash).await?;
             assert!(version.is_some());
             assert_eq!(version.unwrap().size, original_file_size);
 

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -77,7 +77,7 @@ pub async fn get(
     let response: Result<VersionFileResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(version_file) => Ok(Some(version_file.version)),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::versions::get() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -97,7 +97,7 @@ pub async fn clean(
         serde_json::from_str(&body);
     match response {
         Ok(response) => Ok(response),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::client::versions::clean() Could not deserialize response [{err}]\n{body}"
         ))),
     }
@@ -150,7 +150,7 @@ async fn create_multipart_large_file_upload(
         None => {
             // Figure out how many parts we need to upload
             let Ok(metadata) = file_path.metadata() else {
-                return Err(OxenError::path_does_not_exist(file_path));
+                return Err(OxenError::path_does_not_exist(file_path.to_path_buf()));
             };
             let file_size = metadata.len();
             let hash = util::hasher::hash_file_contents(file_path)?;
@@ -216,7 +216,7 @@ pub async fn download_data_from_version_paths(
         hashes.len(),
         total_retries
     );
-    Err(OxenError::basic_str(&err))
+    Err(OxenError::basic_str(err))
 }
 
 pub async fn try_download_data_from_version_paths(
@@ -257,13 +257,13 @@ pub async fn try_download_data_from_version_paths(
                 Ok(file) => file,
                 Err(err) => {
                     let err = format!("Could not unwrap file -> {err:?}");
-                    return Err(OxenError::basic_str(&err));
+                    return Err(OxenError::basic_str(err));
                 }
             };
 
             let file_hash = file
                 .path()
-                .map_err(|e| OxenError::basic_str(&format!("Failed to get entry path: {e}")))?
+                .map_err(|e| OxenError::basic_str(format!("Failed to get entry path: {e}")))?
                 .to_string_lossy()
                 .to_string();
 
@@ -284,7 +284,7 @@ pub async fn try_download_data_from_version_paths(
                 Err(err) => {
                     let err =
                         format!("Could not store file {file_hash} to version store -> {err:?}");
-                    return Err(OxenError::basic_str(&err));
+                    return Err(OxenError::basic_str(err));
                 }
             }
         }
@@ -293,7 +293,7 @@ pub async fn try_download_data_from_version_paths(
     } else {
         let err =
             format!("api::entries::download_data_from_version_paths Err request failed: {url}");
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 
@@ -329,19 +329,19 @@ async fn upload_chunks(
                         .clone()
                         .acquire_owned()
                         .await
-                        .map_err(|err| OxenError::basic_str(&format!("Error acquiring semaphore: {err}")))?;
+                        .map_err(|err| OxenError::basic_str(format!("Error acquiring semaphore: {err}")))?;
                     let mut chunk = upload_chunk(&client, &remote_repo, &upload, start, chunk_size).await;
                     let mut i = 0;
                     if parallel_failures > 0 {
                         while let Err(ul_err) = chunk {
                             if i >= max_retries {
-                                return Err(OxenError::basic_str(&format!(
+                                return Err(OxenError::basic_str(format!(
                                     "Failed after too many retries ({max_retries}): {ul_err}"
                                 )));
                             }
 
                             let parallel_failure_permit = parallel_failures_semaphore.clone().try_acquire_owned().map_err(|err| {
-                                OxenError::basic_str(&format!(
+                                OxenError::basic_str(format!(
                                     "Failed too many failures in parallel ({parallel_failures}): {ul_err} ({err})"
                                 ))
                             })?;
@@ -356,7 +356,7 @@ async fn upload_chunks(
                     }
                     drop(permit);
                     chunk
-                    .map_err(|e| OxenError::basic_str(&format!("Upload error {e}")))
+                    .map_err(|e| OxenError::basic_str(format!("Upload error {e}")))
                     .map(|chunk| (chunk_number, chunk, chunk_size))
                 }));
     }
@@ -376,7 +376,7 @@ async fn upload_chunks(
                 return Err(py_err);
             }
             Err(err) => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Error occurred while uploading: {err}"
                 )));
             }
@@ -426,7 +426,7 @@ async fn upload_chunk(
             name.to_string(),
             value
                 .to_str()
-                .map_err(|e| OxenError::basic_str(&format!("Invalid header value: {e}")))?
+                .map_err(|e| OxenError::basic_str(format!("Invalid header value: {e}")))?
                 .to_owned(),
         );
     }
@@ -498,7 +498,7 @@ pub async fn multipart_batch_upload_with_retry(
     if files_to_retry.is_empty() {
         Ok(())
     } else {
-        Err(OxenError::basic_str(&format!(
+        Err(OxenError::basic_str(format!(
             "Failed to upload files: {files_to_retry:#?}"
         )))
     }
@@ -632,13 +632,11 @@ pub(crate) async fn workspace_multipart_batch_upload_versions(
             }
 
             let Some(_file_name) = path.file_name() else {
-                return Err(OxenError::basic_str(&format!(
-                    "Invalid file path: {path:?}"
-                )));
+                return Err(OxenError::basic_str(format!("Invalid file path: {path:?}")));
             };
 
             let file = std::fs::read(&path).map_err(|e| {
-                OxenError::basic_str(&format!("Failed to read file '{path:?}': {e}"))
+                OxenError::basic_str(format!("Failed to read file '{path:?}': {e}"))
             })?;
 
             let hash = hasher::hash_buffer(&file);
@@ -781,7 +779,7 @@ pub(crate) async fn workspace_multipart_batch_upload_parts_with_retry(
     }
 
     if !files_to_retry.is_empty() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Failed to upload version files after {max_retries} retries"
         )));
     }

--- a/crates/lib/src/api/client/workspaces.rs
+++ b/crates/lib/src/api/client/workspaces.rs
@@ -24,7 +24,7 @@ pub async fn list(remote_repo: &RemoteRepository) -> Result<Vec<WorkspaceRespons
         serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.workspaces),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -32,9 +32,8 @@ pub async fn list(remote_repo: &RemoteRepository) -> Result<Vec<WorkspaceRespons
 
 pub async fn get(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
+    workspace_id: &str,
 ) -> Result<Option<WorkspaceResponse>, OxenError> {
-    let workspace_id = workspace_id.as_ref();
     let url = api::endpoint::url_from_repo(remote_repo, &format!("/workspaces/{workspace_id}"))?;
     let client = client::new_for_url(&url)?;
     let res = client.get(&url).send().await?;
@@ -50,9 +49,8 @@ pub async fn get(
 
 pub async fn get_by_name(
     remote_repo: &RemoteRepository,
-    name: impl AsRef<str>,
+    name: &str,
 ) -> Result<Option<WorkspaceResponse>, OxenError> {
-    let name = name.as_ref();
     let url = api::endpoint::url_from_repo(remote_repo, &format!("/workspaces?name={name}"))?;
     let client = client::new_for_url(&url)?;
     let res = client.get(&url).send().await?;
@@ -66,13 +64,13 @@ pub async fn get_by_name(
             } else if val.workspaces.is_empty() {
                 Ok(None)
             } else {
-                Err(OxenError::basic_str(format!(
+                Err(OxenError::basic_str(&format!(
                     "expected 1 workspace, got {}",
                     val.workspaces.len()
                 )))
             }
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -80,19 +78,19 @@ pub async fn get_by_name(
 
 pub async fn create(
     remote_repo: &RemoteRepository,
-    branch_name: impl AsRef<str>,
-    workspace_id: impl AsRef<str>,
+    branch_name: &str,
+    workspace_id: &str,
 ) -> Result<WorkspaceResponseWithStatus, OxenError> {
     create_with_path(remote_repo, branch_name, workspace_id, Path::new("/"), None).await
 }
 
 pub async fn create_with_name(
     remote_repo: &RemoteRepository,
-    branch_name: impl AsRef<str>,
-    workspace_id: impl AsRef<str>,
-    workspace_name: impl AsRef<str>,
+    branch_name: &str,
+    workspace_id: &str,
+    workspace_name: &str,
 ) -> Result<WorkspaceResponseWithStatus, OxenError> {
-    let workspace_name = workspace_name.as_ref().to_string();
+    let workspace_name = workspace_name.to_string();
     create_with_path(
         remote_repo,
         branch_name,
@@ -105,14 +103,11 @@ pub async fn create_with_name(
 
 pub async fn create_with_path(
     remote_repo: &RemoteRepository,
-    branch_name: impl AsRef<str>,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    branch_name: &str,
+    workspace_id: &str,
+    path: &Path,
     workspace_name: Option<String>,
 ) -> Result<WorkspaceResponseWithStatus, OxenError> {
-    let branch_name = branch_name.as_ref();
-    let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
     let url = api::endpoint::url_from_repo(remote_repo, "/workspaces")?;
     log::debug!("create workspace {url}\n");
 
@@ -139,7 +134,7 @@ pub async fn create_with_path(
             commit: val.workspace.commit,
             status: val.status.status_message,
         }),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -147,9 +142,8 @@ pub async fn create_with_path(
 
 pub async fn delete(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
+    workspace_id: &str,
 ) -> Result<WorkspaceResponse, OxenError> {
-    let workspace_id = workspace_id.as_ref();
     let url = api::endpoint::url_from_repo(remote_repo, &format!("/workspaces/{workspace_id}"))?;
     log::debug!("delete workspace {url}\n");
 
@@ -161,7 +155,7 @@ pub async fn delete(
     let response: Result<WorkspaceResponseView, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.workspace),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -179,7 +173,7 @@ pub async fn clear(remote_repo: &RemoteRepository) -> Result<(), OxenError> {
     let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(_) => Ok(()),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -226,7 +220,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
             assert_eq!(workspace.name, Some(workspace_name.to_string()));
 
-            let workspace = get(&remote_repo, &workspace_id).await?;
+            let workspace = get(&remote_repo, workspace_id).await?;
             assert!(workspace.is_some());
             assert_eq!(
                 workspace.as_ref().unwrap().name,
@@ -234,7 +228,7 @@ mod tests {
             );
             assert_eq!(workspace.as_ref().unwrap().id, workspace_id);
 
-            let workspace = get_by_name(&remote_repo, &workspace_name).await?;
+            let workspace = get_by_name(&remote_repo, workspace_name).await?;
             assert!(workspace.is_some());
             assert_eq!(
                 workspace.as_ref().unwrap().name,
@@ -260,7 +254,7 @@ mod tests {
             let workspace_name2 = "test_workspace_name2";
             create_with_name(&remote_repo, branch_name, workspace_id2, workspace_name2).await?;
 
-            let workspace = get_by_name(&remote_repo, &workspace_name).await?;
+            let workspace = get_by_name(&remote_repo, workspace_name).await?;
             assert!(workspace.is_some());
             assert_eq!(
                 workspace.as_ref().unwrap().name,
@@ -268,7 +262,7 @@ mod tests {
             );
             assert_eq!(workspace.as_ref().unwrap().id, workspace_id);
 
-            let workspace2 = get_by_name(&remote_repo, &workspace_name2).await?;
+            let workspace2 = get_by_name(&remote_repo, workspace_name2).await?;
             assert!(workspace2.is_some());
             assert_eq!(
                 workspace2.as_ref().unwrap().name,
@@ -286,7 +280,7 @@ mod tests {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
             let workspace_name = "name_does_not_exist";
 
-            let workspace = get_by_name(&remote_repo, &workspace_name).await?;
+            let workspace = get_by_name(&remote_repo, workspace_name).await?;
             assert!(workspace.is_none());
 
             Ok(remote_repo)
@@ -299,7 +293,7 @@ mod tests {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
             let workspace_id = "id_does_not_exist";
 
-            let workspace = get(&remote_repo, &workspace_id).await?;
+            let workspace = get(&remote_repo, workspace_id).await?;
             assert!(workspace.is_none());
 
             Ok(remote_repo)
@@ -395,7 +389,7 @@ mod tests {
 
                 // Create workspace
                 let workspace_id = "my_workspace";
-                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_id)
+                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                     .await?;
 
                 // Index the dataset
@@ -438,7 +432,7 @@ mod tests {
                 // Status should have one modified file
                 let remote_status = api::client::workspaces::changes::list(
                     &remote_repo,
-                    &workspace_id,
+                    workspace_id,
                     Path::new(""),
                     constants::DEFAULT_PAGE_NUM,
                     constants::DEFAULT_PAGE_SIZE,
@@ -473,11 +467,11 @@ mod tests {
 
             // Advance head on main branch, leave behind-main behind
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &identifier,
-                main_path,
-                path,
+                Path::new(main_path),
+                &path,
             )
             .await;
             assert!(result.is_ok());
@@ -495,11 +489,11 @@ mod tests {
 
             // Add a file to behind-main
             let image_path = test::test_1k_parquet();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &identifier,
-                main_path,
-                image_path,
+                Path::new(main_path),
+                &image_path,
             )
             .await;
             assert!(result.is_ok());
@@ -518,11 +512,11 @@ mod tests {
 
             // Add file at images/folder to behind-main, committed to main
             let image_path = test::test_100_parquet();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &identifier,
-                main_path,
-                image_path,
+                Path::new(main_path),
+                &image_path,
             )
             .await;
             assert!(result.is_ok());
@@ -556,11 +550,11 @@ mod tests {
             api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                 .await?;
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
-                &&workspace_id,
-                "",
-                path,
+                workspace_id,
+                Path::new(""),
+                &path,
             )
             .await;
             assert!(result.is_ok());
@@ -572,7 +566,7 @@ mod tests {
             };
             api::client::workspaces::commit(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id, &body)
                 .await?;
-            let get_result = api::client::workspaces::get(&remote_repo, &workspace_id).await?;
+            let get_result = api::client::workspaces::get(&remote_repo, workspace_id).await?;
 
             assert!(get_result.is_none());
 
@@ -594,11 +588,11 @@ mod tests {
             )
             .await?;
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
-                &workspace_name,
-                "",
-                path,
+                workspace_name,
+                Path::new(""),
+                &path,
             )
             .await;
             assert!(result.is_ok());
@@ -615,7 +609,7 @@ mod tests {
                 &body,
             )
             .await?;
-            let workspace = api::client::workspaces::get(&remote_repo, &workspace_name).await?;
+            let workspace = api::client::workspaces::get(&remote_repo, workspace_name).await?;
             assert!(workspace.is_some());
             assert_eq!(workspace.as_ref().unwrap().id, workspace_id);
             Ok(remote_repo)

--- a/crates/lib/src/api/client/workspaces.rs
+++ b/crates/lib/src/api/client/workspaces.rs
@@ -24,7 +24,7 @@ pub async fn list(remote_repo: &RemoteRepository) -> Result<Vec<WorkspaceRespons
         serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.workspaces),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -64,13 +64,13 @@ pub async fn get_by_name(
             } else if val.workspaces.is_empty() {
                 Ok(None)
             } else {
-                Err(OxenError::basic_str(&format!(
+                Err(OxenError::basic_str(format!(
                     "expected 1 workspace, got {}",
                     val.workspaces.len()
                 )))
             }
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -134,7 +134,7 @@ pub async fn create_with_path(
             commit: val.workspace.commit,
             status: val.status.status_message,
         }),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -155,7 +155,7 @@ pub async fn delete(
     let response: Result<WorkspaceResponseView, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.workspace),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -173,7 +173,7 @@ pub async fn clear(remote_repo: &RemoteRepository) -> Result<(), OxenError> {
     let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(_) => Ok(()),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/workspaces/changes.rs
+++ b/crates/lib/src/api/client/workspaces/changes.rs
@@ -29,14 +29,14 @@ pub async fn list(
                 serde_json::from_str(&body);
             match response {
                 Ok(val) => Ok(val.staged),
-                Err(err) => Err(OxenError::basic_str(&format!(
+                Err(err) => Err(OxenError::basic_str(format!(
                     "api::staging::status error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("api::staging::status Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -60,7 +60,7 @@ pub async fn rm(
         }
         Err(err) => {
             let err = format!("rm_file Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }

--- a/crates/lib/src/api/client/workspaces/changes.rs
+++ b/crates/lib/src/api/client/workspaces/changes.rs
@@ -9,13 +9,11 @@ use std::path::Path;
 
 pub async fn list(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    path: &Path,
     page: usize,
     page_size: usize,
 ) -> Result<RemoteStagedStatus, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
     let path_str = path.to_str().unwrap();
     let uri =
         format!("/workspaces/{workspace_id}/changes/{path_str}?page={page}&page_size={page_size}");
@@ -31,14 +29,14 @@ pub async fn list(
                 serde_json::from_str(&body);
             match response {
                 Ok(val) => Ok(val.staged),
-                Err(err) => Err(OxenError::basic_str(format!(
+                Err(err) => Err(OxenError::basic_str(&format!(
                     "api::staging::status error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("api::staging::status Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -47,9 +45,9 @@ pub async fn list(
 pub async fn rm(
     remote_repo: &RemoteRepository,
     workspace_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<(), OxenError> {
-    let file_name = path.as_ref().to_string_lossy();
+    let file_name = path.to_string_lossy();
     let uri = format!("/workspaces/{workspace_id}/changes/{file_name}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("rm_file {url}");
@@ -62,7 +60,7 @@ pub async fn rm(
         }
         Err(err) => {
             let err = format!("rm_file Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -98,7 +96,7 @@ mod tests {
             assert_eq!(branch.name, branch_name);
 
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await;
             assert!(workspace.is_ok());
 
             let page_num = constants::DEFAULT_PAGE_NUM;
@@ -134,7 +132,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let page_num = constants::DEFAULT_PAGE_NUM;

--- a/crates/lib/src/api/client/workspaces/commits.rs
+++ b/crates/lib/src/api/client/workspaces/commits.rs
@@ -18,7 +18,7 @@ pub async fn mergeability(
     let response: Result<MergeableResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.mergeable),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::workspaces::commits::merge error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -57,7 +57,7 @@ pub async fn commit(
             println!("🐂 commit {commit} complete!");
             Ok(commit)
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "api::workspaces::commits error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }

--- a/crates/lib/src/api/client/workspaces/commits.rs
+++ b/crates/lib/src/api/client/workspaces/commits.rs
@@ -18,7 +18,7 @@ pub async fn mergeability(
     let response: Result<MergeableResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
         Ok(val) => Ok(val.mergeable),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::workspaces::commits::merge error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -57,7 +57,7 @@ pub async fn commit(
             println!("🐂 commit {commit} complete!");
             Ok(commit)
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "api::workspaces::commits error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
@@ -94,11 +94,11 @@ mod tests {
                 test::test_img_file(),
                 test::test_img_file_with_name("cole_anthony.jpeg"),
             ];
-            api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
+                &Path::new(directory_name),
                 paths,
                 &None,
             )
@@ -134,7 +134,7 @@ mod tests {
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
+                &Path::new(directory_name),
                 paths,
                 &None,
             )
@@ -161,20 +161,20 @@ mod tests {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
             let workspace_1_id = "workspace_1";
             let directory_name = Path::new("annotations").join("train");
-            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_1_id)
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_1_id)
                 .await?;
 
             // Create a second workspace with the same branch off of the same commit
             let workspace_2_id = "workspace_2";
-            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_2_id)
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_2_id)
                 .await?;
 
             // add an image file to workspace 1
             let paths = vec![test::test_img_file()];
             let result = api::client::workspaces::files::add(
                 &remote_repo,
-                &workspace_1_id,
-                directory_name.to_str().unwrap(),
+                workspace_1_id,
+                &directory_name,
                 paths,
                 &None,
             )
@@ -205,8 +205,8 @@ mod tests {
             let paths = vec![bbox_path];
             let result = api::client::workspaces::files::add(
                 &remote_repo,
-                &workspace_2_id,
-                directory_name.to_str().unwrap(),
+                workspace_2_id,
+                &directory_name,
                 paths,
                 &None,
             )
@@ -249,12 +249,12 @@ mod tests {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
             let workspace_1_id = "workspace_1";
             let directory_name = Path::new("annotations").join("train");
-            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_1_id)
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_1_id)
                 .await?;
 
             // Create a second workspace with the same branch off of the same commit
             let workspace_2_id = "workspace_2";
-            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_2_id)
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_2_id)
                 .await?;
 
             // And write new data to the annotations/train/bounding_box.csv file
@@ -268,8 +268,8 @@ mod tests {
             let paths = vec![bbox_path];
             let result = api::client::workspaces::files::add(
                 &remote_repo,
-                &workspace_1_id,
-                directory_name.to_str().unwrap(),
+                workspace_1_id,
+                &directory_name,
                 paths,
                 &None,
             )
@@ -300,8 +300,8 @@ mod tests {
             let paths = vec![bbox_path];
             let result = api::client::workspaces::files::add(
                 &remote_repo,
-                &workspace_2_id,
-                directory_name.to_str().unwrap(),
+                workspace_2_id,
+                &directory_name,
                 paths,
                 &None,
             )
@@ -355,7 +355,7 @@ mod tests {
             assert_eq!(branch.name, branch_name);
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // train/dog_1.jpg,dog,101.5,32.0,385,330
@@ -427,7 +427,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let ws =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(ws.id, workspace_id);
 
             let directory_name = "";
@@ -436,7 +436,7 @@ mod tests {
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
+                &Path::new(directory_name),
                 paths,
                 &None,
             )
@@ -460,7 +460,7 @@ mod tests {
 
             // List the files on main
             let revision = "main";
-            let path = "";
+            let path = Path::new("");
             let page = 1;
             let page_size = 100;
             let entries =
@@ -473,14 +473,14 @@ mod tests {
             // Add the same file again
             let workspace_id = UserConfig::identifier()? + "2";
             let ws =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(ws.id, workspace_id);
 
             let paths = vec![test::test_100_parquet()];
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
+                &Path::new(directory_name),
                 paths,
                 &None,
             )

--- a/crates/lib/src/api/client/workspaces/data_frames.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames.rs
@@ -18,12 +18,10 @@ pub mod rows;
 
 pub async fn get(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    path: &Path,
     opts: &DFOpts,
 ) -> Result<WorkspaceJsonDataFrameViewResponse, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
     let file_path_str = path.to_string_lossy();
     let query_str = opts.to_http_query_params();
     let uri =
@@ -41,19 +39,17 @@ pub async fn get(
             let err = format!(
                 "workspaces::data_frames::get error parsing from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
 
 pub async fn download(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    path: &Path,
     opts: &DFOpts, // opts holds output path
 ) -> Result<(), OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
     let file_path_str = path.to_string_lossy();
     let query_str = opts.to_http_query_params();
     let uri =
@@ -72,12 +68,12 @@ pub async fn download(
         let status = res.status();
 
         if status == reqwest::StatusCode::NOT_FOUND {
-            return Err(OxenError::resource_not_found(file_path_str));
+            return Err(OxenError::resource_not_found(&file_path_str));
         }
 
         log::error!("api::client::workspaces::data_frames::download failed with status: {status}");
         let body = client::parse_json_body(&url, res).await?;
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Error: Could not download data frame {body:?}"
         )));
     }
@@ -124,7 +120,7 @@ pub async fn list(
             let err = format!(
                 "api::workspaces::get_by_branch error parsing from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -132,13 +128,13 @@ pub async fn list(
 pub async fn index(
     remote_repo: &RemoteRepository,
     workspace_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<StatusMessage, OxenError> {
-    let path = util::fs::linux_path(path.as_ref());
+    let path = util::fs::linux_path(path);
     put(
         remote_repo,
         workspace_id,
-        path,
+        &path,
         &serde_json::json!({"is_indexed": true}),
     )
     .await
@@ -160,12 +156,10 @@ pub async fn unindex(
 
 pub async fn put(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    path: &Path,
     data: &serde_json::Value,
 ) -> Result<StatusMessage, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
     let file_path_str = path.to_string_lossy();
 
     let uri = format!("/workspaces/{workspace_id}/data_frames/resource/{file_path_str}");
@@ -181,7 +175,7 @@ pub async fn put(
         Err(err) => {
             let err =
                 format!("api::workspaces::put error parsing from {url}\n\nErr {err:?} \n\n{body}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -189,9 +183,9 @@ pub async fn put(
 pub async fn restore(
     remote_repo: &RemoteRepository,
     workspace_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<(), OxenError> {
-    let file_name = path.as_ref().to_string_lossy();
+    let file_name = path.to_string_lossy();
     let uri = format!("/workspaces/{workspace_id}/data_frames/resource/{file_name}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("workspaces::data_frames::restore {url}");
@@ -205,9 +199,9 @@ pub async fn restore(
 pub async fn restore_files(
     remote_repo: &RemoteRepository,
     workspace_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<(), OxenError> {
-    let file_name = path.as_ref().to_string_lossy();
+    let file_name = path.to_string_lossy();
     let uri = format!("/workspaces/{workspace_id}/data_frames/resource/{file_name}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("workspaces::data_frames::restore {url}");
@@ -242,32 +236,30 @@ pub async fn diff(
             match response {
                 Ok(data) => Ok(data.data_frame),
 
-                Err(err) => Err(OxenError::basic_str(format!(
+                Err(err) => Err(OxenError::basic_str(&format!(
                     "api::staging::diff error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("api::staging::diff Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
 
 pub async fn rename_data_frame(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
-    new_path: impl AsRef<Path>,
+    workspace_id: &str,
+    path: &Path,
+    new_path: &Path,
 ) -> Result<StatusMessage, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
     let file_path_str = path.to_string_lossy();
 
     let uri = format!("/workspaces/{workspace_id}/data_frames/rename/{file_path_str}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     let params = serde_json::to_string(&serde_json::json!({
-        "new_path": new_path.as_ref().to_string_lossy()
+        "new_path": new_path.to_string_lossy()
     }))?;
 
     let client = client::new_for_url(&url)?;
@@ -279,7 +271,7 @@ pub async fn rename_data_frame(
         Err(err) => {
             let err =
                 format!("api::workspaces::put error parsing from {url}\n\nErr {err:?} \n\n{body}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -381,19 +373,15 @@ mod tests {
             let new_path = Path::new("new/dir/bounding_box_renamed.csv");
 
             // Index the original data frame
-            api::client::workspaces::data_frames::index(
-                &remote_repo,
-                &workspace.id,
-                &original_path,
-            )
-            .await?;
+            api::client::workspaces::data_frames::index(&remote_repo, &workspace.id, original_path)
+                .await?;
 
             // Rename the data frame
             let rename_response = api::client::workspaces::data_frames::rename_data_frame(
                 &remote_repo,
                 &workspace.id,
-                &original_path,
-                &new_path,
+                original_path,
+                new_path,
             )
             .await?;
             assert_eq!(rename_response.status, "success");
@@ -417,7 +405,7 @@ mod tests {
             let renamed_df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                &new_path,
+                new_path,
                 DFOpts::empty(),
             )
             .await?;
@@ -426,7 +414,7 @@ mod tests {
             let original_df = api::client::data_frames::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                &original_path,
+                original_path,
                 DFOpts::empty(),
             )
             .await?;
@@ -803,7 +791,7 @@ mod tests {
                 assert!(output_path.exists());
 
                 // Check the file contents are the same
-                let og_df = tabular::read_df(local_repo.path.join(path), DFOpts::empty()).await?;
+                let og_df = tabular::read_df(&local_repo.path.join(path), DFOpts::empty()).await?;
                 let download_df = tabular::read_df(&output_path, DFOpts::empty()).await?;
                 assert_eq!(og_df.height(), download_df.height());
                 assert_eq!(og_df.width(), download_df.width());
@@ -956,9 +944,12 @@ mod tests {
                     .await;
             assert!(workspace.is_ok());
 
-            let res =
-                api::client::workspaces::data_frames::index(&remote_repo, workspace_id, file_name)
-                    .await?;
+            let res = api::client::workspaces::data_frames::index(
+                &remote_repo,
+                workspace_id,
+                Path::new(file_name),
+            )
+            .await?;
 
             assert_eq!(res.status, "success");
 
@@ -1094,7 +1085,7 @@ mod tests {
             assert_eq!(branch.name, branch_name);
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id)
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id)
                     .await;
             assert!(workspace.is_ok());
 
@@ -1144,7 +1135,7 @@ mod tests {
             assert_eq!(branch.name, branch_name);
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id)
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id)
                     .await;
             assert!(workspace.is_ok());
 
@@ -1243,7 +1234,7 @@ mod tests {
                 let user = UserConfig::get()?.to_user();
                 let workspace_id = "workspace_a";
                 let workspace =
-                    api::client::workspaces::create(&remote_repo, &DEFAULT_BRANCH_NAME, &workspace_id)
+                    api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                         .await;
                 assert!(workspace.is_ok());
 
@@ -1278,7 +1269,7 @@ mod tests {
                 // Add a more rows on this branch
                 let workspace_id = "workspace_b";
                 let workspace =
-                    api::client::workspaces::create(&remote_repo, &DEFAULT_BRANCH_NAME, &workspace_id)
+                    api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                         .await;
                 assert!(workspace.is_ok());
 
@@ -1338,8 +1329,8 @@ mod tests {
                 let workspace_id = "workspace_a";
                 let workspace = api::client::workspaces::create(
                     &remote_repo,
-                    &DEFAULT_BRANCH_NAME,
-                    &workspace_id,
+                    DEFAULT_BRANCH_NAME,
+                    workspace_id,
                 )
                 .await;
                 assert!(workspace.is_ok());
@@ -1386,8 +1377,8 @@ mod tests {
                 let workspace_id = "workspace_b";
                 let workspace = api::client::workspaces::create(
                     &remote_repo,
-                    &DEFAULT_BRANCH_NAME,
-                    &workspace_id,
+                    DEFAULT_BRANCH_NAME,
+                    workspace_id,
                 )
                 .await;
                 assert!(workspace.is_ok());

--- a/crates/lib/src/api/client/workspaces/data_frames.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames.rs
@@ -39,7 +39,7 @@ pub async fn get(
             let err = format!(
                 "workspaces::data_frames::get error parsing from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -58,7 +58,7 @@ pub async fn download(
 
     // Download the file and save it to the output path
     let Some(output_path_str) = &opts.output else {
-        return Err(OxenError::basic_str("output path is required"));
+        return Err(OxenError::basic_str("output path is required".to_string()));
     };
     let output_path = Path::new(&output_path_str);
     let client = client::new_for_url(&url)?;
@@ -68,12 +68,12 @@ pub async fn download(
         let status = res.status();
 
         if status == reqwest::StatusCode::NOT_FOUND {
-            return Err(OxenError::resource_not_found(&file_path_str));
+            return Err(OxenError::resource_not_found(file_path_str.to_string()));
         }
 
         log::error!("api::client::workspaces::data_frames::download failed with status: {status}");
         let body = client::parse_json_body(&url, res).await?;
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Error: Could not download data frame {body:?}"
         )));
     }
@@ -120,7 +120,7 @@ pub async fn list(
             let err = format!(
                 "api::workspaces::get_by_branch error parsing from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -175,7 +175,7 @@ pub async fn put(
         Err(err) => {
             let err =
                 format!("api::workspaces::put error parsing from {url}\n\nErr {err:?} \n\n{body}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -236,14 +236,14 @@ pub async fn diff(
             match response {
                 Ok(data) => Ok(data.data_frame),
 
-                Err(err) => Err(OxenError::basic_str(&format!(
+                Err(err) => Err(OxenError::basic_str(format!(
                     "api::staging::diff error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                 ))),
             }
         }
         Err(err) => {
             let err = format!("api::staging::diff Request failed: {url}\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -271,7 +271,7 @@ pub async fn rename_data_frame(
         Err(err) => {
             let err =
                 format!("api::workspaces::put error parsing from {url}\n\nErr {err:?} \n\n{body}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }

--- a/crates/lib/src/api/client/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames/columns.rs
@@ -17,7 +17,7 @@ pub async fn create(
     data: String,
 ) -> Result<DataFrame, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -44,13 +44,13 @@ pub async fn create(
                     let err = format!(
                         "api::staging::modify_df error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(err))
+                    Err(OxenError::basic_str(&err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::modify_df Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -62,7 +62,7 @@ pub async fn delete(
     column_name: &str,
 ) -> Result<DataFrame, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -86,13 +86,13 @@ pub async fn delete(
                     let err = format!(
                         "api::staging::rm_df_mod error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(err))
+                    Err(OxenError::basic_str(&err))
                 }
             }
         }
         Err(err) => {
             let err = format!("rm_df_mod Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -105,7 +105,7 @@ pub async fn update(
     data: String,
 ) -> Result<JsonDataFrameColumnResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -134,13 +134,13 @@ pub async fn update(
                     let err = format!(
                         "api::staging::update_row error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(err))
+                    Err(OxenError::basic_str(&err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::update_row Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -153,7 +153,7 @@ pub async fn add_column_metadata(
     metadata: serde_json::Value,
 ) -> Result<(), OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -178,7 +178,7 @@ pub async fn add_column_metadata(
         Ok(_) => Ok(()),
         Err(err) => {
             let err = format!("add_column_metadata Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -217,7 +217,7 @@ mod tests {
             assert_eq!(branch.name, branch_name);
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // train/dog_1.jpg,dog,101.5,32.0,385,330
@@ -287,7 +287,7 @@ mod tests {
                 .join("train")
                 .join("bounding_box.csv");
 
-            api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             api::client::workspaces::data_frames::index(&remote_repo, &workspace_id, &path).await?;
 
             let df = api::client::workspaces::data_frames::get(
@@ -326,14 +326,12 @@ mod tests {
                 .iter()
                 .enumerate()
                 .find(|(_index, field)| field.name == column.name)
-            {
-                if <std::option::Option<Changes> as Clone>::clone(&field.changes)
+                && <std::option::Option<Changes> as Clone>::clone(&field.changes)
                     .unwrap()
                     .status
                     != "deleted"
-                {
-                    panic!("Column {} still exists in the data frame", column.name);
-                }
+            {
+                panic!("Column {} still exists in the data frame", column.name);
             }
 
             Ok(remote_repo)
@@ -360,7 +358,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // Path to the CSV file
@@ -437,7 +435,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = Path::new("annotations")
@@ -531,7 +529,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = Path::new("annotations")
@@ -612,7 +610,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = Path::new("annotations")
@@ -706,7 +704,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = Path::new("annotations")
@@ -756,7 +754,7 @@ mod tests {
                 .await?;
 
             let _new_workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
 
             api::client::workspaces::data_frames::index(&remote_repo, &workspace_id, &path).await?;
 

--- a/crates/lib/src/api/client/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames/columns.rs
@@ -17,7 +17,7 @@ pub async fn create(
     data: String,
 ) -> Result<DataFrame, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -44,13 +44,13 @@ pub async fn create(
                     let err = format!(
                         "api::staging::modify_df error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(&err))
+                    Err(OxenError::basic_str(err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::modify_df Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -62,7 +62,7 @@ pub async fn delete(
     column_name: &str,
 ) -> Result<DataFrame, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -86,13 +86,13 @@ pub async fn delete(
                     let err = format!(
                         "api::staging::rm_df_mod error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(&err))
+                    Err(OxenError::basic_str(err))
                 }
             }
         }
         Err(err) => {
             let err = format!("rm_df_mod Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -105,7 +105,7 @@ pub async fn update(
     data: String,
 ) -> Result<JsonDataFrameColumnResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -134,13 +134,13 @@ pub async fn update(
                     let err = format!(
                         "api::staging::update_row error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(&err))
+                    Err(OxenError::basic_str(err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::update_row Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -153,7 +153,7 @@ pub async fn add_column_metadata(
     metadata: serde_json::Value,
 ) -> Result<(), OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -178,7 +178,7 @@ pub async fn add_column_metadata(
         Ok(_) => Ok(()),
         Err(err) => {
             let err = format!("add_column_metadata Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }

--- a/crates/lib/src/api/client/workspaces/data_frames/embeddings.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames/embeddings.rs
@@ -16,7 +16,7 @@ pub async fn get(
     path: &Path,
 ) -> Result<EmbeddingColumnsResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -35,12 +35,12 @@ pub async fn neighbors(
     remote_repo: &RemoteRepository,
     workspace_id: &str,
     path: &Path,
-    column: impl AsRef<str>,
+    column: &str,
     embedding: &Vec<f32>,
     paginate_opts: &PaginateOpts,
 ) -> Result<WorkspaceJsonDataFrameViewResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -50,7 +50,7 @@ pub async fn neighbors(
     log::debug!("get_embeddings {url}");
 
     let body = json!({
-        "column": column.as_ref(),
+        "column": column,
         "embedding": embedding,
         "page_size": paginate_opts.page_size,
         "page_num": paginate_opts.page_num,
@@ -73,7 +73,7 @@ pub async fn index(
     use_background_thread: bool,
 ) -> Result<EmbeddingColumnsResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -133,7 +133,7 @@ mod tests {
             assert_eq!(branch.name, branch_name);
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // train/dog_1.jpg,dog,101.5,32.0,385,330
@@ -168,7 +168,7 @@ mod tests {
             let branch_name = DEFAULT_BRANCH_NAME;
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = Path::new("annotations")
@@ -227,7 +227,7 @@ mod tests {
             let branch_name = DEFAULT_BRANCH_NAME;
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = Path::new("annotations")
@@ -307,10 +307,10 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
-            api::client::workspaces::data_frames::index(&remote_repo, &workspace_id, &path).await?;
+            api::client::workspaces::data_frames::index(&remote_repo, &workspace_id, path).await?;
             let column = "embedding";
             let use_background_thread = false;
             api::client::workspaces::data_frames::embeddings::index(
@@ -331,7 +331,7 @@ mod tests {
                 &remote_repo,
                 &workspace_id,
                 path,
-                &column,
+                column,
                 &embedding,
                 &paginate_opts,
             )
@@ -367,7 +367,7 @@ mod tests {
             let branch_name = DEFAULT_BRANCH_NAME;
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = Path::new("annotations")
@@ -450,7 +450,7 @@ mod tests {
             let branch_name = DEFAULT_BRANCH_NAME;
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = Path::new("annotations")

--- a/crates/lib/src/api/client/workspaces/data_frames/embeddings.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames/embeddings.rs
@@ -16,7 +16,7 @@ pub async fn get(
     path: &Path,
 ) -> Result<EmbeddingColumnsResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -40,7 +40,7 @@ pub async fn neighbors(
     paginate_opts: &PaginateOpts,
 ) -> Result<WorkspaceJsonDataFrameViewResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -73,7 +73,7 @@ pub async fn index(
     use_background_thread: bool,
 ) -> Result<EmbeddingColumnsResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };

--- a/crates/lib/src/api/client/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames/rows.rs
@@ -16,7 +16,7 @@ pub async fn get(
     row_id: &str,
 ) -> Result<JsonDataFrameRowResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -35,7 +35,7 @@ pub async fn get(
             let err = format!(
                 "api::staging::get_row error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -48,7 +48,7 @@ pub async fn update(
     data: String,
 ) -> Result<JsonDataFrameRowResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -73,7 +73,7 @@ pub async fn update(
             let err = format!(
                 "api::staging::update_row error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -85,7 +85,7 @@ pub async fn delete(
     row_id: &str,
 ) -> Result<DataFrame, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -106,7 +106,7 @@ pub async fn delete(
             let err = format!(
                 "api::staging::rm_df_mod error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -118,7 +118,7 @@ pub async fn add(
     data: String,
 ) -> Result<(DataFrame, Option<String>), OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -145,13 +145,13 @@ pub async fn add(
                     let err = format!(
                         "api::staging::modify_df error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(err))
+                    Err(OxenError::basic_str(&err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::modify_df Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -163,7 +163,7 @@ pub async fn restore_row(
     row_id: &str,
 ) -> Result<JsonDataFrameRowResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -189,13 +189,13 @@ pub async fn restore_row(
                     let err = format!(
                         "api::staging::update_row error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(err))
+                    Err(OxenError::basic_str(&err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::update_row Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -207,7 +207,7 @@ pub async fn batch_update(
     data: String,
 ) -> Result<VecBatchUpdateResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -233,13 +233,13 @@ pub async fn batch_update(
                     let err = format!(
                         "api::staging::batch_update error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(err))
+                    Err(OxenError::basic_str(&err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::batch_update Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -275,7 +275,7 @@ mod tests {
             assert_eq!(branch.name, branch_name);
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // train/dog_1.jpg,dog,101.5,32.0,385,330
@@ -342,7 +342,7 @@ mod tests {
             let branch = api::client::branches::create_from_branch(&remote_repo, branch_name, DEFAULT_BRANCH_NAME).await?;
             assert_eq!(branch.name, branch_name);
             let workspace_id = UserConfig::identifier()?;
-            let workspace = api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+            let workspace = api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // train/dog_1.jpg,dog,101.5,32.0,385,330
@@ -392,7 +392,7 @@ mod tests {
             assert_eq!(branch.name, branch_name);
 
             let workspace_id = UserConfig::identifier()?;
-            let workspace = api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+            let workspace = api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // Path to the CSV file
@@ -458,7 +458,7 @@ mod tests {
                 .join("train")
                 .join("bounding_box.csv");
 
-            api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             api::client::workspaces::data_frames::index(&remote_repo, &workspace_id, &path).await?;
 
             let df = api::client::workspaces::data_frames::get(
@@ -535,7 +535,7 @@ mod tests {
 
             let workspace_id = UserConfig::identifier()?;
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // Path to the CSV file
@@ -625,7 +625,7 @@ mod tests {
 
                 // Index dataset
                 let workspace_id = "my_workspace";
-                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_id)
+                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                     .await?;
                 api::client::workspaces::data_frames::index(&remote_repo, workspace_id, &path)
                     .await?;
@@ -691,7 +691,7 @@ mod tests {
             let path = Path::new("annotations").join("train").join("bounding_box.csv");
 
             let workspace_id = "my_workspace";
-            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_id)
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                 .await?;
             api::client::workspaces::data_frames::index(&remote_repo, workspace_id, &path)
                 .await?;
@@ -712,7 +712,7 @@ mod tests {
             // Retrieve the DataFrame to check if the row exists
             let df = api::client::workspaces::data_frames::get(
                 &remote_repo,
-                &workspace_id,
+                workspace_id,
                 &path,
                 &DFOpts::empty(),
             ).await?;

--- a/crates/lib/src/api/client/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/api/client/workspaces/data_frames/rows.rs
@@ -16,7 +16,7 @@ pub async fn get(
     row_id: &str,
 ) -> Result<JsonDataFrameRowResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -35,7 +35,7 @@ pub async fn get(
             let err = format!(
                 "api::staging::get_row error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -48,7 +48,7 @@ pub async fn update(
     data: String,
 ) -> Result<JsonDataFrameRowResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -73,7 +73,7 @@ pub async fn update(
             let err = format!(
                 "api::staging::update_row error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -85,7 +85,7 @@ pub async fn delete(
     row_id: &str,
 ) -> Result<DataFrame, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -106,7 +106,7 @@ pub async fn delete(
             let err = format!(
                 "api::staging::rm_df_mod error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -118,7 +118,7 @@ pub async fn add(
     data: String,
 ) -> Result<(DataFrame, Option<String>), OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -145,13 +145,13 @@ pub async fn add(
                     let err = format!(
                         "api::staging::modify_df error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(&err))
+                    Err(OxenError::basic_str(err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::modify_df Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -163,7 +163,7 @@ pub async fn restore_row(
     row_id: &str,
 ) -> Result<JsonDataFrameRowResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -189,13 +189,13 @@ pub async fn restore_row(
                     let err = format!(
                         "api::staging::update_row error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(&err))
+                    Err(OxenError::basic_str(err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::update_row Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -207,7 +207,7 @@ pub async fn batch_update(
     data: String,
 ) -> Result<VecBatchUpdateResponse, OxenError> {
     let Some(file_path_str) = path.to_str() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Path must be a string: {path:?}"
         )));
     };
@@ -233,13 +233,13 @@ pub async fn batch_update(
                     let err = format!(
                         "api::staging::batch_update error parsing response from {url}\n\nErr {err:?} \n\n{body}"
                     );
-                    Err(OxenError::basic_str(&err))
+                    Err(OxenError::basic_str(err))
                 }
             }
         }
         Err(err) => {
             let err = format!("api::staging::batch_update Request failed: {url}\n\nErr {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -48,14 +48,11 @@ pub type UploadFails = Vec<ErrorFileInfo>;
 // TODO: Test adding removed files
 pub async fn add(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<str>,
+    workspace_id: &str,
+    directory: &Path,
     paths: Vec<PathBuf>,
     local_repo: &Option<LocalRepository>,
 ) -> Result<UploadFails, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let directory = directory.as_ref();
-
     // If no paths provided, return early
     if paths.is_empty() {
         return Ok(vec![]);
@@ -73,7 +70,6 @@ pub async fn add(
     let expanded_paths = util::glob::parse_glob_paths(&glob_opts, local_repo.as_ref())?;
     let expanded_paths: Vec<PathBuf> = expanded_paths.iter().cloned().collect();
     // TODO: add a progress bar
-
     let n_expected_uploads = expanded_paths.len();
 
     let upload_result = upload_multiple_files(
@@ -131,12 +127,12 @@ fn resolve_paths_in_place(base_dir: &Path, paths: &mut [PathBuf]) -> Result<(), 
         paths[i] = std::path::absolute(&(paths[i]))?;
 
         if !paths[i].is_file() {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Cannot upload non-existent file: {}",
                 paths[i].display()
             )));
         } else if !paths[i].starts_with(base_dir) {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Cannot upload path that doesn't exist in base directory ({}): {}",
                 base_dir.display(),
                 paths[i].display()
@@ -156,14 +152,14 @@ fn resolve_paths_in_place(base_dir: &Path, paths: &mut [PathBuf]) -> Result<(), 
 /// repository.
 pub async fn add_files(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    base_dir: impl AsRef<Path>,
+    workspace_id: &str,
+    base_dir: &Path,
     paths: Vec<PathBuf>,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let base_dir = std::path::absolute(base_dir)?;
 
     if !base_dir.is_dir() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "base_dir is not a directory: {}",
             base_dir.display()
         )));
@@ -172,8 +168,6 @@ pub async fn add_files(
     if paths.is_empty() {
         return Err(OxenError::basic_str("No paths to add!"));
     }
-
-    let workspace_id = workspace_id.as_ref();
 
     let paths: Vec<PathBuf> = {
         let mut paths = paths;
@@ -187,7 +181,7 @@ pub async fn add_files(
     match upload_multiple_files(
         remote_repo,
         workspace_id,
-        "", // Each path has the right relative directory components, so it's crucial that they're
+        Path::new(""), // Each path has the right relative directory components, so it's crucial that they're
         //    "placed" at the repo root since the server API expects to add files into a directory
         //    for a single API call.
         paths,
@@ -205,14 +199,11 @@ pub async fn add_files(
 
 pub async fn add_bytes(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<str>,
+    workspace_id: &str,
+    directory: &Path,
     path: PathBuf,
     buf: &[u8],
 ) -> Result<(), OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let directory = directory.as_ref();
-
     match upload_bytes_as_file(remote_repo, workspace_id, directory, &path, buf).await {
         Ok(path) => {
             println!("🐂 oxen added entry {path:?} to workspace {workspace_id}");
@@ -227,12 +218,10 @@ pub async fn add_bytes(
 
 pub async fn upload_single_file(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    directory: &Path,
+    path: &Path,
 ) -> Result<PathBuf, OxenError> {
-    let path = path.as_ref();
-
     let Ok(metadata) = path.metadata() else {
         return Err(OxenError::path_does_not_exist(path));
     };
@@ -240,12 +229,11 @@ pub async fn upload_single_file(
     log::debug!("Uploading file with size: {}", metadata.len());
     // If the file is larger than AVG_CHUNK_SIZE, use the parallel upload strategy
     if metadata.len() > chunk_size() {
-        let directory = directory.as_ref();
         match api::client::versions::parallel_large_file_upload(
             remote_repo,
             path,
             Some(directory),
-            Some(workspace_id.as_ref().to_string()),
+            Some(workspace_id.to_string()),
             None,
             None,
         )
@@ -262,9 +250,9 @@ pub async fn upload_single_file(
 
 pub async fn upload_bytes_as_file(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    directory: &Path,
+    path: &Path,
     buf: &[u8],
 ) -> Result<PathBuf, OxenError> {
     p_upload_bytes_as_file(remote_repo, workspace_id, directory, path, buf).await
@@ -272,17 +260,14 @@ pub async fn upload_bytes_as_file(
 
 async fn upload_multiple_files(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
+    workspace_id: &str,
+    directory: &Path,
     paths: Vec<PathBuf>,
     local_or_base: Option<&LocalOrBase>,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     if paths.is_empty() {
         return Ok(vec![]);
     }
-
-    let workspace_id = workspace_id.as_ref();
-    let directory = directory.as_ref();
 
     let large_file_threshold = chunk_size();
 
@@ -300,7 +285,7 @@ async fn upload_multiple_files(
         let path = match local_or_base {
             Some(LocalOrBase::Local(local_repository)) => {
                 let repo_path = &local_repository.path;
-                let relative_path = util::fs::path_relative_to_dir(path, repo_path)?;
+                let relative_path = util::fs::path_relative_to_dir(&path, repo_path)?;
                 repo_path.join(&relative_path)
             }
             Some(LocalOrBase::Base(_)) | None => path,
@@ -308,7 +293,7 @@ async fn upload_multiple_files(
 
         if !path.exists() {
             log::debug!("Path does not exist: {path:?}");
-            return Err(OxenError::path_does_not_exist(path));
+            return Err(OxenError::path_does_not_exist(&path));
         }
 
         match path.metadata() {
@@ -326,7 +311,7 @@ async fn upload_multiple_files(
             }
             Err(err) => {
                 log::debug!("Failed to get metadata for file {path:?}: {err}");
-                return Err(OxenError::file_metadata_error(path, err));
+                return Err(OxenError::file_metadata_error(&path, err));
             }
         }
     }
@@ -387,8 +372,8 @@ async fn upload_multiple_files(
 
 pub(crate) async fn parallel_batched_small_file_upload(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
+    workspace_id: &str,
+    directory: &Path,
     small_files: Vec<(PathBuf, u64)>,
     small_files_size: u64,
     local_or_base: Option<&LocalOrBase>,
@@ -419,8 +404,8 @@ pub(crate) async fn parallel_batched_small_file_upload(
         small_files_size
     );
 
-    let workspace_id = workspace_id.as_ref().to_string();
-    let directory = directory.as_ref().to_str().unwrap_or_default().to_string();
+    let workspace_id = workspace_id.to_string();
+    let directory = directory.to_str().unwrap_or_default().to_string();
 
     // Represents unprocessed batches
     type PieceOfWork = Vec<(PathBuf, u64)>;
@@ -535,7 +520,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                     };
 
                                     let file = std::fs::read(&path).map_err(|e| {
-                                        OxenError::basic_str(format!(
+                                        OxenError::basic_str(&format!(
                                             "Failed to read file '{path:?}': {e}"
                                         ))
                                     })?;
@@ -548,7 +533,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
 
                                         std::io::copy(&mut file.as_slice(), &mut encoder).map_err(
                                             |e| {
-                                                OxenError::basic_str(format!(
+                                                OxenError::basic_str(&format!(
                                                     "Failed to copy file '{path:?}' to encoder: {e}"
                                                 ))
                                             },
@@ -558,7 +543,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                             Ok(bytes) => bytes,
                                             Err(e) => {
                                                 // If compressing a file fails, cancel the operation
-                                                return Err(OxenError::basic_str(format!(
+                                                return Err(OxenError::basic_str(&format!(
                                                     "Failed to finish gzip for file {}: {}",
                                                     &hash, e
                                                 )));
@@ -596,13 +581,13 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                 (batch_parts, files_to_stage, batch_size);
                             match tx_clone.send(processed_batch).await {
                                 Ok(_) => Ok(()),
-                                Err(e) => Err(OxenError::basic_str(format!("{e:?}"))),
+                                Err(e) => Err(OxenError::basic_str(&format!("{e:?}"))),
                             }
                         }
                         .await;
 
                         if let Err(e) = result {
-                            errors.lock().push(OxenError::basic_str(format!("{e:?}")));
+                            errors.lock().push(OxenError::basic_str(&format!("{e:?}")));
                         }
                     }
                 }
@@ -695,7 +680,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                         // If staging failed, cancel the operation
                                         Err(e) => {
                                             log::error!("failed to stage files to workspace: {e}");
-                                            return Err(OxenError::basic_str(format!(
+                                            return Err(OxenError::basic_str(&format!(
                                                 "failed to stage to workspace: {e}"
                                             )));
                                         }
@@ -718,7 +703,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                     );
 
                                     log::error!("failed to upload version files to workspace: {e}");
-                                    Err(OxenError::basic_str(format!(
+                                    Err(OxenError::basic_str(&format!(
                                         "failed to upload version files to workspace: {e}"
                                     )))
                                 }
@@ -726,7 +711,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                         }.await;
 
                         if let Err(e) = result {
-                            errors.lock().push(OxenError::basic_str(format!("{e:?}")));
+                            errors.lock().push(OxenError::basic_str(&format!("{e:?}")));
                         }
                     }
                 }
@@ -785,14 +770,13 @@ pub(crate) async fn parallel_batched_small_file_upload(
 pub async fn stage_files_to_workspace_with_retry(
     remote_repo: &RemoteRepository,
     client: Arc<reqwest::Client>,
-    workspace_id: impl AsRef<str>,
+    workspace_id: &str,
     files_to_add: Arc<Vec<FileWithHash>>,
-    directory_str: impl AsRef<str>,
+    directory_str: &str,
     err_files: Vec<ErrorFileInfo>,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let mut retry_count: usize = 0;
-    let directory_str = directory_str.as_ref();
-    let workspace_id = workspace_id.as_ref().to_string();
+    let workspace_id = workspace_id.to_string();
     let max_retries = max_retries();
 
     while retry_count < max_retries {
@@ -815,7 +799,7 @@ pub async fn stage_files_to_workspace_with_retry(
             Err(e) => {
                 log::error!("Error staging files to workspace: {e:?}");
                 if retry_count == max_retries {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(OxenError::basic_str(&format!(
                         "failed to stage files to workspace after retries: {e:?}"
                     )));
                 }
@@ -839,13 +823,11 @@ pub async fn stage_files_to_workspace_with_retry(
 pub async fn stage_files_to_workspace(
     remote_repo: &RemoteRepository,
     client: Arc<reqwest::Client>,
-    workspace_id: impl AsRef<str>,
+    workspace_id: &str,
     files_to_add: Arc<Vec<FileWithHash>>,
-    directory_str: impl AsRef<str>,
+    directory_str: &str,
     err_files: Vec<ErrorFileInfo>,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let directory_str = directory_str.as_ref();
     let uri = format!("/workspaces/{workspace_id}/versions/{directory_str}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
@@ -872,18 +854,15 @@ pub async fn stage_files_to_workspace(
 
 async fn p_upload_single_file(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    directory: &Path,
+    path: &Path,
 ) -> Result<PathBuf, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let directory = directory.as_ref();
     let directory_name = directory.to_string_lossy();
-    let path = path.as_ref();
     log::debug!("multipart_file_upload path: {path:?}");
     let Ok(file) = std::fs::read(path) else {
         let err = format!("Error reading file at path: {path:?}");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     };
 
     let uri = format!("/workspaces/{workspace_id}/files/{directory_name}");
@@ -911,16 +890,16 @@ async fn p_upload_single_file(
             let err = format!(
                 "api::staging::add_file error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
 
 async fn p_upload_bytes_as_file(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    directory: &Path,
+    path: &Path,
     mut buf: &[u8],
 ) -> Result<PathBuf, OxenError> {
     // Check if the total size of the files is too large (over 100mb for now)
@@ -932,13 +911,10 @@ async fn p_upload_bytes_as_file(
             ByteSize::b(total_size),
             ByteSize::b(limit)
         );
-        return Err(OxenError::basic_str(error_msg));
+        return Err(OxenError::basic_str(&error_msg));
     }
 
-    let workspace_id = workspace_id.as_ref();
-    let directory = directory.as_ref();
     let directory_name = directory.to_string_lossy();
-    let path = path.as_ref();
     log::debug!("multipart_file_upload path: {path:?}");
 
     let file_name: String = path.file_name().unwrap().to_string_lossy().into();
@@ -949,7 +925,7 @@ async fn p_upload_bytes_as_file(
     let compressed_bytes = match encoder.finish() {
         Ok(bytes) => bytes,
         Err(e) => {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Failed to finish gzip for file {}: {}",
                 &file_name, e
             )));
@@ -982,7 +958,7 @@ async fn p_upload_bytes_as_file(
             let err = format!(
                 "api::staging::add_file error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -992,9 +968,9 @@ async fn p_upload_bytes_as_file(
 pub async fn rm(
     remote_repo: &RemoteRepository,
     workspace_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<(), OxenError> {
-    let file_name = path.as_ref().to_string_lossy();
+    let file_name = path.to_string_lossy();
     let uri = format!("/workspaces/{workspace_id}/files/{file_name}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("rm_file {url}");
@@ -1008,11 +984,9 @@ pub async fn rm(
 pub async fn rm_files(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
+    workspace_id: &str,
     paths: Vec<PathBuf>,
 ) -> Result<(), OxenError> {
-    let workspace_id = workspace_id.as_ref();
-
     // Parse glob paths
     let glob_opts = GlobOpts {
         paths: paths.clone(),
@@ -1059,7 +1033,7 @@ pub async fn rm_files(
         log::error!("rm_files failed with status: {}", response.status());
         let body = client::parse_json_body(&url, response).await?;
 
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Error: Could not remove paths {body:?}"
         )));
     }
@@ -1070,17 +1044,15 @@ pub async fn rm_files(
 pub async fn rm_files_from_staged(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
+    workspace_id: &str,
     paths: Vec<PathBuf>,
 ) -> Result<(), OxenError> {
-    let workspace_id = workspace_id.as_ref();
-
     // Parse glob paths
     let repo_path = local_repo.path.clone();
     let mut expanded_paths: HashSet<PathBuf> = HashSet::new();
 
     for path in paths.clone() {
-        let relative_path = util::fs::path_relative_to_dir(&path, local_repo.path.clone())?;
+        let relative_path = util::fs::path_relative_to_dir(&path, &local_repo.path.clone())?;
         let full_path = repo_path.join(&relative_path);
         if util::fs::is_glob_path(&full_path) {
             let Some(ref head_commit) = repositories::commits::head_commit_maybe(local_repo)?
@@ -1139,18 +1111,16 @@ pub async fn rm_files_from_staged(
 /// Sends a PATCH request to update the file's path.
 pub async fn mv(
     remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
-    new_path: impl AsRef<Path>,
+    workspace_id: &str,
+    path: &Path,
+    new_path: &Path,
 ) -> Result<view::StatusMessage, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
     let file_path_str = path.to_string_lossy();
 
     let uri = format!("/workspaces/{workspace_id}/files/{file_path_str}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     let params = serde_json::to_string(&serde_json::json!({
-        "new_path": new_path.as_ref().to_string_lossy()
+        "new_path": new_path.to_string_lossy()
     }))?;
 
     let client = client::new_for_url(&url)?;
@@ -1163,7 +1133,7 @@ pub async fn mv(
             let err = format!(
                 "api::workspaces::files::mv error parsing from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -1174,7 +1144,7 @@ pub async fn download(
     path: &str,
     output_path: Option<&Path>,
 ) -> Result<(), OxenError> {
-    let uri = if util::fs::has_tabular_extension(path) {
+    let uri = if util::fs::has_tabular_extension(Path::new(path)) {
         format!("/workspaces/{workspace_id}/data_frames/download/{path}")
     } else {
         format!("/workspaces/{workspace_id}/files/{path}")
@@ -1207,12 +1177,12 @@ pub async fn download(
         let status = response.status();
 
         if status == reqwest::StatusCode::NOT_FOUND {
-            return Err(OxenError::path_does_not_exist(path));
+            return Err(OxenError::path_does_not_exist(Path::new(path)));
         }
 
         log::error!("api::client::workspace::files::download failed with status: {status}");
         let body = client::parse_json_body(&url, response).await?;
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Error: Could not download file {body:?}"
         )));
     }
@@ -1280,14 +1250,14 @@ mod tests {
             let directory_name = "images";
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = test::test_img_file();
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
+                &Path::new(directory_name),
                 vec![path],
                 &None,
             )
@@ -1336,14 +1306,14 @@ mod tests {
             let directory_name = "my_large_file";
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = test::test_30k_parquet();
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
+                &Path::new(directory_name),
                 vec![path],
                 &None,
             )
@@ -1383,7 +1353,7 @@ mod tests {
 
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let directory_name = "data";
@@ -1394,7 +1364,7 @@ mod tests {
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
+                &Path::new(directory_name),
                 paths,
                 &None,
             )
@@ -1431,12 +1401,12 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
 
             let file_to_post = test::test_1k_parquet();
-            let directory_name = "";
-            let result = api::client::workspaces::files::upload_single_file(
+            let directory_name = Path::new("");
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
-                file_to_post,
+                &file_to_post,
             )
             .await;
             println!("result: {result:?}");
@@ -1458,7 +1428,7 @@ mod tests {
             // List the entries
             let entries = api::client::entries::list_entries_with_type(
                 &remote_repo,
-                "",
+                Path::new(""),
                 DEFAULT_BRANCH_NAME,
                 &EntryDataType::Tabular,
             )
@@ -1471,12 +1441,12 @@ mod tests {
                     .await?;
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_csv_file_with_name("emojis.csv");
-            let directory_name = "moare_data";
-            let result = api::client::workspaces::files::upload_single_file(
+            let directory_name = Path::new("moare_data");
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
-                file_to_post,
+                &file_to_post,
             )
             .await;
             println!("result: {result:?}");
@@ -1498,7 +1468,7 @@ mod tests {
             // List the entries
             let entries = api::client::entries::list_entries_with_type(
                 &remote_repo,
-                "",
+                Path::new(""),
                 DEFAULT_BRANCH_NAME,
                 &EntryDataType::Tabular,
             )
@@ -1512,12 +1482,12 @@ mod tests {
                     .await?;
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_invalid_parquet_file();
-            let directory_name = "broken_data";
-            let result = api::client::workspaces::files::upload_single_file(
+            let directory_name = Path::new("broken_data");
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
-                file_to_post,
+                &file_to_post,
             )
             .await;
             println!("result: {result:?}");
@@ -1539,7 +1509,7 @@ mod tests {
             // List the entries
             let entries = api::client::entries::list_entries_with_type(
                 &remote_repo,
-                "",
+                Path::new(""),
                 DEFAULT_BRANCH_NAME,
                 &EntryDataType::Tabular,
             )
@@ -1562,12 +1532,12 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
 
             let file_to_post = test::test_1k_parquet();
-            let directory_name = "";
-            let result = api::client::workspaces::files::upload_single_file(
+            let directory_name = Path::new("");
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
-                file_to_post,
+                &file_to_post,
             )
             .await;
             println!("result: {result:?}");
@@ -1589,7 +1559,7 @@ mod tests {
             // List the entries
             let entries = api::client::entries::list_entries_with_type(
                 &remote_repo,
-                "",
+                Path::new(""),
                 DEFAULT_BRANCH_NAME,
                 &EntryDataType::Tabular,
             )
@@ -1602,12 +1572,12 @@ mod tests {
                     .await?;
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_csv_file_with_name("emojis.csv");
-            let directory_name = "moare_data";
-            let result = api::client::workspaces::files::upload_single_file(
+            let directory_name = Path::new("moare_data");
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
-                file_to_post,
+                &file_to_post,
             )
             .await;
             println!("result: {result:?}");
@@ -1629,7 +1599,7 @@ mod tests {
             // List the entries
             let entries = api::client::entries::list_entries_with_type(
                 &remote_repo,
-                "",
+                Path::new(""),
                 DEFAULT_BRANCH_NAME,
                 &EntryDataType::Tabular,
             )
@@ -1643,12 +1613,12 @@ mod tests {
                     .await?;
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_invalid_parquet_file();
-            let directory_name = "broken_data";
-            let result = api::client::workspaces::files::upload_single_file(
+            let directory_name = Path::new("broken_data");
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
-                file_to_post,
+                &file_to_post,
             )
             .await;
             println!("result: {result:?}");
@@ -1670,7 +1640,7 @@ mod tests {
             // List the entries
             let entries = api::client::entries::list_entries_with_type(
                 &remote_repo,
-                "",
+                Path::new(""),
                 DEFAULT_BRANCH_NAME,
                 &EntryDataType::Tabular,
             )
@@ -1697,16 +1667,16 @@ mod tests {
 
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let file_to_post = test::test_img_file();
             let directory_name = "data";
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
-                file_to_post,
+                Path::new(directory_name),
+                &file_to_post,
             )
             .await;
             assert!(result.is_ok());
@@ -1727,7 +1697,8 @@ mod tests {
             let remote_repo_cloned = remote_repo.clone();
             test::run_empty_dir_test_async(|cloned_repo_dir| async move {
                 // Clone repo
-                let opts = CloneOpts::new(remote_repo.remote.url, cloned_repo_dir.join("new_repo"));
+                let opts =
+                    CloneOpts::new(&remote_repo.remote.url, &cloned_repo_dir.join("new_repo"));
                 let cloned_repo = repositories::clone(&opts).await?;
 
                 // Make sure that image is not on main branch
@@ -1776,27 +1747,27 @@ mod tests {
             let directory_name = "tabular";
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // Post a parquet file
             let path = test::test_1k_parquet();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
-                path,
+                Path::new(directory_name),
+                &path,
             )
             .await;
             assert!(result.is_ok());
 
             // Post an image file
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
-                path,
+                Path::new(directory_name),
+                &path,
             )
             .await;
             assert!(result.is_ok());
@@ -1817,7 +1788,8 @@ mod tests {
 
             // List the file counts on that branch in that directory
             let file_counts =
-                api::client::dir::file_counts(&remote_repo, branch_name, directory_name).await?;
+                api::client::dir::file_counts(&remote_repo, branch_name, Path::new(directory_name))
+                    .await?;
             assert_eq!(file_counts.dir.data_types.len(), 2);
             assert_eq!(
                 file_counts
@@ -1841,7 +1813,8 @@ mod tests {
             );
 
             // List the file counts on that branch in the root directory
-            let file_counts = api::client::dir::file_counts(&remote_repo, branch_name, "").await?;
+            let file_counts =
+                api::client::dir::file_counts(&remote_repo, branch_name, Path::new("")).await?;
             assert_eq!(file_counts.dir.data_types.len(), 2);
             assert_eq!(
                 file_counts
@@ -1883,24 +1856,27 @@ mod tests {
 
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let directory_name = "images";
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
-                path,
+                Path::new(directory_name),
+                &path,
             )
             .await;
             assert!(result.is_ok());
 
             // Remove the file
-            let result =
-                api::client::workspaces::files::rm(&remote_repo, &workspace_id, result.unwrap())
-                    .await;
+            let result = api::client::workspaces::files::rm(
+                &remote_repo,
+                &workspace_id,
+                result.as_ref().unwrap(),
+            )
+            .await;
             assert!(result.is_ok());
 
             // Make sure we have 0 files staged
@@ -1938,15 +1914,15 @@ mod tests {
             let directory_name = "my/images/dir/is/long";
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
-                path,
+                Path::new(directory_name),
+                &path,
             )
             .await;
             assert!(result.is_ok());
@@ -1984,7 +1960,7 @@ mod tests {
 
             let workspace_id = format!("test-workspace-{}", uuid::Uuid::new_v4());
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // Prepare paths and directory
@@ -1992,13 +1968,13 @@ mod tests {
                 test::test_img_file(),
                 test::test_img_file_with_name("cole_anthony.jpeg"),
             ];
-            let directory = "test_data";
+            let directory_name = "test_data";
 
             // Call the add function with multiple files
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory,
+                Path::new(directory_name),
                 paths,
                 &None,
             )
@@ -2008,11 +1984,10 @@ mod tests {
             // Verify that both files were added
             let page_num = constants::DEFAULT_PAGE_NUM;
             let page_size = constants::DEFAULT_PAGE_SIZE;
-            let path = Path::new(directory);
             let entries = api::client::workspaces::changes::list(
                 &remote_repo,
                 &workspace_id,
-                path,
+                Path::new(directory_name),
                 page_num,
                 page_size,
             )
@@ -2040,7 +2015,7 @@ mod tests {
             let directory_name = "new-images";
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             // Get the absolute path to the file
@@ -2048,7 +2023,7 @@ mod tests {
             let result = api::client::workspaces::files::add(
                 &remote_repo,
                 &workspace_id,
-                directory_name,
+                &Path::new(directory_name),
                 vec![path],
                 &None,
             )
@@ -2089,7 +2064,7 @@ mod tests {
 
             let workspace_id = uuid::Uuid::new_v4().to_string();
             let workspace =
-                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+                api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
             assert_eq!(workspace.id, workspace_id);
 
             let bounding_box_path = PathBuf::from("README.md");
@@ -2145,8 +2120,8 @@ mod tests {
             let mv_response = api::client::workspaces::files::mv(
                 &remote_repo,
                 &workspace_id,
-                original_path,
-                new_path,
+                Path::new(original_path),
+                Path::new(new_path),
             )
             .await?;
             assert_eq!(mv_response.status, "success");
@@ -2163,12 +2138,13 @@ mod tests {
 
             // Verify the file exists at the new path after commit
             let new_file =
-                api::client::entries::get_entry(&remote_repo, new_path, &commit.id).await?;
+                api::client::entries::get_entry(&remote_repo, Path::new(new_path), &commit.id)
+                    .await?;
             assert!(new_file.is_some(), "File should exist at new path");
 
             // Verify the actual file content is accessible at the new path
             let file_bytes =
-                api::client::file::get_file(&remote_repo, branch_name, new_path).await?;
+                api::client::file::get_file(&remote_repo, branch_name, Path::new(new_path)).await?;
             assert!(
                 !file_bytes.is_empty(),
                 "File content should not be empty at new path"
@@ -2176,7 +2152,8 @@ mod tests {
 
             // Verify the original path no longer exists
             let old_file =
-                api::client::entries::get_entry(&remote_repo, original_path, &commit.id).await?;
+                api::client::entries::get_entry(&remote_repo, Path::new(original_path), &commit.id)
+                    .await?;
             assert!(old_file.is_none(), "File should not exist at original path");
 
             Ok(remote_repo)
@@ -2221,7 +2198,7 @@ mod tests {
         let workspace_id = uuid::Uuid::new_v4().to_string();
         let workspace = api::client::workspaces::create(
             remote_repo,
-            &constants::DEFAULT_BRANCH_NAME,
+            constants::DEFAULT_BRANCH_NAME,
             &workspace_id,
         )
         .await?;
@@ -2252,7 +2229,7 @@ mod tests {
                 api::client::workspaces::files::upload_single_file(
                     &remote_repo,
                     &workspace_id,
-                    upload_path,
+                    Path::new(upload_path),
                     &test_file,
                 )
                 .await?;
@@ -2358,7 +2335,7 @@ mod tests {
                 let workspace_id = uuid::Uuid::new_v4().to_string();
                 let workspace = api::client::workspaces::create_with_name(
                     &remote_repo,
-                    &constants::DEFAULT_BRANCH_NAME,
+                    constants::DEFAULT_BRANCH_NAME,
                     &workspace_id,
                     workspace_name,
                 )

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -127,12 +127,12 @@ fn resolve_paths_in_place(base_dir: &Path, paths: &mut [PathBuf]) -> Result<(), 
         paths[i] = std::path::absolute(&(paths[i]))?;
 
         if !paths[i].is_file() {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Cannot upload non-existent file: {}",
                 paths[i].display()
             )));
         } else if !paths[i].starts_with(base_dir) {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Cannot upload path that doesn't exist in base directory ({}): {}",
                 base_dir.display(),
                 paths[i].display()
@@ -159,14 +159,14 @@ pub async fn add_files(
     let base_dir = std::path::absolute(base_dir)?;
 
     if !base_dir.is_dir() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "base_dir is not a directory: {}",
             base_dir.display()
         )));
     }
 
     if paths.is_empty() {
-        return Err(OxenError::basic_str("No paths to add!"));
+        return Err(OxenError::basic_str("No paths to add!".to_string()));
     }
 
     let paths: Vec<PathBuf> = {
@@ -223,7 +223,7 @@ pub async fn upload_single_file(
     path: &Path,
 ) -> Result<PathBuf, OxenError> {
     let Ok(metadata) = path.metadata() else {
-        return Err(OxenError::path_does_not_exist(path));
+        return Err(OxenError::path_does_not_exist(path.to_path_buf()));
     };
 
     log::debug!("Uploading file with size: {}", metadata.len());
@@ -293,7 +293,7 @@ async fn upload_multiple_files(
 
         if !path.exists() {
             log::debug!("Path does not exist: {path:?}");
-            return Err(OxenError::path_does_not_exist(&path));
+            return Err(OxenError::path_does_not_exist(path));
         }
 
         match path.metadata() {
@@ -520,7 +520,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                     };
 
                                     let file = std::fs::read(&path).map_err(|e| {
-                                        OxenError::basic_str(&format!(
+                                        OxenError::basic_str(format!(
                                             "Failed to read file '{path:?}': {e}"
                                         ))
                                     })?;
@@ -533,7 +533,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
 
                                         std::io::copy(&mut file.as_slice(), &mut encoder).map_err(
                                             |e| {
-                                                OxenError::basic_str(&format!(
+                                                OxenError::basic_str(format!(
                                                     "Failed to copy file '{path:?}' to encoder: {e}"
                                                 ))
                                             },
@@ -543,7 +543,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                             Ok(bytes) => bytes,
                                             Err(e) => {
                                                 // If compressing a file fails, cancel the operation
-                                                return Err(OxenError::basic_str(&format!(
+                                                return Err(OxenError::basic_str(format!(
                                                     "Failed to finish gzip for file {}: {}",
                                                     &hash, e
                                                 )));
@@ -581,13 +581,13 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                 (batch_parts, files_to_stage, batch_size);
                             match tx_clone.send(processed_batch).await {
                                 Ok(_) => Ok(()),
-                                Err(e) => Err(OxenError::basic_str(&format!("{e:?}"))),
+                                Err(e) => Err(OxenError::basic_str(format!("{e:?}"))),
                             }
                         }
                         .await;
 
                         if let Err(e) = result {
-                            errors.lock().push(OxenError::basic_str(&format!("{e:?}")));
+                            errors.lock().push(OxenError::basic_str(format!("{e:?}")));
                         }
                     }
                 }
@@ -680,7 +680,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                         // If staging failed, cancel the operation
                                         Err(e) => {
                                             log::error!("failed to stage files to workspace: {e}");
-                                            return Err(OxenError::basic_str(&format!(
+                                            return Err(OxenError::basic_str(format!(
                                                 "failed to stage to workspace: {e}"
                                             )));
                                         }
@@ -703,7 +703,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                     );
 
                                     log::error!("failed to upload version files to workspace: {e}");
-                                    Err(OxenError::basic_str(&format!(
+                                    Err(OxenError::basic_str(format!(
                                         "failed to upload version files to workspace: {e}"
                                     )))
                                 }
@@ -711,7 +711,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
                         }.await;
 
                         if let Err(e) = result {
-                            errors.lock().push(OxenError::basic_str(&format!("{e:?}")));
+                            errors.lock().push(OxenError::basic_str(format!("{e:?}")));
                         }
                     }
                 }
@@ -728,7 +728,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
         Err(e) => {
             let err = format!("Couldn't acquire mutex guard for err_files: {e:?}");
             log::error!("{err}");
-            return Err(OxenError::basic_str(&err));
+            return Err(OxenError::basic_str(err));
         }
     };
 
@@ -740,7 +740,7 @@ pub(crate) async fn parallel_batched_small_file_upload(
         Err(e) => {
             let err = format!("Couldn't acquire mutex guard for errors: {e:?}");
             log::error!("{err}");
-            return Err(OxenError::basic_str(&err));
+            return Err(OxenError::basic_str(err));
         }
     };
 
@@ -799,7 +799,7 @@ pub async fn stage_files_to_workspace_with_retry(
             Err(e) => {
                 log::error!("Error staging files to workspace: {e:?}");
                 if retry_count == max_retries {
-                    return Err(OxenError::basic_str(&format!(
+                    return Err(OxenError::basic_str(format!(
                         "failed to stage files to workspace after retries: {e:?}"
                     )));
                 }
@@ -815,7 +815,7 @@ pub async fn stage_files_to_workspace_with_retry(
         files_to_add.len()
     );
     Err(OxenError::basic_str(
-        "failed to stage files to workspace after retries",
+        "failed to stage files to workspace after retries".to_string(),
     ))
 }
 
@@ -862,7 +862,7 @@ async fn p_upload_single_file(
     log::debug!("multipart_file_upload path: {path:?}");
     let Ok(file) = std::fs::read(path) else {
         let err = format!("Error reading file at path: {path:?}");
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     };
 
     let uri = format!("/workspaces/{workspace_id}/files/{directory_name}");
@@ -883,14 +883,16 @@ async fn p_upload_single_file(
             if let Some(path) = val.paths.first() {
                 Ok(path.clone())
             } else {
-                Err(OxenError::basic_str("No file path returned from server"))
+                Err(OxenError::basic_str(
+                    "No file path returned from server".to_string(),
+                ))
             }
         }
         Err(err) => {
             let err = format!(
                 "api::staging::add_file error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -911,7 +913,7 @@ async fn p_upload_bytes_as_file(
             ByteSize::b(total_size),
             ByteSize::b(limit)
         );
-        return Err(OxenError::basic_str(&error_msg));
+        return Err(OxenError::basic_str(error_msg));
     }
 
     let directory_name = directory.to_string_lossy();
@@ -925,7 +927,7 @@ async fn p_upload_bytes_as_file(
     let compressed_bytes = match encoder.finish() {
         Ok(bytes) => bytes,
         Err(e) => {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Failed to finish gzip for file {}: {}",
                 &file_name, e
             )));
@@ -951,14 +953,16 @@ async fn p_upload_bytes_as_file(
             if let Some(path) = val.paths.first() {
                 Ok(path.clone())
             } else {
-                Err(OxenError::basic_str("No file path returned from server"))
+                Err(OxenError::basic_str(
+                    "No file path returned from server".to_string(),
+                ))
             }
         }
         Err(err) => {
             let err = format!(
                 "api::staging::add_file error parsing response from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -1033,7 +1037,7 @@ pub async fn rm_files(
         log::error!("rm_files failed with status: {}", response.status());
         let body = client::parse_json_body(&url, response).await?;
 
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Error: Could not remove paths {body:?}"
         )));
     }
@@ -1059,7 +1063,8 @@ pub async fn rm_files_from_staged(
             else {
                 // TODO: Better error message?
                 return Err(OxenError::basic_str(
-                    "Error: Cannot rm with glob paths in remote-mode repo without HEAD commit",
+                    "Error: Cannot rm with glob paths in remote-mode repo without HEAD commit"
+                        .to_string(),
                 ));
             };
             let glob_pattern = relative_path
@@ -1133,7 +1138,7 @@ pub async fn mv(
             let err = format!(
                 "api::workspaces::files::mv error parsing from {url}\n\nErr {err:?} \n\n{body}"
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -1177,12 +1182,12 @@ pub async fn download(
         let status = response.status();
 
         if status == reqwest::StatusCode::NOT_FOUND {
-            return Err(OxenError::path_does_not_exist(Path::new(path)));
+            return Err(OxenError::path_does_not_exist(PathBuf::from(path)));
         }
 
         log::error!("api::client::workspace::files::download failed with status: {status}");
         let body = client::parse_json_body(&url, response).await?;
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Error: Could not download file {body:?}"
         )));
     }

--- a/crates/lib/src/api/endpoint.rs
+++ b/crates/lib/src/api/endpoint.rs
@@ -7,21 +7,12 @@ use url::Url;
 
 pub const API_NAMESPACE: &str = "/api/repos";
 
-pub fn get_scheme(host: impl AsRef<str>) -> String {
-    RepoNew::scheme_default(host.as_ref())
+pub fn get_scheme(host: &str) -> String {
+    RepoNew::scheme_default(host)
 }
 
-pub fn url_from_host_and_scheme(
-    host: impl AsRef<str>,
-    uri: impl AsRef<str>,
-    scheme: impl AsRef<str>,
-) -> String {
-    format!(
-        "{}://{}{API_NAMESPACE}{}",
-        scheme.as_ref(),
-        host.as_ref(),
-        uri.as_ref()
-    )
+pub fn url_from_host_and_scheme(host: &str, uri: &str, scheme: &str) -> String {
+    format!("{}://{}{API_NAMESPACE}{}", scheme, host, uri)
 }
 
 pub fn url_from_host(host: &str, uri: &str) -> String {

--- a/crates/lib/src/command/config.rs
+++ b/crates/lib/src/command/config.rs
@@ -16,7 +16,7 @@ pub fn set_remote(repo: &mut LocalRepository, name: &str, url: &str) -> Result<R
 
     if repo.is_remote_mode() {
         return Err(OxenError::basic_str(
-            "Error: Cannot change remote of remote-mode repos",
+            "Error: Cannot change remote of remote-mode repos".to_string(),
         ));
     }
 
@@ -30,7 +30,7 @@ pub fn set_remote(repo: &mut LocalRepository, name: &str, url: &str) -> Result<R
 pub fn delete_remote(repo: &mut LocalRepository, name: &str) -> Result<(), OxenError> {
     if repo.is_remote_mode() {
         return Err(OxenError::basic_str(
-            "Error: Cannot delete from remote of remote-mode repos",
+            "Error: Cannot delete from remote of remote-mode repos".to_string(),
         ));
     }
 

--- a/crates/lib/src/command/db.rs
+++ b/crates/lib/src/command/db.rs
@@ -12,8 +12,7 @@ use std::path::Path;
 use std::str;
 
 /// List the key -> value pairs in a database
-pub fn list(path: impl AsRef<Path>, limit: Option<usize>) -> Result<(), OxenError> {
-    let path = path.as_ref();
+pub fn list(path: &Path, limit: Option<usize>) -> Result<(), OxenError> {
     let mut opts = Options::default();
     opts.set_log_level(LogLevel::Fatal);
 
@@ -77,15 +76,14 @@ pub fn list(path: impl AsRef<Path>, limit: Option<usize>) -> Result<(), OxenErro
 }
 
 /// Count the values in a database
-pub fn count(path: impl AsRef<Path>) -> Result<usize, OxenError> {
-    let path = path.as_ref();
+pub fn count(path: &Path) -> Result<usize, OxenError> {
     let opts = Options::default();
     log::debug!("Opening db at {path:?}");
     let db = DB::open_for_read_only(&opts, dunce::simplified(path), false)?;
     log::debug!("Opened db at {path:?}");
     let iter = db.iterator(IteratorMode::Start);
     log::debug!("Iterating over db at {path:?}");
-    let progress = spinner_with_msg(format!("Counting db at {path:?}"));
+    let progress = spinner_with_msg(&format!("Counting db at {path:?}"));
     let mut count = 0;
     for _ in iter {
         count += 1;
@@ -97,13 +95,8 @@ pub fn count(path: impl AsRef<Path>) -> Result<usize, OxenError> {
 }
 
 /// Get a value from a database
-pub fn get(
-    path: impl AsRef<Path>,
-    key: impl AsRef<str>,
-    dtype: Option<&str>,
-) -> Result<String, OxenError> {
-    let path = path.as_ref();
-    let str_key = key.as_ref();
+pub fn get(path: &Path, key: &str, dtype: Option<&str>) -> Result<String, OxenError> {
+    let str_key = key;
     let mut opts = Options::default();
     opts.set_log_level(LogLevel::Fatal);
 
@@ -130,6 +123,6 @@ pub fn get(
             Ok(format!("<{} bytes>", value.len()))
         }
     } else {
-        Err(OxenError::basic_str(format!("Key {str_key} not found")))
+        Err(OxenError::basic_str(&format!("Key {str_key} not found")))
     }
 }

--- a/crates/lib/src/command/db.rs
+++ b/crates/lib/src/command/db.rs
@@ -34,13 +34,13 @@ pub fn list(path: &Path, limit: Option<usize>) -> Result<(), OxenError> {
                     // deserialize as u128
                     if key.len() == 16 {
                         let key: [u8; 16] = (*key).try_into().map_err(|_| {
-                            OxenError::basic_str("Could not convert key to [u8; 16]")
+                            OxenError::basic_str("Could not convert key to [u8; 16]".to_string())
                         })?;
                         let key = u128::from_le_bytes(key);
                         format!("{key}")
                     } else {
                         return Err(OxenError::basic_str(
-                            "Could not read iterate over db values",
+                            "Could not read iterate over db values".to_string(),
                         ));
                     }
                 };
@@ -63,7 +63,7 @@ pub fn list(path: &Path, limit: Option<usize>) -> Result<(), OxenError> {
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -123,6 +123,6 @@ pub fn get(path: &Path, key: &str, dtype: Option<&str>) -> Result<String, OxenEr
             Ok(format!("<{} bytes>", value.len()))
         }
     } else {
-        Err(OxenError::basic_str(&format!("Key {str_key} not found")))
+        Err(OxenError::basic_str(format!("Key {str_key} not found")))
     }
 }

--- a/crates/lib/src/command/df.rs
+++ b/crates/lib/src/command/df.rs
@@ -35,11 +35,11 @@ pub async fn df_revision(
     opts: DFOpts,
 ) -> Result<(), OxenError> {
     let commit = repositories::revisions::get(repo, revision)?.ok_or(OxenError::basic_str(
-        &format!("Revision {} not found", revision),
+        format!("Revision {} not found", revision),
     ))?;
     let Some(root) = repositories::tree::get_node_by_path_with_children(repo, &commit, input)?
     else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Merkle tree for revision {} not found",
             revision
         )));
@@ -69,7 +69,7 @@ pub async fn add_row(path: &Path, data: &str) -> Result<(), OxenError> {
         df(path, opts).await
     } else {
         let err = format!("{} is not a tabular file", path.display());
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 
@@ -82,6 +82,6 @@ pub async fn add_column(path: &Path, data: &str) -> Result<(), OxenError> {
         df(path, opts).await
     } else {
         let err = format!("{} is not a tabular file", path.display());
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }

--- a/crates/lib/src/command/df.rs
+++ b/crates/lib/src/command/df.rs
@@ -12,17 +12,17 @@ use crate::opts::DFOpts;
 use crate::{repositories, util};
 
 /// Interact with DataFrames
-pub async fn df(input: impl AsRef<Path>, opts: DFOpts) -> Result<(), OxenError> {
+pub async fn df(input: &Path, opts: DFOpts) -> Result<(), OxenError> {
     let mut df = tabular::show_path(input, opts.clone()).await?;
 
     if let Some(write) = opts.write {
         println!("Writing {write:?}");
-        tabular::write_df(&mut df, write)?;
+        tabular::write_df(&mut df, &write)?;
     }
 
     if let Some(output) = opts.output {
         println!("Writing {output:?}");
-        tabular::write_df(&mut df, output)?;
+        tabular::write_df(&mut df, &output)?;
     }
 
     Ok(())
@@ -30,19 +30,18 @@ pub async fn df(input: impl AsRef<Path>, opts: DFOpts) -> Result<(), OxenError> 
 
 pub async fn df_revision(
     repo: &LocalRepository,
-    input: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    input: &Path,
+    revision: &str,
     opts: DFOpts,
 ) -> Result<(), OxenError> {
-    let commit = repositories::revisions::get(repo, &revision)?.ok_or(OxenError::basic_str(
-        format!("Revision {} not found", revision.as_ref()),
+    let commit = repositories::revisions::get(repo, revision)?.ok_or(OxenError::basic_str(
+        &format!("Revision {} not found", revision),
     ))?;
-    let path = input.as_ref();
-    let Some(root) = repositories::tree::get_node_by_path_with_children(repo, &commit, path)?
+    let Some(root) = repositories::tree::get_node_by_path_with_children(repo, &commit, input)?
     else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Merkle tree for revision {} not found",
-            revision.as_ref()
+            revision
         )));
     };
 
@@ -50,14 +49,14 @@ pub async fn df_revision(
 
     if let Some(output) = opts.output {
         println!("Writing {output:?}");
-        tabular::write_df(&mut df, output)?;
+        tabular::write_df(&mut df, &output)?;
     }
 
     Ok(())
 }
 
 /// Get a human readable schema for a DataFrame
-pub fn schema<P: AsRef<Path>>(input: P, flatten: bool, opts: DFOpts) -> Result<String, OxenError> {
+pub fn schema(input: &Path, flatten: bool, opts: DFOpts) -> Result<String, OxenError> {
     tabular::schema_to_string(input, flatten, &opts)
 }
 
@@ -70,7 +69,7 @@ pub async fn add_row(path: &Path, data: &str) -> Result<(), OxenError> {
         df(path, opts).await
     } else {
         let err = format!("{} is not a tabular file", path.display());
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }
 
@@ -83,6 +82,6 @@ pub async fn add_column(path: &Path, data: &str) -> Result<(), OxenError> {
         df(path, opts).await
     } else {
         let err = format!("{} is not a tabular file", path.display());
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }

--- a/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -309,7 +309,7 @@ mod tests {
     async fn test_add_child_counts_to_nodes_migration() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate an older repository
-            let repo = repositories::init::init_with_version(dir, MinOxenVersion::V0_19_0)?;
+            let repo = repositories::init::init_with_version(&dir, MinOxenVersion::V0_19_0)?;
 
             // Populate the repo with some files
             test::populate_dir_with_training_data(&repo.path)?;
@@ -406,7 +406,7 @@ mod tests {
     async fn test_add_child_counts_migration_with_many_vnodes() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate an older repository
-            let mut repo = repositories::init::init_with_version(dir, MinOxenVersion::V0_19_0)?;
+            let mut repo = repositories::init::init_with_version(&dir, MinOxenVersion::V0_19_0)?;
             // Set the vnode size to 3
             repo.set_vnode_size(3);
 
@@ -499,7 +499,7 @@ mod tests {
             let file_node = repositories::tree::get_node_by_path(
                 &repo,
                 &latest_commit,
-                PathBuf::from("README.md"),
+                &PathBuf::from("README.md"),
             )?;
             assert!(file_node.is_some());
 

--- a/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -120,12 +120,14 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
     // *******************************************************************
 
     let Some(root_node) = repositories::tree::get_root_with_children(&old_repo, commit)? else {
-        return Err(OxenError::basic_str("Root node not found"));
+        return Err(OxenError::basic_str("Root node not found".to_string()));
     };
 
     let root_dir_node = repositories::tree::get_root_dir(&root_node)?;
     let EMerkleTreeNode::Directory(dir_node) = root_dir_node.node.clone() else {
-        return Err(OxenError::basic_str("Root node must be CommitNode"));
+        return Err(OxenError::basic_str(
+            "Root node must be CommitNode".to_string(),
+        ));
     };
 
     // ✍️ Do all the rewriting

--- a/crates/lib/src/config/auth_config.rs
+++ b/crates/lib/src/config/auth_config.rs
@@ -114,20 +114,18 @@ impl AuthConfig {
 
     pub fn save(&self, path: &Path) -> Result<(), OxenError> {
         let toml = toml::to_string(&self)?;
-        util::fs::write_to_path(path, toml)?;
+        util::fs::write_to_path(path, &toml)?;
         Ok(())
     }
 
-    pub fn add_host_auth_token<S: AsRef<str>>(&mut self, host: S, token: S) {
-        let host = host.as_ref();
+    pub fn add_host_auth_token(&mut self, host: &str, token: &str) {
         self.host_configs.replace(HostConfig {
             host: String::from(host),
-            auth_token: Some(String::from(token.as_ref())),
+            auth_token: Some(String::from(token)),
         });
     }
 
-    pub fn auth_token_for_host<S: AsRef<str>>(&self, host: S) -> Option<String> {
-        let host = host.as_ref();
+    pub fn auth_token_for_host(&self, host: &str) -> Option<String> {
         if let Some(token) = self.host_configs.get(&HostConfig::from_host(host)) {
             if token.auth_token.is_none() {
                 log::trace!("no auth_token found for host \"{}\"", token.host);

--- a/crates/lib/src/config/repository_config.rs
+++ b/crates/lib/src/config/repository_config.rs
@@ -61,15 +61,15 @@ impl RepositoryConfig {
         Self::from_file(&path)
     }
 
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, OxenError> {
-        let contents = util::fs::read_from_path(&path)?;
+    pub fn from_file(path: &Path) -> Result<Self, OxenError> {
+        let contents = util::fs::read_from_path(path)?;
         let remote_config: RepositoryConfig = toml::from_str(&contents)?;
         Ok(remote_config)
     }
 
-    pub fn save(&self, path: impl AsRef<Path>) -> Result<(), OxenError> {
+    pub fn save(&self, path: &Path) -> Result<(), OxenError> {
         let toml = toml::to_string(&self)?;
-        util::fs::write_to_path(&path, toml)?;
+        util::fs::write_to_path(path, &toml)?;
         Ok(())
     }
 

--- a/crates/lib/src/config/runtime_config.rs
+++ b/crates/lib/src/config/runtime_config.rs
@@ -47,7 +47,7 @@ impl RuntimeConfig {
         get_runtime_config()
             .read()
             .map(|config| config.clone())
-            .map_err(|_| OxenError::basic_str("Failed to read global configuration"))
+            .map_err(|_| OxenError::basic_str("Failed to read global configuration".to_string()))
     }
 
     pub fn update(config: RuntimeConfig) -> Result<(), OxenError> {
@@ -56,7 +56,7 @@ impl RuntimeConfig {
             Ok(())
         } else {
             Err(OxenError::basic_str(
-                "Failed to update global configuration",
+                "Failed to update global configuration".to_string(),
             ))
         }
     }

--- a/crates/lib/src/config/user_config.rs
+++ b/crates/lib/src/config/user_config.rs
@@ -78,7 +78,7 @@ impl UserConfig {
 
     pub fn identifier() -> Result<String, OxenError> {
         Ok(util::hasher::hash_str_sha256(
-            UserConfig::get()?.to_user().email,
+            &UserConfig::get()?.to_user().email,
         ))
     }
 
@@ -109,7 +109,7 @@ impl UserConfig {
 
     pub fn save(&self, path: &Path) -> Result<(), OxenError> {
         let toml = toml::to_string(&self)?;
-        util::fs::write_to_path(path, toml)?;
+        util::fs::write_to_path(path, &toml)?;
         Ok(())
     }
 }

--- a/crates/lib/src/core/commit_sync_status.rs
+++ b/crates/lib/src/core/commit_sync_status.rs
@@ -38,7 +38,7 @@ pub fn mark_commit_as_synced(
             log::debug!("Wrote is synced file: {is_synced_path:?}");
             Ok(())
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "Could not write is_synced file: {err}"
         ))),
     }

--- a/crates/lib/src/core/commit_sync_status.rs
+++ b/crates/lib/src/core/commit_sync_status.rs
@@ -38,7 +38,7 @@ pub fn mark_commit_as_synced(
             log::debug!("Wrote is synced file: {is_synced_path:?}");
             Ok(())
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "Could not write is_synced file: {err}"
         ))),
     }

--- a/crates/lib/src/core/db/data_frames/columns.rs
+++ b/crates/lib/src/core/db/data_frames/columns.rs
@@ -106,10 +106,9 @@ pub fn revert_column_changes(db: &DB, column_name: &str) -> Result<(), OxenError
 
 pub fn polar_insert_column(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     new_column: &NewColumn,
 ) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
     let data_type = DataType::from_string(&new_column.data_type).to_sql();
     let sql = format!(
         "ALTER TABLE {} ADD COLUMN {} {}",
@@ -125,11 +124,9 @@ pub fn polar_insert_column(
 
 pub fn polar_delete_column(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     column_to_delete: &ColumnToDelete,
 ) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
-
     // Corrected to DROP COLUMN instead of ADD COLUMN
     let sql = format!(
         "ALTER TABLE {} DROP COLUMN {}",
@@ -145,10 +142,9 @@ pub fn polar_delete_column(
 
 pub fn polar_update_column(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     column_to_update: &ColumnToUpdate,
 ) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
     let mut sql_commands = Vec::new();
 
     if let Some(ref new_data_type) = column_to_update.new_data_type {

--- a/crates/lib/src/core/db/data_frames/df_db.rs
+++ b/crates/lib/src/core/db/data_frames/df_db.rs
@@ -38,8 +38,8 @@ static DF_DB_INSTANCES: LazyLock<RwLock<LruCache<PathBuf, Arc<Mutex<duckdb::Conn
     LazyLock::new(|| RwLock::new(LruCache::new(DF_DB_CACHE_SIZE)));
 
 /// Removes a database instance from the cache.
-pub fn remove_df_db_from_cache(db_path: impl AsRef<Path>) -> Result<(), OxenError> {
-    let db_path = db_path.as_ref().to_path_buf();
+pub fn remove_df_db_from_cache(db_path: &Path) -> Result<(), OxenError> {
+    let db_path = db_path.to_path_buf();
     let mut instances = DF_DB_INSTANCES.write();
     let _ = instances.pop(&db_path); // drop immediately
     Ok(())
@@ -47,11 +47,7 @@ pub fn remove_df_db_from_cache(db_path: impl AsRef<Path>) -> Result<(), OxenErro
 
 /// Removes a database instance and all its subdirectories from the cache.
 /// This is mostly useful in test cleanup to ensure all DB instances are removed.
-pub fn remove_df_db_from_cache_with_children(
-    db_path_prefix: impl AsRef<Path>,
-) -> Result<(), OxenError> {
-    let db_path_prefix = db_path_prefix.as_ref();
-
+pub fn remove_df_db_from_cache_with_children(db_path_prefix: &Path) -> Result<(), OxenError> {
     let mut dbs_to_remove: Vec<PathBuf> = vec![];
     let mut instances = DF_DB_INSTANCES.write();
     for (key, _) in instances.iter() {
@@ -72,11 +68,11 @@ pub struct DfDBManager {
     df_db: Arc<Mutex<duckdb::Connection>>,
 }
 
-pub fn with_df_db_manager<F, T>(db_path: impl AsRef<Path>, operation: F) -> Result<T, OxenError>
+pub fn with_df_db_manager<F, T>(db_path: &Path, operation: F) -> Result<T, OxenError>
 where
     F: FnOnce(&DfDBManager) -> Result<T, OxenError>,
 {
-    let db_path = db_path.as_ref().to_path_buf();
+    let db_path = db_path.to_path_buf();
 
     let df_db = {
         // 1. If df db exists in cache, return the existing connection
@@ -100,13 +96,13 @@ where
             {
                 std::fs::create_dir_all(parent).map_err(|e| {
                     log::error!("Failed to create df db directory: {e}");
-                    OxenError::basic_str(format!("Failed to create df db directory: {e}"))
+                    OxenError::basic_str(&format!("Failed to create df db directory: {e}"))
                 })?;
             }
 
             let conn = get_connection(&db_path).map_err(|e| {
                 log::error!("Failed to open df db: {e}");
-                OxenError::basic_str(format!("Failed to open df db: {e}"))
+                OxenError::basic_str(&format!("Failed to open df db: {e}"))
             })?;
 
             // Wrap the Connection in a Mutex and store it in the cache
@@ -146,8 +142,7 @@ impl DfDBManager {
 }
 
 /// Get a connection to a duckdb database.
-pub fn get_connection(path: impl AsRef<Path>) -> Result<duckdb::Connection, OxenError> {
-    let path = path.as_ref();
+pub fn get_connection(path: &Path) -> Result<duckdb::Connection, OxenError> {
     log::debug!("get_connection: Opening new DuckDB connection for path: {path:?}");
 
     if let Some(parent) = path.parent() {
@@ -163,27 +158,22 @@ pub fn get_connection(path: impl AsRef<Path>) -> Result<duckdb::Connection, Oxen
 /// Create a table in a duckdb database based on an oxen schema.
 pub fn create_table_if_not_exists(
     conn: &duckdb::Connection,
-    name: impl AsRef<str>,
+    name: &str,
     schema: &Schema,
 ) -> Result<String, OxenError> {
     p_create_table_if_not_exists(conn, name, &schema.fields)
 }
 
 /// Drop a table in a duckdb database.
-pub fn drop_table(conn: &duckdb::Connection, table_name: impl AsRef<str>) -> Result<(), OxenError> {
-    let table_name = table_name.as_ref();
+pub fn drop_table(conn: &duckdb::Connection, table_name: &str) -> Result<(), OxenError> {
     let sql = format!("DROP TABLE IF EXISTS {table_name}");
     log::debug!("drop_table sql: {sql}");
     conn.execute(&sql, []).map_err(OxenError::from)?;
     Ok(())
 }
 
-pub fn table_exists(
-    conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-) -> Result<bool, OxenError> {
+pub fn table_exists(conn: &duckdb::Connection, table_name: &str) -> Result<bool, OxenError> {
     log::debug!("checking exists in path {conn:?}");
-    let table_name = table_name.as_ref();
     let sql = "SELECT EXISTS (SELECT 1 FROM duckdb_tables WHERE table_name = ?) AS table_exists";
     let mut stmt = conn.prepare(sql)?;
     let exists: bool = stmt.query_row(params![table_name], |row| row.get(0))?;
@@ -194,10 +184,9 @@ pub fn table_exists(
 /// Create a table from a set of oxen fields with data types.
 fn p_create_table_if_not_exists(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     fields: &[Field],
 ) -> Result<String, OxenError> {
-    let table_name = table_name.as_ref();
     let columns: Vec<String> = fields.iter().map(|f| f.to_sql()).collect();
     let columns = columns.join(" NOT NULL,\n");
     let sql = format!("CREATE TABLE IF NOT EXISTS {table_name} (\n{columns});");
@@ -207,11 +196,7 @@ fn p_create_table_if_not_exists(
 }
 
 /// Get the schema from the table.
-pub fn get_schema(
-    conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-) -> Result<Schema, OxenError> {
-    let table_name = table_name.as_ref();
+pub fn get_schema(conn: &duckdb::Connection, table_name: &str) -> Result<Schema, OxenError> {
     let sql = format!(
         "SELECT column_name, data_type FROM information_schema.columns WHERE table_name == '{table_name}'"
     );
@@ -229,7 +214,7 @@ pub fn get_schema(
         let (column_name, data_type) = row?;
         fields.push(Field::new(
             &column_name,
-            &model::data_frame::schema::DataType::from_sql(data_type).as_str(),
+            &model::data_frame::schema::DataType::from_sql(&data_type).as_str(),
         ));
     }
 
@@ -239,10 +224,9 @@ pub fn get_schema(
 // Get the schema from the table excluding specified columns - useful for virtual cols like .oxen.diff.status
 pub fn get_schema_excluding_cols(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     cols: &[&str],
 ) -> Result<Schema, OxenError> {
-    let table_name = table_name.as_ref();
     let sql = format!(
         "SELECT column_name, data_type FROM information_schema.columns WHERE table_name == '{}' AND column_name NOT IN ({})",
         table_name,
@@ -265,7 +249,7 @@ pub fn get_schema_excluding_cols(
         let (column_name, data_type) = row?;
         fields.push(Field::new(
             &column_name,
-            &model::data_frame::schema::DataType::from_sql(data_type).as_str(),
+            &model::data_frame::schema::DataType::from_sql(&data_type).as_str(),
         ));
     }
 
@@ -273,8 +257,7 @@ pub fn get_schema_excluding_cols(
 }
 
 /// Query number of rows in a table.
-pub fn count(conn: &duckdb::Connection, table_name: impl AsRef<str>) -> Result<usize, OxenError> {
-    let table_name = table_name.as_ref();
+pub fn count(conn: &duckdb::Connection, table_name: &str) -> Result<usize, OxenError> {
     let sql = format!("SELECT count(*) FROM {table_name}");
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query([])?;
@@ -282,7 +265,7 @@ pub fn count(conn: &duckdb::Connection, table_name: impl AsRef<str>) -> Result<u
         let size: usize = row.get(0)?;
         Ok(size)
     } else {
-        Err(OxenError::basic_str(format!(
+        Err(OxenError::basic_str(&format!(
             "No rows in table {table_name}"
         )))
     }
@@ -291,11 +274,9 @@ pub fn count(conn: &duckdb::Connection, table_name: impl AsRef<str>) -> Result<u
 /// Query number of rows in a table.
 pub fn count_where(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-    where_clause: impl AsRef<str>,
+    table_name: &str,
+    where_clause: &str,
 ) -> Result<usize, OxenError> {
-    let table_name = table_name.as_ref();
-    let where_clause = where_clause.as_ref();
     let sql = format!("SELECT count(*) FROM {table_name} WHERE {where_clause}");
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query([])?;
@@ -303,7 +284,7 @@ pub fn count_where(
         let size: usize = row.get(0)?;
         Ok(size)
     } else {
-        Err(OxenError::basic_str(format!(
+        Err(OxenError::basic_str(&format!(
             "No rows in table {table_name}"
         )))
     }
@@ -320,18 +301,16 @@ pub fn select(
     opts: Option<&DFOpts>,
 ) -> Result<DataFrame, OxenError> {
     let sql = stmt.as_string();
-    let df = select_str(conn, sql, opts)?;
+    let df = select_str(conn, &sql, opts)?;
     Ok(df)
 }
 
 pub fn export(
     conn: &duckdb::Connection,
-    sql: impl AsRef<str>,
+    sql: &str,
     _opts: Option<&DFOpts>,
-    tmp_path: impl AsRef<Path>,
+    tmp_path: &Path,
 ) -> Result<(), OxenError> {
-    let tmp_path = tmp_path.as_ref();
-    let sql = sql.as_ref();
     // let sql = prepare_sql(sql, opts)?;
     // Get the file extension from the tmp_path
     if !is_valid_export_extension(tmp_path) {
@@ -347,10 +326,10 @@ pub fn export(
 
 pub fn prepare_sql(
     conn: &duckdb::Connection,
-    stmt: impl AsRef<str>,
+    stmt: &str,
     opts: Option<&DFOpts>,
 ) -> Result<String, OxenError> {
-    let mut sql = stmt.as_ref().to_string();
+    let mut sql = stmt.to_string();
     let empty_opts = DFOpts::empty();
     let opts = opts.unwrap_or(&empty_opts);
 
@@ -464,10 +443,9 @@ fn add_special_columns(conn: &duckdb::Connection, sql: &str) -> Result<String, O
 
 pub fn select_str(
     conn: &duckdb::Connection,
-    sql: impl AsRef<str>,
+    sql: &str,
     opts: Option<&DFOpts>,
 ) -> Result<DataFrame, OxenError> {
-    let sql = sql.as_ref();
     let sql = prepare_sql(conn, sql, opts)?;
     let df = select_raw(conn, &sql)?;
     log::debug!("select_str() got raw df {df:?}");
@@ -490,7 +468,7 @@ pub fn select_raw(conn: &duckdb::Connection, stmt: &str) -> Result<DataFrame, Ox
 
 pub fn modify_row_with_polars_df(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     id: &str,
     df: &DataFrame,
 ) -> Result<DataFrame, OxenError> {
@@ -499,8 +477,6 @@ pub fn modify_row_with_polars_df(
             "df must have exactly one row to be used for modification",
         ));
     }
-
-    let table_name = table_name.as_ref();
 
     let schema = df.schema();
     let column_names: Vec<String> = schema
@@ -540,10 +516,9 @@ pub fn modify_row_with_polars_df(
 
 pub fn modify_rows_with_polars_df(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     row_map: &HashMap<String, DataFrame>,
 ) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
     let mut all_result_batches = Vec::new();
 
     let mut set_clauses = Vec::new();
@@ -757,11 +732,7 @@ pub fn from_clause_from_disk_path(path: &Path) -> Result<String, OxenError> {
     }
 }
 
-pub fn preview(
-    conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
+pub fn preview(conn: &duckdb::Connection, table_name: &str) -> Result<DataFrame, OxenError> {
     let query = format!("SELECT * FROM {table_name} LIMIT 10");
     let df = select_raw(conn, &query)?;
     Ok(df)
@@ -796,7 +767,7 @@ mod tests {
     fn test_df_db_create() -> Result<(), OxenError> {
         test::run_empty_dir_test(|data_dir| {
             let db_file = data_dir.join("data.db");
-            let conn = get_connection(db_file)?;
+            let conn = get_connection(&db_file)?;
             // bounding_box -> min_x, min_y, width, height
             let schema = test::schema_bounding_box();
             let table_name = "bounding_box";
@@ -846,7 +817,7 @@ mod tests {
     fn test_df_db_get_schema() -> Result<(), OxenError> {
         test::run_empty_dir_test(|data_dir| {
             let db_file = data_dir.join("data.db");
-            let conn = get_connection(db_file)?;
+            let conn = get_connection(&db_file)?;
             // bounding_box -> min_x, min_y, width, height
             let schema = test::schema_bounding_box();
             let table_name = "bounding_box";

--- a/crates/lib/src/core/db/data_frames/df_db.rs
+++ b/crates/lib/src/core/db/data_frames/df_db.rs
@@ -96,13 +96,13 @@ where
             {
                 std::fs::create_dir_all(parent).map_err(|e| {
                     log::error!("Failed to create df db directory: {e}");
-                    OxenError::basic_str(&format!("Failed to create df db directory: {e}"))
+                    OxenError::basic_str(format!("Failed to create df db directory: {e}"))
                 })?;
             }
 
             let conn = get_connection(&db_path).map_err(|e| {
                 log::error!("Failed to open df db: {e}");
-                OxenError::basic_str(&format!("Failed to open df db: {e}"))
+                OxenError::basic_str(format!("Failed to open df db: {e}"))
             })?;
 
             // Wrap the Connection in a Mutex and store it in the cache
@@ -265,7 +265,7 @@ pub fn count(conn: &duckdb::Connection, table_name: &str) -> Result<usize, OxenE
         let size: usize = row.get(0)?;
         Ok(size)
     } else {
-        Err(OxenError::basic_str(&format!(
+        Err(OxenError::basic_str(format!(
             "No rows in table {table_name}"
         )))
     }
@@ -284,7 +284,7 @@ pub fn count_where(
         let size: usize = row.get(0)?;
         Ok(size)
     } else {
-        Err(OxenError::basic_str(&format!(
+        Err(OxenError::basic_str(format!(
             "No rows in table {table_name}"
         )))
     }
@@ -315,7 +315,7 @@ pub fn export(
     // Get the file extension from the tmp_path
     if !is_valid_export_extension(tmp_path) {
         return Err(OxenError::basic_str(
-            "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
+            "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson".to_string(),
         ));
     }
     let export_sql = wrap_sql_for_export(sql, tmp_path);
@@ -474,7 +474,7 @@ pub fn modify_row_with_polars_df(
 ) -> Result<DataFrame, OxenError> {
     if df.height() != 1 {
         return Err(OxenError::basic_str(
-            "df must have exactly one row to be used for modification",
+            "df must have exactly one row to be used for modification".to_string(),
         ));
     }
 
@@ -612,7 +612,8 @@ pub fn index_file(path: &Path, conn: &duckdb::Connection) -> Result<(), OxenErro
         }
         _ => {
             return Err(OxenError::basic_str(
-                "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
+                "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson"
+                    .to_string(),
             ));
         }
     }
@@ -688,7 +689,8 @@ pub fn index_file_with_id(
         }
         _ => {
             return Err(OxenError::basic_str(
-                "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
+                "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson"
+                    .to_string(),
             ));
         }
     }
@@ -727,7 +729,7 @@ pub fn from_clause_from_disk_path(path: &Path) -> Result<String, OxenError> {
             Ok(format!("read_json('{str_path}')"))
         }
         _ => Err(OxenError::basic_str(
-            "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
+            "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson".to_string(),
         )),
     }
 }

--- a/crates/lib/src/core/db/data_frames/rows.rs
+++ b/crates/lib/src/core/db/data_frames/rows.rs
@@ -69,7 +69,9 @@ pub fn modify_row(
     uuid: &str,
 ) -> Result<DataFrame, OxenError> {
     if df.height() != 1 {
-        return Err(OxenError::basic_str("Modify row requires exactly one row"));
+        return Err(OxenError::basic_str(
+            "Modify row requires exactly one row".to_string(),
+        ));
     }
 
     let table_schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
@@ -125,7 +127,7 @@ pub fn modify_row(
     ))?;
     let result = df_db::modify_row_with_polars_df(conn, TABLE_NAME, uuid, &new_row)?;
     if result.height() == 0 {
-        return Err(OxenError::resource_not_found(uuid));
+        return Err(OxenError::resource_not_found(uuid.to_string()));
     }
     Ok(result)
 }
@@ -142,7 +144,7 @@ pub fn modify_rows(
     for (row_id, df) in row_map.iter() {
         if df.height() != 1 {
             return Err(OxenError::basic_str(
-                "df must have exactly one row to be used for modification",
+                "df must have exactly one row to be used for modification".to_string(),
             ));
         }
         let schema = df.schema();
@@ -196,11 +198,11 @@ pub fn modify_rows(
 
     let result = df_db::modify_rows_with_polars_df(conn, TABLE_NAME, &update_map)?;
     if result.height() == 0 {
-        return Err(OxenError::resource_not_found(""));
+        return Err(OxenError::resource_not_found("".to_string()));
     }
 
     if result.height() != update_map.len() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Expected {} rows to be modified, but got {}",
             update_map.len(),
             result.height()
@@ -219,7 +221,7 @@ pub fn delete_row(conn: &duckdb::Connection, uuid: &str) -> Result<DataFrame, Ox
     let row_to_delete = df_db::select(conn, &select_stmt, None)?;
 
     if row_to_delete.height() == 0 {
-        return Err(OxenError::resource_not_found(uuid));
+        return Err(OxenError::resource_not_found(uuid.to_string()));
     }
 
     // If it's newly added, delete it. Otherwise, set it to removed
@@ -228,7 +230,11 @@ pub fn delete_row(conn: &duckdb::Connection, uuid: &str) -> Result<DataFrame, Ox
 
     let status = match status_str {
         Some(status) => status,
-        None => return Err(OxenError::basic_str("Diff status column is not a string")),
+        None => {
+            return Err(OxenError::basic_str(
+                "Diff status column is not a string".to_string(),
+            ));
+        }
     };
     log::debug!("status is: {status}");
 
@@ -267,7 +273,7 @@ fn get_hash_and_status_for_modification(
     let old_status = old_row.column(DIFF_STATUS_COL)?.get(0)?;
     let old_status = old_status
         .get_str()
-        .ok_or_else(|| OxenError::basic_str("Diff status column is not a string"))?;
+        .ok_or_else(|| OxenError::basic_str("Diff status column is not a string".to_string()))?;
 
     let old_hash = old_row.column(DIFF_HASH_COL)?.get(0)?;
 
@@ -275,7 +281,7 @@ fn get_hash_and_status_for_modification(
     let new_hash = new_hash_df.column("_temp_hash")?.get(0)?;
     let new_hash = new_hash
         .get_str()
-        .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string"))?;
+        .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string".to_string()))?;
 
     // We need to calculate the original hash for the row
     // Use a temp hash column to avoid collision with the column that's already there.
@@ -285,12 +291,12 @@ fn get_hash_and_status_for_modification(
         let original_data_hash = original_data_hash.column("_temp_hash")?.get(0)?;
         original_data_hash
             .get_str()
-            .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string"))?
+            .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string".to_string()))?
             .to_owned()
     } else {
         old_hash
             .get_str()
-            .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string"))?
+            .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string".to_string()))?
             .to_owned()
     };
 

--- a/crates/lib/src/core/db/data_frames/rows.rs
+++ b/crates/lib/src/core/db/data_frames/rows.rs
@@ -28,7 +28,8 @@ pub fn append_row(conn: &duckdb::Connection, df: &DataFrame) -> Result<DataFrame
     let df_schema = df.schema();
 
     let df_names: Vec<String> = df_schema.iter_names().map(|s| s.to_string()).collect();
-    if !table_schema.has_field_names(&df_names) {
+    let df_names_str: Vec<&str> = df_names.iter().map(String::as_str).collect();
+    if !table_schema.has_field_names(&df_names_str) {
         return Err(OxenError::incompatible_schemas(table_schema.clone()));
     }
 
@@ -82,7 +83,8 @@ pub fn modify_row(
         .filter(|col| !OXEN_COLS.contains(&col.as_str()))
         .collect();
     let df = df.select(&df_cols)?;
-    if !table_schema.has_field_names(&df_cols) {
+    let df_cols_str: Vec<&str> = df_cols.iter().map(String::as_str).collect();
+    if !table_schema.has_field_names(&df_cols_str) {
         log::error!("modify_row incompatible_schemas {table_schema:?}\n{df_cols:?}");
         return Err(OxenError::incompatible_schemas(table_schema));
     }
@@ -151,7 +153,8 @@ pub fn modify_rows(
             .filter(|col| !OXEN_COLS.contains(&col.as_str()))
             .collect();
         let df = df.select(&df_cols)?;
-        if !table_schema.has_field_names(&df_cols) {
+        let df_cols_str: Vec<&str> = df_cols.iter().map(String::as_str).collect();
+        if !table_schema.has_field_names(&df_cols_str) {
             log::error!("modify_row incompatible_schemas {table_schema:?}\n{df_cols:?}");
             return Err(OxenError::incompatible_schemas(table_schema));
         }
@@ -197,7 +200,7 @@ pub fn modify_rows(
     }
 
     if result.height() != update_map.len() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Expected {} rows to be modified, but got {}",
             update_map.len(),
             result.height()
@@ -317,11 +320,9 @@ fn get_hash_and_status_for_modification(
 /// Insert a row from a polars dataframe into a duckdb table.
 pub fn insert_polars_df(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     df: &DataFrame,
 ) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
-
     let schema = df.schema();
     let column_names: Vec<String> = schema
         .iter_fields()

--- a/crates/lib/src/core/db/data_frames/workspace_df_db.rs
+++ b/crates/lib/src/core/db/data_frames/workspace_df_db.rs
@@ -41,7 +41,7 @@ pub fn full_staged_table_schema(conn: &duckdb::Connection) -> Result<Schema, Oxe
 
 pub fn schema_without_oxen_cols(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
 ) -> Result<Schema, OxenError> {
     let table_schema = df_db::get_schema_excluding_cols(conn, table_name, &OXEN_COLS)?;
     Ok(table_schema)

--- a/crates/lib/src/core/db/dir_hashes/dir_hashes_db.rs
+++ b/crates/lib/src/core/db/dir_hashes/dir_hashes_db.rs
@@ -35,7 +35,7 @@ pub fn dir_hash_db_path_from_commit_id(repo: &LocalRepository, commit_id: &str) 
 /// Used in test cleanup to release file handles before directory deletion.
 pub fn remove_from_cache_with_children(db_path_prefix: &Path) -> Result<(), OxenError> {
     let mut instances = DB_INSTANCES.write().map_err(|e| {
-        OxenError::basic_str(&format!("Could not write LRU for dir hash db cache: {e:?}"))
+        OxenError::basic_str(format!("Could not write LRU for dir hash db cache: {e:?}"))
     })?;
 
     let dbs_to_remove = instances
@@ -67,7 +67,7 @@ where
             let cache_r = match DB_INSTANCES.read() {
                 Ok(cache_r) => cache_r,
                 Err(e) => {
-                    return Err(OxenError::basic_str(&format!(
+                    return Err(OxenError::basic_str(format!(
                         "Could not open LRU for dir hash db cache: {e:?}"
                     )));
                 }
@@ -83,7 +83,7 @@ where
         let mut cache_w = match DB_INSTANCES.write() {
             Ok(cache_w) => cache_w,
             Err(e) => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Could not open LRU for dir hash db cache: {e:?}"
                 )));
             }
@@ -95,7 +95,7 @@ where
             // Cache miss: open a new connection to the db
 
             if !dir_hashes_db_dir.exists() {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Could not find dir_hashes db for commit {commit_id}"
                 )));
             }

--- a/crates/lib/src/core/db/dir_hashes/dir_hashes_db.rs
+++ b/crates/lib/src/core/db/dir_hashes/dir_hashes_db.rs
@@ -24,11 +24,7 @@ pub fn dir_hash_db_path(repo: &LocalRepository, commit: &Commit) -> PathBuf {
     dir_hash_db_path_from_commit_id(repo, commit_id)
 }
 
-pub fn dir_hash_db_path_from_commit_id(
-    repo: &LocalRepository,
-    commit_id: impl AsRef<str>,
-) -> PathBuf {
-    let commit_id = commit_id.as_ref();
+pub fn dir_hash_db_path_from_commit_id(repo: &LocalRepository, commit_id: &str) -> PathBuf {
     util::fs::oxen_hidden_dir(&repo.path)
         .join(Path::new(HISTORY_DIR))
         .join(commit_id)
@@ -37,11 +33,9 @@ pub fn dir_hash_db_path_from_commit_id(
 
 /// Removes all dir_hashes DB instances from cache whose path starts with the given prefix.
 /// Used in test cleanup to release file handles before directory deletion.
-pub fn remove_from_cache_with_children(db_path_prefix: impl AsRef<Path>) -> Result<(), OxenError> {
-    let db_path_prefix = db_path_prefix.as_ref();
-
+pub fn remove_from_cache_with_children(db_path_prefix: &Path) -> Result<(), OxenError> {
     let mut instances = DB_INSTANCES.write().map_err(|e| {
-        OxenError::basic_str(format!("Could not write LRU for dir hash db cache: {e:?}"))
+        OxenError::basic_str(&format!("Could not write LRU for dir hash db cache: {e:?}"))
     })?;
 
     let dbs_to_remove = instances
@@ -73,7 +67,7 @@ where
             let cache_r = match DB_INSTANCES.read() {
                 Ok(cache_r) => cache_r,
                 Err(e) => {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(OxenError::basic_str(&format!(
                         "Could not open LRU for dir hash db cache: {e:?}"
                     )));
                 }
@@ -89,7 +83,7 @@ where
         let mut cache_w = match DB_INSTANCES.write() {
             Ok(cache_w) => cache_w,
             Err(e) => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Could not open LRU for dir hash db cache: {e:?}"
                 )));
             }
@@ -101,7 +95,7 @@ where
             // Cache miss: open a new connection to the db
 
             if !dir_hashes_db_dir.exists() {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Could not find dir_hashes db for commit {commit_id}"
                 )));
             }

--- a/crates/lib/src/core/db/key_val/index_db.rs
+++ b/crates/lib/src/core/db/key_val/index_db.rs
@@ -5,13 +5,11 @@ use std::collections::HashMap;
 use std::mem;
 use std::str;
 
-pub fn insert_indices<S: AsRef<str>>(
+pub fn insert_indices(
     db: &DBWithThreadMode<MultiThreaded>,
-    key: S,
+    key: &str,
     indices: Vec<u32>,
 ) -> Result<(), OxenError> {
-    let key = key.as_ref();
-
     // Could not use the bytevec library here when inserting a larger set of indices
     let byte_indices = u32_to_u8(indices);
 
@@ -19,11 +17,10 @@ pub fn insert_indices<S: AsRef<str>>(
     Ok(())
 }
 
-pub fn get_indices<S: AsRef<str>>(
+pub fn get_indices(
     db: &DBWithThreadMode<MultiThreaded>,
-    key: S,
+    key: &str,
 ) -> Result<Option<Vec<u32>>, OxenError> {
-    let key = key.as_ref();
     let bytes = key.as_bytes();
     match db.get(bytes) {
         Ok(Some(raw_indices)) => {
@@ -39,7 +36,7 @@ pub fn get_indices<S: AsRef<str>>(
         Err(err) => {
             // error from the DB
             let err = format!("Err could not fetch value {key:?} from db: {err:?}",);
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }

--- a/crates/lib/src/core/db/key_val/index_db.rs
+++ b/crates/lib/src/core/db/key_val/index_db.rs
@@ -36,7 +36,7 @@ pub fn get_indices(
         Err(err) => {
             // error from the DB
             let err = format!("Err could not fetch value {key:?} from db: {err:?}",);
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -59,12 +59,14 @@ pub fn list_indices(
                     results.push((key, value));
                 }
                 _ => {
-                    return Err(OxenError::basic_str("Could not read utf8 val..."));
+                    return Err(OxenError::basic_str(
+                        "Could not read utf8 val...".to_string(),
+                    ));
                 }
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -95,7 +97,7 @@ pub fn hash_map_indices(
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }

--- a/crates/lib/src/core/db/key_val/kv_db.rs
+++ b/crates/lib/src/core/db/key_val/kv_db.rs
@@ -4,8 +4,7 @@ use rocksdb::{DBWithThreadMode, IteratorMode, ThreadMode};
 use std::str;
 
 /// More efficient than get since it does not actual deserialize the value
-pub fn has_key<T: ThreadMode, S: AsRef<str>>(db: &DBWithThreadMode<T>, key: S) -> bool {
-    let key = key.as_ref();
+pub fn has_key<T: ThreadMode>(db: &DBWithThreadMode<T>, key: &str) -> bool {
     let bytes = key.as_bytes();
     match db.get_pinned(bytes) {
         Ok(Some(_value)) => true,
@@ -24,11 +23,7 @@ pub fn count<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<usize, OxenError
 }
 
 /// Remove key from database
-pub fn delete<T: ThreadMode, S: AsRef<str>>(
-    db: &DBWithThreadMode<T>,
-    key: S,
-) -> Result<(), OxenError> {
-    let key = key.as_ref();
+pub fn delete<T: ThreadMode>(db: &DBWithThreadMode<T>, key: &str) -> Result<(), OxenError> {
     log::debug!("kv_db::delete {:?} from db: {:?}", key, db.path());
 
     db.delete(key)?;

--- a/crates/lib/src/core/db/key_val/kv_db.rs
+++ b/crates/lib/src/core/db/key_val/kv_db.rs
@@ -49,7 +49,7 @@ pub fn list_keys<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<Vec<String>,
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -67,7 +67,7 @@ pub fn clear<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<(), OxenError> {
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }

--- a/crates/lib/src/core/db/key_val/path_db.rs
+++ b/crates/lib/src/core/db/key_val/path_db.rs
@@ -87,7 +87,7 @@ pub fn count<T: ThreadMode>(
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -121,7 +121,7 @@ pub fn list_paths<T: ThreadMode>(
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -168,7 +168,7 @@ where
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -211,7 +211,7 @@ where
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -254,7 +254,7 @@ where
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -307,7 +307,7 @@ where
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }

--- a/crates/lib/src/core/db/key_val/path_db.rs
+++ b/crates/lib/src/core/db/key_val/path_db.rs
@@ -13,66 +13,58 @@ use crate::core::db::key_val::str_json_db;
 
 /// # Checks if the file exists in this directory
 /// More efficient than get_entry since it does not actual deserialize the entry
-pub fn has_entry<T: ThreadMode, P: AsRef<Path>>(db: &DBWithThreadMode<T>, path: P) -> bool {
-    let path = path.as_ref();
-
+pub fn has_entry<T: ThreadMode>(db: &DBWithThreadMode<T>, path: &Path) -> bool {
     // strip trailing / if exists for looking up directories
     let path_str = path.to_str().map(|s| s.trim_end_matches('/'));
     if let Some(key) = path_str {
         // Check if the path_str has windows \\ in it, all databases use / so we are consistent across OS's
         let key = key.replace('\\', "/");
-        return str_json_db::has_key(db, key);
+        return str_json_db::has_key(db, &key);
     }
 
     false
 }
 
 /// # Get the staged entry object from the file path
-pub fn get_entry<T: ThreadMode, P: AsRef<Path>, D>(
+pub fn get_entry<T: ThreadMode, D>(
     db: &DBWithThreadMode<T>,
-    path: P,
+    path: &Path,
 ) -> Result<Option<D>, OxenError>
 where
     D: de::DeserializeOwned,
 {
-    let path = path.as_ref();
     if let Some(key) = path.to_str() {
         // de-windows-ify the path
         let key = key.replace('\\', "/");
-        return str_json_db::get(db, key);
+        return str_json_db::get(db, &key);
     }
     Err(OxenError::could_not_convert_path_to_str(path))
 }
 
 /// # Serializes the entry to json and writes to db
-pub fn put<T: ThreadMode, P: AsRef<Path>, S>(
+pub fn put<T: ThreadMode, S>(
     db: &DBWithThreadMode<T>,
-    path: P,
+    path: &Path,
     entry: &S,
 ) -> Result<(), OxenError>
 where
     S: Serialize,
 {
-    let path = path.as_ref();
     if let Some(key) = path.to_str() {
         // de-windows-ify the path
         let key = key.replace('\\', "/");
-        str_json_db::put(db, key, entry)
+        str_json_db::put(db, &key, entry)
     } else {
         Err(OxenError::could_not_convert_path_to_str(path))
     }
 }
 
 /// # Removes path entry from database
-pub fn delete<T: ThreadMode, P: AsRef<Path>>(
-    db: &DBWithThreadMode<T>,
-    path: P,
-) -> Result<(), OxenError> {
-    let path = path.as_ref();
+pub fn delete<T: ThreadMode>(db: &DBWithThreadMode<T>, path: &Path) -> Result<(), OxenError> {
     if let Some(key) = path.to_str() {
         // de-windows-ify the path
         let key = key.replace('\\', "/");
-        str_json_db::delete(db, key)
+        str_json_db::delete(db, &key)
     } else {
         Err(OxenError::could_not_convert_path_to_str(path))
     }

--- a/crates/lib/src/core/db/key_val/str_json_db.rs
+++ b/crates/lib/src/core/db/key_val/str_json_db.rs
@@ -55,7 +55,7 @@ where
                 err,
                 db.path()
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -107,7 +107,7 @@ where
             Err(err) => {
                 log::error!("error iterating over db values is: {err}");
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -151,7 +151,7 @@ where
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -189,7 +189,7 @@ where
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }

--- a/crates/lib/src/core/db/key_val/str_json_db.rs
+++ b/crates/lib/src/core/db/key_val/str_json_db.rs
@@ -6,7 +6,7 @@ use rocksdb::{DBWithThreadMode, IteratorMode, ThreadMode};
 use std::{collections::HashMap, str};
 
 /// More efficient than get since it does not actual deserialize the entry
-pub fn has_key<T: ThreadMode, S: AsRef<str>>(db: &DBWithThreadMode<T>, key: S) -> bool {
+pub fn has_key<T: ThreadMode>(db: &DBWithThreadMode<T>, key: &str) -> bool {
     kv_db::has_key(db, key)
 }
 
@@ -16,10 +16,7 @@ pub fn clear<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<(), OxenError> {
 }
 
 /// # Removes key from database
-pub fn delete<T: ThreadMode, S: AsRef<str>>(
-    db: &DBWithThreadMode<T>,
-    key: S,
-) -> Result<(), OxenError> {
+pub fn delete<T: ThreadMode>(db: &DBWithThreadMode<T>, key: &str) -> Result<(), OxenError> {
     kv_db::delete(db, key)
 }
 
@@ -29,14 +26,10 @@ pub fn list_keys<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<Vec<String>,
 }
 
 /// # Get the value from the key
-pub fn get<T: ThreadMode, S: AsRef<str>, D>(
-    db: &DBWithThreadMode<T>,
-    key: S,
-) -> Result<Option<D>, OxenError>
+pub fn get<T: ThreadMode, D>(db: &DBWithThreadMode<T>, key: &str) -> Result<Option<D>, OxenError>
 where
     D: de::DeserializeOwned,
 {
-    let key = key.as_ref();
     // log::debug!("str_json_db::get({:?}) from db {:?}", key, db.path());
 
     let bytes = key.as_bytes();
@@ -62,21 +55,20 @@ where
                 err,
                 db.path()
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
 
 /// # Serializes the entry to json and writes to db
-pub fn put<T: ThreadMode, S: AsRef<str>, D>(
+pub fn put<T: ThreadMode, D>(
     db: &DBWithThreadMode<T>,
-    key: S,
+    key: &str,
     entry: &D,
 ) -> Result<(), OxenError>
 where
     D: Serialize,
 {
-    let key = key.as_ref();
     let json_val = serde_json::to_string(entry)?;
 
     // log::debug!(

--- a/crates/lib/src/core/db/key_val/str_val_db.rs
+++ b/crates/lib/src/core/db/key_val/str_val_db.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::str;
 
 /// More efficient than get since it does not actual deserialize the entry
-pub fn has_key<T: ThreadMode, S: AsRef<str>>(db: &DBWithThreadMode<T>, key: S) -> bool {
+pub fn has_key<T: ThreadMode>(db: &DBWithThreadMode<T>, key: &str) -> bool {
     kv_db::has_key(db, key)
 }
 
@@ -16,10 +16,7 @@ pub fn clear<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<(), OxenError> {
 }
 
 /// # Removes key from database
-pub fn delete<T: ThreadMode, S: AsRef<str>>(
-    db: &DBWithThreadMode<T>,
-    key: S,
-) -> Result<(), OxenError> {
+pub fn delete<T: ThreadMode>(db: &DBWithThreadMode<T>, key: &str) -> Result<(), OxenError> {
     kv_db::delete(db, key)
 }
 
@@ -29,14 +26,10 @@ pub fn list_keys<T: ThreadMode>(db: &DBWithThreadMode<T>) -> Result<Vec<String>,
 }
 
 /// # Get the value from the key
-pub fn get<T: ThreadMode, S: AsRef<str>, D>(
-    db: &DBWithThreadMode<T>,
-    key: S,
-) -> Result<Option<D>, OxenError>
+pub fn get<T: ThreadMode, D>(db: &DBWithThreadMode<T>, key: &str) -> Result<Option<D>, OxenError>
 where
     D: bytevec::ByteDecodable,
 {
-    let key = key.as_ref();
     log::trace!("str_val_db::get({:?}) from db {:?}", key, db.path());
 
     let key_bytes = key.as_bytes();
@@ -61,22 +54,20 @@ where
                 err,
                 db.path()
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
 
 /// # Serializes the entry to json and writes to db
-pub fn put<T: ThreadMode, S: AsRef<str>, D>(
+pub fn put<T: ThreadMode, D>(
     db: &DBWithThreadMode<T>,
-    key: S,
+    key: &str,
     entry: &D,
 ) -> Result<(), OxenError>
 where
     D: bytevec::ByteEncodable + std::fmt::Debug,
 {
-    let key = key.as_ref();
-
     log::trace!(
         "str_val_db::put {:?} -> {:?} db: {:?}",
         key,

--- a/crates/lib/src/core/db/key_val/str_val_db.rs
+++ b/crates/lib/src/core/db/key_val/str_val_db.rs
@@ -54,7 +54,7 @@ where
                 err,
                 db.path()
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -82,7 +82,9 @@ where
         }
         Err(err) => {
             log::error!("Err: Could not encode value {err}");
-            Err(OxenError::basic_str("Could not encode value..."))
+            Err(OxenError::basic_str(
+                "Could not encode value...".to_string(),
+            ))
         }
     }
 }
@@ -107,7 +109,7 @@ where
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -141,7 +143,7 @@ where
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -175,7 +177,7 @@ where
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }

--- a/crates/lib/src/core/db/key_val/u128_kv_db.rs
+++ b/crates/lib/src/core/db/key_val/u128_kv_db.rs
@@ -27,7 +27,7 @@ where
             if let Ok(entry) = D::decode::<u8>(&value) {
                 Ok(Some(entry))
             } else {
-                Err(OxenError::basic_str(&format!(
+                Err(OxenError::basic_str(format!(
                     "Could not decode value {value:?}"
                 )))
             }
@@ -43,7 +43,7 @@ where
                 err,
                 db.path()
             );
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -66,7 +66,9 @@ where
         }
         Err(err) => {
             log::error!("Err: Could not encode value {err}");
-            Err(OxenError::basic_str("Could not encode value..."))
+            Err(OxenError::basic_str(
+                "Could not encode value...".to_string(),
+            ))
         }
     }
 }

--- a/crates/lib/src/core/db/key_val/u128_kv_db.rs
+++ b/crates/lib/src/core/db/key_val/u128_kv_db.rs
@@ -27,7 +27,7 @@ where
             if let Ok(entry) = D::decode::<u8>(&value) {
                 Ok(Some(entry))
             } else {
-                Err(OxenError::basic_str(format!(
+                Err(OxenError::basic_str(&format!(
                     "Could not decode value {value:?}"
                 )))
             }
@@ -43,7 +43,7 @@ where
                 err,
                 db.path()
             );
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }

--- a/crates/lib/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/lib/src/core/db/merkle_node/merkle_node_db.rs
@@ -251,7 +251,7 @@ impl MerkleNodeDB {
 
     pub fn open_read_only(repo: &LocalRepository, hash: &MerkleHash) -> Result<Self, OxenError> {
         let path = node_db_path(repo, hash);
-        Self::open(path, true)
+        Self::open(&path, true)
     }
 
     pub fn open_read_write_if_not_exists(
@@ -281,14 +281,12 @@ impl MerkleNodeDB {
             util::fs::create_dir_all(&path)?;
         }
         log::debug!("open_read_write merkle node db at {}", path.display());
-        let mut db = Self::open(path, false)?;
+        let mut db = Self::open(&path, false)?;
         db.write_node(node, parent_id)?;
         Ok(db)
     }
 
-    pub fn open(path: impl AsRef<Path>, read_only: bool) -> Result<Self, OxenError> {
-        let path = path.as_ref();
-
+    pub fn open(path: &Path, read_only: bool) -> Result<Self, OxenError> {
         // mkdir if not exists
         if !path.exists() {
             util::fs::create_dir_all(path)?;
@@ -307,8 +305,8 @@ impl MerkleNodeDB {
             Option<File>,
             Option<File>,
         ) = if read_only {
-            let mut node_file = util::fs::open_file(node_path)?;
-            let children_file = util::fs::open_file(children_path)?;
+            let mut node_file = util::fs::open_file(&node_path)?;
+            let children_file = util::fs::open_file(&children_path)?;
             // log::debug!("Opened merkle node db read_only at {}", path.display());
             (
                 Some(MerkleNodeLookup::load(&mut node_file)?),
@@ -479,7 +477,7 @@ impl MerkleNodeDB {
         children_file.read_exact(&mut data)?;
 
         let val: D = rmp_serde::from_slice(&data).map_err(|e| {
-            OxenError::basic_str(format!(
+            OxenError::basic_str(&format!(
                 "MerkleNodeDB.get({}): Error deserializing data: {:?}",
                 hash, e
             ))

--- a/crates/lib/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/lib/src/core/db/merkle_node/merkle_node_db.rs
@@ -345,14 +345,18 @@ impl MerkleNodeDB {
             node_file.flush()?;
             node_file.sync_data()?;
         } else {
-            return Err(OxenError::basic_str("Must call open before closing"));
+            return Err(OxenError::basic_str(
+                "Must call open before closing".to_string(),
+            ));
         }
 
         if let Some(children_file) = &mut self.children_file {
             children_file.flush()?;
             children_file.sync_data()?;
         } else {
-            return Err(OxenError::basic_str("Must call open before closing"));
+            return Err(OxenError::basic_str(
+                "Must call open before closing".to_string(),
+            ));
         }
 
         self.node_file = None;
@@ -368,15 +372,21 @@ impl MerkleNodeDB {
         parent_id: Option<MerkleHash>,
     ) -> Result<(), OxenError> {
         if self.read_only {
-            return Err(OxenError::basic_str("Cannot write to read-only db"));
+            return Err(OxenError::basic_str(
+                "Cannot write to read-only db".to_string(),
+            ));
         }
 
         if self.data_offset > 0 {
-            return Err(OxenError::basic_str("Cannot write size after writing data"));
+            return Err(OxenError::basic_str(
+                "Cannot write size after writing data".to_string(),
+            ));
         }
 
         let Some(node_file) = self.node_file.as_mut() else {
-            return Err(OxenError::basic_str("Must call open before writing"));
+            return Err(OxenError::basic_str(
+                "Must call open before writing".to_string(),
+            ));
         };
         // log::debug!("write_node node: {}", node);
 
@@ -413,14 +423,20 @@ impl MerkleNodeDB {
 
     pub fn add_child<N: TMerkleTreeNode>(&mut self, item: &N) -> Result<(), OxenError> {
         if self.read_only {
-            return Err(OxenError::basic_str("Cannot write to read-only db"));
+            return Err(OxenError::basic_str(
+                "Cannot write to read-only db".to_string(),
+            ));
         }
 
         let Some(node_file) = self.node_file.as_mut() else {
-            return Err(OxenError::basic_str("Must call open() before writing"));
+            return Err(OxenError::basic_str(
+                "Must call open() before writing".to_string(),
+            ));
         };
         let Some(children_file) = self.children_file.as_mut() else {
-            return Err(OxenError::basic_str("Must call open() before writing"));
+            return Err(OxenError::basic_str(
+                "Must call open() before writing".to_string(),
+            ));
         };
 
         // TODO: Abstract and re-use in write_all
@@ -477,7 +493,7 @@ impl MerkleNodeDB {
         children_file.read_exact(&mut data)?;
 
         let val: D = rmp_serde::from_slice(&data).map_err(|e| {
-            OxenError::basic_str(&format!(
+            OxenError::basic_str(format!(
                 "MerkleNodeDB.get({}): Error deserializing data: {:?}",
                 hash, e
             ))
@@ -489,10 +505,14 @@ impl MerkleNodeDB {
     pub fn map(&mut self) -> Result<Vec<(MerkleHash, MerkleTreeNode)>, OxenError> {
         // log::debug!("Loading merkle node db map");
         let Some(lookup) = self.lookup.as_ref() else {
-            return Err(OxenError::basic_str("Must call open before reading"));
+            return Err(OxenError::basic_str(
+                "Must call open before reading".to_string(),
+            ));
         };
         let Some(children_file) = self.children_file.as_mut() else {
-            return Err(OxenError::basic_str("Must call open before writing"));
+            return Err(OxenError::basic_str(
+                "Must call open before writing".to_string(),
+            ));
         };
 
         // Parse the node parent id

--- a/crates/lib/src/core/df/filter.rs
+++ b/crates/lib/src/core/df/filter.rs
@@ -97,7 +97,7 @@ fn find_next_logical_op(
 pub fn parse(query: Option<String>) -> Result<Option<DFFilterExp>, OxenError> {
     if let Some(mut filter) = query {
         if filter.is_empty() {
-            return Err(OxenError::parse_error(filter));
+            return Err(OxenError::parse_error(&filter));
         }
 
         // 1) Iterate over string finding DFLogicalOps and collecting the sub expressions

--- a/crates/lib/src/core/df/pretty_print.rs
+++ b/crates/lib/src/core/df/pretty_print.rs
@@ -30,7 +30,7 @@ use std::fmt::Write;
 fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
     match writeln!(output, "{text}") {
         Ok(_) => Ok(()),
-        Err(_) => Err(OxenError::basic_str("Could not write to pager")),
+        Err(_) => Err(OxenError::basic_str("Could not write to pager".to_string())),
     }
 }
 

--- a/crates/lib/src/core/df/sql.rs
+++ b/crates/lib/src/core/df/sql.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::core::df::tabular;
 use crate::core::v_latest::workspaces;
@@ -15,7 +15,7 @@ use uuid::Uuid;
 pub async fn query_df_from_repo(
     sql: String,
     repo: &LocalRepository,
-    path: &PathBuf,
+    path: &Path,
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
     let commit = repositories::commits::head_commit(repo)?;
@@ -24,7 +24,7 @@ pub async fn query_df_from_repo(
     {
         // If not, proceed to create a new workspace and index the data frame.
         let workspace_id = Uuid::new_v4().to_string();
-        let workspace = repositories::workspaces::create(repo, &commit, workspace_id, false)?;
+        let workspace = repositories::workspaces::create(repo, &commit, &workspace_id, false)?;
         repositories::workspaces::data_frames::index(repo, &workspace, path).await?;
     }
 
@@ -32,7 +32,7 @@ pub async fn query_df_from_repo(
         workspaces::data_frames::get_queryable_data_frame_workspace(repo, path, &commit)?;
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-    let df = with_df_db_manager(db_path, |manager| {
+    let df = with_df_db_manager(&db_path, |manager| {
         manager.with_conn_mut(|conn| query_df(conn, sql, Some(opts)))
     })?;
 
@@ -46,7 +46,7 @@ pub fn query_df(
     sql: String,
     opts: Option<&DFOpts>,
 ) -> Result<DataFrame, OxenError> {
-    let df = df_db::select_str(conn, sql, opts)?;
+    let df = df_db::select_str(conn, &sql, opts)?;
 
     Ok(df)
 }
@@ -55,7 +55,7 @@ pub fn export_df(
     conn: &duckdb::Connection,
     sql: String,
     opts: Option<&DFOpts>,
-    tmp_path: impl AsRef<Path>,
+    tmp_path: &Path,
 ) -> Result<(), OxenError> {
-    df_db::export(conn, sql, opts, tmp_path)
+    df_db::export(conn, &sql, opts, tmp_path)
 }

--- a/crates/lib/src/core/df/tabular.rs
+++ b/crates/lib/src/core/df/tabular.rs
@@ -34,12 +34,7 @@ use super::filter::{DFFilterExp, DFFilterOp, DFFilterVal};
 
 const READ_ERROR: &str = "Could not read tabular data from path";
 
-fn base_lazy_csv_reader(
-    path: impl AsRef<Path>,
-    delimiter: u8,
-    quote_char: Option<u8>,
-) -> LazyCsvReader {
-    let path = path.as_ref();
+fn base_lazy_csv_reader(path: &Path, delimiter: u8, quote_char: Option<u8>) -> LazyCsvReader {
     let reader = LazyCsvReader::new(path);
     reader
         .with_infer_schema_length(Some(10000))
@@ -57,46 +52,40 @@ pub fn new_df() -> DataFrame {
     DataFrame::empty()
 }
 
-fn read_df_csv(
-    path: impl AsRef<Path>,
-    delimiter: u8,
-    quote_char: Option<u8>,
-) -> Result<LazyFrame, OxenError> {
-    let reader = base_lazy_csv_reader(path.as_ref(), delimiter, quote_char);
+fn read_df_csv(path: &Path, delimiter: u8, quote_char: Option<u8>) -> Result<LazyFrame, OxenError> {
+    let reader = base_lazy_csv_reader(path, delimiter, quote_char);
     reader
         .finish()
-        .map_err(|_| OxenError::basic_str(format!("{}: {:?}", READ_ERROR, path.as_ref())))
+        .map_err(|_| OxenError::basic_str(&format!("{}: {:?}", READ_ERROR, path)))
 }
 
-fn read_df_jsonl(path: impl AsRef<Path>) -> Result<LazyFrame, OxenError> {
+fn read_df_jsonl(path: &Path) -> Result<LazyFrame, OxenError> {
     let path = path
-        .as_ref()
         .to_str()
         .ok_or(OxenError::basic_str("Could not convert path to string"))?;
     LazyJsonLineReader::new(path)
         .with_infer_schema_length(Some(NonZeroUsize::new(10000).unwrap()))
         .finish()
-        .map_err(|_| OxenError::basic_str(format!("{READ_ERROR}: {path:?}")))
+        .map_err(|_| OxenError::basic_str(&format!("{READ_ERROR}: {path:?}")))
 }
 
-fn scan_df_json(path: impl AsRef<Path>) -> Result<LazyFrame, OxenError> {
+fn scan_df_json(path: &Path) -> Result<LazyFrame, OxenError> {
     // cannot lazy read json array
     let df = read_df_json(path)?;
     Ok(df)
 }
 
-pub fn read_df_json(path: impl AsRef<Path>) -> Result<LazyFrame, OxenError> {
-    let path = path.as_ref();
+pub fn read_df_json(path: &Path) -> Result<LazyFrame, OxenError> {
     let error_str = format!("Could not read json data from path {path:?}");
     let file = File::open(path)?;
     let df = JsonReader::new(file)
         .infer_schema_len(Some(NonZeroUsize::new(10000).unwrap()))
         .finish()
-        .map_err(|e| OxenError::basic_str(format!("{error_str}: {e}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{error_str}: {e}")))?;
     Ok(df.lazy())
 }
 
-pub fn read_df_parquet(path: impl AsRef<Path>) -> Result<LazyFrame, OxenError> {
+pub fn read_df_parquet(path: &Path) -> Result<LazyFrame, OxenError> {
     let args = ScanArgsParquet {
         n_rows: None,
         ..Default::default()
@@ -106,58 +95,56 @@ pub fn read_df_parquet(path: impl AsRef<Path>) -> Result<LazyFrame, OxenError> {
     //     path.as_ref(),
     //     args.n_rows
     // )
-    LazyFrame::scan_parquet(&path, args).map_err(|_| {
-        OxenError::basic_str(format!(
+    LazyFrame::scan_parquet(path, args).map_err(|_| {
+        OxenError::basic_str(&format!(
             "Error scanning parquet file {}: {:?}",
-            READ_ERROR,
-            path.as_ref()
+            READ_ERROR, path
         ))
     })
 }
 
-fn read_df_arrow(path: impl AsRef<Path>) -> Result<LazyFrame, OxenError> {
-    LazyFrame::scan_ipc(&path, ScanArgsIpc::default())
-        .map_err(|_| OxenError::basic_str(format!("{}: {:?}", READ_ERROR, path.as_ref())))
+fn read_df_arrow(path: &Path) -> Result<LazyFrame, OxenError> {
+    LazyFrame::scan_ipc(path, ScanArgsIpc::default())
+        .map_err(|_| OxenError::basic_str(&format!("{}: {:?}", READ_ERROR, path)))
 }
 
 pub fn take(df: LazyFrame, indices: Vec<u32>) -> Result<DataFrame, OxenError> {
     let idx = IdxCa::new(PlSmallStr::from_str("idx"), &indices);
     let collected = df
         .collect()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     // log::debug!("take indices {:?}", indices);
     // log::debug!("from df {:?}", collected);
     collected
         .take(&idx)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
 }
 
 pub fn scan_df_csv(
-    path: impl AsRef<Path>,
+    path: &Path,
     delimiter: u8,
     quote_char: Option<u8>,
     total_rows: usize,
 ) -> Result<LazyFrame, OxenError> {
-    let reader = base_lazy_csv_reader(path.as_ref(), delimiter, quote_char);
+    let reader = base_lazy_csv_reader(path, delimiter, quote_char);
     reader
         .with_n_rows(Some(total_rows))
         .finish()
-        .map_err(|_| OxenError::basic_str(format!("{}: {:?}", READ_ERROR, path.as_ref())))
+        .map_err(|_| OxenError::basic_str(&format!("{}: {:?}", READ_ERROR, path)))
 }
 
-pub fn scan_df_jsonl(path: impl AsRef<Path>, total_rows: usize) -> Result<LazyFrame, OxenError> {
+pub fn scan_df_jsonl(path: &Path, total_rows: usize) -> Result<LazyFrame, OxenError> {
     let path = path
-        .as_ref()
         .to_str()
         .ok_or(OxenError::basic_str("Could not convert path to string"))?;
     LazyJsonLineReader::new(path)
         .with_infer_schema_length(Some(NonZeroUsize::new(10000).unwrap()))
         .with_n_rows(Some(total_rows))
         .finish()
-        .map_err(|_| OxenError::basic_str(format!("{READ_ERROR}: {path:?}")))
+        .map_err(|_| OxenError::basic_str(&format!("{READ_ERROR}: {path:?}")))
 }
 
-pub fn scan_df_parquet(path: impl AsRef<Path>, total_rows: usize) -> Result<LazyFrame, OxenError> {
+pub fn scan_df_parquet(path: &Path, total_rows: usize) -> Result<LazyFrame, OxenError> {
     let args = ScanArgsParquet {
         n_rows: Some(total_rows),
         ..Default::default()
@@ -167,23 +154,22 @@ pub fn scan_df_parquet(path: impl AsRef<Path>, total_rows: usize) -> Result<Lazy
     //     path.as_ref(),
     //     args.n_rows
     // );
-    LazyFrame::scan_parquet(&path, args).map_err(|_| {
-        OxenError::basic_str(format!(
+    LazyFrame::scan_parquet(path, args).map_err(|_| {
+        OxenError::basic_str(&format!(
             "Error scanning parquet file {}: {:?}",
-            READ_ERROR,
-            path.as_ref()
+            READ_ERROR, path
         ))
     })
 }
 
-pub fn scan_df_arrow(path: impl AsRef<Path>, total_rows: usize) -> Result<LazyFrame, OxenError> {
+pub fn scan_df_arrow(path: &Path, total_rows: usize) -> Result<LazyFrame, OxenError> {
     let args = ScanArgsIpc {
         n_rows: Some(total_rows),
         ..Default::default()
     };
 
-    LazyFrame::scan_ipc(&path, args)
-        .map_err(|_| OxenError::basic_str(format!("{}: {:?}", READ_ERROR, path.as_ref())))
+    LazyFrame::scan_ipc(path, args)
+        .map_err(|_| OxenError::basic_str(&format!("{}: {:?}", READ_ERROR, path)))
 }
 
 pub async fn add_col_lazy(
@@ -195,12 +181,12 @@ pub async fn add_col_lazy(
 ) -> Result<LazyFrame, OxenError> {
     let mut df = match task::spawn_blocking(move || -> Result<DataFrame, OxenError> {
         df.collect()
-            .map_err(|e| OxenError::basic_str(format!("{e:?}")))
+            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
     })
     .await?
     {
         Ok(df) => df,
-        Err(e) => return Err(OxenError::basic_str(format!("{e:?}"))),
+        Err(e) => return Err(OxenError::basic_str(&format!("{e:?}"))),
     };
 
     let dtype = DataType::from_string(dtype).to_polars();
@@ -208,13 +194,13 @@ pub async fn add_col_lazy(
     let column = Series::new_empty(PlSmallStr::from_str(name), &dtype);
     let column = column
         .extend_constant(val_from_str_and_dtype(val, &dtype), df.height())
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     if let Some(at) = at {
         df.insert_column(at, column)
-            .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     } else {
         df.with_column(column)
-            .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     }
     let df = df.lazy();
     Ok(df)
@@ -231,29 +217,29 @@ pub fn add_col(
     let column = Series::new_empty(PlSmallStr::from_str(name), &dtype);
     let column = column
         .extend_constant(val_from_str_and_dtype(val, &dtype), df.height())
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     df.with_column(column)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     Ok(df)
 }
 
 pub async fn add_row(df: LazyFrame, data: String) -> Result<LazyFrame, OxenError> {
     let df = match task::spawn_blocking(move || -> Result<DataFrame, OxenError> {
         df.collect()
-            .map_err(|e| OxenError::basic_str(format!("{e:?}")))
+            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
     })
     .await?
     {
         Ok(df) => df,
-        Err(e) => return Err(OxenError::basic_str(format!("{e:?}"))),
+        Err(e) => return Err(OxenError::basic_str(&format!("{e:?}"))),
     };
 
-    let new_row = row_from_str_and_schema(data, df.schema())?;
+    let new_row = row_from_str_and_schema(&data, df.schema())?;
     log::debug!("add_row og df: {df:?}");
     log::debug!("add_row new_row: {new_row:?}");
     let df = df
         .vstack(&new_row)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?
         .lazy();
     Ok(df)
 }
@@ -268,18 +254,15 @@ pub fn n_duped_rows(df: &DataFrame, cols: &[&str]) -> Result<u64, OxenError> {
     Ok(n_dupes)
 }
 
-pub fn row_from_str_and_schema(
-    data: impl AsRef<str>,
-    schema: &SchemaRef,
-) -> Result<DataFrame, OxenError> {
-    if serde_json::from_str::<Value>(data.as_ref()).is_ok() {
+pub fn row_from_str_and_schema(data: &str, schema: &SchemaRef) -> Result<DataFrame, OxenError> {
+    if serde_json::from_str::<Value>(data).is_ok() {
         return parse_str_to_df(data);
     }
 
-    let values: Vec<&str> = data.as_ref().split(',').collect();
+    let values: Vec<&str> = data.split(',').collect();
 
     if values.len() != schema.len() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Error: Added row must have same number of columns as df\nRow columns: {}\ndf columns: {}",
             values.len(),
             schema.len()
@@ -295,7 +278,7 @@ pub fn row_from_str_and_schema(
                 vec.push(Column::Series(series.into()));
             }
             Err(err) => {
-                return Err(OxenError::basic_str(format!("Error parsing json: {err}")));
+                return Err(OxenError::basic_str(&format!("Error parsing json: {err}")));
             }
         }
     }
@@ -305,9 +288,7 @@ pub fn row_from_str_and_schema(
     Ok(df)
 }
 
-pub fn parse_str_to_df(data: impl AsRef<str>) -> Result<DataFrame, OxenError> {
-    let data = data.as_ref();
-
+pub fn parse_str_to_df(data: &str) -> Result<DataFrame, OxenError> {
     if data == "{}" {
         return Ok(DataFrame::default());
     }
@@ -318,13 +299,13 @@ pub fn parse_str_to_df(data: impl AsRef<str>) -> Result<DataFrame, OxenError> {
 
     match reader.finish() {
         Ok(df) => Ok(df),
-        Err(err) => Err(OxenError::basic_str(format!("Error parsing json: {err}"))),
+        Err(err) => Err(OxenError::basic_str(&format!("Error parsing json: {err}"))),
     }
 }
 
 pub fn parse_json_to_df(data: &serde_json::Value) -> Result<DataFrame, OxenError> {
     let data = serde_json::to_string(data)?;
-    parse_str_to_df(data)
+    parse_str_to_df(&data)
 }
 
 fn val_from_str_and_dtype<'a>(s: &'a str, dtype: &polars::prelude::DataType) -> AnyValue<'a> {
@@ -448,14 +429,14 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
         for path in vstack.iter() {
             let empty_opts = DFOpts::empty();
             let extension = path.extension().and_then(OsStr::to_str).ok_or_else(|| {
-                OxenError::basic_str(format!("Cannot vstack file without extension: {path:?}"))
+                OxenError::basic_str(&format!("Cannot vstack file without extension: {path:?}"))
             })?;
 
-            let new_df = _read_lazy_df_with_extension(path.clone(), extension, &empty_opts).await?;
+            let new_df = _read_lazy_df_with_extension(path, extension, &empty_opts).await?;
             frames.push(new_df);
         }
         df = concat(frames, Default::default())
-            .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     }
 
     if let Some(col_vals) = opts.add_col_vals() {
@@ -535,7 +516,7 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
 
             if old_name.is_empty() || new_name.is_empty() {
                 log::error!("Invalid rename_col format: old name and new name cannot be empty");
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Invalid rename_col format `{names}`"
                 )));
             }
@@ -543,7 +524,7 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
             df = df.rename([old_name], [new_name], true);
         } else {
             log::error!("Invalid rename_col format: {names}");
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Invalid rename_col format '{names}', expected 'old_name:new_name'"
             )));
         }
@@ -599,7 +580,7 @@ pub fn strip_excluded_cols(df: DataFrame) -> Result<DataFrame, OxenError> {
         .collect::<Vec<String>>();
     let cols = select_cols.iter().map(col).collect::<Vec<Expr>>();
     let result = df.lazy().select(&cols).collect();
-    result.map_err(|e| OxenError::basic_str(format!("{e:?}")))
+    result.map_err(|e| OxenError::basic_str(&format!("{e:?}")))
 }
 
 fn head(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
@@ -625,7 +606,7 @@ pub fn slice_df(df: DataFrame, start: usize, end: usize) -> Result<DataFrame, Ox
     let df = df.lazy();
     let df = slice(df, &opts);
     df.collect()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
 }
 
 pub fn paginate_df(df: DataFrame, page_opts: &PaginateOpts) -> Result<DataFrame, OxenError> {
@@ -638,7 +619,7 @@ pub fn paginate_df(df: DataFrame, page_opts: &PaginateOpts) -> Result<DataFrame,
     let df = df.lazy();
     let df = slice(df, &opts);
     df.collect()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
 }
 
 fn slice(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
@@ -657,7 +638,7 @@ fn slice(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
 
 pub fn df_add_row_num(df: DataFrame) -> Result<DataFrame, OxenError> {
     df.with_row_index(PlSmallStr::from_str(constants::ROW_NUM_COL_NAME), Some(0))
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
 }
 
 pub fn df_add_row_num_starting_at(df: DataFrame, start: u32) -> Result<DataFrame, OxenError> {
@@ -665,7 +646,7 @@ pub fn df_add_row_num_starting_at(df: DataFrame, start: u32) -> Result<DataFrame
         PlSmallStr::from_str(constants::ROW_NUM_COL_NAME),
         Some(start),
     )
-    .map_err(|e| OxenError::basic_str(format!("{e:?}")))
+    .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
 }
 
 pub fn any_val_to_bytes(value: &AnyValue) -> Vec<u8> {
@@ -1048,7 +1029,7 @@ struct CsvDialect {
     quote_char: Option<u8>,
 }
 
-fn sniff_csv_dialect(path: impl AsRef<Path>, opts: &DFOpts) -> Result<CsvDialect, OxenError> {
+fn sniff_csv_dialect(path: &Path, opts: &DFOpts) -> Result<CsvDialect, OxenError> {
     let user_delimiter = match &opts.delimiter {
         Some(delimiter) => {
             if delimiter.len() != 1 {
@@ -1080,7 +1061,7 @@ fn sniff_csv_dialect(path: impl AsRef<Path>, opts: &DFOpts) -> Result<CsvDialect
         });
     }
 
-    match qsv_sniffer::Sniffer::new().sniff_path(&path) {
+    match qsv_sniffer::Sniffer::new().sniff_path(path) {
         Ok(metadata) => {
             log::debug!("Sniffed csv dialect: {:?}", metadata.dialect);
             Ok(CsvDialect {
@@ -1089,7 +1070,7 @@ fn sniff_csv_dialect(path: impl AsRef<Path>, opts: &DFOpts) -> Result<CsvDialect
             })
         }
         Err(err) => {
-            log::warn!("Error sniffing csv {:?} -> {:?}", path.as_ref(), err);
+            log::warn!("Error sniffing csv {:?} -> {:?}", path, err);
             Ok(CsvDialect {
                 delimiter: user_delimiter.unwrap_or(DEFAULT_DELIMITER),
                 quote_char: user_quote.or(Some(DEFAULT_QUOTE_CHAR)),
@@ -1110,9 +1091,8 @@ fn sniffed_quote(metadata: &qsv_sniffer::metadata::Metadata) -> u8 {
     }
 }
 
-pub async fn read_df(path: impl AsRef<Path>, opts: DFOpts) -> Result<DataFrame, OxenError> {
-    log::debug!("Reading df with path: {:?}", path.as_ref());
-    let path = path.as_ref();
+pub async fn read_df(path: &Path, opts: DFOpts) -> Result<DataFrame, OxenError> {
+    log::debug!("Reading df with path: {:?}", path);
     if !path.exists() {
         return Err(OxenError::path_does_not_exist(path));
     }
@@ -1124,28 +1104,28 @@ pub async fn read_df(path: impl AsRef<Path>, opts: DFOpts) -> Result<DataFrame, 
     } else {
         let err =
             format!("Could not load data frame with path: {path:?} and extension: {extension:?}");
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }
 
 pub async fn read_df_with_extension(
-    path: impl AsRef<Path>,
-    extension: impl AsRef<str>,
+    path: &Path,
+    extension: &str,
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
-    let path = path.as_ref().to_path_buf();
-    let extension_str = extension.as_ref();
+    let path = path.to_path_buf();
+    let extension_str = extension;
 
-    p_read_df_with_extension(path, extension_str, opts.clone()).await
+    p_read_df_with_extension(&path, extension_str, opts.clone()).await
 }
 
 async fn _read_lazy_df_with_extension(
-    path: impl AsRef<Path> + Send + 'static,
-    extension: impl AsRef<str>,
+    path: &Path,
+    extension: &str,
     opts: &DFOpts,
 ) -> Result<LazyFrame, OxenError> {
-    let path = path.as_ref().to_path_buf();
-    let extension = extension.as_ref().to_string();
+    let path = path.to_path_buf();
+    let extension = extension.to_string();
     let opts_clone = opts.clone();
 
     task::spawn_blocking(move || {
@@ -1179,20 +1159,20 @@ async fn _read_lazy_df_with_extension(
                 let err = format!(
                     "Could not load data frame with path: {path:?} and extension: {extension}"
                 );
-                Err(OxenError::basic_str(err))
+                Err(OxenError::basic_str(&err))
             }
         }
     })
     .await
-    .map_err(|e| OxenError::basic_str(format!("Task panicked: {e}")))?
+    .map_err(|e| OxenError::basic_str(&format!("Task panicked: {e}")))?
 }
 
 pub async fn p_read_df_with_extension(
-    path: impl AsRef<Path> + Send + 'static,
-    extension: impl AsRef<str>,
+    path: &Path,
+    extension: &str,
     opts: DFOpts,
 ) -> Result<DataFrame, OxenError> {
-    let df_lazy = _read_lazy_df_with_extension(path, extension.as_ref(), &opts).await?;
+    let df_lazy = _read_lazy_df_with_extension(path, extension, &opts).await?;
 
     let result_df_lazy = if opts.has_transform() {
         transform_new(df_lazy, &opts).await?
@@ -1202,17 +1182,16 @@ pub async fn p_read_df_with_extension(
 
     task::spawn_blocking(move || result_df_lazy.collect().map_err(OxenError::from))
         .await
-        .map_err(|e| OxenError::basic_str(format!("Collect task panicked: {e}")))?
+        .map_err(|e| OxenError::basic_str(&format!("Collect task panicked: {e}")))?
 }
 
 pub async fn maybe_read_df_with_extension(
     repo: &LocalRepository,
-    version_path: impl AsRef<Path>,
-    path: impl AsRef<Path>,
+    version_path: &Path,
+    path: &Path,
     commit_id: &str,
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
-    let version_path = version_path.as_ref();
     if !version_path.exists() {
         return Err(OxenError::entry_does_not_exist(path));
     }
@@ -1227,55 +1206,50 @@ pub async fn maybe_read_df_with_extension(
             try_to_read_extension_from_node(repo, version_path, path, &commit, opts).await
         } else {
             let err = format!("Could not find commit: {commit_id}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
 
 async fn try_to_read_extension_from_node(
     repo: &LocalRepository,
-    version_path: impl AsRef<Path>,
-    path: impl AsRef<Path>,
+    version_path: &Path,
+    path: &Path,
     commit: &Commit,
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
-    let node = repositories::tree::get_file_by_path(repo, commit, &path)?;
+    let node = repositories::tree::get_file_by_path(repo, commit, path)?;
     if let Some(file_node) = node {
-        read_df_with_extension(&version_path, file_node.extension(), opts).await
+        read_df_with_extension(version_path, file_node.extension(), opts).await
     } else {
-        let err = format!("Could not find file node {:?}", path.as_ref());
-        Err(OxenError::basic_str(err))
+        let err = format!("Could not find file node {:?}", path);
+        Err(OxenError::basic_str(&err))
     }
 }
 
-pub fn scan_df(
-    path: impl AsRef<Path>,
-    opts: &DFOpts,
-    total_rows: usize,
-) -> Result<LazyFrame, OxenError> {
-    let input_path = path.as_ref();
+pub fn scan_df(path: &Path, opts: &DFOpts, total_rows: usize) -> Result<LazyFrame, OxenError> {
+    let input_path = path;
     log::debug!("Scanning df {input_path:?}");
     let extension = input_path.extension().and_then(OsStr::to_str);
     scan_df_with_extension(input_path, extension, opts, total_rows)
 }
 
 pub fn scan_df_with_extension(
-    path: impl AsRef<Path>,
+    path: &Path,
     extension: Option<&str>,
     opts: &DFOpts,
     total_rows: usize,
 ) -> Result<LazyFrame, OxenError> {
-    let path = path.as_ref();
     p_scan_df_with_extension(path, extension, opts, total_rows)
 }
 
 fn p_scan_df_with_extension(
-    path: impl AsRef<Path>,
+    path: &Path,
     extension: Option<&str>,
     opts: &DFOpts,
     total_rows: usize,
 ) -> Result<LazyFrame, OxenError> {
-    let input_path = path.as_ref();
+    let input_path = path;
     log::debug!("Scanning df {input_path:?} with extension {extension:?}");
     let err = format!("Unknown file type scan_df {input_path:?} {extension:?}");
     match extension {
@@ -1284,48 +1258,47 @@ fn p_scan_df_with_extension(
             "jsonl" => scan_df_jsonl(path, total_rows),
             "json" => scan_df_json(path),
             "csv" | "data" => {
-                let dialect = sniff_csv_dialect(&path, opts)?;
+                let dialect = sniff_csv_dialect(path, opts)?;
                 scan_df_csv(path, dialect.delimiter, dialect.quote_char, total_rows)
             }
             "tsv" => {
-                let dialect = sniff_csv_dialect(&path, opts)?;
+                let dialect = sniff_csv_dialect(path, opts)?;
                 scan_df_csv(path, b'\t', dialect.quote_char, total_rows)
             }
             "parquet" => scan_df_parquet(path, total_rows),
             "arrow" => scan_df_arrow(path, total_rows),
-            _ => Err(OxenError::basic_str(err)),
+            _ => Err(OxenError::basic_str(&err)),
         },
-        None => Err(OxenError::basic_str(err)),
+        None => Err(OxenError::basic_str(&err)),
     }
 }
 
-pub fn get_size(path: impl AsRef<Path>) -> Result<DataFrameSize, OxenError> {
-    let input_path = path.as_ref();
+pub fn get_size(path: &Path) -> Result<DataFrameSize, OxenError> {
+    let input_path = path;
     let extension = input_path.extension().and_then(OsStr::to_str);
     get_size_with_extension(input_path, extension)
 }
 
 pub fn get_size_with_extension(
-    path: impl AsRef<Path>,
+    path: &Path,
     extension: Option<&str>,
 ) -> Result<DataFrameSize, OxenError> {
-    let path = path.as_ref();
     p_get_size_with_extension(path, extension)
 }
 
 fn p_get_size_with_extension(
-    path: impl AsRef<Path>,
+    path: &Path,
     extension: Option<&str>,
 ) -> Result<DataFrameSize, OxenError> {
-    let input_path = path.as_ref();
+    let input_path = path;
     log::debug!("Getting size of df {input_path:?} with extension {extension:?}");
 
     // Don't need that many rows to get the width
     let num_scan_rows = constants::DEFAULT_PAGE_SIZE;
-    let mut lazy_df = scan_df_with_extension(&path, extension, &DFOpts::empty(), num_scan_rows)?;
+    let mut lazy_df = scan_df_with_extension(path, extension, &DFOpts::empty(), num_scan_rows)?;
     let schema = lazy_df
         .collect_schema()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     let width = schema.len();
 
     let err = format!("Unknown file type get_size {input_path:?} {extension:?}");
@@ -1370,80 +1343,70 @@ fn p_get_size_with_extension(
                 let height = df.height();
                 Ok(DataFrameSize { width, height })
             }
-            _ => Err(OxenError::basic_str(err)),
+            _ => Err(OxenError::basic_str(&err)),
         },
-        None => Err(OxenError::basic_str(err)),
+        None => Err(OxenError::basic_str(&err)),
     }
 }
 
-pub fn write_df_json<P: AsRef<Path>>(df: &mut DataFrame, output: P) -> Result<(), OxenError> {
-    let output = output.as_ref();
+pub fn write_df_json(df: &mut DataFrame, output: &Path) -> Result<(), OxenError> {
     log::debug!("Writing file {output:?}");
     log::debug!("{df:?}");
     let f = std::fs::File::create(output).unwrap();
     JsonWriter::new(f)
         .with_json_format(JsonFormat::Json)
         .finish(df)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     Ok(())
 }
 
-pub fn write_df_jsonl<P: AsRef<Path>>(df: &mut DataFrame, output: P) -> Result<(), OxenError> {
-    let output = output.as_ref();
+pub fn write_df_jsonl(df: &mut DataFrame, output: &Path) -> Result<(), OxenError> {
     log::debug!("Writing file {output:?}");
     let f = std::fs::File::create(output).unwrap();
     JsonWriter::new(f)
         .with_json_format(JsonFormat::JsonLines)
         .finish(df)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     Ok(())
 }
 
-pub fn write_df_csv<P: AsRef<Path>>(
-    df: &mut DataFrame,
-    output: P,
-    delimiter: u8,
-) -> Result<(), OxenError> {
-    let output = output.as_ref();
+pub fn write_df_csv(df: &mut DataFrame, output: &Path, delimiter: u8) -> Result<(), OxenError> {
     log::debug!("Writing file {output:?}");
     let f = std::fs::File::create(output).unwrap();
     CsvWriter::new(f)
         .include_header(true)
         .with_separator(delimiter)
         .finish(df)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     Ok(())
 }
 
-pub fn write_df_parquet<P: AsRef<Path>>(df: &mut DataFrame, output: P) -> Result<(), OxenError> {
-    let output = output.as_ref();
+pub fn write_df_parquet(df: &mut DataFrame, output: &Path) -> Result<(), OxenError> {
     log::debug!("Writing file {output:?}");
     match std::fs::File::create(output) {
         Ok(f) => {
             ParquetWriter::new(f)
                 .finish(df)
-                .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+                .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
             Ok(())
         }
         Err(err) => {
             let error_str = format!("Could not create file {err:?}");
-            Err(OxenError::basic_str(error_str))
+            Err(OxenError::basic_str(&error_str))
         }
     }
 }
 
-pub fn write_df_arrow<P: AsRef<Path>>(df: &mut DataFrame, output: P) -> Result<(), OxenError> {
-    let output = output.as_ref();
+pub fn write_df_arrow(df: &mut DataFrame, output: &Path) -> Result<(), OxenError> {
     log::debug!("Writing file {output:?}");
     let f = std::fs::File::create(output).unwrap();
     IpcWriter::new(f)
         .finish(df)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     Ok(())
 }
 
-pub fn write_df(df: &mut DataFrame, path: impl AsRef<Path>) -> Result<(), OxenError> {
-    let path = path.as_ref();
+pub fn write_df(df: &mut DataFrame, path: &Path) -> Result<(), OxenError> {
     let extension = path.extension().and_then(OsStr::to_str);
     let err = format!("Unknown file type write_df {path:?} {extension:?}");
 
@@ -1456,36 +1419,30 @@ pub fn write_df(df: &mut DataFrame, path: impl AsRef<Path>) -> Result<(), OxenEr
             "csv" => write_df_csv(df, path, b','),
             "parquet" => write_df_parquet(df, path),
             "arrow" => write_df_arrow(df, path),
-            _ => Err(OxenError::basic_str(err)),
+            _ => Err(OxenError::basic_str(&err)),
         },
-        None => Err(OxenError::basic_str(err)),
+        None => Err(OxenError::basic_str(&err)),
     }
 }
 
-pub async fn copy_df(
-    input: impl AsRef<Path>,
-    output: impl AsRef<Path>,
-) -> Result<DataFrame, OxenError> {
+pub async fn copy_df(input: &Path, output: &Path) -> Result<DataFrame, OxenError> {
     let mut df = read_df(input, DFOpts::empty()).await?;
     write_df_arrow(&mut df, output)?;
     Ok(df)
 }
 
-pub async fn copy_df_add_row_num(
-    input: impl AsRef<Path>,
-    output: impl AsRef<Path>,
-) -> Result<DataFrame, OxenError> {
+pub async fn copy_df_add_row_num(input: &Path, output: &Path) -> Result<DataFrame, OxenError> {
     let df = read_df(input, DFOpts::empty()).await?;
     let mut df = df
         .lazy()
         .with_row_index("_row_num", Some(0))
         .collect()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     write_df_arrow(&mut df, output)?;
     Ok(df)
 }
 
-pub async fn show_path(input: impl AsRef<Path>, opts: DFOpts) -> Result<DataFrame, OxenError> {
+pub async fn show_path(input: &Path, opts: DFOpts) -> Result<DataFrame, OxenError> {
     log::debug!("Got opts {opts:?}");
     let df = read_df(input, opts.clone()).await?;
     log::debug!("Transform finished");
@@ -1518,40 +1475,36 @@ pub async fn show_path(input: impl AsRef<Path>, opts: DFOpts) -> Result<DataFram
 }
 
 pub fn get_schema_with_extension(
-    path: impl AsRef<Path>,
+    path: &Path,
     extension: Option<&str>,
 ) -> Result<crate::model::Schema, OxenError> {
-    let input_path = path.as_ref();
+    let input_path = path;
     let opts = DFOpts::empty();
     let total_rows = constants::DEFAULT_PAGE_SIZE;
     let mut df = scan_df_with_extension(input_path, extension, &opts, total_rows)?;
     let schema = df
         .collect_schema()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
     Ok(crate::model::Schema::from_polars(&schema))
 }
 
-pub fn get_schema(input: impl AsRef<Path>) -> Result<crate::model::Schema, OxenError> {
+pub fn get_schema(input: &Path) -> Result<crate::model::Schema, OxenError> {
     let opts = DFOpts::empty();
     // don't need many rows to get schema
     let total_rows = constants::DEFAULT_PAGE_SIZE;
     let mut df = scan_df(input, &opts, total_rows)?;
     let schema = df
         .collect_schema()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
 
     Ok(crate::model::Schema::from_polars(&schema))
 }
 
-pub fn schema_to_string<P: AsRef<Path>>(
-    input: P,
-    flatten: bool,
-    opts: &DFOpts,
-) -> Result<String, OxenError> {
+pub fn schema_to_string(input: &Path, flatten: bool, opts: &DFOpts) -> Result<String, OxenError> {
     let mut df = scan_df(input, opts, constants::DEFAULT_PAGE_SIZE)?;
     let schema = df
         .collect_schema()
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
 
     if flatten {
         let result = polars_schema_to_flat_str(&schema);
@@ -1605,7 +1558,7 @@ pub async fn show_node(
                 log::debug!("Finished reading chunked parquet");
                 Ok(df)
             }
-            err => Err(OxenError::basic_str(format!(
+            err => Err(OxenError::basic_str(&format!(
                 "Could not read chunked parquet: {err:?}"
             ))),
         }?
@@ -1619,7 +1572,7 @@ pub async fn show_node(
                 log::debug!("Finished reading chunked arrow");
                 Ok(df)
             }
-            err => Err(OxenError::basic_str(format!(
+            err => Err(OxenError::basic_str(&format!(
                 "Could not read chunked arrow: {err:?}"
             ))),
         }?
@@ -1632,7 +1585,7 @@ pub async fn show_node(
                 log::debug!("Finished reading line delimited json");
                 Ok(df)
             }
-            err => Err(OxenError::basic_str(format!(
+            err => Err(OxenError::basic_str(&format!(
                 "Could not read chunked json: {err:?}"
             ))),
         }?
@@ -1858,7 +1811,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_json() -> Result<(), OxenError> {
-        let df = tabular::read_df_json(test::test_text_json())?.collect()?;
+        let df = tabular::read_df_json(&test::test_text_json())?.collect()?;
 
         println!("{df}");
 
@@ -1881,7 +1834,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_jsonl() -> Result<(), OxenError> {
         let df = match task::spawn_blocking(move || -> Result<DataFrame, OxenError> {
-            tabular::read_df_jsonl(test::test_text_jsonl())?
+            tabular::read_df_jsonl(&test::test_text_jsonl())?
                 .collect()
                 .map_err(OxenError::from)
         })
@@ -1912,7 +1865,7 @@ mod tests {
     #[tokio::test]
     async fn test_sniff_empty_rows_carriage_return_csv() -> Result<(), OxenError> {
         let opts = DFOpts::empty();
-        let df = tabular::read_df(test::test_csv_empty_rows_carriage_return(), opts).await?;
+        let df = tabular::read_df(&test::test_csv_empty_rows_carriage_return(), opts).await?;
         assert_eq!(df.width(), 4);
         Ok(())
     }
@@ -1920,7 +1873,7 @@ mod tests {
     #[tokio::test]
     async fn test_sniff_delimiter_tabs() -> Result<(), OxenError> {
         let opts = DFOpts::empty();
-        let df = tabular::read_df(test::test_tabs_csv(), opts).await?;
+        let df = tabular::read_df(&test::test_tabs_csv(), opts).await?;
         assert_eq!(df.width(), 4);
         Ok(())
     }
@@ -1928,7 +1881,7 @@ mod tests {
     #[tokio::test]
     async fn test_sniff_emoji_csv() -> Result<(), OxenError> {
         let opts = DFOpts::empty();
-        let df = tabular::read_df(test::test_emojis(), opts).await?;
+        let df = tabular::read_df(&test::test_emojis(), opts).await?;
         assert_eq!(df.width(), 2);
         Ok(())
     }
@@ -1937,7 +1890,7 @@ mod tests {
     async fn test_slice_parquet_lazy() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
         opts.slice = Some("329..333".to_string());
-        let df = tabular::scan_df_parquet(test::test_1k_parquet(), 333)?;
+        let df = tabular::scan_df_parquet(&test::test_1k_parquet(), 333)?;
         let df = tabular::transform_lazy(df, opts.clone()).await?;
 
         let mut df = match task::spawn_blocking(move || -> Result<DataFrame, OxenError> {
@@ -1972,7 +1925,7 @@ mod tests {
     async fn test_slice_parquet_full_read() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
         opts.slice = Some("329..333".to_string());
-        let mut df = tabular::read_df(test::test_1k_parquet(), opts).await?;
+        let mut df = tabular::read_df(&test::test_1k_parquet(), opts).await?;
         println!("{df:?}");
 
         assert_eq!(df.width(), 3);
@@ -1993,7 +1946,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_file_with_unmatched_quotes() -> Result<(), OxenError> {
-        let df = tabular::read_df(test::test_spam_ham(), DFOpts::empty()).await?;
+        let df = tabular::read_df(&test::test_spam_ham(), DFOpts::empty()).await?;
         assert_eq!(df.width(), 2);
         assert_eq!(df.height(), 100);
         Ok(())
@@ -2002,7 +1955,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_csv_with_quoted_fields_default() -> Result<(), OxenError> {
         let df = tabular::read_df(
-            TEST_DATA_DIR
+            &TEST_DATA_DIR
                 .join("test")
                 .join("csvs")
                 .join("quoted_fields.csv"),
@@ -2024,7 +1977,7 @@ mod tests {
     #[test]
     fn test_sniff_csv_dialect_detects_quote_char() -> Result<(), OxenError> {
         let dialect = sniff_csv_dialect(
-            TEST_DATA_DIR
+            &TEST_DATA_DIR
                 .join("test")
                 .join("csvs")
                 .join("quoted_fields.csv"),
@@ -2038,7 +1991,7 @@ mod tests {
     #[test]
     fn test_reject_empty_quote() -> Result<(), OxenError> {
         let r = sniff_csv_dialect(
-            TEST_DATA_DIR
+            &TEST_DATA_DIR
                 .join("test")
                 .join("csvs")
                 .join("quoted_fields.csv"),
@@ -2055,7 +2008,7 @@ mod tests {
     #[tokio::test]
     async fn test_csv_video_captions_quoting() -> Result<(), OxenError> {
         let df = tabular::read_df(
-            TEST_DATA_DIR
+            &TEST_DATA_DIR
                 .join("test")
                 .join("csvs")
                 .join("caption_video_gen_fmt.csv"),
@@ -2202,7 +2155,7 @@ mod tests {
     async fn test_transform_randomize() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
         opts.should_randomize = true;
-        let df = tabular::read_df(test::test_1k_parquet(), opts).await?;
+        let df = tabular::read_df(&test::test_1k_parquet(), opts).await?;
         // All rows should still be present, just in a different order
         let height = df.height();
         assert!(height > 0);
@@ -2214,7 +2167,7 @@ mod tests {
     async fn test_transform_rename_col() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
         opts.rename_col = Some("title:new_title".to_string());
-        let df = tabular::read_df(test::test_1k_parquet(), opts).await?;
+        let df = tabular::read_df(&test::test_1k_parquet(), opts).await?;
         assert!(df.height() > 0);
         assert!(df.column("new_title").is_ok());
         assert!(df.column("title").is_err());
@@ -2225,7 +2178,7 @@ mod tests {
     async fn test_transform_add_col() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
         opts.add_col = Some("new_col:test_val:str".to_string());
-        let df = tabular::read_df(test::test_1k_parquet(), opts).await?;
+        let df = tabular::read_df(&test::test_1k_parquet(), opts).await?;
         assert!(df.height() > 0);
         assert_eq!(df.width(), 4);
         assert!(df.column("new_col").is_ok());
@@ -2235,23 +2188,23 @@ mod tests {
     #[tokio::test]
     async fn test_transform_add_row() -> Result<(), OxenError> {
         let mut opts = DFOpts::empty();
-        let base_df = tabular::read_df(test::test_1k_parquet(), DFOpts::empty()).await?;
+        let base_df = tabular::read_df(&test::test_1k_parquet(), DFOpts::empty()).await?;
         let expected_height = base_df.height() + 1;
         opts.add_row =
             Some(r#"{"id":"999","url":"https://example.com","title":"new_title"}"#.to_string());
-        let df = tabular::read_df(test::test_1k_parquet(), opts).await?;
+        let df = tabular::read_df(&test::test_1k_parquet(), opts).await?;
         assert_eq!(df.height(), expected_height);
         Ok(())
     }
 
     #[tokio::test]
     async fn test_transform_vstack() -> Result<(), OxenError> {
-        let base_df = tabular::read_df(test::test_1k_parquet(), DFOpts::empty()).await?;
+        let base_df = tabular::read_df(&test::test_1k_parquet(), DFOpts::empty()).await?;
         let base_height = base_df.height();
 
         let mut opts = DFOpts::empty();
         opts.vstack = Some(vec![test::test_1k_parquet()]);
-        let df = tabular::read_df(test::test_1k_parquet(), opts).await?;
+        let df = tabular::read_df(&test::test_1k_parquet(), opts).await?;
         assert_eq!(df.height(), base_height * 2);
         assert_eq!(df.width(), base_df.width());
         Ok(())

--- a/crates/lib/src/core/df/tabular.rs
+++ b/crates/lib/src/core/df/tabular.rs
@@ -56,17 +56,17 @@ fn read_df_csv(path: &Path, delimiter: u8, quote_char: Option<u8>) -> Result<Laz
     let reader = base_lazy_csv_reader(path, delimiter, quote_char);
     reader
         .finish()
-        .map_err(|_| OxenError::basic_str(&format!("{}: {:?}", READ_ERROR, path)))
+        .map_err(|_| OxenError::basic_str(format!("{}: {:?}", READ_ERROR, path)))
 }
 
 fn read_df_jsonl(path: &Path) -> Result<LazyFrame, OxenError> {
-    let path = path
-        .to_str()
-        .ok_or(OxenError::basic_str("Could not convert path to string"))?;
+    let path = path.to_str().ok_or(OxenError::basic_str(
+        "Could not convert path to string".to_string(),
+    ))?;
     LazyJsonLineReader::new(path)
         .with_infer_schema_length(Some(NonZeroUsize::new(10000).unwrap()))
         .finish()
-        .map_err(|_| OxenError::basic_str(&format!("{READ_ERROR}: {path:?}")))
+        .map_err(|_| OxenError::basic_str(format!("{READ_ERROR}: {path:?}")))
 }
 
 fn scan_df_json(path: &Path) -> Result<LazyFrame, OxenError> {
@@ -81,7 +81,7 @@ pub fn read_df_json(path: &Path) -> Result<LazyFrame, OxenError> {
     let df = JsonReader::new(file)
         .infer_schema_len(Some(NonZeroUsize::new(10000).unwrap()))
         .finish()
-        .map_err(|e| OxenError::basic_str(&format!("{error_str}: {e}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{error_str}: {e}")))?;
     Ok(df.lazy())
 }
 
@@ -96,7 +96,7 @@ pub fn read_df_parquet(path: &Path) -> Result<LazyFrame, OxenError> {
     //     args.n_rows
     // )
     LazyFrame::scan_parquet(path, args).map_err(|_| {
-        OxenError::basic_str(&format!(
+        OxenError::basic_str(format!(
             "Error scanning parquet file {}: {:?}",
             READ_ERROR, path
         ))
@@ -105,19 +105,19 @@ pub fn read_df_parquet(path: &Path) -> Result<LazyFrame, OxenError> {
 
 fn read_df_arrow(path: &Path) -> Result<LazyFrame, OxenError> {
     LazyFrame::scan_ipc(path, ScanArgsIpc::default())
-        .map_err(|_| OxenError::basic_str(&format!("{}: {:?}", READ_ERROR, path)))
+        .map_err(|_| OxenError::basic_str(format!("{}: {:?}", READ_ERROR, path)))
 }
 
 pub fn take(df: LazyFrame, indices: Vec<u32>) -> Result<DataFrame, OxenError> {
     let idx = IdxCa::new(PlSmallStr::from_str("idx"), &indices);
     let collected = df
         .collect()
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     // log::debug!("take indices {:?}", indices);
     // log::debug!("from df {:?}", collected);
     collected
         .take(&idx)
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
 }
 
 pub fn scan_df_csv(
@@ -130,18 +130,18 @@ pub fn scan_df_csv(
     reader
         .with_n_rows(Some(total_rows))
         .finish()
-        .map_err(|_| OxenError::basic_str(&format!("{}: {:?}", READ_ERROR, path)))
+        .map_err(|_| OxenError::basic_str(format!("{}: {:?}", READ_ERROR, path)))
 }
 
 pub fn scan_df_jsonl(path: &Path, total_rows: usize) -> Result<LazyFrame, OxenError> {
-    let path = path
-        .to_str()
-        .ok_or(OxenError::basic_str("Could not convert path to string"))?;
+    let path = path.to_str().ok_or(OxenError::basic_str(
+        "Could not convert path to string".to_string(),
+    ))?;
     LazyJsonLineReader::new(path)
         .with_infer_schema_length(Some(NonZeroUsize::new(10000).unwrap()))
         .with_n_rows(Some(total_rows))
         .finish()
-        .map_err(|_| OxenError::basic_str(&format!("{READ_ERROR}: {path:?}")))
+        .map_err(|_| OxenError::basic_str(format!("{READ_ERROR}: {path:?}")))
 }
 
 pub fn scan_df_parquet(path: &Path, total_rows: usize) -> Result<LazyFrame, OxenError> {
@@ -155,7 +155,7 @@ pub fn scan_df_parquet(path: &Path, total_rows: usize) -> Result<LazyFrame, Oxen
     //     args.n_rows
     // );
     LazyFrame::scan_parquet(path, args).map_err(|_| {
-        OxenError::basic_str(&format!(
+        OxenError::basic_str(format!(
             "Error scanning parquet file {}: {:?}",
             READ_ERROR, path
         ))
@@ -169,7 +169,7 @@ pub fn scan_df_arrow(path: &Path, total_rows: usize) -> Result<LazyFrame, OxenEr
     };
 
     LazyFrame::scan_ipc(path, args)
-        .map_err(|_| OxenError::basic_str(&format!("{}: {:?}", READ_ERROR, path)))
+        .map_err(|_| OxenError::basic_str(format!("{}: {:?}", READ_ERROR, path)))
 }
 
 pub async fn add_col_lazy(
@@ -181,12 +181,12 @@ pub async fn add_col_lazy(
 ) -> Result<LazyFrame, OxenError> {
     let mut df = match task::spawn_blocking(move || -> Result<DataFrame, OxenError> {
         df.collect()
-            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
+            .map_err(|e| OxenError::basic_str(format!("{e:?}")))
     })
     .await?
     {
         Ok(df) => df,
-        Err(e) => return Err(OxenError::basic_str(&format!("{e:?}"))),
+        Err(e) => return Err(OxenError::basic_str(format!("{e:?}"))),
     };
 
     let dtype = DataType::from_string(dtype).to_polars();
@@ -194,13 +194,13 @@ pub async fn add_col_lazy(
     let column = Series::new_empty(PlSmallStr::from_str(name), &dtype);
     let column = column
         .extend_constant(val_from_str_and_dtype(val, &dtype), df.height())
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     if let Some(at) = at {
         df.insert_column(at, column)
-            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+            .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     } else {
         df.with_column(column)
-            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+            .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     }
     let df = df.lazy();
     Ok(df)
@@ -217,21 +217,21 @@ pub fn add_col(
     let column = Series::new_empty(PlSmallStr::from_str(name), &dtype);
     let column = column
         .extend_constant(val_from_str_and_dtype(val, &dtype), df.height())
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     df.with_column(column)
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     Ok(df)
 }
 
 pub async fn add_row(df: LazyFrame, data: String) -> Result<LazyFrame, OxenError> {
     let df = match task::spawn_blocking(move || -> Result<DataFrame, OxenError> {
         df.collect()
-            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
+            .map_err(|e| OxenError::basic_str(format!("{e:?}")))
     })
     .await?
     {
         Ok(df) => df,
-        Err(e) => return Err(OxenError::basic_str(&format!("{e:?}"))),
+        Err(e) => return Err(OxenError::basic_str(format!("{e:?}"))),
     };
 
     let new_row = row_from_str_and_schema(&data, df.schema())?;
@@ -239,7 +239,7 @@ pub async fn add_row(df: LazyFrame, data: String) -> Result<LazyFrame, OxenError
     log::debug!("add_row new_row: {new_row:?}");
     let df = df
         .vstack(&new_row)
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?
         .lazy();
     Ok(df)
 }
@@ -262,7 +262,7 @@ pub fn row_from_str_and_schema(data: &str, schema: &SchemaRef) -> Result<DataFra
     let values: Vec<&str> = data.split(',').collect();
 
     if values.len() != schema.len() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Error: Added row must have same number of columns as df\nRow columns: {}\ndf columns: {}",
             values.len(),
             schema.len()
@@ -278,7 +278,7 @@ pub fn row_from_str_and_schema(data: &str, schema: &SchemaRef) -> Result<DataFra
                 vec.push(Column::Series(series.into()));
             }
             Err(err) => {
-                return Err(OxenError::basic_str(&format!("Error parsing json: {err}")));
+                return Err(OxenError::basic_str(format!("Error parsing json: {err}")));
             }
         }
     }
@@ -299,7 +299,7 @@ pub fn parse_str_to_df(data: &str) -> Result<DataFrame, OxenError> {
 
     match reader.finish() {
         Ok(df) => Ok(df),
-        Err(err) => Err(OxenError::basic_str(&format!("Error parsing json: {err}"))),
+        Err(err) => Err(OxenError::basic_str(format!("Error parsing json: {err}"))),
     }
 }
 
@@ -429,14 +429,14 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
         for path in vstack.iter() {
             let empty_opts = DFOpts::empty();
             let extension = path.extension().and_then(OsStr::to_str).ok_or_else(|| {
-                OxenError::basic_str(&format!("Cannot vstack file without extension: {path:?}"))
+                OxenError::basic_str(format!("Cannot vstack file without extension: {path:?}"))
             })?;
 
             let new_df = _read_lazy_df_with_extension(path, extension, &empty_opts).await?;
             frames.push(new_df);
         }
         df = concat(frames, Default::default())
-            .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+            .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     }
 
     if let Some(col_vals) = opts.add_col_vals() {
@@ -516,7 +516,7 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
 
             if old_name.is_empty() || new_name.is_empty() {
                 log::error!("Invalid rename_col format: old name and new name cannot be empty");
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Invalid rename_col format `{names}`"
                 )));
             }
@@ -524,7 +524,7 @@ pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame
             df = df.rename([old_name], [new_name], true);
         } else {
             log::error!("Invalid rename_col format: {names}");
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Invalid rename_col format '{names}', expected 'old_name:new_name'"
             )));
         }
@@ -580,7 +580,7 @@ pub fn strip_excluded_cols(df: DataFrame) -> Result<DataFrame, OxenError> {
         .collect::<Vec<String>>();
     let cols = select_cols.iter().map(col).collect::<Vec<Expr>>();
     let result = df.lazy().select(&cols).collect();
-    result.map_err(|e| OxenError::basic_str(&format!("{e:?}")))
+    result.map_err(|e| OxenError::basic_str(format!("{e:?}")))
 }
 
 fn head(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
@@ -606,7 +606,7 @@ pub fn slice_df(df: DataFrame, start: usize, end: usize) -> Result<DataFrame, Ox
     let df = df.lazy();
     let df = slice(df, &opts);
     df.collect()
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
 }
 
 pub fn paginate_df(df: DataFrame, page_opts: &PaginateOpts) -> Result<DataFrame, OxenError> {
@@ -619,7 +619,7 @@ pub fn paginate_df(df: DataFrame, page_opts: &PaginateOpts) -> Result<DataFrame,
     let df = df.lazy();
     let df = slice(df, &opts);
     df.collect()
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
 }
 
 fn slice(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
@@ -638,7 +638,7 @@ fn slice(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
 
 pub fn df_add_row_num(df: DataFrame) -> Result<DataFrame, OxenError> {
     df.with_row_index(PlSmallStr::from_str(constants::ROW_NUM_COL_NAME), Some(0))
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))
 }
 
 pub fn df_add_row_num_starting_at(df: DataFrame, start: u32) -> Result<DataFrame, OxenError> {
@@ -646,7 +646,7 @@ pub fn df_add_row_num_starting_at(df: DataFrame, start: u32) -> Result<DataFrame
         PlSmallStr::from_str(constants::ROW_NUM_COL_NAME),
         Some(start),
     )
-    .map_err(|e| OxenError::basic_str(&format!("{e:?}")))
+    .map_err(|e| OxenError::basic_str(format!("{e:?}")))
 }
 
 pub fn any_val_to_bytes(value: &AnyValue) -> Vec<u8> {
@@ -1033,7 +1033,9 @@ fn sniff_csv_dialect(path: &Path, opts: &DFOpts) -> Result<CsvDialect, OxenError
     let user_delimiter = match &opts.delimiter {
         Some(delimiter) => {
             if delimiter.len() != 1 {
-                return Err(OxenError::basic_str("Delimiter must be a single character"));
+                return Err(OxenError::basic_str(
+                    "Delimiter must be a single character".to_string(),
+                ));
             }
             Some(delimiter.as_bytes()[0])
         }
@@ -1047,7 +1049,7 @@ fn sniff_csv_dialect(path: &Path, opts: &DFOpts) -> Result<CsvDialect, OxenError
                 Some(b[0])
             } else {
                 return Err(OxenError::basic_str(
-                    "If provided, quote character must be non empty!",
+                    "If provided, quote character must be non empty!".to_string(),
                 ));
             }
         }
@@ -1094,7 +1096,7 @@ fn sniffed_quote(metadata: &qsv_sniffer::metadata::Metadata) -> u8 {
 pub async fn read_df(path: &Path, opts: DFOpts) -> Result<DataFrame, OxenError> {
     log::debug!("Reading df with path: {:?}", path);
     if !path.exists() {
-        return Err(OxenError::path_does_not_exist(path));
+        return Err(OxenError::path_does_not_exist(path.to_path_buf()));
     }
 
     let extension = path.extension().and_then(OsStr::to_str);
@@ -1104,7 +1106,7 @@ pub async fn read_df(path: &Path, opts: DFOpts) -> Result<DataFrame, OxenError> 
     } else {
         let err =
             format!("Could not load data frame with path: {path:?} and extension: {extension:?}");
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 
@@ -1130,7 +1132,7 @@ async fn _read_lazy_df_with_extension(
 
     task::spawn_blocking(move || {
         if !path.exists() {
-            return Err(OxenError::entry_does_not_exist(&path));
+            return Err(OxenError::entry_does_not_exist(path));
         }
 
         log::debug!("Reading df with extension {:?} {:?}", &extension, &path);
@@ -1150,7 +1152,7 @@ async fn _read_lazy_df_with_extension(
             "arrow" => {
                 if opts_clone.sql.is_some() {
                     return Err(OxenError::basic_str(
-                        "Error: SQL queries are not supported for .arrow files",
+                        "Error: SQL queries are not supported for .arrow files".to_string(),
                     ));
                 }
                 read_df_arrow(&path)
@@ -1159,12 +1161,12 @@ async fn _read_lazy_df_with_extension(
                 let err = format!(
                     "Could not load data frame with path: {path:?} and extension: {extension}"
                 );
-                Err(OxenError::basic_str(&err))
+                Err(OxenError::basic_str(err))
             }
         }
     })
     .await
-    .map_err(|e| OxenError::basic_str(&format!("Task panicked: {e}")))?
+    .map_err(|e| OxenError::basic_str(format!("Task panicked: {e}")))?
 }
 
 pub async fn p_read_df_with_extension(
@@ -1182,7 +1184,7 @@ pub async fn p_read_df_with_extension(
 
     task::spawn_blocking(move || result_df_lazy.collect().map_err(OxenError::from))
         .await
-        .map_err(|e| OxenError::basic_str(&format!("Collect task panicked: {e}")))?
+        .map_err(|e| OxenError::basic_str(format!("Collect task panicked: {e}")))?
 }
 
 pub async fn maybe_read_df_with_extension(
@@ -1193,7 +1195,7 @@ pub async fn maybe_read_df_with_extension(
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
     if !version_path.exists() {
-        return Err(OxenError::entry_does_not_exist(path));
+        return Err(OxenError::entry_does_not_exist(path.to_path_buf()));
     }
 
     let extension = version_path.extension().and_then(OsStr::to_str);
@@ -1206,7 +1208,7 @@ pub async fn maybe_read_df_with_extension(
             try_to_read_extension_from_node(repo, version_path, path, &commit, opts).await
         } else {
             let err = format!("Could not find commit: {commit_id}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -1223,7 +1225,7 @@ async fn try_to_read_extension_from_node(
         read_df_with_extension(version_path, file_node.extension(), opts).await
     } else {
         let err = format!("Could not find file node {:?}", path);
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 
@@ -1267,9 +1269,9 @@ fn p_scan_df_with_extension(
             }
             "parquet" => scan_df_parquet(path, total_rows),
             "arrow" => scan_df_arrow(path, total_rows),
-            _ => Err(OxenError::basic_str(&err)),
+            _ => Err(OxenError::basic_str(err)),
         },
-        None => Err(OxenError::basic_str(&err)),
+        None => Err(OxenError::basic_str(err)),
     }
 }
 
@@ -1298,7 +1300,7 @@ fn p_get_size_with_extension(
     let mut lazy_df = scan_df_with_extension(path, extension, &DFOpts::empty(), num_scan_rows)?;
     let schema = lazy_df
         .collect_schema()
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     let width = schema.len();
 
     let err = format!("Unknown file type get_size {input_path:?} {extension:?}");
@@ -1339,13 +1341,13 @@ fn p_get_size_with_extension(
             "json" => {
                 let df = lazy_df
                     .collect()
-                    .map_err(|_| OxenError::basic_str("Could not collect json df"))?;
+                    .map_err(|_| OxenError::basic_str("Could not collect json df".to_string()))?;
                 let height = df.height();
                 Ok(DataFrameSize { width, height })
             }
-            _ => Err(OxenError::basic_str(&err)),
+            _ => Err(OxenError::basic_str(err)),
         },
-        None => Err(OxenError::basic_str(&err)),
+        None => Err(OxenError::basic_str(err)),
     }
 }
 
@@ -1356,7 +1358,7 @@ pub fn write_df_json(df: &mut DataFrame, output: &Path) -> Result<(), OxenError>
     JsonWriter::new(f)
         .with_json_format(JsonFormat::Json)
         .finish(df)
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     Ok(())
 }
 
@@ -1366,7 +1368,7 @@ pub fn write_df_jsonl(df: &mut DataFrame, output: &Path) -> Result<(), OxenError
     JsonWriter::new(f)
         .with_json_format(JsonFormat::JsonLines)
         .finish(df)
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     Ok(())
 }
 
@@ -1377,7 +1379,7 @@ pub fn write_df_csv(df: &mut DataFrame, output: &Path, delimiter: u8) -> Result<
         .include_header(true)
         .with_separator(delimiter)
         .finish(df)
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     Ok(())
 }
 
@@ -1387,12 +1389,12 @@ pub fn write_df_parquet(df: &mut DataFrame, output: &Path) -> Result<(), OxenErr
         Ok(f) => {
             ParquetWriter::new(f)
                 .finish(df)
-                .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+                .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
             Ok(())
         }
         Err(err) => {
             let error_str = format!("Could not create file {err:?}");
-            Err(OxenError::basic_str(&error_str))
+            Err(OxenError::basic_str(error_str))
         }
     }
 }
@@ -1402,7 +1404,7 @@ pub fn write_df_arrow(df: &mut DataFrame, output: &Path) -> Result<(), OxenError
     let f = std::fs::File::create(output).unwrap();
     IpcWriter::new(f)
         .finish(df)
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     Ok(())
 }
 
@@ -1419,9 +1421,9 @@ pub fn write_df(df: &mut DataFrame, path: &Path) -> Result<(), OxenError> {
             "csv" => write_df_csv(df, path, b','),
             "parquet" => write_df_parquet(df, path),
             "arrow" => write_df_arrow(df, path),
-            _ => Err(OxenError::basic_str(&err)),
+            _ => Err(OxenError::basic_str(err)),
         },
-        None => Err(OxenError::basic_str(&err)),
+        None => Err(OxenError::basic_str(err)),
     }
 }
 
@@ -1437,7 +1439,7 @@ pub async fn copy_df_add_row_num(input: &Path, output: &Path) -> Result<DataFram
         .lazy()
         .with_row_index("_row_num", Some(0))
         .collect()
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     write_df_arrow(&mut df, output)?;
     Ok(df)
 }
@@ -1484,7 +1486,7 @@ pub fn get_schema_with_extension(
     let mut df = scan_df_with_extension(input_path, extension, &opts, total_rows)?;
     let schema = df
         .collect_schema()
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
     Ok(crate::model::Schema::from_polars(&schema))
 }
 
@@ -1495,7 +1497,7 @@ pub fn get_schema(input: &Path) -> Result<crate::model::Schema, OxenError> {
     let mut df = scan_df(input, &opts, total_rows)?;
     let schema = df
         .collect_schema()
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
 
     Ok(crate::model::Schema::from_polars(&schema))
 }
@@ -1504,7 +1506,7 @@ pub fn schema_to_string(input: &Path, flatten: bool, opts: &DFOpts) -> Result<St
     let mut df = scan_df(input, opts, constants::DEFAULT_PAGE_SIZE)?;
     let schema = df
         .collect_schema()
-        .map_err(|e| OxenError::basic_str(&format!("{e:?}")))?;
+        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
 
     if flatten {
         let result = polars_schema_to_flat_str(&schema);
@@ -1558,7 +1560,7 @@ pub async fn show_node(
                 log::debug!("Finished reading chunked parquet");
                 Ok(df)
             }
-            err => Err(OxenError::basic_str(&format!(
+            err => Err(OxenError::basic_str(format!(
                 "Could not read chunked parquet: {err:?}"
             ))),
         }?
@@ -1572,7 +1574,7 @@ pub async fn show_node(
                 log::debug!("Finished reading chunked arrow");
                 Ok(df)
             }
-            err => Err(OxenError::basic_str(&format!(
+            err => Err(OxenError::basic_str(format!(
                 "Could not read chunked arrow: {err:?}"
             ))),
         }?
@@ -1585,7 +1587,7 @@ pub async fn show_node(
                 log::debug!("Finished reading line delimited json");
                 Ok(df)
             }
-            err => Err(OxenError::basic_str(&format!(
+            err => Err(OxenError::basic_str(format!(
                 "Could not read chunked json: {err:?}"
             ))),
         }?

--- a/crates/lib/src/core/index/schema_reader/duckdb_schema_reader.rs
+++ b/crates/lib/src/core/index/schema_reader/duckdb_schema_reader.rs
@@ -31,9 +31,9 @@ impl DuckDBSchemaReader {
         DuckDBSchemaReader::new(repository, &commit.id, workspace)
     }
 
-    pub fn get_schema_for_file<P: AsRef<Path>>(
+    pub fn get_schema_for_file(
         &self,
-        path: P,
+        path: &Path,
     ) -> Result<Option<Schema>, OxenError> {
         let staged_db_path = duckdb_path(&self.workspace, &path);
         let df_schema = with_df_db_manager(staged_db_path, |manager| {

--- a/crates/lib/src/core/index/schema_reader/objects_schema_reader.rs
+++ b/crates/lib/src/core/index/schema_reader/objects_schema_reader.rs
@@ -105,7 +105,7 @@ impl ObjectsSchemaReader {
         let commit =
             commit_reader
                 .get_commit_by_id(&self.commit_id)?
-                .ok_or(OxenError::basic_str(format!(
+                .ok_or(OxenError::basic_str(&format!(
                     "Could not find commit {}",
                     self.commit_id
                 )))?;
@@ -163,7 +163,7 @@ impl ObjectsSchemaReader {
 
     pub fn list_schemas_for_ref(
         &self,
-        schema_ref: impl AsRef<str>,
+        schema_ref: &str,
     ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
         let all_schemas = self.list_schemas()?;
         log::debug!("list_schemas_for_ref all schemas {}", all_schemas.len());

--- a/crates/lib/src/core/index/schema_reader/objects_schema_reader.rs
+++ b/crates/lib/src/core/index/schema_reader/objects_schema_reader.rs
@@ -105,7 +105,7 @@ impl ObjectsSchemaReader {
         let commit =
             commit_reader
                 .get_commit_by_id(&self.commit_id)?
-                .ok_or(OxenError::basic_str(&format!(
+                .ok_or(OxenError::basic_str(format!(
                     "Could not find commit {}",
                     self.commit_id
                 )))?;

--- a/crates/lib/src/core/merge/entry_merge_conflict_db_reader.rs
+++ b/crates/lib/src/core/merge/entry_merge_conflict_db_reader.rs
@@ -34,7 +34,7 @@ impl EntryMergeConflictDBReader {
                 let err = format!(
                     "EntryMergeConflictDBReader::get_conflict Error reading db\nErr: {err}"
                 );
-                Err(OxenError::basic_str(err))
+                Err(OxenError::basic_str(&err))
             }
         }
     }
@@ -56,7 +56,7 @@ impl EntryMergeConflictDBReader {
                     let err = format!(
                         "EntryMergeConflictDBReader::list_conflicts Error reading db\nErr: {err}"
                     );
-                    return Err(OxenError::basic_str(err));
+                    return Err(OxenError::basic_str(&err));
                 }
             }
         }

--- a/crates/lib/src/core/merge/entry_merge_conflict_db_reader.rs
+++ b/crates/lib/src/core/merge/entry_merge_conflict_db_reader.rs
@@ -26,7 +26,7 @@ impl EntryMergeConflictDBReader {
                     Ok(Some(entry))
                 }
                 Err(_) => Err(OxenError::basic_str(
-                    "EntryMergeConflictDBReader::get_conflict invalid entry",
+                    "EntryMergeConflictDBReader::get_conflict invalid entry".to_string(),
                 )),
             },
             Ok(None) => Ok(None),
@@ -34,7 +34,7 @@ impl EntryMergeConflictDBReader {
                 let err = format!(
                     "EntryMergeConflictDBReader::get_conflict Error reading db\nErr: {err}"
                 );
-                Err(OxenError::basic_str(&err))
+                Err(OxenError::basic_str(err))
             }
         }
     }
@@ -56,7 +56,7 @@ impl EntryMergeConflictDBReader {
                     let err = format!(
                         "EntryMergeConflictDBReader::list_conflicts Error reading db\nErr: {err}"
                     );
-                    return Err(OxenError::basic_str(&err));
+                    return Err(OxenError::basic_str(err));
                 }
             }
         }

--- a/crates/lib/src/core/merge/entry_merge_conflict_reader.rs
+++ b/crates/lib/src/core/merge/entry_merge_conflict_reader.rs
@@ -34,8 +34,8 @@ impl EntryMergeConflictReader {
     pub fn get_conflict_commit(&self) -> Result<Option<Commit>, OxenError> {
         let hidden_dir = util::fs::oxen_hidden_dir(&self.repository.path);
         let merge_head_path = hidden_dir.join(MERGE_HEAD_FILE);
-        let commit_id = util::fs::read_first_line(merge_head_path)?;
-        repositories::commits::get_by_id(&self.repository, commit_id)
+        let commit_id = util::fs::read_first_line(&merge_head_path)?;
+        repositories::commits::get_by_id(&self.repository, &commit_id)
     }
 
     pub fn has_conflicts(&self) -> Result<bool, OxenError> {

--- a/crates/lib/src/core/merge/entry_merge_conflict_writer.rs
+++ b/crates/lib/src/core/merge/entry_merge_conflict_writer.rs
@@ -36,8 +36,8 @@ pub fn write_conflicts_to_disk(
     let hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
     let merge_head_path = hidden_dir.join(MERGE_HEAD_FILE);
     let orig_head_path = hidden_dir.join(ORIG_HEAD_FILE);
-    util::fs::write_to_path(merge_head_path, &merge_commit.id)?;
-    util::fs::write_to_path(orig_head_path, &base_commit.id)?;
+    util::fs::write_to_path(&merge_head_path, &merge_commit.id)?;
+    util::fs::write_to_path(&orig_head_path, &base_commit.id)?;
 
     for conflict in conflicts.iter() {
         let key = conflict.base_entry.path.to_str().unwrap();

--- a/crates/lib/src/core/merge/node_merge_conflict_db_reader.rs
+++ b/crates/lib/src/core/merge/node_merge_conflict_db_reader.rs
@@ -33,7 +33,7 @@ impl NodeMergeConflictDBReader {
             Err(err) => {
                 let err =
                     format!("NodeMergeConflictDBReader::get_conflict Error reading db\nErr: {err}");
-                Err(OxenError::basic_str(err))
+                Err(OxenError::basic_str(&err))
             }
         }
     }
@@ -55,7 +55,7 @@ impl NodeMergeConflictDBReader {
                     let err = format!(
                         "NodeMergeConflictDBReader::list_conflicts Error reading db\nErr: {err}"
                     );
-                    return Err(OxenError::basic_str(err));
+                    return Err(OxenError::basic_str(&err));
                 }
             }
         }

--- a/crates/lib/src/core/merge/node_merge_conflict_db_reader.rs
+++ b/crates/lib/src/core/merge/node_merge_conflict_db_reader.rs
@@ -26,14 +26,14 @@ impl NodeMergeConflictDBReader {
                     Ok(Some(entry))
                 }
                 Err(_) => Err(OxenError::basic_str(
-                    "NodeMergeConflictDBReader::get_conflict invalid entry",
+                    "NodeMergeConflictDBReader::get_conflict invalid entry".to_string(),
                 )),
             },
             Ok(None) => Ok(None),
             Err(err) => {
                 let err =
                     format!("NodeMergeConflictDBReader::get_conflict Error reading db\nErr: {err}");
-                Err(OxenError::basic_str(&err))
+                Err(OxenError::basic_str(err))
             }
         }
     }
@@ -55,7 +55,7 @@ impl NodeMergeConflictDBReader {
                     let err = format!(
                         "NodeMergeConflictDBReader::list_conflicts Error reading db\nErr: {err}"
                     );
-                    return Err(OxenError::basic_str(&err));
+                    return Err(OxenError::basic_str(err));
                 }
             }
         }

--- a/crates/lib/src/core/merge/node_merge_conflict_reader.rs
+++ b/crates/lib/src/core/merge/node_merge_conflict_reader.rs
@@ -34,8 +34,8 @@ impl NodeMergeConflictReader {
     pub fn get_conflict_commit(&self) -> Result<Option<Commit>, OxenError> {
         let hidden_dir = util::fs::oxen_hidden_dir(&self.repository.path);
         let merge_head_path = hidden_dir.join(MERGE_HEAD_FILE);
-        let commit_id = util::fs::read_first_line(merge_head_path)?;
-        repositories::commits::get_by_id(&self.repository, commit_id)
+        let commit_id = util::fs::read_first_line(&merge_head_path)?;
+        repositories::commits::get_by_id(&self.repository, &commit_id)
     }
 
     pub fn has_conflicts(&self) -> Result<bool, OxenError> {

--- a/crates/lib/src/core/merge/node_merge_conflict_writer.rs
+++ b/crates/lib/src/core/merge/node_merge_conflict_writer.rs
@@ -35,8 +35,8 @@ pub fn write_conflicts_to_disk(
     let hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
     let merge_head_path = hidden_dir.join(MERGE_HEAD_FILE);
     let orig_head_path = hidden_dir.join(ORIG_HEAD_FILE);
-    util::fs::write_to_path(merge_head_path, &merge_commit.id)?;
-    util::fs::write_to_path(orig_head_path, &base_commit.id)?;
+    util::fs::write_to_path(&merge_head_path, &merge_commit.id)?;
+    util::fs::write_to_path(&orig_head_path, &base_commit.id)?;
 
     for conflict in conflicts.iter() {
         let (_, base_path) = &conflict.base_entry;
@@ -53,7 +53,7 @@ pub fn write_conflicts_to_disk(
 
 pub fn mark_conflict_as_resolved_in_db(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<(), OxenError> {
     let db_path = merge::db_path(repo);
     let opts = db::key_val::opts::default();
@@ -61,11 +61,11 @@ pub fn mark_conflict_as_resolved_in_db(
 
     log::debug!(
         "mark_conflict_as_resolved_in_db path: {:?} db: {:?}",
-        path.as_ref(),
+        path,
         db_path
     );
 
-    let key = path.as_ref().to_str().unwrap();
+    let key = path.to_str().unwrap();
     let key_bytes = key.as_bytes();
     db.delete(key_bytes)?;
 

--- a/crates/lib/src/core/node_sync_status.rs
+++ b/crates/lib/src/core/node_sync_status.rs
@@ -38,7 +38,7 @@ pub fn mark_node_as_synced(
             log::debug!("Wrote is synced file: {is_synced_path:?}");
             Ok(())
         }
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "Could not write is_synced file: {err}"
         ))),
     }

--- a/crates/lib/src/core/node_sync_status.rs
+++ b/crates/lib/src/core/node_sync_status.rs
@@ -38,7 +38,7 @@ pub fn mark_node_as_synced(
             log::debug!("Wrote is synced file: {is_synced_path:?}");
             Ok(())
         }
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "Could not write is_synced file: {err}"
         ))),
     }

--- a/crates/lib/src/core/refs/ref_manager.rs
+++ b/crates/lib/src/core/refs/ref_manager.rs
@@ -21,7 +21,7 @@ static DB_INSTANCES: LazyLock<Mutex<LruCache<PathBuf, Arc<DB>>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(DB_CACHE_SIZE)));
 
 /// Removes a repository's DB instance from the cache.
-pub fn remove_from_cache(repository_path: impl AsRef<std::path::Path>) -> Result<(), OxenError> {
+pub fn remove_from_cache(repository_path: &std::path::Path) -> Result<(), OxenError> {
     let refs_dir = util::fs::oxen_hidden_dir(repository_path).join(REFS_DIR);
     let mut instances = DB_INSTANCES.lock();
     let _ = instances.pop(&refs_dir); // drop immediately
@@ -30,13 +30,11 @@ pub fn remove_from_cache(repository_path: impl AsRef<std::path::Path>) -> Result
 
 /// Removes a repository's DB instance and all its subdirectories from the cache.
 /// This is mostly useful in test cleanup to ensure all DB instances are removed.
-pub fn remove_from_cache_with_children(
-    repository_path: impl AsRef<std::path::Path>,
-) -> Result<(), OxenError> {
+pub fn remove_from_cache_with_children(repository_path: &std::path::Path) -> Result<(), OxenError> {
     let mut dbs_to_remove: Vec<PathBuf> = vec![];
     let mut instances = DB_INSTANCES.lock();
     for (key, _) in instances.iter() {
-        if key.starts_with(&repository_path) {
+        if key.starts_with(repository_path) {
             dbs_to_remove.push(key.clone());
         }
     }
@@ -68,14 +66,14 @@ where
             if !refs_dir.exists() {
                 util::fs::create_dir_all(&refs_dir).map_err(|e| {
                     log::error!("Failed to create refs directory: {e}");
-                    OxenError::basic_str(format!("Failed to create refs directory: {e}"))
+                    OxenError::basic_str(&format!("Failed to create refs directory: {e}"))
                 })?;
             }
 
             let opts = db::key_val::opts::default();
             let db = DB::open(&opts, dunce::simplified(&refs_dir)).map_err(|e| {
                 log::error!("Failed to open refs database: {e}");
-                OxenError::basic_str(format!("Failed to open refs database: {e}"))
+                OxenError::basic_str(&format!("Failed to open refs database: {e}"))
             })?;
             let arc_db = Arc::new(db);
             instances.put(refs_dir, arc_db.clone());
@@ -129,7 +127,7 @@ impl RefManager {
             Ok(None) => Ok(None),
             Err(err) => {
                 log::error!("get_commit_id_for_branch error finding commit id for branch {name}");
-                Err(OxenError::basic_str(err))
+                Err(OxenError::basic_str(err.as_ref()))
             }
         }
     }
@@ -178,7 +176,7 @@ impl RefManager {
                 },
                 Err(err) => {
                     let err = format!("Error reading refs db\nErr: {err}");
-                    return Err(OxenError::basic_str(err));
+                    return Err(OxenError::basic_str(&err));
                 }
             }
         }
@@ -198,7 +196,7 @@ impl RefManager {
                             let id = String::from(value);
                             let ref_commit = repositories::commits::get_commit_or_head(
                                 &self.repository,
-                                Some(ref_name.clone()),
+                                Some(&ref_name.clone()),
                             )?;
                             branch_names.push((
                                 Branch {
@@ -215,7 +213,7 @@ impl RefManager {
                 },
                 Err(err) => {
                     let err = format!("Error reading refs db\nErr: {err}");
-                    return Err(OxenError::basic_str(err));
+                    return Err(OxenError::basic_str(&err));
                 }
             }
         }
@@ -224,27 +222,19 @@ impl RefManager {
 
     // Write operations (from RefWriter)
 
-    pub fn set_head(&self, name: impl AsRef<str>) {
-        let name = name.as_ref();
+    pub fn set_head(&self, name: &str) {
         util::fs::write_to_path(&self.head_file, name).expect("Could not write to head");
     }
 
-    pub fn create_branch(
-        &self,
-        name: impl AsRef<str>,
-        commit_id: impl AsRef<str>,
-    ) -> Result<Branch, OxenError> {
-        let name = name.as_ref();
-        let commit_id = commit_id.as_ref();
-
+    pub fn create_branch(&self, name: &str, commit_id: &str) -> Result<Branch, OxenError> {
         if self.is_invalid_branch_name(name) {
             let err = format!("'{name}' is not a valid branch name.");
-            return Err(OxenError::basic_str(err));
+            return Err(OxenError::basic_str(&err));
         }
 
         if self.has_branch(name) {
             let err = format!("Branch already exists: {name}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         } else {
             self.set_branch_commit_id(name, commit_id)?;
             Ok(Branch {
@@ -278,11 +268,11 @@ impl RefManager {
         if !self.has_branch(old_name) {
             Err(OxenError::local_branch_not_found(old_name))
         } else if self.has_branch(new_name) {
-            Err(OxenError::basic_str(format!(
+            Err(OxenError::basic_str(&format!(
                 "Branch already exists: {new_name}"
             )))
         } else if self.is_invalid_branch_name(new_name) {
-            Err(OxenError::basic_str(format!(
+            Err(OxenError::basic_str(&format!(
                 "'{new_name}' is not a valid branch name."
             )))
         } else {
@@ -296,19 +286,13 @@ impl RefManager {
     pub fn delete_branch(&self, name: &str) -> Result<Branch, OxenError> {
         let Some(branch) = self.get_branch_by_name(name)? else {
             let err = format!("Branch does not exist: {name}");
-            return Err(OxenError::basic_str(err));
+            return Err(OxenError::basic_str(&err));
         };
         self.refs_db.delete(name)?;
         Ok(branch)
     }
 
-    pub fn set_branch_commit_id(
-        &self,
-        name: impl AsRef<str>,
-        commit_id: impl AsRef<str>,
-    ) -> Result<(), OxenError> {
-        let name = name.as_ref();
-        let commit_id = commit_id.as_ref();
+    pub fn set_branch_commit_id(&self, name: &str, commit_id: &str) -> Result<(), OxenError> {
         self.refs_db.put(name, commit_id)?;
         Ok(())
     }
@@ -362,7 +346,7 @@ mod tests {
                 let handle = thread::spawn(move || {
                     // Each thread creates its own branch and reads all branches
                     with_ref_manager(&repo_clone, |manager| {
-                        manager.create_branch(format!("branch-{i}"), format!("commit-{i}"))?;
+                        manager.create_branch(&format!("branch-{i}"), &format!("commit-{i}"))?;
                         manager.list_branches()
                     })
                 });
@@ -396,8 +380,8 @@ mod tests {
         test::run_empty_local_repo_test_async(|repo| async move {
             // add and commit a file
             let new_file = repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&repo, &new_file).await?;
             repositories::commit(&repo, "Added a new file")?;
 
             repositories::branches::create_from_head(&repo, "feature/add-something")?;

--- a/crates/lib/src/core/refs/ref_manager.rs
+++ b/crates/lib/src/core/refs/ref_manager.rs
@@ -66,14 +66,14 @@ where
             if !refs_dir.exists() {
                 util::fs::create_dir_all(&refs_dir).map_err(|e| {
                     log::error!("Failed to create refs directory: {e}");
-                    OxenError::basic_str(&format!("Failed to create refs directory: {e}"))
+                    OxenError::basic_str(format!("Failed to create refs directory: {e}"))
                 })?;
             }
 
             let opts = db::key_val::opts::default();
             let db = DB::open(&opts, dunce::simplified(&refs_dir)).map_err(|e| {
                 log::error!("Failed to open refs database: {e}");
-                OxenError::basic_str(&format!("Failed to open refs database: {e}"))
+                OxenError::basic_str(format!("Failed to open refs database: {e}"))
             })?;
             let arc_db = Arc::new(db);
             instances.put(refs_dir, arc_db.clone());
@@ -127,7 +127,7 @@ impl RefManager {
             Ok(None) => Ok(None),
             Err(err) => {
                 log::error!("get_commit_id_for_branch error finding commit id for branch {name}");
-                Err(OxenError::basic_str(err.as_ref()))
+                Err(OxenError::basic_str(err.as_ref().to_string()))
             }
         }
     }
@@ -171,12 +171,14 @@ impl RefManager {
                         });
                     }
                     _ => {
-                        return Err(OxenError::basic_str("Could not read utf8 val..."));
+                        return Err(OxenError::basic_str(
+                            "Could not read utf8 val...".to_string(),
+                        ));
                     }
                 },
                 Err(err) => {
                     let err = format!("Error reading refs db\nErr: {err}");
-                    return Err(OxenError::basic_str(&err));
+                    return Err(OxenError::basic_str(err));
                 }
             }
         }
@@ -208,12 +210,14 @@ impl RefManager {
                         }
                     }
                     _ => {
-                        return Err(OxenError::basic_str("Could not read utf8 val..."));
+                        return Err(OxenError::basic_str(
+                            "Could not read utf8 val...".to_string(),
+                        ));
                     }
                 },
                 Err(err) => {
                     let err = format!("Error reading refs db\nErr: {err}");
-                    return Err(OxenError::basic_str(&err));
+                    return Err(OxenError::basic_str(err));
                 }
             }
         }
@@ -229,12 +233,12 @@ impl RefManager {
     pub fn create_branch(&self, name: &str, commit_id: &str) -> Result<Branch, OxenError> {
         if self.is_invalid_branch_name(name) {
             let err = format!("'{name}' is not a valid branch name.");
-            return Err(OxenError::basic_str(&err));
+            return Err(OxenError::basic_str(err));
         }
 
         if self.has_branch(name) {
             let err = format!("Branch already exists: {name}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         } else {
             self.set_branch_commit_id(name, commit_id)?;
             Ok(Branch {
@@ -268,11 +272,11 @@ impl RefManager {
         if !self.has_branch(old_name) {
             Err(OxenError::local_branch_not_found(old_name))
         } else if self.has_branch(new_name) {
-            Err(OxenError::basic_str(&format!(
+            Err(OxenError::basic_str(format!(
                 "Branch already exists: {new_name}"
             )))
         } else if self.is_invalid_branch_name(new_name) {
-            Err(OxenError::basic_str(&format!(
+            Err(OxenError::basic_str(format!(
                 "'{new_name}' is not a valid branch name."
             )))
         } else {
@@ -286,7 +290,7 @@ impl RefManager {
     pub fn delete_branch(&self, name: &str) -> Result<Branch, OxenError> {
         let Some(branch) = self.get_branch_by_name(name)? else {
             let err = format!("Branch does not exist: {name}");
-            return Err(OxenError::basic_str(&err));
+            return Err(OxenError::basic_str(err));
         };
         self.refs_db.delete(name)?;
         Ok(branch)

--- a/crates/lib/src/core/staged/staged_db_manager.rs
+++ b/crates/lib/src/core/staged/staged_db_manager.rs
@@ -108,13 +108,13 @@ pub fn get_staged_db_manager(repository: &LocalRepository) -> Result<StagedDBMan
     if !staged_db_dir.exists() {
         std::fs::create_dir_all(&staged_db_dir).map_err(|e| {
             log::error!("Failed to create staged db directory: {e}");
-            OxenError::basic_str(&format!("Failed to create staged db directory: {e}"))
+            OxenError::basic_str(format!("Failed to create staged db directory: {e}"))
         })?;
     }
     let opts = db::key_val::opts::default();
     let db = DB::open(&opts, dunce::simplified(&staged_db_dir)).map_err(|e| {
         log::error!("Failed to open staged db: {e}");
-        OxenError::basic_str(&format!("Failed to open staged db: {e}"))
+        OxenError::basic_str(format!("Failed to open staged db: {e}"))
     })?;
     let db_lock = Arc::new(RwLock::new(db));
     cache_w.put(staged_db_dir.clone(), db_lock.clone());
@@ -161,7 +161,7 @@ impl StagedDBManager {
         let mut buf = Vec::new();
         staged_node
             .serialize(&mut Serializer::new(&mut buf))
-            .map_err(|e| OxenError::basic_str(&e.to_string()))?;
+            .map_err(|e| OxenError::basic_str(e.to_string()))?;
 
         match db_w {
             Some(write_guard) => {
@@ -234,7 +234,7 @@ impl StagedDBManager {
         dir_entry
             .serialize(&mut Serializer::new(&mut buf))
             .map_err(|e| {
-                OxenError::basic_str(&format!("Failed to serialize directory entry: {e}"))
+                OxenError::basic_str(format!("Failed to serialize directory entry: {e}"))
             })?;
         let db_w = self.staged_db.write();
         db_w.put(directory_path_str, &buf)?;
@@ -275,7 +275,7 @@ impl StagedDBManager {
             Ok(val) => Ok(Some(val)),
             Err(e) => {
                 log::error!("Failed to deserialize data for key {key}: {e}");
-                Err(OxenError::basic_str(&format!(
+                Err(OxenError::basic_str(format!(
                     "Failed to deserialize staged data: {e}"
                 )))
             }
@@ -299,7 +299,7 @@ impl StagedDBManager {
                 Ok((key, value)) => {
                     // log::debug!("Key is {key:?}, value is {value:?}");
                     let key =
-                        str::from_utf8(&key).map_err(|e| OxenError::basic_str(&e.to_string()))?;
+                        str::from_utf8(&key).map_err(|e| OxenError::basic_str(e.to_string()))?;
                     let path = Path::new(key);
                     if !path.starts_with(&start_path) {
                         continue;
@@ -391,14 +391,14 @@ impl StagedDBManager {
                         }
                     }
                     Err(e) => {
-                        return Err(OxenError::basic_str(&format!(
+                        return Err(OxenError::basic_str(format!(
                             "Could not read utf8 val: {e}"
                         )));
                     }
                 },
                 _ => {
                     return Err(OxenError::basic_str(
-                        "Could not read iterate over db values",
+                        "Could not read iterate over db values".to_string(),
                     ));
                 }
             }
@@ -425,14 +425,14 @@ impl StagedDBManager {
                         }
                     }
                     Err(e) => {
-                        return Err(OxenError::basic_str(&format!(
+                        return Err(OxenError::basic_str(format!(
                             "Could not read utf8 val: {e}"
                         )));
                     }
                 },
                 _ => {
                     return Err(OxenError::basic_str(
-                        "Could not read iterate over db values",
+                        "Could not read iterate over db values".to_string(),
                     ));
                 }
             }

--- a/crates/lib/src/core/staged/staged_db_manager.rs
+++ b/crates/lib/src/core/staged/staged_db_manager.rs
@@ -31,7 +31,7 @@ static DB_INSTANCES: LazyLock<RwLock<LruCache<PathBuf, Arc<RwLock<DB>>>>> =
     LazyLock::new(|| RwLock::new(LruCache::new(DB_CACHE_SIZE)));
 
 /// Removes a repository's DB instance from the cache.
-pub fn remove_from_cache(repository_path: impl AsRef<std::path::Path>) -> Result<(), OxenError> {
+pub fn remove_from_cache(repository_path: &std::path::Path) -> Result<(), OxenError> {
     let staged_dir = util::fs::oxen_hidden_dir(repository_path).join(STAGED_DIR);
     let mut instances = DB_INSTANCES.write();
     let _ = instances.pop(&staged_dir); // drop immediately
@@ -40,13 +40,11 @@ pub fn remove_from_cache(repository_path: impl AsRef<std::path::Path>) -> Result
 
 /// Removes a repository's DB instance and all its subdirectories from the cache.
 /// This is mostly useful in test cleanup to ensure all DB instances are removed.
-pub fn remove_from_cache_with_children(
-    repository_path: impl AsRef<std::path::Path>,
-) -> Result<(), OxenError> {
+pub fn remove_from_cache_with_children(repository_path: &std::path::Path) -> Result<(), OxenError> {
     let mut dbs_to_remove: Vec<PathBuf> = vec![];
     let mut instances = DB_INSTANCES.write();
     for (key, _) in instances.iter() {
-        if key.starts_with(&repository_path) {
+        if key.starts_with(repository_path) {
             dbs_to_remove.push(key.clone());
         }
     }
@@ -110,13 +108,13 @@ pub fn get_staged_db_manager(repository: &LocalRepository) -> Result<StagedDBMan
     if !staged_db_dir.exists() {
         std::fs::create_dir_all(&staged_db_dir).map_err(|e| {
             log::error!("Failed to create staged db directory: {e}");
-            OxenError::basic_str(format!("Failed to create staged db directory: {e}"))
+            OxenError::basic_str(&format!("Failed to create staged db directory: {e}"))
         })?;
     }
     let opts = db::key_val::opts::default();
     let db = DB::open(&opts, dunce::simplified(&staged_db_dir)).map_err(|e| {
         log::error!("Failed to open staged db: {e}");
-        OxenError::basic_str(format!("Failed to open staged db: {e}"))
+        OxenError::basic_str(&format!("Failed to open staged db: {e}"))
     })?;
     let db_lock = Arc::new(RwLock::new(db));
     cache_w.put(staged_db_dir.clone(), db_lock.clone());
@@ -129,15 +127,15 @@ pub fn get_staged_db_manager(repository: &LocalRepository) -> Result<StagedDBMan
 
 /// Normalizes a path to use forward slashes for use as a DB key.
 /// This ensures cross-platform consistency since DB keys should be platform-agnostic.
-fn normalize_key(path: impl AsRef<Path>) -> String {
-    path.as_ref().to_string_lossy().replace('\\', "/")
+fn normalize_key(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 impl StagedDBManager {
     /// Upsert a file node to the staged db
     pub fn upsert_file_node(
         &self,
-        relative_path: impl AsRef<Path>,
+        relative_path: &Path,
         status: StagedEntryStatus,
         file_node: &FileNode,
     ) -> Result<Option<StagedMerkleTreeNode>, OxenError> {
@@ -155,15 +153,15 @@ impl StagedDBManager {
     /// Upsert a staged node to the staged db
     pub fn upsert_staged_node(
         &self,
-        path: impl AsRef<Path>,
+        path: &Path,
         staged_node: &StagedMerkleTreeNode,
         db_w: Option<&parking_lot::RwLockWriteGuard<DB>>,
     ) -> Result<(), OxenError> {
-        let key = normalize_key(&path);
+        let key = normalize_key(path);
         let mut buf = Vec::new();
         staged_node
             .serialize(&mut Serializer::new(&mut buf))
-            .map_err(|e| OxenError::basic_str(e.to_string()))?;
+            .map_err(|e| OxenError::basic_str(&e.to_string()))?;
 
         match db_w {
             Some(write_guard) => {
@@ -193,10 +191,10 @@ impl StagedDBManager {
     /// If db_w is provided, use that write lock; otherwise acquire a new one
     pub fn delete_entry_with_lock(
         &self,
-        path: impl AsRef<Path>,
+        path: &Path,
         db_w: Option<&parking_lot::RwLockWriteGuard<DB>>,
     ) -> Result<(), OxenError> {
-        let key = normalize_key(&path);
+        let key = normalize_key(path);
 
         match db_w {
             Some(write_guard) => {
@@ -211,17 +209,16 @@ impl StagedDBManager {
     }
 
     /// Delete an entry from the staged db (convenience method)
-    pub fn delete_entry(&self, path: impl AsRef<Path>) -> Result<(), OxenError> {
+    pub fn delete_entry(&self, path: &Path) -> Result<(), OxenError> {
         self.delete_entry_with_lock(path, None)
     }
 
     /// Write a directory node to the staged db
     pub fn add_directory(
         &self,
-        directory_path: impl AsRef<Path>,
+        directory_path: &Path,
         seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
     ) -> Result<(), OxenError> {
-        let directory_path = directory_path.as_ref();
         let directory_path_str = directory_path.to_str().unwrap();
         let mut seen_dirs = seen_dirs.lock();
         if !seen_dirs.insert(directory_path.to_path_buf()) {
@@ -237,7 +234,7 @@ impl StagedDBManager {
         dir_entry
             .serialize(&mut Serializer::new(&mut buf))
             .map_err(|e| {
-                OxenError::basic_str(format!("Failed to serialize directory entry: {e}"))
+                OxenError::basic_str(&format!("Failed to serialize directory entry: {e}"))
             })?;
         let db_w = self.staged_db.write();
         db_w.put(directory_path_str, &buf)?;
@@ -246,8 +243,8 @@ impl StagedDBManager {
     }
 
     /// True if the paths exists in the staged db. False means it does not exist.
-    pub fn exists(&self, path: impl AsRef<Path>) -> Result<bool, OxenError> {
-        let key = normalize_key(&path);
+    pub fn exists(&self, path: &Path) -> Result<bool, OxenError> {
+        let key = normalize_key(path);
         Ok({
             let db_r = self.staged_db.read();
             // key_may_exist is a bloom filter that doesn't hit I/O
@@ -265,9 +262,9 @@ impl StagedDBManager {
     /// Read a file node from the staged db
     pub fn read_from_staged_db(
         &self,
-        path: impl AsRef<Path>,
+        path: &Path,
     ) -> Result<Option<StagedMerkleTreeNode>, OxenError> {
-        let key = normalize_key(&path);
+        let key = normalize_key(path);
 
         let db_r = self.staged_db.read();
         let data = match db_r.get(key.as_bytes())? {
@@ -278,7 +275,7 @@ impl StagedDBManager {
             Ok(val) => Ok(Some(val)),
             Err(e) => {
                 log::error!("Failed to deserialize data for key {key}: {e}");
-                Err(OxenError::basic_str(format!(
+                Err(OxenError::basic_str(&format!(
                     "Failed to deserialize staged data: {e}"
                 )))
             }
@@ -288,12 +285,11 @@ impl StagedDBManager {
     /// Read all entries below a path from the staged db
     pub fn read_staged_entries_below_path(
         &self,
-        start_path: impl AsRef<Path>,
+        start_path: &Path,
         read_progress: &ProgressBar,
     ) -> Result<(HashMap<PathBuf, Vec<StagedMerkleTreeNode>>, usize), OxenError> {
         let db = self.staged_db.read();
-        let start_path =
-            util::fs::path_relative_to_dir(start_path.as_ref(), &self.repository.path)?;
+        let start_path = util::fs::path_relative_to_dir(start_path, &self.repository.path)?;
         let mut total_entries = 0;
         let iter = db.iterator(IteratorMode::Start);
         let mut dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>> = HashMap::new();
@@ -303,7 +299,7 @@ impl StagedDBManager {
                 Ok((key, value)) => {
                     // log::debug!("Key is {key:?}, value is {value:?}");
                     let key =
-                        str::from_utf8(&key).map_err(|e| OxenError::basic_str(e.to_string()))?;
+                        str::from_utf8(&key).map_err(|e| OxenError::basic_str(&e.to_string()))?;
                     let path = Path::new(key);
                     if !path.starts_with(&start_path) {
                         continue;
@@ -395,7 +391,7 @@ impl StagedDBManager {
                         }
                     }
                     Err(e) => {
-                        return Err(OxenError::basic_str(format!(
+                        return Err(OxenError::basic_str(&format!(
                             "Could not read utf8 val: {e}"
                         )));
                     }
@@ -429,7 +425,7 @@ impl StagedDBManager {
                         }
                     }
                     Err(e) => {
-                        return Err(OxenError::basic_str(format!(
+                        return Err(OxenError::basic_str(&format!(
                             "Could not read utf8 val: {e}"
                         )));
                     }

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -69,9 +69,9 @@ impl AddAssign<CumulativeStats> for CumulativeStats {
     }
 }
 
-pub async fn add<T: AsRef<Path>>(
+pub async fn add<'a>(
     repo: &LocalRepository,
-    paths: impl IntoIterator<Item = T>,
+    paths: impl IntoIterator<Item = &'a Path>,
 ) -> Result<(), OxenError> {
     // Collect paths that match the glob pattern either:
     // 1. In the repo working directory (untracked or modified files)
@@ -84,8 +84,6 @@ pub async fn add<T: AsRef<Path>>(
     let mut expanded_paths: HashSet<PathBuf> = HashSet::new();
 
     for path in paths {
-        let path = path.as_ref();
-
         let glob_opts = GlobOpts {
             paths: vec![path.to_path_buf()],
             staged_db: false,
@@ -130,7 +128,7 @@ pub async fn add<T: AsRef<Path>>(
 
 pub async fn add_files(
     repo: &LocalRepository,
-    repo_path: &PathBuf,
+    repo_path: &Path,
     paths: &HashSet<PathBuf>, // We assume all paths provided are relative to the repo root
     staged_db: Arc<DBWithThreadMode<MultiThreaded>>,
     version_store: &Arc<dyn VersionStore>,
@@ -379,7 +377,7 @@ pub async fn process_add_dir(
             async move {
                 let process_directory = move || async move {
                     let dir = entry.path();
-                    let dir_path = util::fs::path_relative_to_dir(dir, &*Arc::clone(&repo_path))?;
+                    let dir_path = util::fs::path_relative_to_dir(dir, &Arc::clone(&repo_path))?;
                     // Check if the dir is excluded
                     if let Some(dir_hashes_ref) = dir_hashes.as_ref()
                         && let Some(dir_hash) = dir_hashes_ref.get(&dir_path)
@@ -622,7 +620,7 @@ fn maybe_load_directory(
 
 pub fn get_file_node(
     dir_node: &Option<MerkleTreeNode>,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<FileNode>, OxenError> {
     let Some(node) = dir_node else {
         return Ok(None);
@@ -641,7 +639,7 @@ pub fn get_file_node(
 
 async fn add_file_inner(
     repo: &LocalRepository,
-    repo_path: &PathBuf,
+    repo_path: &Path,
     maybe_head_commit: &Option<Commit>,
     path: &Path,
     staged_db: &DBWithThreadMode<MultiThreaded>,
@@ -680,12 +678,11 @@ async fn add_file_inner(
 
 pub fn determine_file_status(
     maybe_dir_node: &Option<MerkleTreeNode>,
-    file_name: impl AsRef<str>,  // Name of the file in the repository
-    data_path: impl AsRef<Path>, // Path to the data file (maybe in the version store)
+    file_name: &str,  // Name of the file in the repository
+    data_path: &Path, // Path to the data file (maybe in the version store)
 ) -> Result<FileStatus, OxenError> {
     // Check if the file is already in the head commit
     let file_path = file_name.as_ref();
-    let data_path = data_path.as_ref();
     log::debug!("determine_file_status data_path {data_path:?} file_name {file_path:?}",);
 
     let maybe_file_node = get_file_node(maybe_dir_node, file_path)?;
@@ -836,7 +833,13 @@ pub fn process_add_file(
         },
     )?;
 
-    p_add_file_node_to_staged_db(staged_db, relative_path_str, status, &file_node, seen_dirs)
+    p_add_file_node_to_staged_db(
+        staged_db,
+        Path::new(relative_path_str),
+        status,
+        &file_node,
+        seen_dirs,
+    )
 }
 
 /// Add this function in replace of process_add_file for workspaces staged db to handle concurrent add_file calls
@@ -935,13 +938,19 @@ pub fn process_add_file_with_staged_db_manager(
         },
     )?;
 
-    add_file_node_to_staged_db(repo, relative_path_str, status, &file_node, seen_dirs)
+    add_file_node_to_staged_db(
+        repo,
+        Path::new(relative_path_str),
+        status,
+        &file_node,
+        seen_dirs,
+    )
 }
 
 /// Stage file node with staged db manager
 pub fn add_file_node_to_staged_db(
     repo: &LocalRepository,
-    relative_path: impl AsRef<Path>,
+    relative_path: &Path,
     status: StagedEntryStatus,
     file_node: &FileNode,
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
@@ -969,7 +978,7 @@ pub fn stage_file_with_hash(
     let base_repo = &workspace.base_repo;
     let head_commit = &workspace.commit;
 
-    let relative_path = util::fs::path_relative_to_dir(dst_path, base_repo.path.clone())?;
+    let relative_path = util::fs::path_relative_to_dir(dst_path, &base_repo.path.clone())?;
     let metadata = util::fs::metadata(data_path)?;
     let mtime = FileTime::from_last_modification_time(&metadata);
     let maybe_file_node =
@@ -1024,15 +1033,15 @@ pub fn stage_file_with_hash(
 pub fn add_file_node_and_parent_dir(
     file_node: &FileNode,
     status: StagedEntryStatus,
-    relative_path: impl AsRef<Path>,
+    relative_path: &Path,
     staged_db_manager: &StagedDBManager,
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
 ) -> Result<(), OxenError> {
     // Stage the file node
-    staged_db_manager.upsert_file_node(&relative_path, status, file_node)?;
+    staged_db_manager.upsert_file_node(relative_path, status, file_node)?;
 
     // Add all the parent dirs to the staged db
-    let mut parent_path = relative_path.as_ref().to_path_buf();
+    let mut parent_path = relative_path.to_path_buf();
     while let Some(parent) = parent_path.parent() {
         parent_path = parent.to_path_buf();
 
@@ -1158,13 +1167,11 @@ pub fn maybe_construct_generic_metadata_for_tabular(
 
 pub fn p_add_file_node_to_staged_db(
     staged_db: &DBWithThreadMode<MultiThreaded>,
-    relative_path: impl AsRef<Path>,
+    relative_path: &Path,
     status: StagedEntryStatus,
     file_node: &FileNode,
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
 ) -> Result<Option<StagedMerkleTreeNode>, OxenError> {
-    let relative_path = relative_path.as_ref();
-
     log::debug!(
         "writing {:?} [{:?}] to staged db: {:?}",
         relative_path,
@@ -1204,10 +1211,9 @@ pub fn p_add_file_node_to_staged_db(
 
 pub fn add_dir_to_staged_db(
     staged_db: &DBWithThreadMode<MultiThreaded>,
-    relative_path: impl AsRef<Path>,
+    relative_path: &Path,
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
 ) -> Result<(), OxenError> {
-    let relative_path = relative_path.as_ref();
     let relative_path_str = relative_path.to_str().unwrap();
     let mut seen_dirs = seen_dirs.lock();
     if !seen_dirs.insert(relative_path.to_path_buf()) {
@@ -1302,11 +1308,11 @@ mod tests {
             test::write_txt_file_to_path(&file2_1, "dir2/file2_1")?;
             test::write_txt_file_to_path(&file_root, "file_root")?;
 
-            add(&repo, vec![&repo.path]).await?;
+            add(&repo, [repo.path.as_path()]).await?;
 
             repositories::commits::commit(&repo, "Initial commit with multiple files and dirs")?;
 
-            add(&repo, vec![&repo.path]).await?;
+            add(&repo, [repo.path.as_path()]).await?;
 
             let status = repositories::status(&repo);
             assert!(status.is_ok());
@@ -1353,24 +1359,24 @@ mod tests {
 
             // Add files to both directories
             test::write_txt_file_to_path(
-                ignored_dir_path.join("file1.txt"),
+                &ignored_dir_path.join("file1.txt"),
                 "This should be ignored",
             )?;
             test::write_txt_file_to_path(
-                ignored_dir_path.join("file2.txt"),
+                &ignored_dir_path.join("file2.txt"),
                 "This should also be ignored",
             )?;
             test::write_txt_file_to_path(
-                normal_dir_path.join("file1.txt"),
+                &normal_dir_path.join("file1.txt"),
                 "This should be added",
             )?;
             test::write_txt_file_to_path(
-                normal_dir_path.join("file2.txt"),
+                &normal_dir_path.join("file2.txt"),
                 "This should also be added",
             )?;
 
             let oxenignore_path = repo.path.join(".oxenignore");
-            test::write_txt_file_to_path(&oxenignore_path, format!("{dir_to_ignore}/"))?;
+            test::write_txt_file_to_path(&oxenignore_path, &format!("{dir_to_ignore}/"))?;
 
             add(&repo, vec![Path::new(&repo.path)]).await?;
 

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -102,7 +102,7 @@ pub async fn add<'a>(
 
             if !util::fs::is_canonical(path)? {
                 return Err(OxenError::basic_str(
-                    "Err: Cannot use relative paths outside repo scope",
+                    "Err: Cannot use relative paths outside repo scope".to_string(),
                 ));
             }
 

--- a/crates/lib/src/core/v_latest/branches.rs
+++ b/crates/lib/src/core/v_latest/branches.rs
@@ -168,7 +168,7 @@ pub async fn checkout_subtrees(
             repositories::tree::get_subtree_by_depth_with_unique_children(
                 repo,
                 to_commit,
-                subtree_path.clone(),
+                &subtree_path.clone(),
                 None,
                 Some(&mut target_hashes),
                 None,
@@ -198,7 +198,7 @@ pub async fn checkout_subtrees(
                 &mut partial_nodes,
             )
             .map_err(|e| {
-                OxenError::basic_str(format!("Cannot get root node for base commit: {e:?}"))
+                OxenError::basic_str(&format!("Cannot get root node for base commit: {e:?}"))
             })?
         } else {
             log::warn!("head commit missing, might be a clone");

--- a/crates/lib/src/core/v_latest/branches.rs
+++ b/crates/lib/src/core/v_latest/branches.rs
@@ -198,7 +198,7 @@ pub async fn checkout_subtrees(
                 &mut partial_nodes,
             )
             .map_err(|e| {
-                OxenError::basic_str(&format!("Cannot get root node for base commit: {e:?}"))
+                OxenError::basic_str(format!("Cannot get root node for base commit: {e:?}"))
             })?
         } else {
             log::warn!("head commit missing, might be a clone");
@@ -310,7 +310,7 @@ pub async fn set_working_repo_to_commit(
     )?
     else {
         return Err(OxenError::basic_str(
-            "Cannot get root node for target commit",
+            "Cannot get root node for target commit".to_string(),
         ));
     };
 
@@ -334,7 +334,7 @@ pub async fn set_working_repo_to_commit(
             Some(&mut shared_hashes),
             &mut partial_nodes,
         )
-        .map_err(|_| OxenError::basic_str("Cannot get root node for base commit"))?
+        .map_err(|_| OxenError::basic_str("Cannot get root node for base commit".to_string()))?
     } else {
         None
     };
@@ -724,7 +724,7 @@ fn r_restore_missing_or_modified_files(
         }
         _ => {
             return Err(OxenError::basic_str(
-                "Got an unexpected node type during checkout",
+                "Got an unexpected node type during checkout".to_string(),
             ));
         }
     }

--- a/crates/lib/src/core/v_latest/clone.rs
+++ b/crates/lib/src/core/v_latest/clone.rs
@@ -18,7 +18,7 @@ pub async fn clone_repo(
     let repo_path = &opts.dst;
     if repo_path.exists() {
         let err = format!("Directory already exists: {}", repo_path.to_string_lossy());
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
     // if directory does not exist, create it
@@ -73,7 +73,7 @@ pub async fn clone_repo_remote_mode(
     let repo_path = &opts.dst;
     if repo_path.exists() {
         let err = format!("Directory already exists: {}", repo_path.to_string_lossy());
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
     // if directory does not exist, create it
@@ -107,7 +107,7 @@ pub async fn clone_repo_remote_mode(
 
     let workspace = api::client::workspaces::create_with_path(
         &remote_repo,
-        &branch_name,
+        branch_name,
         &workspace_id,
         Path::new("/"),
         Some(name.clone()),
@@ -139,8 +139,8 @@ pub async fn clone_repo_remote_mode(
     }
     println!("{} {}", "Workspace ID:".green().bold(), workspace.id.bold());
 
-    local_repo.add_workspace(name.clone());
-    local_repo.set_workspace(name.clone())?;
+    local_repo.add_workspace(&name.clone());
+    local_repo.set_workspace(&name.clone())?;
     local_repo.save()?;
 
     if remote_repo.is_empty {

--- a/crates/lib/src/core/v_latest/clone.rs
+++ b/crates/lib/src/core/v_latest/clone.rs
@@ -18,7 +18,7 @@ pub async fn clone_repo(
     let repo_path = &opts.dst;
     if repo_path.exists() {
         let err = format!("Directory already exists: {}", repo_path.to_string_lossy());
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     // if directory does not exist, create it
@@ -73,7 +73,7 @@ pub async fn clone_repo_remote_mode(
     let repo_path = &opts.dst;
     if repo_path.exists() {
         let err = format!("Directory already exists: {}", repo_path.to_string_lossy());
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     // if directory does not exist, create it
@@ -131,7 +131,7 @@ pub async fn clone_repo_remote_mode(
                 workspace_id.clone()
             );
             println!("{}", err_msg.yellow().bold());
-            return Err(OxenError::basic_str("Err: Cannot "));
+            return Err(OxenError::basic_str("Err: Cannot ".to_string()));
         }
         other => {
             println!("{}", format!("Unexpected workspace status: {other}").red());

--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -45,24 +45,19 @@ struct CommitTraversalConfig<'a> {
     known_total_count: Option<usize>,
 }
 
-pub fn commit(repo: &LocalRepository, message: impl AsRef<str>) -> Result<Commit, OxenError> {
+pub fn commit(repo: &LocalRepository, message: &str) -> Result<Commit, OxenError> {
     repositories::commits::commit_writer::commit(repo, message)
 }
 
 pub fn commit_with_user(
     repo: &LocalRepository,
-    message: impl AsRef<str>,
+    message: &str,
     user: &User,
 ) -> Result<Commit, OxenError> {
     repositories::commits::commit_writer::commit_with_user(repo, message, user)
 }
 
-pub fn commit_allow_empty(
-    repo: &LocalRepository,
-    message: impl AsRef<str>,
-) -> Result<Commit, OxenError> {
-    let message = message.as_ref();
-
+pub fn commit_allow_empty(repo: &LocalRepository, message: &str) -> Result<Commit, OxenError> {
     // Check if there are staged changes
     let status = crate::core::v_latest::status::status(repo)?;
     let has_changes = !status.staged_files.is_empty() || !status.staged_dirs.is_empty();
@@ -103,13 +98,13 @@ pub fn commit_allow_empty(
     }
 }
 
-pub fn get_commit_or_head<S: AsRef<str> + Clone>(
+pub fn get_commit_or_head(
     repo: &LocalRepository,
-    commit_id_or_branch_name: Option<S>,
+    commit_id_or_branch_name: Option<&str>,
 ) -> Result<Commit, OxenError> {
     match commit_id_or_branch_name {
         Some(ref_name) => {
-            log::debug!("get_commit_or_head: ref_name: {:?}", ref_name.as_ref());
+            log::debug!("get_commit_or_head: ref_name: {:?}", ref_name);
             get_commit_by_ref(repo, ref_name)
         }
         None => {
@@ -119,12 +114,9 @@ pub fn get_commit_or_head<S: AsRef<str> + Clone>(
     }
 }
 
-fn get_commit_by_ref<S: AsRef<str> + Clone>(
-    repo: &LocalRepository,
-    ref_name: S,
-) -> Result<Commit, OxenError> {
-    get_by_id(repo, ref_name.clone())?
-        .or_else(|| get_commit_by_branch(repo, ref_name.as_ref()))
+fn get_commit_by_ref(repo: &LocalRepository, ref_name: &str) -> Result<Commit, OxenError> {
+    get_by_id(repo, ref_name)?
+        .or_else(|| get_commit_by_branch(repo, ref_name))
         .ok_or_else(|| OxenError::basic_str("Commit not found"))
 }
 
@@ -175,7 +167,7 @@ pub fn head_commit(repo: &LocalRepository) -> Result<Commit, OxenError> {
 
     let node =
         repositories::tree::get_node_by_id(repo, &head_commit_id)?.ok_or(OxenError::basic_str(
-            format!("Merkle tree node not found for head commit: '{head_commit_id}'"),
+            &format!("Merkle tree node not found for head commit: '{head_commit_id}'"),
         ))?;
     let commit = node.commit()?;
     Ok(commit.to_commit())
@@ -227,11 +219,7 @@ fn root_commit_recursive(
     }
 }
 
-pub fn get_by_id(
-    repo: &LocalRepository,
-    commit_id_str: impl AsRef<str>,
-) -> Result<Option<Commit>, OxenError> {
-    let commit_id_str = commit_id_str.as_ref();
+pub fn get_by_id(repo: &LocalRepository, commit_id_str: &str) -> Result<Option<Commit>, OxenError> {
     let Ok(commit_id) = commit_id_str.parse() else {
         // log::debug!(
         //     "get_by_id could not create commit_id from [{}]",
@@ -252,17 +240,16 @@ pub fn get_by_hash(repo: &LocalRepository, hash: &MerkleHash) -> Result<Option<C
 
 pub fn create_empty_commit(
     repo: &LocalRepository,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
     new_commit: &Commit,
 ) -> Result<Commit, OxenError> {
-    let branch_name = branch_name.as_ref();
     let Some(existing_commit) = repositories::revisions::get(repo, branch_name)? else {
         return Err(OxenError::revision_not_found(branch_name.into()));
     };
     let existing_commit_id = existing_commit.id.parse()?;
     let existing_node =
         repositories::tree::get_node_by_id_with_children(repo, &existing_commit_id)?.ok_or(
-            OxenError::basic_str(format!(
+            OxenError::basic_str(&format!(
                 "Merkle tree node not found for commit: '{}'",
                 existing_commit.id
             )),
@@ -291,7 +278,7 @@ pub fn create_empty_commit(
 
     // Update the ref
     with_ref_manager(repo, |manager| {
-        manager.set_branch_commit_id(branch_name, commit_node.hash().to_string())
+        manager.set_branch_commit_id(branch_name, &commit_node.hash().to_string())
     })?;
 
     Ok(commit_node.to_commit())
@@ -302,13 +289,10 @@ pub fn create_empty_commit(
 /// Returns an error if the repository already has commits.
 pub fn create_initial_commit(
     repo: &LocalRepository,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
     user: &User,
-    message: impl AsRef<str>,
+    message: &str,
 ) -> Result<Commit, OxenError> {
-    let branch_name = branch_name.as_ref();
-    let message = message.as_ref();
-
     // Ensure the repository is actually empty
     if head_commit_maybe(repo)?.is_some() {
         return Err(OxenError::basic_str(
@@ -374,7 +358,7 @@ pub fn create_initial_commit(
 
     // Create the branch pointing to this commit
     with_ref_manager(repo, |manager| {
-        manager.create_branch(branch_name, commit_id.to_string())
+        manager.create_branch(branch_name, &commit_id.to_string())
     })?;
 
     // Set HEAD to the new branch
@@ -601,9 +585,8 @@ pub fn list_all(repo: &LocalRepository) -> Result<HashSet<Commit>, OxenError> {
 
 pub fn list_unsynced_from(
     repo: &LocalRepository,
-    revision: impl AsRef<str>,
+    revision: &str,
 ) -> Result<HashSet<Commit>, OxenError> {
-    let revision = revision.as_ref();
     let all_commits: HashSet<Commit> = list_from(repo, revision)?.into_iter().collect();
     filter_unsynced(repo, all_commits)
 }
@@ -654,23 +637,19 @@ fn list_all_recursive(
 }
 
 /// Get commit history given a revision (branch name or commit id)
-pub fn list_from(
-    repo: &LocalRepository,
-    revision: impl AsRef<str>,
-) -> Result<Vec<Commit>, OxenError> {
+pub fn list_from(repo: &LocalRepository, revision: &str) -> Result<Vec<Commit>, OxenError> {
     let (commits, _, _) = list_from_paginated_impl(repo, revision, 0, usize::MAX)?;
     Ok(commits)
 }
 
 pub fn list_from_paginated_impl(
     repo: &LocalRepository,
-    revision: impl AsRef<str>,
+    revision: &str,
     skip: usize,
     limit: usize,
 ) -> Result<(Vec<Commit>, usize, bool), OxenError> {
     let _perf = crate::perf_guard!("core::commits::list_from_paginated_impl");
 
-    let revision = revision.as_ref();
     if revision.contains("..") {
         let _perf_between = crate::perf_guard!("core::commits::list_between_range");
         let split: Vec<&str> = revision.split("..").collect();
@@ -720,7 +699,7 @@ pub fn list_from_paginated_impl(
 /// Get commit history given a revision (branch name or commit id)
 pub fn list_from_with_depth(
     repo: &LocalRepository,
-    revision: impl AsRef<str>,
+    revision: &str,
 ) -> Result<HashMap<Commit, usize>, OxenError> {
     let mut results = HashMap::new();
     let commit = repositories::revisions::get(repo, revision)?;
@@ -784,12 +763,7 @@ fn cache_count(
     str_val_db::put(db, commit_id, &count)
 }
 
-pub fn count_from(
-    repo: &LocalRepository,
-    revision: impl AsRef<str>,
-) -> Result<(usize, bool), OxenError> {
-    let revision = revision.as_ref();
-
+pub fn count_from(repo: &LocalRepository, revision: &str) -> Result<(usize, bool), OxenError> {
     let commit = repositories::revisions::get(repo, revision)?
         .ok_or_else(|| OxenError::revision_not_found(revision.into()))?;
 
@@ -832,9 +806,8 @@ pub fn list_between(
 pub fn search_entries(
     repo: &LocalRepository,
     commit: &Commit,
-    pattern: impl AsRef<str>,
+    pattern: &str,
 ) -> Result<HashSet<PathBuf>, OxenError> {
-    let pattern = pattern.as_ref();
     let pattern = Pattern::new(pattern)?;
 
     let mut results = HashSet::new();
@@ -891,7 +864,7 @@ fn list_by_path_recursive_impl(
                 if modified {
                     return Ok(true);
                 }
-                let parent_hash = match repositories::revisions::get(repo, parent_id.clone())? {
+                let parent_hash = match repositories::revisions::get(repo, &parent_id.clone())? {
                     Some(pc) => {
                         repositories::tree::get_node_by_path(repo, &pc, path)?.map(|n| n.hash)
                     }
@@ -908,7 +881,7 @@ fn list_by_path_recursive_impl(
         } else {
             // File not modified here. Use last_commit_id to jump ahead to the
             // next commit that did, skipping intermediate unmodified commits.
-            match repositories::revisions::get(repo, last_commit_id.to_string())? {
+            match repositories::revisions::get(repo, &last_commit_id.to_string())? {
                 Some(jump_commit) if !visited.contains(&jump_commit.id) => {
                     stack.push(jump_commit);
                 }
@@ -927,7 +900,7 @@ fn push_unvisited_parents(
     stack: &mut Vec<Commit>,
 ) -> Result<(), OxenError> {
     for parent_id in &commit.parent_ids {
-        if let Some(parent) = repositories::revisions::get(repo, parent_id.clone())?
+        if let Some(parent) = repositories::revisions::get(repo, &parent_id.clone())?
             && !visited.contains(&parent.id)
         {
             stack.push(parent);
@@ -948,13 +921,13 @@ pub fn list_by_path_from_paginated(
     // Check if the path is a directory or file
     let _perf_node = crate::perf_guard!("core::commits::get_node_by_path");
     let node = repositories::tree::get_node_by_path(repo, commit, path)?.ok_or(
-        OxenError::basic_str(format!("Merkle tree node not found for path: {path:?}")),
+        OxenError::basic_str(&format!("Merkle tree node not found for path: {path:?}")),
     )?;
     let last_commit_id = match &node.node {
         EMerkleTreeNode::File(file_node) => file_node.last_commit_id(),
         EMerkleTreeNode::Directory(dir_node) => dir_node.last_commit_id(),
         _ => {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Merkle tree node not found for path: {path:?}"
             )));
         }
@@ -998,7 +971,7 @@ mod tests {
             for i in 0..15 {
                 let filename = format!("file_{i}.txt");
                 let file_path = repo.path.join(&filename);
-                test::write_txt_file_to_path(&file_path, format!("Content {i}"))?;
+                test::write_txt_file_to_path(&file_path, &format!("Content {i}"))?;
 
                 repositories::add(&repo, &file_path).await?;
                 let commit = repositories::commit(&repo, &format!("Commit {i}"))?;
@@ -1058,7 +1031,7 @@ mod tests {
             for i in 0..10 {
                 let filename = format!("file_{i}.txt");
                 let file_path = repo.path.join(&filename);
-                test::write_txt_file_to_path(&file_path, format!("Content {i}"))?;
+                test::write_txt_file_to_path(&file_path, &format!("Content {i}"))?;
 
                 repositories::add(&repo, &file_path).await?;
                 let commit = repositories::commit(&repo, &format!("Commit {i}"))?;

--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -69,7 +69,7 @@ pub fn commit_allow_empty(repo: &LocalRepository, message: &str) -> Result<Commi
         // No changes, create an empty commit
         let cfg = crate::config::UserConfig::get()?;
         let branch = repositories::branches::current_branch(repo)?
-            .ok_or_else(|| OxenError::basic_str("No current branch found"))?;
+            .ok_or_else(|| OxenError::basic_str("No current branch found".to_string()))?;
 
         let head_commit = head_commit(repo)?;
 
@@ -117,7 +117,7 @@ pub fn get_commit_or_head(
 fn get_commit_by_ref(repo: &LocalRepository, ref_name: &str) -> Result<Commit, OxenError> {
     get_by_id(repo, ref_name)?
         .or_else(|| get_commit_by_branch(repo, ref_name))
-        .ok_or_else(|| OxenError::basic_str("Commit not found"))
+        .ok_or_else(|| OxenError::basic_str("Commit not found".to_string()))
 }
 
 fn get_commit_by_branch(repo: &LocalRepository, branch_name: &str) -> Option<Commit> {
@@ -167,7 +167,7 @@ pub fn head_commit(repo: &LocalRepository) -> Result<Commit, OxenError> {
 
     let node =
         repositories::tree::get_node_by_id(repo, &head_commit_id)?.ok_or(OxenError::basic_str(
-            &format!("Merkle tree node not found for head commit: '{head_commit_id}'"),
+            format!("Merkle tree node not found for head commit: '{head_commit_id}'"),
         ))?;
     let commit = node.commit()?;
     Ok(commit.to_commit())
@@ -200,7 +200,9 @@ fn root_commit_recursive(
     loop {
         // Check if we've already seen this commit
         if !seen.insert(current_id.to_string()) {
-            return Err(OxenError::basic_str("Cycle detected in commit history"));
+            return Err(OxenError::basic_str(
+                "Cycle detected in commit history".to_string(),
+            ));
         }
 
         if let Some(commit) = get_by_hash(repo, &current_id)? {
@@ -215,7 +217,7 @@ fn root_commit_recursive(
             }
         }
 
-        return Err(OxenError::basic_str("No root commit found"));
+        return Err(OxenError::basic_str("No root commit found".to_string()));
     }
 }
 
@@ -249,7 +251,7 @@ pub fn create_empty_commit(
     let existing_commit_id = existing_commit.id.parse()?;
     let existing_node =
         repositories::tree::get_node_by_id_with_children(repo, &existing_commit_id)?.ok_or(
-            OxenError::basic_str(&format!(
+            OxenError::basic_str(format!(
                 "Merkle tree node not found for commit: '{}'",
                 existing_commit.id
             )),
@@ -296,7 +298,7 @@ pub fn create_initial_commit(
     // Ensure the repository is actually empty
     if head_commit_maybe(repo)?.is_some() {
         return Err(OxenError::basic_str(
-            "Cannot create initial commit: repository already has commits",
+            "Cannot create initial commit: repository already has commits".to_string(),
         ));
     }
 
@@ -812,7 +814,7 @@ pub fn search_entries(
 
     let mut results = HashSet::new();
     let tree = repositories::tree::get_root_with_children(repo, commit)?
-        .ok_or(OxenError::basic_str("Root not found"))?;
+        .ok_or(OxenError::basic_str("Root not found".to_string()))?;
     let (files, _) = repositories::tree::list_files_and_dirs(&tree)?;
     for file in files {
         let path = file.dir.join(file.file_node.name());
@@ -921,13 +923,13 @@ pub fn list_by_path_from_paginated(
     // Check if the path is a directory or file
     let _perf_node = crate::perf_guard!("core::commits::get_node_by_path");
     let node = repositories::tree::get_node_by_path(repo, commit, path)?.ok_or(
-        OxenError::basic_str(&format!("Merkle tree node not found for path: {path:?}")),
+        OxenError::basic_str(format!("Merkle tree node not found for path: {path:?}")),
     )?;
     let last_commit_id = match &node.node {
         EMerkleTreeNode::File(file_node) => file_node.last_commit_id(),
         EMerkleTreeNode::Directory(dir_node) => dir_node.last_commit_id(),
         _ => {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Merkle tree node not found for path: {path:?}"
             )));
         }

--- a/crates/lib/src/core/v_latest/data_frames.rs
+++ b/crates/lib/src/core/v_latest/data_frames.rs
@@ -20,7 +20,7 @@ pub mod schemas;
 pub async fn get_slice(
     repo: &LocalRepository,
     resource: &ParsedResource,
-    path: impl AsRef<Path>,
+    path: &Path,
     opts: &DFOpts,
 ) -> Result<DataFrameSlice, OxenError> {
     let workspace = resource.workspace.as_ref();
@@ -41,7 +41,7 @@ pub async fn get_slice(
         Some(ws) => {
             let staged_db_manager = get_staged_db_manager(staged_repo)?;
             // Try staged DB first
-            if let Some(staged_node) = staged_db_manager.read_from_staged_db(&path)? {
+            if let Some(staged_node) = staged_db_manager.read_from_staged_db(path)? {
                 match staged_node.node.node {
                     EMerkleTreeNode::File(f) => Ok(f),
                     _ => Err(OxenError::basic_str(
@@ -51,8 +51,8 @@ pub async fn get_slice(
             } else {
                 // Fall back to commit tree using workspace's commit
                 let commit = &ws.commit;
-                repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                    .ok_or(OxenError::path_does_not_exist(path.as_ref()))?
+                repositories::tree::get_file_by_path(base_repo, commit, path)?
+                    .ok_or(OxenError::path_does_not_exist(path))?
             }
         }
         None => {
@@ -60,8 +60,8 @@ pub async fn get_slice(
                 .commit
                 .as_ref()
                 .ok_or(OxenError::basic_str("Commit not found"))?;
-            repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(path.as_ref()))?
+            repositories::tree::get_file_by_path(base_repo, commit, path)?
+                .ok_or(OxenError::path_does_not_exist(path))?
         }
     };
 
@@ -96,7 +96,8 @@ pub async fn get_slice(
     let version_path = version_store
         .get_version_path(&file_node.hash().to_string())
         .await?;
-    let df = tabular::read_df_with_extension(version_path, file_node.extension(), opts).await?;
+    let df = tabular::read_df_with_extension(&version_path, file_node.extension(), opts).await?;
+
     log::debug!("get_slice df {:?}", df.height());
 
     // Check what the view height is
@@ -133,11 +134,10 @@ pub async fn get_slice(
 async fn handle_sql_querying(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
     opts: &DFOpts,
     data_frame_size: &DataFrameSize,
 ) -> Result<DataFrameSlice, OxenError> {
-    let path = path.as_ref();
     let mut workspace: Option<Workspace> = None;
 
     if opts.sql.is_some() {
@@ -153,7 +153,7 @@ async fn handle_sql_querying(
 
     if let (Some(sql), Some(workspace)) = (opts.sql.clone(), workspace) {
         let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-        let df = with_df_db_manager(db_path, |manager| {
+        let df = with_df_db_manager(&db_path, |manager| {
             manager.with_conn_mut(|conn| sql::query_df(conn, sql, None))
         })?;
         log::debug!("handle_sql_querying got df {df:?}");

--- a/crates/lib/src/core/v_latest/data_frames.rs
+++ b/crates/lib/src/core/v_latest/data_frames.rs
@@ -29,7 +29,7 @@ pub async fn get_slice(
         None => resource
             .commit
             .clone()
-            .ok_or(OxenError::basic_str("Commit not found"))?,
+            .ok_or(OxenError::basic_str("Commit not found".to_string()))?,
     };
 
     let (staged_repo, base_repo) = match workspace {
@@ -45,23 +45,23 @@ pub async fn get_slice(
                 match staged_node.node.node {
                     EMerkleTreeNode::File(f) => Ok(f),
                     _ => Err(OxenError::basic_str(
-                        "Only single file download is supported",
+                        "Only single file download is supported".to_string(),
                     )),
                 }?
             } else {
                 // Fall back to commit tree using workspace's commit
                 let commit = &ws.commit;
                 repositories::tree::get_file_by_path(base_repo, commit, path)?
-                    .ok_or(OxenError::path_does_not_exist(path))?
+                    .ok_or(OxenError::path_does_not_exist(path.to_path_buf()))?
             }
         }
         None => {
             let commit = resource
                 .commit
                 .as_ref()
-                .ok_or(OxenError::basic_str("Commit not found"))?;
+                .ok_or(OxenError::basic_str("Commit not found".to_string()))?;
             repositories::tree::get_file_by_path(base_repo, commit, path)?
-                .ok_or(OxenError::path_does_not_exist(path))?
+                .ok_or(OxenError::path_does_not_exist(path.to_path_buf()))?
         }
     };
 
@@ -71,11 +71,13 @@ pub async fn get_slice(
         Some(metadata) => match metadata {
             GenericMetadata::MetadataTabular(metadata) => Ok(metadata.tabular.clone()),
             _ => {
-                return Err(OxenError::basic_str("Metadata is not tabular"));
+                return Err(OxenError::basic_str("Metadata is not tabular".to_string()));
             }
         },
         None => {
-            return Err(OxenError::basic_str("File node does not have metadata"));
+            return Err(OxenError::basic_str(
+                "File node does not have metadata".to_string(),
+            ));
         }
     };
     let metadata = metadata?;
@@ -189,5 +191,7 @@ async fn handle_sql_querying(
         });
     }
 
-    Err(OxenError::basic_str("Could not query data frame"))
+    Err(OxenError::basic_str(
+        "Could not query data frame".to_string(),
+    ))
 }

--- a/crates/lib/src/core/v_latest/data_frames/schemas.rs
+++ b/crates/lib/src/core/v_latest/data_frames/schemas.rs
@@ -38,29 +38,29 @@ pub fn list(
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     let tree = CommitMerkleTree::from_commit(repo, commit)?;
     let mut schemas = HashMap::new();
-    r_list_schemas(repo, tree.root, PathBuf::new(), &mut schemas)?;
+    r_list_schemas(repo, tree.root, &PathBuf::new(), &mut schemas)?;
     Ok(schemas)
 }
 
 fn r_list_schemas(
     _repo: &LocalRepository,
     node: MerkleTreeNode,
-    current_path: impl AsRef<Path>,
+    current_path: &Path,
     schemas: &mut HashMap<PathBuf, Schema>,
 ) -> Result<(), OxenError> {
     for child in node.children {
         match &child.node {
             EMerkleTreeNode::VNode(_) => {
-                let child_path = current_path.as_ref();
+                let child_path = current_path;
                 r_list_schemas(_repo, child, child_path, schemas)?;
             }
             EMerkleTreeNode::Directory(dir_node) => {
-                let child_path = current_path.as_ref().join(dir_node.name());
-                r_list_schemas(_repo, child, child_path, schemas)?;
+                let child_path = current_path.join(dir_node.name());
+                r_list_schemas(_repo, child, &child_path, schemas)?;
             }
             EMerkleTreeNode::File(file_node) => {
                 if let Some(GenericMetadata::MetadataTabular(metadata)) = &file_node.metadata() {
-                    let child_path = current_path.as_ref().join(file_node.name());
+                    let child_path = current_path.join(file_node.name());
                     schemas.insert(child_path, metadata.tabular.schema.clone());
                 }
             }
@@ -73,9 +73,8 @@ fn r_list_schemas(
 pub fn get_by_path(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<Schema>, OxenError> {
-    let path = path.as_ref();
     let node = repositories::tree::get_file_by_path(repo, commit, path)?;
     let Some(node) = node else {
         return Err(OxenError::path_does_not_exist(path));
@@ -89,11 +88,7 @@ pub fn get_by_path(
 }
 
 /// Get a staged schema
-pub fn get_staged(
-    repo: &LocalRepository,
-    path: impl AsRef<Path>,
-) -> Result<Option<Schema>, OxenError> {
-    let path = path.as_ref();
+pub fn get_staged(repo: &LocalRepository, path: &Path) -> Result<Option<Schema>, OxenError> {
     let path = util::fs::path_relative_to_dir(path, &repo.path)?;
     let key = path.to_string_lossy();
     let db = if let Some(db) = get_staged_db_read_only(repo)? {
@@ -120,7 +115,7 @@ pub fn get_staged(
 /// A duplicate function in replace of get_staged for workspaces to use the staged db manager
 pub fn get_staged_schema_with_staged_db_manager(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<Schema>, OxenError> {
     let path = util::fs::path_relative_to_dir(path, &repo.path)?;
     let staged_db_manager = get_staged_db_manager(repo)?;
@@ -141,12 +136,12 @@ pub fn get_staged_schema_with_staged_db_manager(
 /// to match the original schema.
 pub fn restore_schema(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
     og_schema: &Schema,
     before_column: &str,
     after_column: &str,
 ) -> Result<(), OxenError> {
-    let path = util::fs::path_relative_to_dir(&path, &repo.path)?;
+    let path = util::fs::path_relative_to_dir(path, &repo.path)?;
     let staged_db_manager = get_staged_db_manager(repo)?;
     let value = staged_db_manager.read_from_staged_db(&path)?;
     let (mut staged_schema, val) = match value {
@@ -233,12 +228,11 @@ fn db_val_to_schema(val: &StagedMerkleTreeNode) -> Result<Schema, OxenError> {
 }
 
 /// Remove a schema override from the staging area, TODO: Currently undefined behavior for non-staged schemas
-pub fn rm(repo: &LocalRepository, path: impl AsRef<Path>, staged: bool) -> Result<(), OxenError> {
+pub fn rm(repo: &LocalRepository, path: &Path, staged: bool) -> Result<(), OxenError> {
     if !staged {
         panic!("Undefined behavior for non-staged schemas")
     }
 
-    let path = path.as_ref();
     let db = get_staged_db(repo)?;
     let key = path.to_string_lossy();
     db.delete(key.as_bytes())?;
@@ -249,10 +243,9 @@ pub fn rm(repo: &LocalRepository, path: impl AsRef<Path>, staged: bool) -> Resul
 /// Add metadata to the schema
 pub fn add_schema_metadata(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-    let path = path.as_ref();
     let db = get_staged_db(repo)?;
 
     let key = path.to_string_lossy();
@@ -287,7 +280,7 @@ pub fn add_schema_metadata(
                 continue;
             };
             dir_path = dir_path.parent().unwrap().to_path_buf();
-            dir_node.set_name(dir_path.to_string_lossy());
+            dir_node.set_name(&dir_path.to_string_lossy());
             parent_node.node = EMerkleTreeNode::Directory(dir_node);
             let staged_parent_node = StagedMerkleTreeNode {
                 status: StagedEntryStatus::Modified,
@@ -347,17 +340,14 @@ pub fn add_schema_metadata(
 /// Add metadata to a specific column
 pub fn add_column_metadata(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
-    column: impl AsRef<str>,
+    path: &Path,
+    column: &str,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     let db = get_staged_db(repo)?;
-    let path = path.as_ref();
     let path = util::fs::path_relative_to_dir(path, &repo.path)?;
 
     log::debug!("add_column_metadata: path: {path:?}");
-
-    let column = column.as_ref();
 
     let key = path.to_string_lossy();
 
@@ -379,7 +369,7 @@ pub fn add_column_metadata(
         };
         log::debug!("add_column_metadata: commit: {commit} path: {path:?}");
         let Some(node) = repositories::tree::get_node_by_path(repo, &commit, &path)? else {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "path {path:?} not found in commit {commit:?}"
             )));
         };
@@ -395,7 +385,7 @@ pub fn add_column_metadata(
                 continue;
             };
             dir_path = dir_path.parent().unwrap().to_path_buf();
-            dir_node.set_name(dir_path.to_string_lossy());
+            dir_node.set_name(&dir_path.to_string_lossy());
             parent_node.node = EMerkleTreeNode::Directory(dir_node);
             let staged_parent_node = StagedMerkleTreeNode {
                 status: StagedEntryStatus::Modified,
@@ -426,7 +416,7 @@ pub fn add_column_metadata(
             results.insert(path.clone(), m.tabular.schema.clone());
         }
         _ => {
-            return Err(OxenError::path_does_not_exist(path));
+            return Err(OxenError::path_does_not_exist(&path));
         }
     }
 

--- a/crates/lib/src/core/v_latest/data_frames/schemas.rs
+++ b/crates/lib/src/core/v_latest/data_frames/schemas.rs
@@ -77,11 +77,11 @@ pub fn get_by_path(
 ) -> Result<Option<Schema>, OxenError> {
     let node = repositories::tree::get_file_by_path(repo, commit, path)?;
     let Some(node) = node else {
-        return Err(OxenError::path_does_not_exist(path));
+        return Err(OxenError::path_does_not_exist(path.to_path_buf()));
     };
 
     let Some(GenericMetadata::MetadataTabular(metadata)) = &node.metadata() else {
-        return Err(OxenError::path_does_not_exist(path));
+        return Err(OxenError::path_does_not_exist(path.to_path_buf()));
     };
 
     Ok(Some(metadata.tabular.schema.clone()))
@@ -178,7 +178,9 @@ pub fn restore_schema(
             ),
         )));
     } else {
-        return Err(OxenError::basic_str("Expected tabular metadata"));
+        return Err(OxenError::basic_str(
+            "Expected tabular metadata".to_string(),
+        ));
     }
 
     staged_db_manager.upsert_file_node(&path, StagedEntryStatus::Modified, &file_node)?;
@@ -202,7 +204,7 @@ pub fn list_staged(repo: &LocalRepository) -> Result<HashMap<PathBuf, Schema>, O
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -217,12 +219,16 @@ fn db_val_to_schema(val: &StagedMerkleTreeNode) -> Result<Schema, OxenError> {
             Some(GenericMetadata::MetadataTabular(m)) => Ok(m.tabular.schema.to_owned()),
             _ => {
                 log::error!("File node metadata must be tabular.");
-                Err(OxenError::basic_str("File node metadata must be tabular."))
+                Err(OxenError::basic_str(
+                    "File node metadata must be tabular.".to_string(),
+                ))
             }
         },
         _ => {
             log::error!("Merkle tree node type must be file.");
-            Err(OxenError::basic_str("Merkle tree node type must be file."))
+            Err(OxenError::basic_str(
+                "Merkle tree node type must be file.".to_string(),
+            ))
         }
     }
 }
@@ -261,11 +267,11 @@ pub fn add_schema_metadata(
         // Get the FileNode from the CommitMerkleTree
         let Some(commit) = repositories::commits::head_commit_maybe(repo)? else {
             return Err(OxenError::basic_str(
-                "Cannot add metadata, no commits found.",
+                "Cannot add metadata, no commits found.".to_string(),
             ));
         };
         let Some(file_node) = repositories::tree::get_file_by_path(repo, &commit, path)? else {
-            return Err(OxenError::path_does_not_exist(path));
+            return Err(OxenError::path_does_not_exist(path.to_path_buf()));
         };
         let node = repositories::tree::get_node_by_path(repo, &commit, path)?.unwrap();
         let mut parent_id = node.parent_id;
@@ -297,7 +303,7 @@ pub fn add_schema_metadata(
             m.tabular.schema.metadata = Some(metadata.to_owned());
         }
         _ => {
-            return Err(OxenError::path_does_not_exist(path));
+            return Err(OxenError::path_does_not_exist(path.to_path_buf()));
         }
     }
 
@@ -364,12 +370,12 @@ pub fn add_column_metadata(
         // Get the FileNode from the CommitMerkleTree
         let Some(commit) = repositories::commits::head_commit_maybe(repo)? else {
             return Err(OxenError::basic_str(
-                "Cannot add metadata, no commits found.",
+                "Cannot add metadata, no commits found.".to_string(),
             ));
         };
         log::debug!("add_column_metadata: commit: {commit} path: {path:?}");
         let Some(node) = repositories::tree::get_node_by_path(repo, &commit, &path)? else {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "path {path:?} not found in commit {commit:?}"
             )));
         };
@@ -395,7 +401,7 @@ pub fn add_column_metadata(
         }
 
         let Some(file_node) = repositories::tree::get_file_by_path(repo, &commit, &path)? else {
-            return Err(OxenError::path_does_not_exist(&path));
+            return Err(OxenError::path_does_not_exist(path));
         };
         file_node
     };
@@ -416,7 +422,7 @@ pub fn add_column_metadata(
             results.insert(path.clone(), m.tabular.schema.clone());
         }
         _ => {
-            return Err(OxenError::path_does_not_exist(&path));
+            return Err(OxenError::path_does_not_exist(path));
         }
     }
 

--- a/crates/lib/src/core/v_latest/diff.rs
+++ b/crates/lib/src/core/v_latest/diff.rs
@@ -70,7 +70,7 @@ pub async fn list_diff_entries(
                     head_dirs.extend(dirs);
                 }
                 _ => {
-                    return Err(OxenError::basic_str(&format!(
+                    return Err(OxenError::basic_str(format!(
                         "Failed to get base tree for commit: {base_commit}"
                     )));
                 }
@@ -94,7 +94,7 @@ pub async fn list_diff_entries(
                 base_dirs.extend(dirs);
             }
             _ => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Failed to get base tree for commit: {base_commit}"
                 )));
             }
@@ -117,7 +117,7 @@ pub async fn list_diff_entries(
                 head_dirs.extend(dirs);
             }
             _ => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Failed to get head tree for commit: {head_commit}"
                 )));
             }
@@ -303,12 +303,12 @@ pub fn list_changed_dirs(
     let mut changed_dirs: Vec<(PathBuf, DiffEntryStatus)> = vec![];
 
     let Some(base_tree) = repositories::tree::get_root_with_children(repo, base_commit)? else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Failed to get base tree for commit: {base_commit}"
         )));
     };
     let Some(head_tree) = repositories::tree::get_root_with_children(repo, head_commit)? else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Failed to get head tree for commit: {head_commit}"
         )));
     };
@@ -335,7 +335,7 @@ pub fn list_changed_dirs(
         let base_dir_hash = match base_dir {
             Some(base_dir) => base_dir.hash,
             None => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Could not calculate dir diff tree: base_dir_hash not found for dir {:?} in commit {}",
                     dir, base_commit.id
                 )));
@@ -345,7 +345,7 @@ pub fn list_changed_dirs(
         let head_dir_hash = match head_dir {
             Some(head_dir) => head_dir.hash,
             None => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Could not calculate dir diff tree: head_dir_hash not found for dir {:?} in commit {}",
                     dir, head_commit.id
                 )));
@@ -371,12 +371,12 @@ pub fn get_dir_diff_entry_with_summary(
     summary: GenericDiffSummary,
 ) -> Result<Option<DiffEntry>, OxenError> {
     let Some(base_tree) = repositories::tree::get_root_with_children(repo, base_commit)? else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Failed to get base tree for commit: {base_commit}"
         )));
     };
     let Some(head_tree) = repositories::tree::get_root_with_children(repo, head_commit)? else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Failed to get head tree for commit: {head_commit}"
         )));
     };
@@ -422,7 +422,7 @@ pub fn get_dir_diff_entry_with_summary(
             DiffEntryStatus::Removed,
         )?)),
         (None, None) => Err(OxenError::basic_str(
-            "Could not calculate dir diff tree: dir does not exist in either commit.",
+            "Could not calculate dir diff tree: dir does not exist in either commit.".to_string(),
         )),
     }
 }
@@ -438,7 +438,7 @@ pub async fn diff_entries(
 ) -> Result<DiffEntry, OxenError> {
     if base_entry.is_none() && head_entry.is_none() {
         return Err(OxenError::basic_str(
-            "Could not calculate diff: neither base nor head entries exist.",
+            "Could not calculate diff: neither base nor head entries exist.".to_string(),
         ));
     }
 

--- a/crates/lib/src/core/v_latest/diff.rs
+++ b/crates/lib/src/core/v_latest/diff.rs
@@ -70,7 +70,7 @@ pub async fn list_diff_entries(
                     head_dirs.extend(dirs);
                 }
                 _ => {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(OxenError::basic_str(&format!(
                         "Failed to get base tree for commit: {base_commit}"
                     )));
                 }
@@ -94,7 +94,7 @@ pub async fn list_diff_entries(
                 base_dirs.extend(dirs);
             }
             _ => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Failed to get base tree for commit: {base_commit}"
                 )));
             }
@@ -117,7 +117,7 @@ pub async fn list_diff_entries(
                 head_dirs.extend(dirs);
             }
             _ => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Failed to get head tree for commit: {head_commit}"
                 )));
             }
@@ -263,7 +263,7 @@ pub async fn list_diff_entries(
         .map(|entry| async move {
             DiffEntry::from_file_nodes(
                 repo,
-                entry.path,
+                &entry.path,
                 entry.base_entry,
                 base_commit,
                 entry.head_entry,
@@ -303,12 +303,12 @@ pub fn list_changed_dirs(
     let mut changed_dirs: Vec<(PathBuf, DiffEntryStatus)> = vec![];
 
     let Some(base_tree) = repositories::tree::get_root_with_children(repo, base_commit)? else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Failed to get base tree for commit: {base_commit}"
         )));
     };
     let Some(head_tree) = repositories::tree::get_root_with_children(repo, head_commit)? else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Failed to get head tree for commit: {head_commit}"
         )));
     };
@@ -335,7 +335,7 @@ pub fn list_changed_dirs(
         let base_dir_hash = match base_dir {
             Some(base_dir) => base_dir.hash,
             None => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Could not calculate dir diff tree: base_dir_hash not found for dir {:?} in commit {}",
                     dir, base_commit.id
                 )));
@@ -345,7 +345,7 @@ pub fn list_changed_dirs(
         let head_dir_hash = match head_dir {
             Some(head_dir) => head_dir.hash,
             None => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Could not calculate dir diff tree: head_dir_hash not found for dir {:?} in commit {}",
                     dir, head_commit.id
                 )));
@@ -371,12 +371,12 @@ pub fn get_dir_diff_entry_with_summary(
     summary: GenericDiffSummary,
 ) -> Result<Option<DiffEntry>, OxenError> {
     let Some(base_tree) = repositories::tree::get_root_with_children(repo, base_commit)? else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Failed to get base tree for commit: {base_commit}"
         )));
     };
     let Some(head_tree) = repositories::tree::get_root_with_children(repo, head_commit)? else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Failed to get head tree for commit: {head_commit}"
         )));
     };
@@ -429,7 +429,7 @@ pub fn get_dir_diff_entry_with_summary(
 
 pub async fn diff_entries(
     repo: &LocalRepository,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     base_entry: Option<FileNode>,
     base_commit: &Commit,
     head_entry: Option<FileNode>,
@@ -481,7 +481,7 @@ fn collect_added_directories(
     head_dirs: &HashSet<DirNodeWithPath>,
     head_commit: &Commit,
     diff_entries: &mut Vec<DiffEntry>,
-    base_path: impl AsRef<Path>,
+    base_path: &Path,
 ) -> Result<(), OxenError> {
     // DEBUG
     // for base_dir in base_dirs.iter() {
@@ -491,14 +491,13 @@ fn collect_added_directories(
     // for head_dir in head_dirs.iter() {
     //     log::debug!("collect_added_directories HEAD dir {:?}", head_dir);
     // }
-    let base_path = base_path.as_ref();
     for head_dir in head_dirs {
         // HEAD entry is *not* in BASE
         if !base_dirs.contains(head_dir) {
             log::debug!("collect_added_directories adding dir {head_dir:?}");
             diff_entries.push(DiffEntry::from_dir_nodes(
                 repo,
-                base_path.join(&head_dir.path),
+                &base_path.join(&head_dir.path),
                 None,
                 base_commit,
                 Some(head_dir.dir_node.clone()),
@@ -518,7 +517,7 @@ fn collect_removed_directories(
     head_dirs: &HashSet<DirNodeWithPath>,
     head_commit: &Commit,
     diff_entries: &mut Vec<DiffEntry>,
-    base_path: impl AsRef<Path>,
+    base_path: &Path,
 ) -> Result<(), OxenError> {
     // DEBUG
     // for base_dir in base_dirs.iter() {
@@ -534,14 +533,13 @@ fn collect_removed_directories(
     //         head_dir.display()
     //     );
     // }
-    let base_path = base_path.as_ref();
     for base_dir in base_dirs {
         // HEAD entry is *not* in BASE
         if !head_dirs.contains(base_dir) {
             log::debug!("collect_removed_directories adding dir {base_dir:?}");
             diff_entries.push(DiffEntry::from_dir_nodes(
                 repo,
-                base_path.join(&base_dir.path),
+                &base_path.join(&base_dir.path),
                 Some(base_dir.dir_node.clone()),
                 base_commit,
                 None,
@@ -561,16 +559,15 @@ fn collect_modified_directories(
     head_dirs: &HashSet<DirNodeWithPath>,
     head_commit: &Commit,
     diff_entries: &mut Vec<DiffEntry>,
-    base_path: impl AsRef<Path>,
+    base_path: &Path,
 ) -> Result<(), OxenError> {
-    let base_path = base_path.as_ref();
     for head_dir in head_dirs {
         // HEAD entry is in BASE
         if let Some(base_dir) = base_dirs.get(head_dir) {
             log::debug!("collect_modified_directories adding dir {head_dir:?}");
             let diff_entry = DiffEntry::from_dir_nodes(
                 repo,
-                base_path.join(&head_dir.path),
+                &base_path.join(&head_dir.path),
                 Some(base_dir.dir_node.clone()),
                 base_commit,
                 Some(head_dir.dir_node.clone()),
@@ -591,7 +588,7 @@ fn collect_added_entries(
     base_entries: &HashSet<FileNodeWithDir>,
     head_entries: &HashSet<FileNodeWithDir>,
     diff_entries: &mut Vec<DiffFileNode>,
-    base_path: impl AsRef<Path>,
+    base_path: &Path,
 ) -> Result<(), OxenError> {
     // log::debug!(
     //     "collect_added_entries Computing difference for add entries head {} base {}",
@@ -606,7 +603,6 @@ fn collect_added_entries(
     // for head in head_entries.iter() {
     //     log::debug!("collect_added_entries HEAD {:?}", head);
     // }
-    let base_path = base_path.as_ref();
     let diff = head_entries.difference(base_entries);
     for head_entry in diff {
         // HEAD entry is *not* in BASE
@@ -625,9 +621,8 @@ fn collect_removed_entries(
     base_entries: &HashSet<FileNodeWithDir>,
     head_entries: &HashSet<FileNodeWithDir>,
     diff_entries: &mut Vec<DiffFileNode>,
-    base_path: impl AsRef<Path>,
+    base_path: &Path,
 ) -> Result<(), OxenError> {
-    let base_path = base_path.as_ref();
     for base_entry in base_entries {
         // BASE entry is *not* in HEAD
         if !head_entries.contains(base_entry) {
@@ -647,9 +642,8 @@ fn collect_modified_entries(
     base_entries: &HashSet<FileNodeWithDir>,
     head_entries: &HashSet<FileNodeWithDir>,
     diff_entries: &mut Vec<DiffFileNode>,
-    base_path: impl AsRef<Path>,
+    base_path: &Path,
 ) -> Result<(), OxenError> {
-    let base_path = base_path.as_ref();
     log::debug!(
         "collect_modified_entries modified entries base.len() {} head.len() {}",
         base_entries.len(),

--- a/crates/lib/src/core/v_latest/download.rs
+++ b/crates/lib/src/core/v_latest/download.rs
@@ -16,11 +16,9 @@ use crate::core;
 pub async fn download_dir(
     remote_repo: &RemoteRepository,
     entry: &MetadataEntry,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
+    remote_path: &Path,
+    local_path: &Path,
 ) -> Result<(), OxenError> {
-    let remote_path = remote_path.as_ref();
-    let local_path = local_path.as_ref();
     log::debug!("downloading dir {remote_path:?}");
     // Initialize temp repo to download node into
     // TODO: Where should this repo be?
@@ -32,7 +30,7 @@ pub async fn download_dir(
         &tmp_repo,
         remote_repo,
         commit_id,
-        remote_path.to_string_lossy(),
+        &remote_path.to_string_lossy(),
         true,
     )
     .await?;
@@ -59,11 +57,9 @@ pub async fn download_dir_entries(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
     entry: &MetadataEntry,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
+    remote_path: &Path,
+    local_path: &Path,
 ) -> Result<(), OxenError> {
-    let remote_path = remote_path.as_ref();
-    let local_path = local_path.as_ref();
     log::debug!("downloading dir {remote_path:?}");
 
     // Get tree from local repos

--- a/crates/lib/src/core/v_latest/entries.rs
+++ b/crates/lib/src/core/v_latest/entries.rs
@@ -21,7 +21,7 @@ use super::index::CommitMerkleTree;
 pub fn get_directory(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<DirNode>, OxenError> {
     let node = repositories::tree::get_node_by_path(repo, commit, path)?;
     let Some(node) = node else {
@@ -33,7 +33,7 @@ pub fn get_directory(
 pub fn get_file(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<FileNode>, OxenError> {
     let file_node = repositories::tree::get_file_by_path(repo, commit, path)?;
     Ok(file_node)
@@ -41,7 +41,7 @@ pub fn get_file(
 
 pub fn list_directory(
     repo: &LocalRepository,
-    directory: impl AsRef<Path>,
+    directory: &Path,
     parsed_resource: &ParsedResource,
     paginate_opts: &PaginateOpts,
 ) -> Result<PaginatedDirEntries, OxenError> {
@@ -50,14 +50,13 @@ pub fn list_directory(
 
 pub fn list_directory_with_depth(
     repo: &LocalRepository,
-    directory: impl AsRef<Path>,
+    directory: &Path,
     parsed_resource: &ParsedResource,
     paginate_opts: &PaginateOpts,
     depth: usize,
 ) -> Result<PaginatedDirEntries, OxenError> {
     let _perf = crate::perf_guard!("core::entries::list_directory");
 
-    let directory = directory.as_ref();
     let revision = parsed_resource.version.to_str().unwrap_or("").to_string();
     let page = paginate_opts.page_num;
     let page_size = paginate_opts.page_size;
@@ -195,7 +194,7 @@ pub fn get_meta_entry(
 pub fn dir_entries(
     repo: &LocalRepository,
     dir: &MerkleTreeNode,
-    search_directory: impl AsRef<Path>,
+    search_directory: &Path,
     parsed_resource: &ParsedResource,
     found_commits: &mut HashMap<MerkleHash, Commit>,
 ) -> Result<Vec<MetadataEntry>, OxenError> {
@@ -203,17 +202,17 @@ pub fn dir_entries(
 
     log::debug!(
         "dir_entries search_directory {:?} dir {}",
-        search_directory.as_ref(),
+        search_directory,
         dir
     );
     let mut entries: Vec<MetadataEntry> = Vec::new();
-    let current_directory = search_directory.as_ref();
+    let current_directory = search_directory;
 
     let _perf_recurse = crate::perf_guard!("core::entries::p_dir_entries_recurse");
     p_dir_entries(
         repo,
         dir,
-        &search_directory,
+        search_directory,
         current_directory,
         parsed_resource,
         found_commits,
@@ -239,7 +238,7 @@ pub fn dir_entries(
 pub fn dir_entries_with_depth(
     repo: &LocalRepository,
     dir: &MerkleTreeNode,
-    search_directory: impl AsRef<Path>,
+    search_directory: &Path,
     parsed_resource: &ParsedResource,
     found_commits: &mut HashMap<MerkleHash, Commit>,
     depth: usize,
@@ -248,18 +247,18 @@ pub fn dir_entries_with_depth(
 
     log::debug!(
         "dir_entries search_directory {:?} dir {} depth {}",
-        search_directory.as_ref(),
+        search_directory,
         dir,
         depth
     );
     let mut entries: Vec<MetadataEntry> = Vec::new();
-    let current_directory = search_directory.as_ref();
+    let current_directory = search_directory;
 
     let _perf_recurse = crate::perf_guard!("core::entries::p_dir_entries_recurse");
     p_dir_entries(
         repo,
         dir,
-        &search_directory,
+        search_directory,
         current_directory,
         parsed_resource,
         found_commits,
@@ -302,7 +301,7 @@ fn dir_node_to_metadata_entry(
     {
         let _perf_commit = crate::perf_guard!("core::entries::get_commit_by_hash");
         let commit = repositories::commits::get_by_hash(repo, dir_node.last_commit_id())?.ok_or(
-            OxenError::commit_id_does_not_exist(dir_node.last_commit_id().to_string()),
+            OxenError::commit_id_does_not_exist(&dir_node.last_commit_id().to_string()),
         )?;
         e.insert(commit);
     }
@@ -345,7 +344,7 @@ fn file_node_to_metadata_entry(
     {
         let _perf_commit = crate::perf_guard!("core::entries::get_commit_by_hash");
         let commit = repositories::commits::get_by_hash(repo, file_node.last_commit_id())?.ok_or(
-            OxenError::commit_id_does_not_exist(file_node.last_commit_id().to_string()),
+            OxenError::commit_id_does_not_exist(&file_node.last_commit_id().to_string()),
         )?;
         e.insert(commit);
     }
@@ -395,16 +394,13 @@ fn file_node_to_metadata_entry(
 fn p_dir_entries(
     repo: &LocalRepository,
     node: &MerkleTreeNode,
-    search_directory: impl AsRef<Path>,
-    current_directory: impl AsRef<Path>,
+    search_directory: &Path,
+    current_directory: &Path,
     parsed_resource: &ParsedResource,
     found_commits: &mut HashMap<MerkleHash, Commit>,
     entries: &mut Vec<MetadataEntry>,
     depth: usize,
 ) -> Result<(), OxenError> {
-    let search_directory = search_directory.as_ref();
-    let current_directory = current_directory.as_ref();
-
     for child in &node.children {
         match &child.node {
             EMerkleTreeNode::VNode(_) => {
@@ -480,7 +476,7 @@ fn p_dir_entries(
                     repo,
                     child,
                     search_directory,
-                    current_directory,
+                    &current_directory,
                     parsed_resource,
                     found_commits,
                     entries,
@@ -535,9 +531,9 @@ pub fn list_for_commit(
         .collect())
 }
 
-pub fn update_metadata(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<(), OxenError> {
-    let commit = repositories::revisions::get(repo, revision.as_ref())?
-        .ok_or_else(|| OxenError::revision_not_found(revision.as_ref().to_string().into()))?;
+pub fn update_metadata(repo: &LocalRepository, revision: &str) -> Result<(), OxenError> {
+    let commit = repositories::revisions::get(repo, revision)?
+        .ok_or_else(|| OxenError::revision_not_found(revision.to_string().into()))?;
     let tree: CommitMerkleTree = CommitMerkleTree::from_commit(repo, &commit)?;
     let mut node = tree.root;
 
@@ -615,7 +611,7 @@ fn traverse_and_update_sizes_and_counts(
                 .or_insert(0) += file_node.num_bytes();
         }
         _ => {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "compute_dir_node found unexpected node type: {:?}",
                 node.node
             )));

--- a/crates/lib/src/core/v_latest/entries.rs
+++ b/crates/lib/src/core/v_latest/entries.rs
@@ -76,14 +76,17 @@ pub fn list_directory_with_depth(
     log::debug!("list_directory commit {commit}");
 
     let _perf_get_dir = crate::perf_guard!("core::entries::get_dir_with_children");
-    let dir = repositories::tree::get_dir_with_children(repo, &commit, directory, None)?
-        .ok_or(OxenError::resource_not_found(directory.to_str().unwrap()))?;
+    let dir = repositories::tree::get_dir_with_children(repo, &commit, directory, None)?.ok_or(
+        OxenError::resource_not_found(directory.to_str().unwrap().to_string()),
+    )?;
     drop(_perf_get_dir);
 
     log::debug!("list_directory dir {dir}");
 
     let EMerkleTreeNode::Directory(dir_node) = &dir.node else {
-        return Err(OxenError::resource_not_found(directory.to_str().unwrap()));
+        return Err(OxenError::resource_not_found(
+            directory.to_str().unwrap().to_string(),
+        ));
     };
 
     log::debug!("list_directory dir_node {dir_node}");
@@ -186,7 +189,9 @@ pub fn get_meta_entry(
                 "get_meta_entry path not found: {:?}",
                 path.to_str().unwrap()
             );
-            Err(OxenError::resource_not_found(path.to_str().unwrap()))
+            Err(OxenError::resource_not_found(
+                path.to_str().unwrap().to_string(),
+            ))
         }
     }
 }
@@ -429,10 +434,9 @@ fn p_dir_entries(
                     // Populate children if depth > 0
                     if depth > 0 {
                         let child_path = search_directory.join(child_dir.name());
-                        let commit = parsed_resource
-                            .commit
-                            .as_ref()
-                            .ok_or_else(|| OxenError::basic_str("No commit in parsed resource"))?;
+                        let commit = parsed_resource.commit.as_ref().ok_or_else(|| {
+                            OxenError::basic_str("No commit in parsed resource".to_string())
+                        })?;
 
                         if let Some(subdir_node) = repositories::tree::get_dir_with_children(
                             repo,
@@ -611,7 +615,7 @@ fn traverse_and_update_sizes_and_counts(
                 .or_insert(0) += file_node.num_bytes();
         }
         _ => {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "compute_dir_node found unexpected node type: {:?}",
                 node.node
             )));
@@ -660,7 +664,7 @@ fn add_children_to_db(
                 dir_db.add_child(vnode)?;
             }
             _ => {
-                return Err(OxenError::basic_str("Unsupported node type"));
+                return Err(OxenError::basic_str("Unsupported node type".to_string()));
             }
         }
     }

--- a/crates/lib/src/core/v_latest/fetch.rs
+++ b/crates/lib/src/core/v_latest/fetch.rs
@@ -116,7 +116,7 @@ pub async fn fetch_remote_branch(
     } else {
         let hash = remote_branch.commit_id.parse()?;
         let commit_node = repositories::tree::get_node_by_id(repo, &hash)?
-            .ok_or(OxenError::basic_str("Commit node not found"))?;
+            .ok_or(OxenError::basic_str("Commit node not found".to_string()))?;
 
         if !fetch_opts.missing_files && core::commit_sync_status::commit_is_synced(repo, &hash) {
             HashSet::new()
@@ -637,13 +637,17 @@ pub async fn pull_entries_to_versions_dir(
         }
         (Err(err), Ok(_)) => {
             let err = format!("Error syncing large entries: {err}");
-            return Err(OxenError::basic_str(&err));
+            return Err(OxenError::basic_str(err));
         }
         (Ok(_), Err(err)) => {
             let err = format!("Error syncing small entries: {err}");
-            return Err(OxenError::basic_str(&err));
+            return Err(OxenError::basic_str(err));
         }
-        _ => return Err(OxenError::basic_str("Unknown error syncing entries")),
+        _ => {
+            return Err(OxenError::basic_str(
+                "Unknown error syncing entries".to_string(),
+            ));
+        }
     }
 
     Ok(())
@@ -711,7 +715,7 @@ async fn pull_large_entries(
     for res in join_results {
         match res {
             // TODO: return join error!
-            Err(e) => return Err(OxenError::basic_str(&format!("worker task panicked: {e}"))),
+            Err(e) => return Err(OxenError::basic_str(format!("worker task panicked: {e}"))),
             Ok(Err(e)) => return Err(e),
             Ok(Ok(())) => {}
         }
@@ -799,7 +803,7 @@ async fn pull_small_entries(
     for res in join_results {
         match res {
             // TODO: return join error!
-            Err(e) => return Err(OxenError::basic_str(&format!("worker task panicked: {e}"))),
+            Err(e) => return Err(OxenError::basic_str(format!("worker task panicked: {e}"))),
             Ok(Err(e)) => return Err(e),
             Ok(Ok(())) => {}
         }
@@ -862,13 +866,17 @@ pub async fn download_entries_to_working_dir(
         }
         (Err(err), Ok(_)) => {
             let err = format!("Error syncing large entries: {err}");
-            return Err(OxenError::basic_str(&err));
+            return Err(OxenError::basic_str(err));
         }
         (Ok(_), Err(err)) => {
             let err = format!("Error syncing small entries: {err}");
-            return Err(OxenError::basic_str(&err));
+            return Err(OxenError::basic_str(err));
         }
-        _ => return Err(OxenError::basic_str("Unknown error syncing entries")),
+        _ => {
+            return Err(OxenError::basic_str(
+                "Unknown error syncing entries".to_string(),
+            ));
+        }
     }
     log::info!("Finished download_entries_to_working_dir");
     Ok(())
@@ -951,7 +959,7 @@ async fn download_large_entries(
     for res in join_results {
         match res {
             // TODO: return join error!
-            Err(e) => return Err(OxenError::basic_str(&format!("worker task panicked: {e}"))),
+            Err(e) => return Err(OxenError::basic_str(format!("worker task panicked: {e}"))),
             Ok(Err(e)) => return Err(e),
             Ok(Ok(())) => {}
         }
@@ -1039,7 +1047,7 @@ async fn download_small_entries(
     for res in join_results {
         match res {
             // TODO: return join error!
-            Err(e) => return Err(OxenError::basic_str(&format!("worker task panicked: {e}"))),
+            Err(e) => return Err(OxenError::basic_str(format!("worker task panicked: {e}"))),
             Ok(Err(e)) => return Err(e),
             Ok(Ok(())) => {}
         }

--- a/crates/lib/src/core/v_latest/fetch.rs
+++ b/crates/lib/src/core/v_latest/fetch.rs
@@ -229,21 +229,16 @@ async fn sync_from_head(
 async fn sync_tree_from_commit(
     repo: &LocalRepository,
     remote_repo: &RemoteRepository,
-    commit_id: impl AsRef<str>,
+    commit_id: &str,
     fetch_opts: &FetchOpts,
     pull_progress: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
     let repo_hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
 
-    pull_progress.set_message(format!("Downloading commits from {}", commit_id.as_ref()));
-    api::client::tree::download_trees_from(repo, remote_repo, &commit_id.as_ref(), fetch_opts)
+    pull_progress.set_message(format!("Downloading commits from {}", commit_id));
+    api::client::tree::download_trees_from(repo, remote_repo, commit_id, fetch_opts).await?;
+    api::client::commits::download_dir_hashes_from_commit(remote_repo, commit_id, &repo_hidden_dir)
         .await?;
-    api::client::commits::download_dir_hashes_from_commit(
-        remote_repo,
-        commit_id.as_ref(),
-        &repo_hidden_dir,
-    )
-    .await?;
     Ok(())
 }
 
@@ -313,7 +308,7 @@ fn collect_missing_entries(
             let Some(tree) = repositories::tree::get_subtree_by_depth_with_unique_children(
                 repo,
                 commit,
-                PathBuf::from("."),
+                &PathBuf::from("."),
                 Some(&shared_hashes),
                 Some(&mut unique_hashes),
                 None,
@@ -642,11 +637,11 @@ pub async fn pull_entries_to_versions_dir(
         }
         (Err(err), Ok(_)) => {
             let err = format!("Error syncing large entries: {err}");
-            return Err(OxenError::basic_str(err));
+            return Err(OxenError::basic_str(&err));
         }
         (Ok(_), Err(err)) => {
             let err = format!("Error syncing small entries: {err}");
-            return Err(OxenError::basic_str(err));
+            return Err(OxenError::basic_str(&err));
         }
         _ => return Err(OxenError::basic_str("Unknown error syncing entries")),
     }
@@ -701,7 +696,7 @@ async fn pull_large_entries(
                 let remote_path = &entry.path();
 
                 // Download to the tmp path, then copy over to the entries dir
-                api::client::entries::pull_large_entry(&repo, &remote_repo, &remote_path, &entry)
+                api::client::entries::pull_large_entry(&repo, &remote_repo, remote_path, &entry)
                     .await?;
 
                 log::debug!("Pulled large entry {remote_path:?} to versions dir");
@@ -715,7 +710,8 @@ async fn pull_large_entries(
     let join_results = future::join_all(handles).await;
     for res in join_results {
         match res {
-            Err(e) => return Err(OxenError::basic_str(format!("worker task panicked: {e}"))),
+            // TODO: return join error!
+            Err(e) => return Err(OxenError::basic_str(&format!("worker task panicked: {e}"))),
             Ok(Err(e)) => return Err(e),
             Ok(Ok(())) => {}
         }
@@ -802,7 +798,8 @@ async fn pull_small_entries(
     let join_results = future::join_all(handles).await;
     for res in join_results {
         match res {
-            Err(e) => return Err(OxenError::basic_str(format!("worker task panicked: {e}"))),
+            // TODO: return join error!
+            Err(e) => return Err(OxenError::basic_str(&format!("worker task panicked: {e}"))),
             Ok(Err(e)) => return Err(e),
             Ok(Ok(())) => {}
         }
@@ -853,11 +850,10 @@ pub async fn download_entries_to_working_dir(
         .map(|e| e.to_owned())
         .collect();
 
-    let large_entries_sync =
-        download_large_entries(remote_repo, larger_entries, &dst, progress_bar);
+    let large_entries_sync = download_large_entries(remote_repo, larger_entries, dst, progress_bar);
     log::info!("Downloaded large entries");
     let small_entries_sync =
-        download_small_entries(remote_repo, smaller_entries, &dst, progress_bar);
+        download_small_entries(remote_repo, smaller_entries, dst, progress_bar);
     log::info!("Downloaded small entries");
 
     match tokio::join!(large_entries_sync, small_entries_sync) {
@@ -866,11 +862,11 @@ pub async fn download_entries_to_working_dir(
         }
         (Err(err), Ok(_)) => {
             let err = format!("Error syncing large entries: {err}");
-            return Err(OxenError::basic_str(err));
+            return Err(OxenError::basic_str(&err));
         }
         (Ok(_), Err(err)) => {
             let err = format!("Error syncing small entries: {err}");
-            return Err(OxenError::basic_str(err));
+            return Err(OxenError::basic_str(&err));
         }
         _ => return Err(OxenError::basic_str("Unknown error syncing entries")),
     }
@@ -881,7 +877,7 @@ pub async fn download_entries_to_working_dir(
 async fn download_large_entries(
     remote_repo: &RemoteRepository,
     entries: Vec<Entry>,
-    dst: impl AsRef<Path>,
+    dst: &Path,
     progress_bar: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
     if entries.is_empty() {
@@ -892,7 +888,7 @@ async fn download_large_entries(
     type TaskQueue = deadqueue::limited::Queue<PieceOfWork>;
 
     log::debug!("Chunking and sending {} larger files", entries.len());
-    let large_entry_paths = working_dir_paths_from_large_entries(&entries, dst.as_ref());
+    let large_entry_paths = working_dir_paths_from_large_entries(&entries, dst);
     let entries: Vec<PieceOfWork> = entries
         .iter()
         .zip(large_entry_paths.iter())
@@ -900,7 +896,7 @@ async fn download_large_entries(
             (
                 remote_repo.to_owned(),
                 e.to_owned(),
-                dst.as_ref().to_owned(),
+                dst.to_owned(),
                 path.to_owned(),
             )
         })
@@ -937,7 +933,7 @@ async fn download_large_entries(
                 // Download to the tmp path, then copy over to the entries dir
                 api::client::entries::download_large_entry(
                     &remote_repo,
-                    &remote_path,
+                    remote_path,
                     &download_path,
                     &entry.commit_id(),
                     entry.num_bytes(),
@@ -954,7 +950,8 @@ async fn download_large_entries(
     let join_results = future::join_all(handles).await;
     for res in join_results {
         match res {
-            Err(e) => return Err(OxenError::basic_str(format!("worker task panicked: {e}"))),
+            // TODO: return join error!
+            Err(e) => return Err(OxenError::basic_str(&format!("worker task panicked: {e}"))),
             Ok(Err(e)) => return Err(e),
             Ok(Ok(())) => {}
         }
@@ -968,7 +965,7 @@ async fn download_large_entries(
 async fn download_small_entries(
     remote_repo: &RemoteRepository,
     entries: Vec<Entry>,
-    dst: impl AsRef<Path>,
+    dst: &Path,
     progress_bar: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
     if entries.is_empty() {
@@ -1001,7 +998,7 @@ async fn download_small_entries(
             for e in chunk {
                 content_ids.push((e.hash(), e.path().to_owned()));
             }
-            (remote_repo.to_owned(), content_ids, dst.as_ref().to_owned())
+            (remote_repo.to_owned(), content_ids, dst.to_owned())
         })
         .collect();
 
@@ -1041,7 +1038,8 @@ async fn download_small_entries(
     let join_results = future::join_all(handles).await;
     for res in join_results {
         match res {
-            Err(e) => return Err(OxenError::basic_str(format!("worker task panicked: {e}"))),
+            // TODO: return join error!
+            Err(e) => return Err(OxenError::basic_str(&format!("worker task panicked: {e}"))),
             Ok(Err(e)) => return Err(e),
             Ok(Ok(())) => {}
         }

--- a/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -42,7 +42,7 @@ impl CommitMerkleTree {
                     }
                     _ => {
                         return Err(OxenError::basic_str(
-                            "Could not read iterate over db values",
+                            "Could not read iterate over db values".to_string(),
                         ));
                     }
                 }
@@ -68,7 +68,7 @@ impl CommitMerkleTree {
         log::debug!("Load tree from commit: {} in repo: {:?}", commit, repo.path);
         let root =
             CommitMerkleTree::root_with_children(repo, commit)?.ok_or(OxenError::basic_str(
-                &format!("Merkle tree hash not found for commit: '{}'", commit.id),
+                format!("Merkle tree hash not found for commit: '{}'", commit.id),
             ))?;
 
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
@@ -85,7 +85,7 @@ impl CommitMerkleTree {
         // if you see it in the logs being called too much, it could be why the code is slow.
         log::debug!("Load tree from commit: {} in repo: {:?}", commit, repo.path);
         let node = CommitMerkleTree::read_from_path(repo, commit, path, load_recursive)?.ok_or(
-            OxenError::basic_str(&format!(
+            OxenError::basic_str(format!(
                 "Merkle tree hash not found for commit: '{}'",
                 commit.id
             )),
@@ -435,7 +435,7 @@ impl CommitMerkleTree {
         let root = if let Some(node_hash) = dir_hashes.get(&node_path).cloned() {
             // We are reading a node with children
             let Some(root) = CommitMerkleTree::read_depth(repo, &node_hash, depth)? else {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Merkle tree hash not found for dir: '{}' in commit: {:?}",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -447,7 +447,7 @@ impl CommitMerkleTree {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
             CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
-                OxenError::basic_str(&format!(
+                OxenError::basic_str(format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -484,7 +484,7 @@ impl CommitMerkleTree {
                 depth,
             )?
             else {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Merkle tree hash not found for dir: '{}' in commit: {:?}",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -496,7 +496,7 @@ impl CommitMerkleTree {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
             CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
-                OxenError::basic_str(&format!(
+                OxenError::basic_str(format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -533,7 +533,7 @@ impl CommitMerkleTree {
                 depth,
             )?
             else {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Merkle tree hash not found for dir: '{}' in commit: {:?}",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -545,7 +545,7 @@ impl CommitMerkleTree {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
             CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
-                OxenError::basic_str(&format!(
+                OxenError::basic_str(format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -689,7 +689,7 @@ impl CommitMerkleTree {
         let node = self
             .root
             .get_by_path(path)?
-            .ok_or(OxenError::basic_str(&format!(
+            .ok_or(OxenError::basic_str(format!(
                 "Merkle tree hash not found for parent: {path:?}"
             )))?;
         let mut children = HashSet::new();
@@ -722,7 +722,7 @@ impl CommitMerkleTree {
                 Ok(file_entries)
             }
             EMerkleTreeNode::File(file_node) => Ok(vec![file_node.clone()]),
-            _ => Err(OxenError::basic_str(&format!(
+            _ => Err(OxenError::basic_str(format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             ))),

--- a/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -54,7 +54,7 @@ impl CommitMerkleTree {
         Ok(dir_hashes)
     }
 
-    pub fn dir_hash_db_path_from_commit_id(repo: &LocalRepository, commit_id: &String) -> PathBuf {
+    pub fn dir_hash_db_path_from_commit_id(repo: &LocalRepository, commit_id: &str) -> PathBuf {
         dir_hash_db_path_from_commit_id(repo, commit_id)
     }
 
@@ -68,7 +68,7 @@ impl CommitMerkleTree {
         log::debug!("Load tree from commit: {} in repo: {:?}", commit, repo.path);
         let root =
             CommitMerkleTree::root_with_children(repo, commit)?.ok_or(OxenError::basic_str(
-                format!("Merkle tree hash not found for commit: '{}'", commit.id),
+                &format!("Merkle tree hash not found for commit: '{}'", commit.id),
             ))?;
 
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
@@ -78,14 +78,14 @@ impl CommitMerkleTree {
     pub fn from_path(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         load_recursive: bool,
     ) -> Result<Self, OxenError> {
         // This debug log is to help make sure we don't load the tree too many times
         // if you see it in the logs being called too much, it could be why the code is slow.
         log::debug!("Load tree from commit: {} in repo: {:?}", commit, repo.path);
         let node = CommitMerkleTree::read_from_path(repo, commit, path, load_recursive)?.ok_or(
-            OxenError::basic_str(format!(
+            OxenError::basic_str(&format!(
                 "Merkle tree hash not found for commit: '{}'",
                 commit.id
             )),
@@ -398,7 +398,7 @@ impl CommitMerkleTree {
     pub fn read_from_path(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         load_recursive: bool,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         let depth = if load_recursive { -1 } else { 1 };
@@ -409,7 +409,7 @@ impl CommitMerkleTree {
     pub fn read_from_path_maybe(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         load_recursive: bool,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         let maybe_tree_node = CommitMerkleTree::read_from_path(repo, commit, path, load_recursive);
@@ -423,10 +423,10 @@ impl CommitMerkleTree {
     pub fn read_depth_from_path(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let mut node_path = path.as_ref().to_path_buf();
+        let mut node_path = path.to_path_buf();
         if node_path == Path::new(".") {
             node_path = PathBuf::from("");
         }
@@ -435,7 +435,7 @@ impl CommitMerkleTree {
         let root = if let Some(node_hash) = dir_hashes.get(&node_path).cloned() {
             // We are reading a node with children
             let Some(root) = CommitMerkleTree::read_depth(repo, &node_hash, depth)? else {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Merkle tree hash not found for dir: '{}' in commit: {:?}",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -447,7 +447,7 @@ impl CommitMerkleTree {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
             CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
-                OxenError::basic_str(format!(
+                OxenError::basic_str(&format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -461,13 +461,13 @@ impl CommitMerkleTree {
     pub fn read_depth_from_path_and_collect_hashes(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         base_hashes: Option<&HashSet<MerkleHash>>,
         unique_hashes: Option<&mut HashSet<MerkleHash>>,
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let mut node_path = path.as_ref().to_path_buf();
+        let mut node_path = path.to_path_buf();
         if node_path == Path::new(".") {
             node_path = PathBuf::from("");
         }
@@ -484,7 +484,7 @@ impl CommitMerkleTree {
                 depth,
             )?
             else {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Merkle tree hash not found for dir: '{}' in commit: {:?}",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -496,7 +496,7 @@ impl CommitMerkleTree {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
             CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
-                OxenError::basic_str(format!(
+                OxenError::basic_str(&format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -510,13 +510,13 @@ impl CommitMerkleTree {
     pub fn read_depth_from_path_and_collect_paths(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         base_hashes: Option<&HashMap<(MerkleHash, MerkleTreeNodeType), PathBuf>>,
         shared_hashes: Option<&mut HashMap<(MerkleHash, MerkleTreeNodeType), PathBuf>>,
         unique_hashes: Option<&mut HashMap<(MerkleHash, MerkleTreeNodeType), PathBuf>>,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let mut node_path = path.as_ref().to_path_buf();
+        let mut node_path = path.to_path_buf();
         if node_path == Path::new(".") {
             node_path = PathBuf::from("");
         }
@@ -533,7 +533,7 @@ impl CommitMerkleTree {
                 depth,
             )?
             else {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Merkle tree hash not found for dir: '{}' in commit: {:?}",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -545,7 +545,7 @@ impl CommitMerkleTree {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
             CommitMerkleTree::read_file(repo, &dir_hashes, &node_path)?.ok_or(
-                OxenError::basic_str(format!(
+                OxenError::basic_str(&format!(
                     "Merkle tree hash not found for file: '{}' in commit: '{}'",
                     node_path.to_str().unwrap(),
                     commit.id
@@ -559,10 +559,10 @@ impl CommitMerkleTree {
     pub fn dir_without_children(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         dir_hashes: Option<&HashMap<PathBuf, MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let node_path = path.as_ref();
+        let node_path = path;
         let dir_hashes = if let Some(dir_hashes) = dir_hashes {
             dir_hashes
         } else {
@@ -584,10 +584,10 @@ impl CommitMerkleTree {
     pub fn dir_with_children(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         dir_hashes: Option<&HashMap<PathBuf, MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let node_path = path.as_ref();
+        let node_path = path;
         let dir_hashes = if let Some(dir_hashes) = dir_hashes {
             dir_hashes
         } else {
@@ -607,12 +607,12 @@ impl CommitMerkleTree {
     pub fn dir_with_unique_children(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         base_hashes: &HashSet<MerkleHash>,
         unique_hashes: &mut HashSet<MerkleHash>,
         dir_hashes: Option<&HashMap<PathBuf, MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let node_path = path.as_ref();
+        let node_path = path;
         let dir_hashes = if let Some(dir_hashes) = dir_hashes {
             dir_hashes
         } else {
@@ -639,10 +639,10 @@ impl CommitMerkleTree {
     pub fn dir_with_children_recursive(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         dir_hashes: Option<&HashMap<PathBuf, MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let node_path = path.as_ref();
+        let node_path = path;
         log::debug!("Read path {node_path:?} in commit {commit:?}");
         let dir_hashes = if let Some(dir_hashes) = dir_hashes {
             dir_hashes
@@ -659,30 +659,23 @@ impl CommitMerkleTree {
         }
     }
 
-    pub fn has_dir(&self, path: impl AsRef<Path>) -> bool {
+    pub fn has_dir(&self, path: &Path) -> bool {
         // log::debug!("has_dir path: {:?}", path.as_ref());
         // log::debug!("has_dir dir_hashes: {:?}", self.dir_hashes);
-        let path = path.as_ref();
         self.dir_hashes.contains_key(path)
     }
 
-    pub fn has_path(&self, path: impl AsRef<Path>) -> Result<bool, OxenError> {
-        let path = path.as_ref();
+    pub fn has_path(&self, path: &Path) -> Result<bool, OxenError> {
         let node = self.root.get_by_path(path)?;
         Ok(node.is_some())
     }
 
-    pub fn get_by_path(&self, path: impl AsRef<Path>) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let path = path.as_ref();
+    pub fn get_by_path(&self, path: &Path) -> Result<Option<MerkleTreeNode>, OxenError> {
         let node = self.root.get_by_path(path)?;
         Ok(node)
     }
 
-    pub fn get_vnodes_for_dir(
-        &self,
-        path: impl AsRef<Path>,
-    ) -> Result<Vec<MerkleTreeNode>, OxenError> {
-        let path = path.as_ref();
+    pub fn get_vnodes_for_dir(&self, path: &Path) -> Result<Vec<MerkleTreeNode>, OxenError> {
         let nodes = self.root.get_vnodes_for_dir(path)?;
         Ok(nodes)
     }
@@ -692,15 +685,11 @@ impl CommitMerkleTree {
     }
 
     // call node_files_and_filders
-    pub fn files_and_folders(
-        &self,
-        path: impl AsRef<Path>,
-    ) -> Result<HashSet<MerkleTreeNode>, OxenError> {
-        let path = path.as_ref();
+    pub fn files_and_folders(&self, path: &Path) -> Result<HashSet<MerkleTreeNode>, OxenError> {
         let node = self
             .root
             .get_by_path(path)?
-            .ok_or(OxenError::basic_str(format!(
+            .ok_or(OxenError::basic_str(&format!(
                 "Merkle tree hash not found for parent: {path:?}"
             )))?;
         let mut children = HashSet::new();
@@ -733,7 +722,7 @@ impl CommitMerkleTree {
                 Ok(file_entries)
             }
             EMerkleTreeNode::File(file_node) => Ok(vec![file_node.clone()]),
-            _ => Err(OxenError::basic_str(format!(
+            _ => Err(OxenError::basic_str(&format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             ))),
@@ -744,14 +733,13 @@ impl CommitMerkleTree {
     pub fn read_file(
         repo: &LocalRepository,
         dir_hashes: &HashMap<PathBuf, MerkleHash>,
-        path: impl AsRef<Path>,
+        path: &Path,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // Get the directory from the path
-        let path = path.as_ref();
         let Some(parent_path) = path.parent() else {
             return Ok(None);
         };
-        let file_name = path.file_name().unwrap().to_str().unwrap();
+        let file_name = Path::new(path.file_name().unwrap().to_str().unwrap());
 
         log::debug!("read_file path {path:?} parent_path {parent_path:?} file_name {file_name:?}");
 
@@ -1250,7 +1238,7 @@ mod tests {
     async fn test_load_dir_nodes() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let repo = repositories::init::init_with_version(dir, MinOxenVersion::LATEST)?;
+            let repo = repositories::init::init_with_version(&dir, MinOxenVersion::LATEST)?;
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;

--- a/crates/lib/src/core/v_latest/index/file_chunker.rs
+++ b/crates/lib/src/core/v_latest/index/file_chunker.rs
@@ -162,7 +162,7 @@ impl ChunkShardFile {
 
     pub fn add_buffer(&mut self, hash: u128, buffer: &[u8]) -> Result<(), OxenError> {
         if !self.has_capacity(buffer.len()) {
-            return Err(OxenError::basic_str("Shard is full"));
+            return Err(OxenError::basic_str("Shard is full".to_string()));
         }
 
         self.index
@@ -334,7 +334,7 @@ impl ChunkShardManager {
         let shard_idx = self
             .db
             .get(hash)?
-            .ok_or(OxenError::basic_str("Chunk not found"))?;
+            .ok_or(OxenError::basic_str("Chunk not found".to_string()))?;
         log::debug!("Reading chunk from shard: [{shard_idx}] for hash: {hash}");
         // Cache the current shard file for faster reads of the same shard
         if shard_idx as i32 != self.current_idx {
@@ -348,7 +348,7 @@ impl ChunkShardManager {
 
     pub fn write_chunk(&mut self, hash: u128, chunk: &[u8]) -> Result<u32, OxenError> {
         let Some(current_file) = self.current_file.as_mut() else {
-            return Err(OxenError::basic_str("Not open for writing"));
+            return Err(OxenError::basic_str("Not open for writing".to_string()));
         };
 
         // log::debug!("Writing chunk {} -> {} to shard: [{}]", hash, chunk.len(), self.current_idx);
@@ -373,7 +373,7 @@ impl ChunkShardManager {
 
     pub fn save_all(&mut self) -> Result<(), OxenError> {
         let Some(current_file) = self.current_file.as_mut() else {
-            return Err(OxenError::basic_str("Not open for writing"));
+            return Err(OxenError::basic_str("Not open for writing".to_string()));
         };
 
         current_file.save()?;

--- a/crates/lib/src/core/v_latest/index/restore.rs
+++ b/crates/lib/src/core/v_latest/index/restore.rs
@@ -73,7 +73,9 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
                 }
             }
             _ => {
-                return Err(OxenError::basic_str("Error: Unexpected node type"));
+                return Err(OxenError::basic_str(
+                    "Error: Unexpected node type".to_string(),
+                ));
             }
         }
     }
@@ -109,7 +111,7 @@ fn restore_staged(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), OxenE
                             break; // Stop when we've passed all entries with the given prefix
                         }
                     }
-                    Err(e) => return Err(OxenError::basic_str(e.as_ref())),
+                    Err(e) => return Err(OxenError::basic_str(e.as_ref().to_string())),
                 }
             }
 

--- a/crates/lib/src/core/v_latest/index/restore.rs
+++ b/crates/lib/src/core/v_latest/index/restore.rs
@@ -32,7 +32,8 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
     let paths = opts.paths;
     log::debug!("restore::restore got {:?} paths", paths.len());
 
-    let commit: Commit = repositories::commits::get_commit_or_head(repo, opts.source_ref)?;
+    let commit: Commit =
+        repositories::commits::get_commit_or_head(repo, opts.source_ref.as_deref())?;
     log::debug!("restore::restore: got commit {:?}", commit.id);
 
     let repo_path = repo.path.clone();
@@ -108,7 +109,7 @@ fn restore_staged(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), OxenE
                             break; // Stop when we've passed all entries with the given prefix
                         }
                     }
-                    Err(e) => return Err(OxenError::basic_str(&e)),
+                    Err(e) => return Err(OxenError::basic_str(e.as_ref())),
                 }
             }
 
@@ -222,9 +223,8 @@ pub fn should_restore_partial_node(
     repo: &LocalRepository,
     base_node: Option<PartialNode>,
     file_node: &FileNode,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<bool, OxenError> {
-    let path = path.as_ref();
     let working_path = repo.path.join(path);
 
     // Check to see if the file has been modified if it exists
@@ -278,9 +278,8 @@ pub fn should_restore_file(
     repo: &LocalRepository,
     base_node: Option<FileNode>,
     file_node: &FileNode,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<bool, OxenError> {
-    let path = path.as_ref();
     let working_path = repo.path.join(path);
     // Check to see if the file has been modified if it exists
     if working_path.exists() {
@@ -364,10 +363,9 @@ pub fn should_restore_file(
 pub async fn restore_file(
     repo: &LocalRepository,
     file_node: &FileNode,
-    path: impl AsRef<Path>,
+    path: &Path,
     version_store: &Arc<dyn VersionStore>,
 ) -> Result<(), OxenError> {
-    let path = path.as_ref();
     let file_hash = file_node.hash();
     let last_modified_seconds = file_node.last_modified_seconds();
     let last_modified_nanoseconds = file_node.last_modified_nanoseconds();

--- a/crates/lib/src/core/v_latest/init.rs
+++ b/crates/lib/src/core/v_latest/init.rs
@@ -10,7 +10,7 @@ pub fn init(path: &Path) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
     if hidden_dir.exists() {
         let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     // Cleanup the .oxen dir if init fails
@@ -33,7 +33,7 @@ pub fn init_with_version_default(
     util::fs::create_dir_all(&hidden_dir)?;
     if util::fs::config_filepath(path).try_exists()? {
         let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     let repo = LocalRepository::new_from_version(path, &version.to_string(), None)?;
@@ -52,7 +52,7 @@ pub async fn init_with_version_and_storage_opts(
     util::fs::create_dir_all(&hidden_dir)?;
     if util::fs::config_filepath(path).try_exists()? {
         let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     let repo = LocalRepository::new_from_version(path, &version.to_string(), storage_opts)?;

--- a/crates/lib/src/core/v_latest/init.rs
+++ b/crates/lib/src/core/v_latest/init.rs
@@ -10,14 +10,14 @@ pub fn init(path: &Path) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
     if hidden_dir.exists() {
         let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
     // Cleanup the .oxen dir if init fails
     match init_with_version_default(path, MinOxenVersion::LATEST) {
         Ok(result) => Ok(result),
         Err(error) => {
-            util::fs::remove_dir_all(hidden_dir)?;
+            util::fs::remove_dir_all(&hidden_dir)?;
             Err(error)
         }
     }
@@ -30,13 +30,13 @@ pub fn init_with_version_default(
 ) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
 
-    util::fs::create_dir_all(hidden_dir)?;
+    util::fs::create_dir_all(&hidden_dir)?;
     if util::fs::config_filepath(path).try_exists()? {
         let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
-    let repo = LocalRepository::new_from_version(path, version.to_string(), None)?;
+    let repo = LocalRepository::new_from_version(path, &version.to_string(), None)?;
     repo.save()?;
 
     Ok(repo)
@@ -49,13 +49,13 @@ pub async fn init_with_version_and_storage_opts(
 ) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
 
-    util::fs::create_dir_all(hidden_dir)?;
+    util::fs::create_dir_all(&hidden_dir)?;
     if util::fs::config_filepath(path).try_exists()? {
         let err = format!("Oxen repository already exists: {path:?}");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
-    let repo = LocalRepository::new_from_version(path, version.to_string(), storage_opts)?;
+    let repo = LocalRepository::new_from_version(path, &version.to_string(), storage_opts)?;
     repo.save()?;
 
     let version_store = repo.version_store()?;

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -50,9 +50,9 @@ pub async fn has_conflicts(
     merge_branch: &Branch,
 ) -> Result<bool, OxenError> {
     let base_commit =
-        repositories::commits::get_commit_or_head(repo, Some(base_branch.commit_id.clone()))?;
+        repositories::commits::get_commit_or_head(repo, Some(&base_branch.commit_id.clone()))?;
     let merge_commit =
-        repositories::commits::get_commit_or_head(repo, Some(merge_branch.commit_id.clone()))?;
+        repositories::commits::get_commit_or_head(repo, Some(&merge_branch.commit_id.clone()))?;
 
     let res = can_merge_commits(repo, &base_commit, &merge_commit).await?;
     Ok(!res)
@@ -106,8 +106,8 @@ pub async fn list_conflicts_between_branches(
     base_branch: &Branch,
     merge_branch: &Branch,
 ) -> Result<Vec<PathBuf>, OxenError> {
-    let base_commit = get_commit_or_head(repo, Some(base_branch.commit_id.clone()))?;
-    let merge_commit = get_commit_or_head(repo, Some(merge_branch.commit_id.clone()))?;
+    let base_commit = get_commit_or_head(repo, Some(&base_branch.commit_id.clone()))?;
+    let merge_commit = get_commit_or_head(repo, Some(&merge_branch.commit_id.clone()))?;
 
     list_conflicts_between_commits(repo, &base_commit, &merge_commit).await
 }
@@ -118,11 +118,11 @@ pub fn list_commits_between_branches(
     head_branch: &Branch,
 ) -> Result<Vec<Commit>, OxenError> {
     log::debug!("list_commits_between_branches() base: {base_branch:?} head: {head_branch:?}");
-    let base_commit = get_commit_or_head(repo, Some(base_branch.commit_id.clone()))?;
-    let head_commit = get_commit_or_head(repo, Some(head_branch.commit_id.clone()))?;
+    let base_commit = get_commit_or_head(repo, Some(&base_branch.commit_id.clone()))?;
+    let head_commit = get_commit_or_head(repo, Some(&head_branch.commit_id.clone()))?;
 
     let Some(lca) = lowest_common_ancestor_from_commits(repo, &base_commit, &head_commit)? else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Error: head commit {:?} and base commit {:?} have no common ancestor",
             head_commit.id, base_commit.id
         )));
@@ -142,7 +142,7 @@ pub fn list_commits_between_commits(
     log::debug!("list_commits_between_commits()\nbase: {base_commit}\nhead: {head_commit}");
 
     let Some(lca) = lowest_common_ancestor_from_commits(repo, base_commit, head_commit)? else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Error: head commit {:?} and base commit {:?} have no common ancestor",
             head_commit.id, base_commit.id
         )));
@@ -194,8 +194,8 @@ pub async fn merge_into_base(
         return Ok(None);
     }
 
-    let base_commit = get_commit_or_head(repo, Some(base_branch.commit_id.clone()))?;
-    let merge_commit = get_commit_or_head(repo, Some(merge_branch.commit_id.clone()))?;
+    let base_commit = get_commit_or_head(repo, Some(&base_branch.commit_id.clone()))?;
+    let merge_commit = get_commit_or_head(repo, Some(&merge_branch.commit_id.clone()))?;
 
     let lca = lowest_common_ancestor_from_commits(repo, &base_commit, &merge_commit)?;
     log::debug!("merge_into_base base: {base_commit:?} merge: {merge_commit:?} lca: {lca:?}");
@@ -210,17 +210,12 @@ pub async fn merge_into_base(
 }
 
 /// Merge into the current branch, returns the merge commit if successful, and None if there is conflicts
-pub async fn merge(
-    repo: &LocalRepository,
-    branch_name: impl AsRef<str>,
-) -> Result<Option<Commit>, OxenError> {
-    let branch_name = branch_name.as_ref();
-
+pub async fn merge(repo: &LocalRepository, branch_name: &str) -> Result<Option<Commit>, OxenError> {
     let merge_branch = repositories::branches::get_by_name(repo, branch_name)?
         .ok_or(OxenError::local_branch_not_found(branch_name))?;
 
     let base_commit = repositories::commits::head_commit(repo)?;
-    let merge_commit = get_commit_or_head(repo, Some(merge_branch.commit_id.clone()))?;
+    let merge_commit = get_commit_or_head(repo, Some(&merge_branch.commit_id.clone()))?;
     let lca = lowest_common_ancestor_from_commits(repo, &base_commit, &merge_commit)?;
     let commits = MergeCommits {
         lca,
@@ -290,17 +285,15 @@ pub fn remove_conflict_path(repo: &LocalRepository, path: &Path) -> Result<(), O
     Ok(())
 }
 
-pub fn find_merge_commits<S: AsRef<str>>(
+pub fn find_merge_commits(
     repo: &LocalRepository,
-    branch_name: S,
+    branch_name: &str,
 ) -> Result<MergeCommits, OxenError> {
-    let branch_name = branch_name.as_ref();
-
     let current_branch = repositories::branches::current_branch(repo)?
         .ok_or(OxenError::basic_str("No current branch"))?;
 
     let head_commit =
-        repositories::commits::get_commit_or_head(repo, Some(current_branch.name.clone()))?;
+        repositories::commits::get_commit_or_head(repo, Some(&current_branch.name.clone()))?;
 
     let merge_commit = get_commit_or_head(repo, Some(branch_name))?;
 
@@ -392,14 +385,13 @@ Found {} conflicts, please resolve them before merging.
 /// Check if HEAD is in the direct parent chain of the merge commit. If it is a direct parent, we can just fast forward
 pub fn lowest_common_ancestor(
     repo: &LocalRepository,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
 ) -> Result<Option<Commit>, OxenError> {
-    let branch_name = branch_name.as_ref();
     let current_branch = repositories::branches::current_branch(repo)?
         .ok_or(OxenError::basic_str("No current branch"))?;
 
     let base_commit =
-        repositories::commits::get_commit_or_head(repo, Some(current_branch.name.clone()))?;
+        repositories::commits::get_commit_or_head(repo, Some(&current_branch.name.clone()))?;
     let merge_commit = repositories::commits::get_commit_or_head(repo, Some(branch_name))?;
 
     lowest_common_ancestor_from_commits(repo, &base_commit, &merge_commit)
@@ -456,7 +448,7 @@ async fn fast_forward_merge(
     r_ff_merge_commit(
         repo,
         &merge_tree,
-        PathBuf::from(""),
+        &PathBuf::from(""),
         &mut merge_tree_results,
         &mut partial_nodes,
         &mut shared_hashes,
@@ -474,7 +466,7 @@ async fn fast_forward_merge(
     r_ff_base_dir(
         repo,
         &base_tree,
-        PathBuf::from(""),
+        &PathBuf::from(""),
         &mut base_tree_results,
         &mut shared_hashes,
         &mut seen_files,
@@ -508,13 +500,12 @@ async fn fast_forward_merge(
 fn r_ff_merge_commit(
     repo: &LocalRepository,
     merge_node: &MerkleTreeNode,
-    path: impl AsRef<Path>,
+    path: &Path,
     results: &mut MergeResult,
     base_files: &mut HashMap<PathBuf, PartialNode>,
     shared_hashes: &mut HashSet<MerkleHash>,
     seen_files: &mut HashSet<PathBuf>,
 ) -> Result<(), OxenError> {
-    let path = path.as_ref();
     match &merge_node.node {
         EMerkleTreeNode::File(merge_file_node) => {
             let file_path = path.join(merge_file_node.name());
@@ -623,12 +614,11 @@ fn r_ff_merge_commit(
 fn r_ff_base_dir(
     repo: &LocalRepository,
     base_node: &MerkleTreeNode,
-    path: impl AsRef<Path>,
+    path: &Path,
     results: &mut MergeResult,
     shared_hashes: &mut HashSet<MerkleHash>,
     merge_files: &mut HashSet<PathBuf>,
 ) -> Result<(), OxenError> {
-    let path = path.as_ref();
     match &base_node.node {
         EMerkleTreeNode::File(base_file_node) => {
             let file_path = path.join(base_file_node.name());
@@ -818,7 +808,7 @@ async fn create_merge_commit_on_branch(
     // The author in this case is the pusher - the author of the merge commit
 
     let commit = commit_writer::commit_with_parent_ids(repo, &commit_msg, parent_ids)?;
-    let mut opts = RmOpts::from_path(PathBuf::from("/"));
+    let mut opts = RmOpts::from_path(&PathBuf::from("/"));
     opts.staged = true;
     opts.recursive = true;
     rm::remove_staged(repo, &HashSet::from([PathBuf::from("/")]), &opts)?;

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -122,7 +122,7 @@ pub fn list_commits_between_branches(
     let head_commit = get_commit_or_head(repo, Some(&head_branch.commit_id.clone()))?;
 
     let Some(lca) = lowest_common_ancestor_from_commits(repo, &base_commit, &head_commit)? else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Error: head commit {:?} and base commit {:?} have no common ancestor",
             head_commit.id, base_commit.id
         )));
@@ -142,7 +142,7 @@ pub fn list_commits_between_commits(
     log::debug!("list_commits_between_commits()\nbase: {base_commit}\nhead: {head_commit}");
 
     let Some(lca) = lowest_common_ancestor_from_commits(repo, base_commit, head_commit)? else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Error: head commit {:?} and base commit {:?} have no common ancestor",
             head_commit.id, base_commit.id
         )));
@@ -290,7 +290,7 @@ pub fn find_merge_commits(
     branch_name: &str,
 ) -> Result<MergeCommits, OxenError> {
     let current_branch = repositories::branches::current_branch(repo)?
-        .ok_or(OxenError::basic_str("No current branch"))?;
+        .ok_or(OxenError::basic_str("No current branch".to_string()))?;
 
     let head_commit =
         repositories::commits::get_commit_or_head(repo, Some(&current_branch.name.clone()))?;
@@ -388,7 +388,7 @@ pub fn lowest_common_ancestor(
     branch_name: &str,
 ) -> Result<Option<Commit>, OxenError> {
     let current_branch = repositories::branches::current_branch(repo)?
-        .ok_or(OxenError::basic_str("No current branch"))?;
+        .ok_or(OxenError::basic_str("No current branch".to_string()))?;
 
     let base_commit =
         repositories::commits::get_commit_or_head(repo, Some(&current_branch.name.clone()))?;
@@ -420,7 +420,9 @@ async fn fast_forward_merge(
         None,
     )?
     else {
-        return Err(OxenError::basic_str("Cannot get root node for base commit"));
+        return Err(OxenError::basic_str(
+            "Cannot get root node for base commit".to_string(),
+        ));
     };
 
     // Collect every shared dir/vnode hash between the trees, load the base tree's unique nodes and collect them as 'partial nodes'
@@ -437,7 +439,7 @@ async fn fast_forward_merge(
     )?
     else {
         return Err(OxenError::basic_str(
-            "Cannot get root node for merge commit",
+            "Cannot get root node for merge commit".to_string(),
         ));
     };
 
@@ -603,7 +605,7 @@ fn r_ff_merge_commit(
         }
         _ => {
             return Err(OxenError::basic_str(
-                "Got an unexpected node type during checkout",
+                "Got an unexpected node type during checkout".to_string(),
             ));
         }
     }

--- a/crates/lib/src/core/v_latest/metadata.rs
+++ b/crates/lib/src/core/v_latest/metadata.rs
@@ -15,11 +15,10 @@ use super::index::CommitMerkleTree;
 /// Returns metadata with latest commit information. Less efficient than get().
 pub fn get_cli(
     repo: &LocalRepository,
-    entry_path: impl AsRef<Path>,
-    data_path: impl AsRef<Path>,
+    entry_path: &Path,
+    data_path: &Path,
 ) -> Result<CLIMetadataEntry, OxenError> {
-    let path = data_path.as_ref();
-    let entry_path = entry_path.as_ref();
+    let path = data_path;
     let base_name = entry_path
         .file_name()
         .ok_or(OxenError::file_has_no_name(path))?;

--- a/crates/lib/src/core/v_latest/pull.rs
+++ b/crates/lib/src/core/v_latest/pull.rs
@@ -73,7 +73,8 @@ pub async fn pull_remote_branch(
                     Ok(None) => {
                         // Merge conflict, keep the previous commit
                         return Err(OxenError::merge_conflict(
-                            "There was a merge conflict, please resolve it before pulling",
+                            "There was a merge conflict, please resolve it before pulling"
+                                .to_string(),
                         ));
                     }
                     Err(e) => return Err(e),

--- a/crates/lib/src/core/v_latest/pull.rs
+++ b/crates/lib/src/core/v_latest/pull.rs
@@ -68,7 +68,7 @@ pub async fn pull_remote_branch(
                 {
                     Ok(Some(commit)) => {
                         // Merge successful, update branch head
-                        repositories::branches::update(repo, branch, commit.id)?;
+                        repositories::branches::update(repo, branch, &commit.id)?;
                     }
                     Ok(None) => {
                         // Merge conflict, keep the previous commit
@@ -82,7 +82,7 @@ pub async fn pull_remote_branch(
         }
 
         None => {
-            repositories::branches::update(repo, branch, new_head_commit.id)?;
+            repositories::branches::update(repo, branch, &new_head_commit.id)?;
             repositories::checkout::checkout(repo, branch).await?;
         }
     }

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -151,7 +151,7 @@ async fn push_to_existing_branch(
                     "Branch {} is behind remote commit {}.\nRun `oxen pull` to update your local branch",
                     remote_branch.name, remote_branch.commit_id
                 );
-                return Err(OxenError::basic_str(err_str));
+                return Err(OxenError::basic_str(&err_str));
             }
         }
         Err(err) => {
@@ -405,7 +405,7 @@ async fn push_commits(
         .map(|commit| {
             let commit_hash = commit.hash()?;
             let info = commit_info.get(&commit_hash).cloned().ok_or_else(|| {
-                OxenError::basic_str(format!("Commit info not found for commit {commit_hash}"))
+                OxenError::basic_str(&format!("Commit info not found for commit {commit_hash}"))
             })?;
             Ok((commit, info))
         })
@@ -477,7 +477,7 @@ async fn push_commits(
 
                     if let Err(err) = result {
                         let err_str = format!("Error pushing commit {id:?}: {err}");
-                        errors.lock().await.push(OxenError::basic_str(err_str));
+                        errors.lock().await.push(OxenError::basic_str(&err_str));
                     }
                 }
             },
@@ -487,7 +487,7 @@ async fn push_commits(
     let errors = errors.lock().await;
     if !errors.is_empty() {
         let error_messages: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Failed to push {} commit(s):\n{}",
             errors.len(),
             error_messages.join("\n")
@@ -545,11 +545,11 @@ pub async fn push_entries(
         }
         (Err(err), Ok(_)) => {
             let err = format!("Error syncing large entries: {err}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
         (Ok(_), Err(err)) => {
             let err = format!("Error syncing small entries: {err}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
         _ => Err(OxenError::basic_str("Unknown error syncing entries")),
     }
@@ -621,8 +621,8 @@ async fn chunk_and_send_large_entries(
 
                 match api::client::versions::parallel_large_file_upload(
                     &remote_repo,
-                    &*version_path,
-                    None::<PathBuf>,
+                    &version_path,
+                    None::<PathBuf>.as_deref(),
                     None,
                     Some(entry.clone()),
                     Some(&bar),
@@ -656,12 +656,12 @@ async fn chunk_and_send_large_entries(
     let join_results = futures::future::join_all(handles).await;
     for res in join_results {
         if let Err(e) = res {
-            return Err(OxenError::basic_str(format!("worker task panicked: {e}")));
+            return Err(OxenError::basic_str(&format!("worker task panicked: {e}")));
         }
     }
 
     if let Some(err) = first_error.lock().await.clone() {
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
     log::debug!("All large file tasks done. :-)");
@@ -794,12 +794,12 @@ async fn bundle_and_send_small_entries(
     let join_results = futures::future::join_all(handles).await;
     for res in join_results {
         if let Err(e) = res {
-            return Err(OxenError::basic_str(format!("worker task panicked: {e}")));
+            return Err(OxenError::basic_str(&format!("worker task panicked: {e}")));
         }
     }
 
     if let Some(err) = first_error.lock().await.clone() {
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
     sleep(Duration::from_millis(100)).await;

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -151,7 +151,7 @@ async fn push_to_existing_branch(
                     "Branch {} is behind remote commit {}.\nRun `oxen pull` to update your local branch",
                     remote_branch.name, remote_branch.commit_id
                 );
-                return Err(OxenError::basic_str(&err_str));
+                return Err(OxenError::basic_str(err_str));
             }
         }
         Err(err) => {
@@ -209,7 +209,7 @@ async fn push_missing_files(
 ) -> Result<(), OxenError> {
     let Some(head_commit) = commits.last() else {
         return Err(OxenError::basic_str(
-            "Cannot push missing files without a head commit",
+            "Cannot push missing files without a head commit".to_string(),
         ));
     };
 
@@ -405,7 +405,7 @@ async fn push_commits(
         .map(|commit| {
             let commit_hash = commit.hash()?;
             let info = commit_info.get(&commit_hash).cloned().ok_or_else(|| {
-                OxenError::basic_str(&format!("Commit info not found for commit {commit_hash}"))
+                OxenError::basic_str(format!("Commit info not found for commit {commit_hash}"))
             })?;
             Ok((commit, info))
         })
@@ -477,7 +477,7 @@ async fn push_commits(
 
                     if let Err(err) = result {
                         let err_str = format!("Error pushing commit {id:?}: {err}");
-                        errors.lock().await.push(OxenError::basic_str(&err_str));
+                        errors.lock().await.push(OxenError::basic_str(err_str));
                     }
                 }
             },
@@ -487,7 +487,7 @@ async fn push_commits(
     let errors = errors.lock().await;
     if !errors.is_empty() {
         let error_messages: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Failed to push {} commit(s):\n{}",
             errors.len(),
             error_messages.join("\n")
@@ -545,13 +545,15 @@ pub async fn push_entries(
         }
         (Err(err), Ok(_)) => {
             let err = format!("Error syncing large entries: {err}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
         (Ok(_), Err(err)) => {
             let err = format!("Error syncing small entries: {err}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
-        _ => Err(OxenError::basic_str("Unknown error syncing entries")),
+        _ => Err(OxenError::basic_str(
+            "Unknown error syncing entries".to_string(),
+        )),
     }
 }
 
@@ -656,12 +658,12 @@ async fn chunk_and_send_large_entries(
     let join_results = futures::future::join_all(handles).await;
     for res in join_results {
         if let Err(e) = res {
-            return Err(OxenError::basic_str(&format!("worker task panicked: {e}")));
+            return Err(OxenError::basic_str(format!("worker task panicked: {e}")));
         }
     }
 
     if let Some(err) = first_error.lock().await.clone() {
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     log::debug!("All large file tasks done. :-)");
@@ -794,12 +796,12 @@ async fn bundle_and_send_small_entries(
     let join_results = futures::future::join_all(handles).await;
     for res in join_results {
         if let Err(e) = res {
-            return Err(OxenError::basic_str(&format!("worker task panicked: {e}")));
+            return Err(OxenError::basic_str(format!("worker task panicked: {e}")));
         }
     }
 
     if let Some(err) = first_error.lock().await.clone() {
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     sleep(Duration::from_millis(100)).await;

--- a/crates/lib/src/core/v_latest/revisions.rs
+++ b/crates/lib/src/core/v_latest/revisions.rs
@@ -6,11 +6,9 @@ use std::path::Path;
 /// Get the version file path from a commit id
 pub async fn get_version_file_from_commit_id(
     repo: &LocalRepository,
-    commit_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    commit_id: &str,
+    path: &Path,
 ) -> Result<LocalFilePath, OxenError> {
-    let commit_id = commit_id.as_ref();
-    let path = path.as_ref();
     let commit = repositories::commits::get_by_id(repo, commit_id)?
         .ok_or(OxenError::commit_id_does_not_exist(commit_id))?;
 

--- a/crates/lib/src/core/v_latest/rm.rs
+++ b/crates/lib/src/core/v_latest/rm.rs
@@ -60,7 +60,7 @@ pub fn rm_with_staged_db(
 ) -> Result<(), OxenError> {
     if has_modified_files(repo, paths)? {
         let error = "There are modified files in the working directory.\n\tUse `oxen status` to see the modified files.".to_string();
-        return Err(OxenError::basic_str(error));
+        return Err(OxenError::basic_str(&error));
     }
 
     if opts.staged && opts.recursive {
@@ -194,7 +194,7 @@ fn remove_staged_inner(
         };
         if entry.node.is_dir() && !rm_opts.recursive {
             let error = format!("`oxen rm` on directory {path:?} requires -r");
-            return Err(OxenError::basic_str(error));
+            return Err(OxenError::basic_str(&error));
         }
         remove_staged_entry(&relative_path, staged_db)?;
     }
@@ -263,11 +263,11 @@ fn remove_file_inner(
         }
         Err(e) => {
             let error = format!("Error adding file {path:?}: {e:?}");
-            Err(OxenError::basic_str(error))
+            Err(OxenError::basic_str(&error))
         }
         _ => {
             let error = format!("Error adding file {path:?}");
-            Err(OxenError::basic_str(error))
+            Err(OxenError::basic_str(&error))
         }
     }
 }
@@ -342,7 +342,7 @@ pub fn remove_dir_with_db_manager(
 
             EMerkleTreeNode::Directory(dir_node) => {
                 let mut dir_node = dir_node.clone();
-                dir_node.set_name(path.to_string_lossy());
+                dir_node.set_name(path.to_string_lossy().as_ref());
                 MerkleTreeNode {
                     hash: node.hash,
                     node: EMerkleTreeNode::Directory(dir_node.clone()),
@@ -429,7 +429,7 @@ fn process_remove_file_and_parents(
     // Add all the parent dirs to the staged db
     let mut parent_path = path.to_path_buf();
     while let Some(parent) = parent_path.parent() {
-        let relative_path = util::fs::path_relative_to_dir(parent, repo_path.clone())?;
+        let relative_path = util::fs::path_relative_to_dir(parent, &repo_path.clone())?;
         parent_path = parent.to_path_buf();
 
         let relative_path_str = relative_path.to_str().unwrap();
@@ -463,7 +463,7 @@ fn remove_inner(
     // Head commit should always exist here, because we're removing committed files
     let Some(head_commit) = repositories::commits::head_commit_maybe(repo)? else {
         let error = "Error: head commit not found".to_string();
-        return Err(OxenError::basic_str(error));
+        return Err(OxenError::basic_str(&error));
     };
 
     let mut total = CumulativeStats {
@@ -483,18 +483,18 @@ fn remove_inner(
             dir_node
         } else {
             let error = format!("Error: parent dir not found in tree for {path:?}");
-            return Err(OxenError::basic_str(error));
+            return Err(OxenError::basic_str(&error));
         };
 
         // Get file name without parent paths for lookup in Merkle Tree
-        let relative_path = util::fs::path_relative_to_dir(path.clone(), parent_path)?;
+        let relative_path = util::fs::path_relative_to_dir(&path.clone(), parent_path)?;
 
         // Lookup node in Merkle Tree
-        if let Some(node) = parent_node.get_by_path(relative_path.clone())? {
+        if let Some(node) = parent_node.get_by_path(&relative_path.clone())? {
             if let EMerkleTreeNode::Directory(_) = &node.node {
                 if !opts.recursive {
                     let error = format!("`oxen rm` on directory {path:?} requires -r");
-                    return Err(OxenError::basic_str(error));
+                    return Err(OxenError::basic_str(&error));
                 }
 
                 total += remove_dir_inner(repo, &head_commit, &path, staged_db)?;
@@ -520,11 +520,11 @@ fn remove_inner(
                 }
             } else {
                 let error = "Error: Unexpected file type".to_string();
-                return Err(OxenError::basic_str(error));
+                return Err(OxenError::basic_str(&error));
             }
         } else {
             let error = format!("Error: {path:?} must be committed in order to use `oxen rm`");
-            return Err(OxenError::basic_str(error));
+            return Err(OxenError::basic_str(&error));
         }
     }
 
@@ -581,7 +581,7 @@ fn remove_dir_inner(
         Some(node) => node,
         None => {
             let error = format!("Error: {path:?} must be committed in order to use `oxen rm`");
-            return Err(OxenError::basic_str(error));
+            return Err(OxenError::basic_str(&error));
         }
     };
 
@@ -627,12 +627,12 @@ fn process_remove_dir(
     // Add all the parent dirs to the staged db
     let mut parent_path = path.to_path_buf();
     while let Some(parent) = parent_path.parent() {
-        let relative_path = util::fs::path_relative_to_dir(parent, repo_path.clone())?;
+        let relative_path = util::fs::path_relative_to_dir(parent, &repo_path.clone())?;
         parent_path = parent.to_path_buf();
 
         let Some(relative_path_str) = relative_path.to_str() else {
             let error = format!("Error: {relative_path:?} is not a valid string");
-            return Err(OxenError::basic_str(error));
+            return Err(OxenError::basic_str(&error));
         };
 
         // Ensures that removed entries don't have their parents re-added by oxen rm
@@ -709,17 +709,17 @@ fn r_process_remove_dir(
                     }
                     Err(e) => {
                         let error = format!("Error adding file {new_path:?}: {e:?}");
-                        return Err(OxenError::basic_str(error));
+                        return Err(OxenError::basic_str(&error));
                     }
                     _ => {
                         let error = format!("Error adding file {new_path:?}");
-                        return Err(OxenError::basic_str(error));
+                        return Err(OxenError::basic_str(&error));
                     }
                 }
             }
             _ => {
                 let error = "Error: Unexpected node type".to_string();
-                return Err(OxenError::basic_str(error));
+                return Err(OxenError::basic_str(&error));
             }
         }
     }
@@ -749,7 +749,7 @@ fn r_process_remove_dir(
 
         // node should always be a directory or vnode, so any other types result in an error
         _ => {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             )));

--- a/crates/lib/src/core/v_latest/rm.rs
+++ b/crates/lib/src/core/v_latest/rm.rs
@@ -60,7 +60,7 @@ pub fn rm_with_staged_db(
 ) -> Result<(), OxenError> {
     if has_modified_files(repo, paths)? {
         let error = "There are modified files in the working directory.\n\tUse `oxen status` to see the modified files.".to_string();
-        return Err(OxenError::basic_str(&error));
+        return Err(OxenError::basic_str(error));
     }
 
     if opts.staged && opts.recursive {
@@ -105,12 +105,14 @@ fn remove_staged_recursively_inner(
                     }
                 }
                 _ => {
-                    return Err(OxenError::basic_str("Could not read utf8 val..."));
+                    return Err(OxenError::basic_str(
+                        "Could not read utf8 val...".to_string(),
+                    ));
                 }
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -161,13 +163,13 @@ fn cleanup_empty_dirs(
                 }
                 _ => {
                     return Err(OxenError::basic_str(
-                        "Could not read iterate over db values",
+                        "Could not read iterate over db values".to_string(),
                     ));
                 }
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Could not read iterate over db values",
+                    "Could not read iterate over db values".to_string(),
                 ));
             }
         }
@@ -194,7 +196,7 @@ fn remove_staged_inner(
         };
         if entry.node.is_dir() && !rm_opts.recursive {
             let error = format!("`oxen rm` on directory {path:?} requires -r");
-            return Err(OxenError::basic_str(&error));
+            return Err(OxenError::basic_str(error));
         }
         remove_staged_entry(&relative_path, staged_db)?;
     }
@@ -263,11 +265,11 @@ fn remove_file_inner(
         }
         Err(e) => {
             let error = format!("Error adding file {path:?}: {e:?}");
-            Err(OxenError::basic_str(&error))
+            Err(OxenError::basic_str(error))
         }
         _ => {
             let error = format!("Error adding file {path:?}");
-            Err(OxenError::basic_str(&error))
+            Err(OxenError::basic_str(error))
         }
     }
 }
@@ -351,7 +353,9 @@ pub fn remove_dir_with_db_manager(
                 }
             }
             _ => {
-                return Err(OxenError::basic_str("Error: Unexpected node type"));
+                return Err(OxenError::basic_str(
+                    "Error: Unexpected node type".to_string(),
+                ));
             }
         };
 
@@ -463,7 +467,7 @@ fn remove_inner(
     // Head commit should always exist here, because we're removing committed files
     let Some(head_commit) = repositories::commits::head_commit_maybe(repo)? else {
         let error = "Error: head commit not found".to_string();
-        return Err(OxenError::basic_str(&error));
+        return Err(OxenError::basic_str(error));
     };
 
     let mut total = CumulativeStats {
@@ -483,7 +487,7 @@ fn remove_inner(
             dir_node
         } else {
             let error = format!("Error: parent dir not found in tree for {path:?}");
-            return Err(OxenError::basic_str(&error));
+            return Err(OxenError::basic_str(error));
         };
 
         // Get file name without parent paths for lookup in Merkle Tree
@@ -494,7 +498,7 @@ fn remove_inner(
             if let EMerkleTreeNode::Directory(_) = &node.node {
                 if !opts.recursive {
                     let error = format!("`oxen rm` on directory {path:?} requires -r");
-                    return Err(OxenError::basic_str(&error));
+                    return Err(OxenError::basic_str(error));
                 }
 
                 total += remove_dir_inner(repo, &head_commit, &path, staged_db)?;
@@ -520,11 +524,11 @@ fn remove_inner(
                 }
             } else {
                 let error = "Error: Unexpected file type".to_string();
-                return Err(OxenError::basic_str(&error));
+                return Err(OxenError::basic_str(error));
             }
         } else {
             let error = format!("Error: {path:?} must be committed in order to use `oxen rm`");
-            return Err(OxenError::basic_str(&error));
+            return Err(OxenError::basic_str(error));
         }
     }
 
@@ -581,7 +585,7 @@ fn remove_dir_inner(
         Some(node) => node,
         None => {
             let error = format!("Error: {path:?} must be committed in order to use `oxen rm`");
-            return Err(OxenError::basic_str(&error));
+            return Err(OxenError::basic_str(error));
         }
     };
 
@@ -632,7 +636,7 @@ fn process_remove_dir(
 
         let Some(relative_path_str) = relative_path.to_str() else {
             let error = format!("Error: {relative_path:?} is not a valid string");
-            return Err(OxenError::basic_str(&error));
+            return Err(OxenError::basic_str(error));
         };
 
         // Ensures that removed entries don't have their parents re-added by oxen rm
@@ -709,17 +713,17 @@ fn r_process_remove_dir(
                     }
                     Err(e) => {
                         let error = format!("Error adding file {new_path:?}: {e:?}");
-                        return Err(OxenError::basic_str(&error));
+                        return Err(OxenError::basic_str(error));
                     }
                     _ => {
                         let error = format!("Error adding file {new_path:?}");
-                        return Err(OxenError::basic_str(&error));
+                        return Err(OxenError::basic_str(error));
                     }
                 }
             }
             _ => {
                 let error = "Error: Unexpected node type".to_string();
-                return Err(OxenError::basic_str(&error));
+                return Err(OxenError::basic_str(error));
             }
         }
     }
@@ -749,7 +753,7 @@ fn r_process_remove_dir(
 
         // node should always be a directory or vnode, so any other types result in an error
         _ => {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             )));

--- a/crates/lib/src/core/v_latest/status.rs
+++ b/crates/lib/src/core/v_latest/status.rs
@@ -253,7 +253,7 @@ pub fn status_from_dir_entries(
                     }
                 }
                 _ => {
-                    return Err(OxenError::basic_str(&format!(
+                    return Err(OxenError::basic_str(format!(
                         "status_from_dir found unexpected node type: {:?}",
                         entry.node
                     )));
@@ -466,7 +466,7 @@ fn find_changes(
     let mut entries: Vec<(PathBuf, bool, Result<std::fs::Metadata, OxenError>)> = Vec::new();
     if is_dir {
         let Ok(dir_entries) = std::fs::read_dir(&full_path) else {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Could not read dir {full_path:?}"
             )));
         };
@@ -478,7 +478,7 @@ fn find_changes(
                     let is_dir = path.is_dir();
                     let md = match entry.metadata() {
                         Ok(md) => Ok(md),
-                        Err(err) => Err(OxenError::basic_str(&err.to_string())),
+                        Err(err) => Err(OxenError::basic_str(err.to_string())),
                     };
                     Some((path, is_dir, md))
                 }
@@ -682,7 +682,7 @@ fn find_local_changes(
     let mut entries: Vec<(PathBuf, bool, std::fs::Metadata)> = Vec::new();
     if is_dir {
         let Ok(dir_entries) = std::fs::read_dir(&full_path) else {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Could not read dir {full_path:?}"
             )));
         };

--- a/crates/lib/src/core/v_latest/status.rs
+++ b/crates/lib/src/core/v_latest/status.rs
@@ -32,12 +32,9 @@ pub fn status(repo: &LocalRepository) -> Result<StagedData, OxenError> {
     status_from_dir(repo, &repo.path)
 }
 
-pub fn status_from_dir(
-    repo: &LocalRepository,
-    dir: impl AsRef<Path>,
-) -> Result<StagedData, OxenError> {
+pub fn status_from_dir(repo: &LocalRepository, dir: &Path) -> Result<StagedData, OxenError> {
     let opts = StagedDataOpts {
-        paths: vec![dir.as_ref().to_path_buf()],
+        paths: vec![dir.to_path_buf()],
         ..StagedDataOpts::default()
     };
     status_from_opts(repo, &opts)
@@ -256,7 +253,7 @@ pub fn status_from_dir_entries(
                     }
                 }
                 _ => {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(OxenError::basic_str(&format!(
                         "status_from_dir found unexpected node type: {:?}",
                         entry.node
                     )));
@@ -364,7 +361,7 @@ pub fn read_staged_entries_with_staged_db_manager(
 /// Duplicate function using staged db manager in workspaces
 pub fn read_staged_entries_below_path_with_staged_db_manager(
     repo: &LocalRepository,
-    start_path: impl AsRef<Path>,
+    start_path: &Path,
     read_progress: &ProgressBar,
 ) -> Result<(HashMap<PathBuf, Vec<StagedMerkleTreeNode>>, usize), OxenError> {
     let staged_db_manager = get_staged_db_manager(repo)?;
@@ -374,10 +371,10 @@ pub fn read_staged_entries_below_path_with_staged_db_manager(
 pub fn read_staged_entries_below_path(
     repo: &LocalRepository,
     db: &DBWithThreadMode<SingleThreaded>,
-    start_path: impl AsRef<Path>,
+    start_path: &Path,
     read_progress: &ProgressBar,
 ) -> Result<(HashMap<PathBuf, Vec<StagedMerkleTreeNode>>, usize), OxenError> {
-    let start_path = util::fs::path_relative_to_dir(start_path.as_ref(), &repo.path)?;
+    let start_path = util::fs::path_relative_to_dir(start_path, &repo.path)?;
     let mut total_entries = 0;
     let iter = db.iterator(IteratorMode::Start);
     let mut dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>> = HashMap::new();
@@ -445,13 +442,12 @@ pub fn read_staged_entries_below_path(
 fn find_changes(
     repo: &LocalRepository,
     opts: &StagedDataOpts,
-    search_node_path: impl AsRef<Path>,
+    search_node_path: &Path,
     staged_db: &Option<DBWithThreadMode<SingleThreaded>>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     progress: &ProgressBar,
     total_entries: &mut usize,
 ) -> Result<(UntrackedData, HashSet<PathBuf>, HashSet<PathBuf>), OxenError> {
-    let search_node_path = search_node_path.as_ref();
     let full_path = repo.path.join(search_node_path);
     let is_dir = full_path.is_dir();
     log::debug!("find_changes search_node_path: {search_node_path:?} full_path: {full_path:?}");
@@ -470,7 +466,7 @@ fn find_changes(
     let mut entries: Vec<(PathBuf, bool, Result<std::fs::Metadata, OxenError>)> = Vec::new();
     if is_dir {
         let Ok(dir_entries) = std::fs::read_dir(&full_path) else {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Could not read dir {full_path:?}"
             )));
         };
@@ -482,7 +478,7 @@ fn find_changes(
                     let is_dir = path.is_dir();
                     let md = match entry.metadata() {
                         Ok(md) => Ok(md),
-                        Err(err) => Err(OxenError::basic_str(err.to_string())),
+                        Err(err) => Err(OxenError::basic_str(&err.to_string())),
                     };
                     Some((path, is_dir, md))
                 }
@@ -646,7 +642,7 @@ fn find_changes(
 fn find_local_changes(
     repo: &LocalRepository,
     opts: &StagedDataOpts,
-    search_node_path: impl AsRef<Path>,
+    search_node_path: &Path,
     staged_data: &StagedData,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     progress: &ProgressBar,
@@ -660,7 +656,6 @@ fn find_local_changes(
     ),
     OxenError,
 > {
-    let search_node_path = search_node_path.as_ref();
     let full_path = repo.path.join(search_node_path);
     let is_dir = full_path.is_dir();
 
@@ -687,7 +682,7 @@ fn find_local_changes(
     let mut entries: Vec<(PathBuf, bool, std::fs::Metadata)> = Vec::new();
     if is_dir {
         let Ok(dir_entries) = std::fs::read_dir(&full_path) else {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Could not read dir {full_path:?}"
             )));
         };
@@ -927,9 +922,8 @@ fn get_dir_hashes(
 fn maybe_get_node(
     repo: &LocalRepository,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
-    let path = path.as_ref();
     if let Some(hash) = dir_hashes.get(path) {
         CommitMerkleTree::read_depth(repo, hash, 1)
     } else {
@@ -1059,14 +1053,14 @@ impl UnsyncedData {
 }
 
 fn maybe_get_child_node(
-    path: impl AsRef<Path>,
+    path: &Path,
     dir_children: &Option<HashMap<PathBuf, MerkleTreeNode>>,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
     let Some(children) = dir_children else {
         return Ok(None);
     };
 
-    let child = children.get(path.as_ref());
+    let child = children.get(path);
     Ok(child.cloned())
 }
 

--- a/crates/lib/src/core/v_latest/workspaces.rs
+++ b/crates/lib/src/core/v_latest/workspaces.rs
@@ -14,9 +14,8 @@ pub mod status;
 
 pub fn init_workspace_repo(
     repo: &LocalRepository,
-    workspace_dir: impl AsRef<Path>,
+    workspace_dir: &Path,
 ) -> Result<LocalRepository, OxenError> {
-    let workspace_dir = workspace_dir.as_ref();
     let oxen_hidden_dir = repo.path.join(constants::OXEN_HIDDEN_DIR);
     let workspace_hidden_dir = workspace_dir.join(constants::OXEN_HIDDEN_DIR);
     log::debug!("init_workspace_repo {workspace_hidden_dir:?}");
@@ -25,7 +24,7 @@ pub fn init_workspace_repo(
     // Copy the config file
     let config_file = oxen_hidden_dir.join(constants::REPO_CONFIG_FILENAME);
     let target_config_file = workspace_hidden_dir.join(constants::REPO_CONFIG_FILENAME);
-    util::fs::copy(config_file, &target_config_file)?;
+    util::fs::copy(&config_file, &target_config_file)?;
 
     // Read the storage config from the config file
     let config = RepositoryConfig::from_file(&target_config_file)?;

--- a/crates/lib/src/core/v_latest/workspaces/commit.rs
+++ b/crates/lib/src/core/v_latest/workspaces/commit.rs
@@ -27,9 +27,8 @@ use indicatif::ProgressBar;
 pub async fn commit(
     workspace: &Workspace,
     new_commit: &NewCommitBody,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
 ) -> Result<Commit, OxenError> {
-    let branch_name = branch_name.as_ref();
     let repo = &workspace.base_repo;
     let commit = &workspace.commit;
 
@@ -78,7 +77,7 @@ pub async fn commit(
     // Clear the staged db
     log::debug!("Removing staged_db_path: {staged_db_path:?}");
     remove_from_cache(&workspace.workspace_repo.path)?;
-    util::fs::remove_dir_all(staged_db_path)?;
+    util::fs::remove_dir_all(&staged_db_path)?;
 
     // DEBUG
     // let tree = repositories::tree::get_by_commit(&workspace.base_repo, &commit)?;
@@ -103,11 +102,7 @@ pub async fn commit(
     Ok(commit)
 }
 
-pub fn mergeability(
-    workspace: &Workspace,
-    branch_name: impl AsRef<str>,
-) -> Result<Mergeable, OxenError> {
-    let branch_name = branch_name.as_ref();
+pub fn mergeability(workspace: &Workspace, branch_name: &str) -> Result<Mergeable, OxenError> {
     let Some(branch) = repositories::branches::get_by_name(&workspace.base_repo, branch_name)?
     else {
         return Err(OxenError::revision_not_found(

--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -88,10 +88,10 @@ pub fn get_queryable_data_frame_workspace(
 ) -> Result<Workspace, OxenError> {
     log::debug!("get_queryable_data_frame_workspace path: {path:?}");
     let file_node = repositories::tree::get_file_by_path(repo, commit, path)?
-        .ok_or(OxenError::path_does_not_exist(path))?;
+        .ok_or(OxenError::path_does_not_exist(path.to_path_buf()))?;
     if *file_node.data_type() != EntryDataType::Tabular {
         return Err(OxenError::basic_str(
-            "File format not supported, must be tabular.",
+            "File format not supported, must be tabular.".to_string(),
         ));
     }
     get_queryable_data_frame_workspace_from_file_node(repo, &commit.id.parse()?, path)
@@ -101,10 +101,10 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     // Is tabular just looks at the file extensions
     let file_node =
         repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
-            .ok_or(OxenError::path_does_not_exist(path))?;
+            .ok_or(OxenError::path_does_not_exist(path.to_path_buf()))?;
     if *file_node.data_type() != EntryDataType::Tabular {
         return Err(OxenError::basic_str(
-            "File format not supported, must be tabular.",
+            "File format not supported, must be tabular.".to_string(),
         ));
     }
 
@@ -118,7 +118,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     let Ok(Some(commit_merkle_tree)) =
         repositories::tree::get_node_by_path_with_children(repo, commit, path)
     else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Merkle tree for commit {commit} not found"
         )));
     };
@@ -132,7 +132,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
     let Some(parent) = db_path.parent() else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Failed to get parent directory for {db_path:?}"
         )));
     };
@@ -150,7 +150,9 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     let extension = match &commit_merkle_tree.node {
         EMerkleTreeNode::File(file_node) => file_node.extension(),
         _ => {
-            return Err(OxenError::basic_str("File node is not a file node"));
+            return Err(OxenError::basic_str(
+                "File node is not a file node".to_string(),
+            ));
         }
     };
 
@@ -239,7 +241,7 @@ pub async fn rename(
         log::debug!("rename: staged_entry after add: {staged_entry:?}");
     }
 
-    let mut new_staged_entry = staged_entry.ok_or(OxenError::basic_str(&format!(
+    let mut new_staged_entry = staged_entry.ok_or(OxenError::basic_str(format!(
         "rename: staged entry not found: {path:?}"
     )))?;
 

--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -26,7 +26,7 @@ pub mod schemas;
 pub fn is_queryable_data_frame_indexed(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<bool, OxenError> {
     match get_queryable_data_frame_workspace(repo, path, commit) {
         Ok(_workspace) => Ok(true),
@@ -83,10 +83,9 @@ pub fn get_queryable_data_frame_workspace_from_file_node(
 
 pub fn get_queryable_data_frame_workspace(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
     commit: &Commit,
 ) -> Result<Workspace, OxenError> {
-    let path = path.as_ref();
     log::debug!("get_queryable_data_frame_workspace path: {path:?}");
     let file_node = repositories::tree::get_file_by_path(repo, commit, path)?
         .ok_or(OxenError::path_does_not_exist(path))?;
@@ -119,7 +118,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     let Ok(Some(commit_merkle_tree)) =
         repositories::tree::get_node_by_path_with_children(repo, commit, path)
     else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Merkle tree for commit {commit} not found"
         )));
     };
@@ -133,7 +132,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
     let Some(parent) = db_path.parent() else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Failed to get parent directory for {db_path:?}"
         )));
     };
@@ -155,7 +154,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
         }
     };
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             if df_db::table_exists(conn, TABLE_NAME)? {
                 df_db::drop_table(conn, TABLE_NAME)?;
@@ -174,18 +173,16 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     // Save the current commit id so we know if the branch has advanced
     let commit_path =
         repositories::workspaces::data_frames::previous_commit_ref_path(workspace, path);
-    util::fs::write_to_path(commit_path, &commit.id)?;
+    util::fs::write_to_path(&commit_path, &commit.id)?;
 
     Ok(())
 }
 
 pub async fn rename(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    new_path: impl AsRef<Path>,
+    path: &Path,
+    new_path: &Path,
 ) -> Result<PathBuf, OxenError> {
-    let path = path.as_ref();
-    let new_path = new_path.as_ref();
     let workspace_repo = &workspace.workspace_repo;
 
     // Handle duckdb file operations first
@@ -242,7 +239,7 @@ pub async fn rename(
         log::debug!("rename: staged_entry after add: {staged_entry:?}");
     }
 
-    let mut new_staged_entry = staged_entry.ok_or(OxenError::basic_str(format!(
+    let mut new_staged_entry = staged_entry.ok_or(OxenError::basic_str(&format!(
         "rename: staged entry not found: {path:?}"
     )))?;
 
@@ -296,10 +293,9 @@ fn add_row_status_cols(conn: &Connection) -> Result<(), OxenError> {
 
 pub fn extract_file_node_to_working_dir(
     workspace: &Workspace,
-    dir_path: impl AsRef<Path>,
+    dir_path: &Path,
     file_node: &FileNode,
 ) -> Result<PathBuf, OxenError> {
-    let dir_path = dir_path.as_ref();
     log::debug!("extract_file_node_to_working_dir dir_path: {dir_path:?} file_node: {file_node}");
     let workspace_repo = &workspace.workspace_repo;
     let path = PathBuf::from(file_node.name());
@@ -317,7 +313,7 @@ pub fn extract_file_node_to_working_dir(
         )?;
     }
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let delete = Delete::new().delete_from(TABLE_NAME).where_clause(&format!(
                 "\"{}\" = '{}'",
@@ -343,8 +339,7 @@ pub fn valid_export_extensions() -> Vec<&'static str> {
     vec!["csv", "tsv", "parquet", "jsonl", "json", "ndjson"]
 }
 
-pub fn is_valid_export_extension(path: impl AsRef<Path>) -> bool {
-    let path = path.as_ref();
+pub fn is_valid_export_extension(path: &Path) -> bool {
     let extension = path
         .extension()
         .unwrap_or_default()
@@ -353,8 +348,7 @@ pub fn is_valid_export_extension(path: impl AsRef<Path>) -> bool {
     valid_export_extensions().contains(&extension)
 }
 
-pub fn wrap_sql_for_export(sql: &str, path: impl AsRef<Path>) -> String {
-    let path = path.as_ref();
+pub fn wrap_sql_for_export(sql: &str, path: &Path) -> String {
     let extension = path
         .extension()
         .unwrap_or_default()

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -149,7 +149,9 @@ pub async fn update(
     repositories::workspaces::data_frames::schemas::update_schema(
         workspace,
         file_path,
-        &og_schema.ok_or(OxenError::basic_str("Original schema not found"))?,
+        &og_schema.ok_or(OxenError::basic_str(
+            "Original schema not found".to_string(),
+        ))?,
         &column_to_update.name,
         &column_after_name,
     )?;
@@ -299,8 +301,9 @@ pub async fn restore(
                         ))?
                         .column_name,
                 )?;
-                let og_schema =
-                    og_schema.ok_or(OxenError::basic_str("Original schema not found"))?;
+                let og_schema = og_schema.ok_or(OxenError::basic_str(
+                    "Original schema not found".to_string(),
+                ))?;
 
                 repositories::data_frames::schemas::restore_schema(
                     &workspace.workspace_repo,
@@ -310,14 +313,16 @@ pub async fn restore(
                         .column_before
                         .clone()
                         .ok_or(OxenError::basic_str(
-                            "To restore a modify, the column before object has to be defined",
+                            "To restore a modify, the column before object has to be defined"
+                                .to_string(),
                         ))?
                         .column_name,
                     &change
                         .column_after
                         .clone()
                         .ok_or(OxenError::basic_str(
-                            "To restore a modify, the column after object has to be defined",
+                            "To restore a modify, the column after object has to be defined"
+                                .to_string(),
                         ))?
                         .column_name,
                 )?;
@@ -355,7 +360,7 @@ pub fn add_column_metadata(
             // Get the FileNode from the CommitMerkleTree
             let commit = workspace.commit.clone();
             let node = repositories::tree::get_node_by_path(repo, &commit, &path)?.ok_or(
-                OxenError::basic_str("Node does not exist at the specified path"),
+                OxenError::basic_str("Node does not exist at the specified path".to_string()),
             )?;
             let mut parent_id = node.parent_id;
             let mut dir_path = path.clone();
@@ -387,7 +392,7 @@ pub fn add_column_metadata(
 
             let Some(file_node) = repositories::tree::get_file_by_path(repo, &commit, &path)?
             else {
-                return Err(OxenError::path_does_not_exist(&path));
+                return Err(OxenError::path_does_not_exist(path));
             };
             file_node
         };
@@ -420,7 +425,7 @@ pub fn add_column_metadata(
                 results.insert(path.clone(), m.tabular.schema.clone());
             }
             _ => {
-                return Err(OxenError::path_does_not_exist(&path));
+                return Err(OxenError::path_does_not_exist(path));
             }
         }
 

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -26,10 +26,9 @@ use std::path::{Path, PathBuf};
 
 pub fn add(
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     new_column: &NewColumn,
 ) -> Result<DataFrame, OxenError> {
-    let file_path = file_path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
@@ -57,10 +56,9 @@ pub fn add(
 
 pub fn delete(
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     column_to_delete: &ColumnToDelete,
 ) -> Result<DataFrame, OxenError> {
-    let file_path = file_path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
@@ -99,10 +97,9 @@ pub fn delete(
 
 pub async fn update(
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     column_to_update: &ColumnToUpdate,
 ) -> Result<DataFrame, OxenError> {
-    let file_path = file_path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
@@ -164,10 +161,9 @@ pub async fn update(
 
 pub async fn restore(
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     column_to_restore: &ColumnToRestore,
 ) -> Result<DataFrame, OxenError> {
-    let file_path = file_path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
@@ -342,15 +338,13 @@ pub async fn restore(
 pub fn add_column_metadata(
     repo: &LocalRepository,
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
-    column: impl AsRef<str>,
+    file_path: &Path,
+    column: &str,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
     {
-        let path = file_path.as_ref();
-        let path = util::fs::path_relative_to_dir(path, &workspace.workspace_repo.path)?;
-        let column = column.as_ref();
+        let path = util::fs::path_relative_to_dir(file_path, &workspace.workspace_repo.path)?;
 
         let staged_merkle_tree_node = staged_db_manager.read_from_staged_db(&path)?;
         let mut staged_nodes: HashMap<PathBuf, StagedMerkleTreeNode> = HashMap::new();
@@ -382,7 +376,7 @@ pub fn add_column_metadata(
                     break;
                 };
                 dir_path = parent_dir.to_path_buf();
-                dir_node.set_name(dir_path.to_string_lossy());
+                dir_node.set_name(&dir_path.to_string_lossy());
                 parent_node.node = EMerkleTreeNode::Directory(dir_node);
                 let staged_parent_node = StagedMerkleTreeNode {
                     status: StagedEntryStatus::Modified,
@@ -401,7 +395,7 @@ pub fn add_column_metadata(
         // Stage parent nodes
         staged_db_manager.upsert_staged_nodes(&staged_nodes)?;
 
-        let column_diff = get_column_diff(workspace, &file_path)?;
+        let column_diff = get_column_diff(workspace, file_path)?;
 
         update_column_names_in_metadata(&column_diff, file_node.get_mut_metadata());
 
@@ -426,7 +420,7 @@ pub fn add_column_metadata(
                 results.insert(path.clone(), m.tabular.schema.clone());
             }
             _ => {
-                return Err(OxenError::path_does_not_exist(path));
+                return Err(OxenError::path_does_not_exist(&path));
             }
         }
 

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -30,17 +30,16 @@ use std::path::Path;
 
 pub fn add(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     data: &serde_json::Value,
 ) -> Result<DataFrame, OxenError> {
-    let path = path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let row_changes_path = repositories::workspaces::data_frames::row_changes_path(workspace, path);
 
     let df = tabular::parse_json_to_df(data)?;
     log::debug!("add() df: {df:?}");
 
-    let mut result = with_df_db_manager(db_path, |manager| {
+    let mut result = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| rows::append_row(conn, &df))
     })?;
     let oxen_id_col = result
@@ -63,12 +62,11 @@ pub fn add(
 
 pub async fn restore(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    row_id: impl AsRef<str>,
+    path: &Path,
+    row_id: &str,
 ) -> Result<DataFrame, OxenError> {
-    let row_id = row_id.as_ref();
-    let restored_row = restore_row_in_db(workspace, path.as_ref(), row_id).await?;
-    let diff = repositories::workspaces::data_frames::full_diff(workspace, path.as_ref())?;
+    let restored_row = restore_row_in_db(workspace, path, row_id).await?;
+    let diff = repositories::workspaces::data_frames::full_diff(workspace, path)?;
     if let DiffResult::Tabular(diff) = diff
         && !diff.has_changes()
     {
@@ -78,24 +76,19 @@ pub async fn restore(
         let manager = get_staged_db_manager(&workspace.workspace_repo)?;
         manager.remove_staged_recursively(
             &workspace.workspace_repo,
-            &HashSet::from([path.as_ref().to_path_buf()]),
+            &HashSet::from([path.to_path_buf()]),
         )?;
     }
 
     Ok(restored_row)
 }
 
-pub fn delete(
-    workspace: &Workspace,
-    path: impl AsRef<Path>,
-    row_id: &str,
-) -> Result<DataFrame, OxenError> {
-    log::debug!("delete() row_id: {row_id} from path: {:?}", path.as_ref());
-    let path = path.as_ref();
+pub fn delete(workspace: &Workspace, path: &Path, row_id: &str) -> Result<DataFrame, OxenError> {
+    log::debug!("delete() row_id: {row_id} from path: {:?}", path);
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let row_changes_path = repositories::workspaces::data_frames::row_changes_path(workspace, path);
 
-    let mut deleted_row = with_df_db_manager(db_path, |manager| {
+    let mut deleted_row = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| rows::delete_row(conn, row_id))
     })?;
     log::debug!("delete() deleted_row: {deleted_row:?}");
@@ -135,11 +128,10 @@ pub fn delete(
 
 pub fn update(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     row_id: &str,
     data: &serde_json::Value,
 ) -> Result<DataFrame, OxenError> {
-    let path = path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let row_changes_path = repositories::workspaces::data_frames::row_changes_path(workspace, path);
 
@@ -149,7 +141,7 @@ pub fn update(
         return Err(OxenError::resource_not_found("row not found"));
     }
 
-    let mut result = with_df_db_manager(db_path, |manager| {
+    let mut result = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| rows::modify_row(conn, &mut df, row_id))
     })?;
 
@@ -183,11 +175,9 @@ pub fn update(
 
 pub fn batch_update(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     data: &Value,
 ) -> Result<Vec<UpdateResult>, OxenError> {
-    let path = path.as_ref();
-
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
     let Some(array) = data.as_array() else {
@@ -215,7 +205,7 @@ pub fn batch_update(
         })
         .collect::<Result<_, OxenError>>()?;
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| rows::modify_rows(conn, row_map))
     })?;
 
@@ -230,7 +220,7 @@ pub fn batch_update(
 pub async fn prepare_modified_or_removed_row(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
     row_df: &DataFrame,
 ) -> Result<DataFrame, OxenError> {
     let row_idx = repositories::workspaces::data_frames::rows::get_row_idx(row_df)?
@@ -238,9 +228,9 @@ pub async fn prepare_modified_or_removed_row(
     let row_idx_og = (row_idx - 1) as i64;
 
     let Some(commit_merkle_tree) =
-        repositories::tree::get_node_by_path_with_children(repo, commit, &path)?
+        repositories::tree::get_node_by_path_with_children(repo, commit, path)?
     else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Merkle tree for commit {commit:?} not found"
         )));
     };
@@ -264,9 +254,12 @@ pub async fn prepare_modified_or_removed_row(
     log::debug!("prepare_modified_or_removed_row() committed_df_path: {committed_df_path:?}");
 
     // TODONOW should not be using all rows - just need to parse delim
-    let lazy_df =
-        tabular::read_df_with_extension(committed_df_path, file_node.extension(), &DFOpts::empty())
-            .await?;
+    let lazy_df = tabular::read_df_with_extension(
+        &committed_df_path,
+        file_node.extension(),
+        &DFOpts::empty(),
+    )
+    .await?;
 
     // Get the row by index
     let mut row = lazy_df.slice(row_idx_og, 1_usize);
@@ -284,19 +277,17 @@ pub async fn prepare_modified_or_removed_row(
 
 pub async fn restore_row_in_db(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    row_id: impl AsRef<str>,
+    path: &Path,
+    row_id: &str,
 ) -> Result<DataFrame, OxenError> {
-    let row_id = row_id.as_ref();
-    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path.as_ref());
+    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let opts = db::key_val::opts::default();
     let column_changes_path =
-        repositories::workspaces::data_frames::column_changes_path(workspace, path.as_ref());
+        repositories::workspaces::data_frames::column_changes_path(workspace, path);
     let db = DB::open(&opts, dunce::simplified(&column_changes_path))?;
 
     // Get the row by id
-    let row =
-        repositories::workspaces::data_frames::rows::get_by_id(workspace, path.as_ref(), row_id)?;
+    let row = repositories::workspaces::data_frames::rows::get_by_id(workspace, path, row_id)?;
 
     if row.height() == 0 {
         return Err(OxenError::resource_not_found(row_id));
@@ -319,7 +310,7 @@ pub async fn restore_row_in_db(
             let mut insert_row = prepare_modified_or_removed_row(
                 &workspace.base_repo,
                 &workspace.commit,
-                path.as_ref(),
+                path,
                 &row,
             )
             .await?;

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -138,7 +138,7 @@ pub fn update(
     let mut df = tabular::parse_json_to_df(data)?;
     let mut row = repositories::workspaces::data_frames::rows::get_by_id(workspace, path, row_id)?;
     if row.height() == 0 {
-        return Err(OxenError::resource_not_found("row not found"));
+        return Err(OxenError::resource_not_found("row not found".to_string()));
     }
 
     let mut result = with_df_db_manager(&db_path, |manager| {
@@ -181,7 +181,7 @@ pub fn batch_update(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
     let Some(array) = data.as_array() else {
-        return Err(OxenError::basic_str("Data is not an array"));
+        return Err(OxenError::basic_str("Data is not an array".to_string()));
     };
 
     let mut keys: Vec<String> = Vec::new();
@@ -192,14 +192,14 @@ pub fn batch_update(
             let row_id = obj
                 .get("row_id")
                 .and_then(Value::as_str)
-                .ok_or_else(|| OxenError::basic_str("Missing row_id"))?
+                .ok_or_else(|| OxenError::basic_str("Missing row_id".to_string()))?
                 .to_owned();
 
             keys.push(row_id.clone());
 
             let df = tabular::parse_json_to_df(
                 obj.get("value")
-                    .ok_or_else(|| OxenError::basic_str("Missing value"))?,
+                    .ok_or_else(|| OxenError::basic_str("Missing value".to_string()))?,
             )?;
             Ok((row_id, df))
         })
@@ -224,20 +224,20 @@ pub async fn prepare_modified_or_removed_row(
     row_df: &DataFrame,
 ) -> Result<DataFrame, OxenError> {
     let row_idx = repositories::workspaces::data_frames::rows::get_row_idx(row_df)?
-        .ok_or_else(|| OxenError::basic_str("Row index not found"))?;
+        .ok_or_else(|| OxenError::basic_str("Row index not found".to_string()))?;
     let row_idx_og = (row_idx - 1) as i64;
 
     let Some(commit_merkle_tree) =
         repositories::tree::get_node_by_path_with_children(repo, commit, path)?
     else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Merkle tree for commit {commit:?} not found"
         )));
     };
 
     let file_node = match commit_merkle_tree.node {
         EMerkleTreeNode::File(file_node) => file_node,
-        _ => return Err(OxenError::basic_str("File node not found")),
+        _ => return Err(OxenError::basic_str("File node not found".to_string())),
     };
 
     log::debug!(
@@ -290,11 +290,11 @@ pub async fn restore_row_in_db(
     let row = repositories::workspaces::data_frames::rows::get_by_id(workspace, path, row_id)?;
 
     if row.height() == 0 {
-        return Err(OxenError::resource_not_found(row_id));
+        return Err(OxenError::resource_not_found(row_id.to_string()));
     };
 
     let row_status = repositories::workspaces::data_frames::rows::get_row_status(&row)?
-        .ok_or_else(|| OxenError::basic_str("Row status not found"))?;
+        .ok_or_else(|| OxenError::basic_str("Row status not found".to_string()))?;
     let result_row = match row_status {
         StagedRowStatus::Added => {
             // Row is added, just delete it

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/schemas.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/schemas.rs
@@ -14,7 +14,7 @@ use crate::repositories;
 /// and updating the metadata from the original schema.
 pub fn update_schema(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     og_schema: &Schema,
     before_column: &str,
     after_column: &str,
@@ -22,7 +22,7 @@ pub fn update_schema(
     let staged_schema =
         crate::core::v_latest::data_frames::schemas::get_staged_schema_with_staged_db_manager(
             &workspace.workspace_repo,
-            &path,
+            path,
         )?;
     let ref_schema = if let Some(schema) = staged_schema {
         schema
@@ -44,19 +44,16 @@ pub fn update_schema(
     }
 
     let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
-    let data = staged_db_manager.read_from_staged_db(&path)?;
+    let data = staged_db_manager.read_from_staged_db(path)?;
 
     let mut file_node: FileNode;
 
     if let Some(data) = data {
         file_node = data.node.file()?;
     } else {
-        file_node = repositories::tree::get_file_by_path(
-            &workspace.base_repo,
-            &workspace.commit,
-            path.as_ref(),
-        )?
-        .ok_or(OxenError::basic_str("File not found"))?;
+        file_node =
+            repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
+                .ok_or(OxenError::basic_str("File not found"))?;
     }
 
     if let Some(GenericMetadata::MetadataTabular(tabular_metadata)) = &file_node.metadata() {

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/schemas.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/schemas.rs
@@ -53,7 +53,7 @@ pub fn update_schema(
     } else {
         file_node =
             repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
-                .ok_or(OxenError::basic_str("File not found"))?;
+                .ok_or(OxenError::basic_str("File not found".to_string()))?;
     }
 
     if let Some(GenericMetadata::MetadataTabular(tabular_metadata)) = &file_node.metadata() {
@@ -65,7 +65,9 @@ pub fn update_schema(
             ),
         )));
     } else {
-        return Err(OxenError::basic_str("Expected tabular metadata"));
+        return Err(OxenError::basic_str(
+            "Expected tabular metadata".to_string(),
+        ));
     }
 
     staged_db_manager.upsert_file_node(path, StagedEntryStatus::Modified, &file_node)?;

--- a/crates/lib/src/core/v_latest/workspaces/diff.rs
+++ b/crates/lib/src/core/v_latest/workspaces/diff.rs
@@ -13,10 +13,9 @@ use crate::model::diff::{AddRemoveModifyCounts, DiffResult, TabularDiff};
 use crate::repositories;
 use std::path::Path;
 
-pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffResult, OxenError> {
+pub fn diff(workspace: &Workspace, path: &Path) -> Result<DiffResult, OxenError> {
     let repo = &workspace.base_repo;
     let commit = &workspace.commit;
-    let path = path.as_ref();
     // Get commit for the branch head
     log::debug!(
         "diff_workspace_df {:?} got repo at path {:?}",
@@ -35,7 +34,7 @@ pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffResult,
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    let (diff_df, schema) = with_df_db_manager(db_path, |manager| {
+    let (diff_df, schema) = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let diff_df = workspace_df_db::df_diff(conn)?;
             let schema = workspace_df_db::schema_without_oxen_cols(conn, TABLE_NAME)?;
@@ -79,7 +78,7 @@ pub fn is_indexed(workspace: &Workspace, path: &Path) -> Result<bool, OxenError>
     log::debug!("checking dataset is indexed for {path:?}");
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("getting conn at path {db_path:?}");
-    let table_exists = with_df_db_manager(db_path, |manager| {
+    let table_exists = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| df_db::table_exists(conn, TABLE_NAME))
     })?;
     log::debug!("dataset_is_indexed() got table_exists: {table_exists:?}");

--- a/crates/lib/src/core/v_latest/workspaces/diff.rs
+++ b/crates/lib/src/core/v_latest/workspaces/diff.rs
@@ -24,12 +24,12 @@ pub fn diff(workspace: &Workspace, path: &Path) -> Result<DiffResult, OxenError>
     );
 
     let file_node = repositories::tree::get_file_by_path(repo, commit, path)?
-        .ok_or(OxenError::entry_does_not_exist(path))?;
+        .ok_or(OxenError::entry_does_not_exist(path.to_path_buf()))?;
 
     log::debug!("diff_workspace_df got file_node {file_node}");
 
     if !is_indexed(workspace, path)? {
-        return Err(OxenError::basic_str("Dataset is not indexed"));
+        return Err(OxenError::basic_str("Dataset is not indexed".to_string()));
     };
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -37,8 +37,7 @@ const MAX_DECOMPRESSED_SIZE: u64 = 1024 * 1024 * 1024; // 1GB limit
 const MAX_COMPRESSION_RATIO: u64 = 100; // Maximum allowed
 
 // TODO: Do we depreciate this, if we always upload to version store?
-pub async fn add(workspace: &Workspace, filepath: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
-    let filepath = filepath.as_ref();
+pub async fn add(workspace: &Workspace, filepath: &Path) -> Result<PathBuf, OxenError> {
     let workspace_repo = &workspace.workspace_repo;
     let base_repo = &workspace.base_repo;
 
@@ -51,11 +50,7 @@ pub async fn add(workspace: &Workspace, filepath: impl AsRef<Path>) -> Result<Pa
     Ok(relative_path)
 }
 
-pub async fn rm(
-    workspace: &Workspace,
-    filepath: impl AsRef<Path>,
-) -> Result<Vec<ErrorFileInfo>, OxenError> {
-    let filepath = filepath.as_ref();
+pub async fn rm(workspace: &Workspace, filepath: &Path) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let workspace_repo = &workspace.workspace_repo;
     let base_repo = &workspace.base_repo;
 
@@ -68,20 +63,19 @@ pub async fn rm(
 
 pub fn add_version_file(
     workspace: &Workspace,
-    version_path: impl AsRef<Path>,
-    dst_path: impl AsRef<Path>,
+    version_path: &Path,
+    dst_path: &Path,
     file_hash: &str,
 ) -> Result<PathBuf, OxenError> {
     // version_path is where the file is stored, dst_path is the relative path to the repo
     // let version_path = version_path.as_ref();
-    let dst_path = dst_path.as_ref();
     // let workspace_repo = &workspace.workspace_repo;
     // let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
 
     let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
     stage_file_with_hash(
         workspace,
-        version_path.as_ref(),
+        version_path,
         dst_path,
         file_hash,
         &staged_db_manager,
@@ -95,11 +89,10 @@ pub async fn add_version_files(
     repo: &LocalRepository,
     workspace: &Workspace,
     files_with_hash: &[FileWithHash],
-    directory: impl AsRef<str>,
+    directory: &str,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let version_store = repo.version_store()?;
 
-    let directory = directory.as_ref();
     let workspace_repo = &workspace.workspace_repo;
     let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
 
@@ -153,9 +146,8 @@ pub async fn add_version_files(
 
 pub fn track_modified_data_frame(
     workspace: &Workspace,
-    filepath: impl AsRef<Path>,
+    filepath: &Path,
 ) -> Result<PathBuf, OxenError> {
-    let filepath = filepath.as_ref();
     let workspace_repo = &workspace.workspace_repo;
     let base_repo = &workspace.base_repo;
 
@@ -187,15 +179,16 @@ pub async fn remove_files_from_staged_db(
     Ok(err_files)
 }
 
-pub fn unstage(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), OxenError> {
+pub fn unstage(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
     let workspace_repo = &workspace.workspace_repo;
-    let path = util::fs::path_relative_to_dir(path.as_ref(), &workspace_repo.path)?;
+
+    let path = util::fs::path_relative_to_dir(path, &workspace_repo.path)?;
     get_staged_db_manager(workspace_repo)?.delete_entry(&path)
 }
 
-pub fn exists(workspace: &Workspace, path: impl AsRef<Path>) -> Result<bool, OxenError> {
+pub fn exists(workspace: &Workspace, path: &Path) -> Result<bool, OxenError> {
     let workspace_repo = &workspace.workspace_repo;
-    let path = util::fs::path_relative_to_dir(path.as_ref(), &workspace_repo.path)?;
+    let path = util::fs::path_relative_to_dir(path, &workspace_repo.path)?;
     get_staged_db_manager(workspace_repo)?.exists(&path)
 }
 
@@ -281,12 +274,12 @@ async fn validate_url_target(url: &Url) -> Result<(), OxenError> {
     let addr = format!("{host}:{port}");
 
     let resolved = tokio::net::lookup_host(&addr).await.map_err(|e| {
-        OxenError::file_import_error(format!("DNS resolution failed for {host}: {e}"))
+        OxenError::file_import_error(&format!("DNS resolution failed for {host}: {e}"))
     })?;
 
     for socket_addr in resolved {
         if is_private_ip(&socket_addr.ip()) {
-            return Err(OxenError::file_import_error(format!(
+            return Err(OxenError::file_import_error(&format!(
                 "URL resolves to a private/reserved IP address: {}",
                 socket_addr.ip()
             )));
@@ -343,8 +336,8 @@ pub async fn import(
     filename: Option<String>,
     workspace: &Workspace,
 ) -> Result<(), OxenError> {
-    let parsed_url =
-        Url::parse(url).map_err(|_| OxenError::file_import_error(format!("Invalid URL: {url}")))?;
+    let parsed_url = Url::parse(url)
+        .map_err(|_| OxenError::file_import_error(&format!("Invalid URL: {url}")))?;
 
     let scheme = parsed_url.scheme();
     if scheme != "http" && scheme != "https" {
@@ -356,7 +349,7 @@ pub async fn import(
     validate_url_target(&parsed_url).await?;
 
     let auth_header_value = HeaderValue::from_str(auth)
-        .map_err(|_e| OxenError::file_import_error(format!("Invalid header auth value {auth}")))?;
+        .map_err(|_e| OxenError::file_import_error(&format!("Invalid header auth value {auth}")))?;
 
     fetch_file(
         &parsed_url,
@@ -438,7 +431,7 @@ async fn fetch_file(
     let client = Client::builder()
         .redirect(redirect::Policy::none())
         .build()
-        .map_err(|e| OxenError::file_import_error(format!("Failed to build HTTP client: {e}")))?;
+        .map_err(|e| OxenError::file_import_error(&format!("Failed to build HTTP client: {e}")))?;
 
     let mut current_url = url.clone();
     let mut response = None;
@@ -449,10 +442,9 @@ async fn fetch_file(
             req = req.header("Authorization", auth_header_value.clone());
         }
 
-        let resp = req
-            .send()
-            .await
-            .map_err(|e| OxenError::file_import_error(format!("Fetch file request failed: {e}")))?;
+        let resp = req.send().await.map_err(|e| {
+            OxenError::file_import_error(&format!("Fetch file request failed: {e}"))
+        })?;
 
         let status = resp.status();
         if status.is_redirection() {
@@ -470,7 +462,7 @@ async fn fetch_file(
             // Resolve relative redirects
             let next_url = current_url
                 .join(location)
-                .map_err(|e| OxenError::file_import_error(format!("Invalid redirect URL: {e}")))?;
+                .map_err(|e| OxenError::file_import_error(&format!("Invalid redirect URL: {e}")))?;
 
             // Validate redirect target
             let scheme = next_url.scheme();
@@ -486,7 +478,7 @@ async fn fetch_file(
         }
 
         if !status.is_success() {
-            return Err(OxenError::file_import_error(format!(
+            return Err(OxenError::file_import_error(&format!(
                 "HTTP request failed with status {status}"
             )));
         }
@@ -509,7 +501,7 @@ async fn fetch_file(
     if let Some(content_length) = content_length
         && content_length > MAX_CONTENT_LENGTH
     {
-        return Err(OxenError::file_import_error(format!(
+        return Err(OxenError::file_import_error(&format!(
             "Content length {content_length} exceeds maximum allowed size of 1GB"
         )));
     }
@@ -527,7 +519,7 @@ async fn fetch_file(
 
     let filename = sanitize_filename(&raw_filename);
     if filename.is_empty() {
-        return Err(OxenError::file_import_error(format!(
+        return Err(OxenError::file_import_error(&format!(
             "Could not determine a valid filename for {url}"
         )));
     }
@@ -561,7 +553,7 @@ async fn fetch_file(
             save_path = save_stream(workspace, &filepath, buffer.split().freeze().to_vec())
                 .await
                 .map_err(|e| {
-                    OxenError::file_import_error(format!(
+                    OxenError::file_import_error(&format!(
                         "Error occurred when saving file stream: {e}"
                     ))
                 })?;
@@ -572,7 +564,9 @@ async fn fetch_file(
         save_path = save_stream(workspace, &filepath, buffer.freeze().to_vec())
             .await
             .map_err(|e| {
-                OxenError::file_import_error(format!("Error occurred when saving file stream: {e}"))
+                OxenError::file_import_error(&format!(
+                    "Error occurred when saving file stream: {e}"
+                ))
             })?;
     }
     log::debug!("workspace::files::import_file save_path is {save_path:?}");
@@ -615,15 +609,14 @@ async fn fetch_file(
     Ok(())
 }
 
-fn delete_file(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), OxenError> {
-    let path = path.as_ref();
+fn delete_file(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
     let workspace_repo = &workspace.workspace_repo;
     let relative_path = util::fs::path_relative_to_dir(path, &workspace_repo.path)?;
     let full_path = workspace_repo.path.join(&relative_path);
 
     if full_path.exists() {
         std::fs::remove_file(&full_path).map_err(|e| {
-            OxenError::file_import_error(format!(
+            OxenError::file_import_error(&format!(
                 "Failed to remove file {}: {}",
                 full_path.display(),
                 e
@@ -669,13 +662,13 @@ pub async fn save_stream(
             .open(full_dir_cpy)
     })
     .await
-    .map_err(|e| OxenError::basic_str(format!("spawn_blocking join error: {e}")))??;
+    .map_err(|e| OxenError::basic_str(&format!("spawn_blocking join error: {e}")))??;
 
     log::debug!("liboxen::workspace::files::save_stream is writing to file: {file:?}");
 
     tokio::task::spawn_blocking(move || file.write_all(&chunk).map(|_| file))
         .await
-        .map_err(|e| OxenError::basic_str(format!("spawn_blocking join error: {e}")))??;
+        .map_err(|e| OxenError::basic_str(&format!("spawn_blocking join error: {e}")))??;
 
     Ok(full_dir)
 }
@@ -685,13 +678,13 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
     let mut files: Vec<PathBuf> = vec![];
     let file = File::open(zip_filepath)?;
     let mut archive = ZipArchive::new(file)
-        .map_err(|e| OxenError::basic_str(format!("Failed to access zip file: {e}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("Failed to access zip file: {e}")))?;
 
     // Calculate total uncompressed size
     let mut total_size: u64 = 0;
     for i in 0..archive.len() {
         let zip_file = archive.by_index(i).map_err(|e| {
-            OxenError::basic_str(format!("Failed to access zip file at index {i}: {e}"))
+            OxenError::basic_str(&format!("Failed to access zip file at index {i}: {e}"))
         })?;
 
         let uncompressed_size = zip_file.size();
@@ -701,7 +694,7 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
         if compressed_size > 0 {
             let compression_ratio = uncompressed_size / compressed_size;
             if compression_ratio > MAX_COMPRESSION_RATIO {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Suspicious zip compression ratio: {compression_ratio} detected"
                 )));
             }
@@ -734,7 +727,7 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
     // iterate thru zip archive and save the decompressed file
     for i in 0..archive.len() {
         let mut zip_file = archive.by_index(i).map_err(|e| {
-            OxenError::basic_str(format!("Failed to access zip file at index {i}: {e}"))
+            OxenError::basic_str(&format!("Failed to access zip file at index {i}: {e}"))
         })?;
 
         let mut zipfile_name = zip_file.mangled_name();
@@ -756,7 +749,7 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
 
         // Verify the final path is within the parent directory
         if !outpath.starts_with(&parent) {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Attempted path traversal detected: {outpath:?}"
             )));
         }
@@ -802,7 +795,7 @@ fn sanitize_path(path: &PathBuf) -> Result<PathBuf, OxenError> {
             Component::Normal(c) => components.push(c),
             Component::CurDir => {} // Skip current directory components (.)
             Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Invalid path component in zip file: {path:?}"
                 )));
             }
@@ -941,10 +934,7 @@ fn p_modify_file(
     }
 }
 
-fn has_dir_node(
-    dir_node: &Option<MerkleTreeNode>,
-    path: impl AsRef<Path>,
-) -> Result<bool, OxenError> {
+fn has_dir_node(dir_node: &Option<MerkleTreeNode>, path: &Path) -> Result<bool, OxenError> {
     if let Some(node) = dir_node {
         if let Some(node) = node.get_by_path(path)? {
             if let EMerkleTreeNode::Directory(_dir_node) = &node.node {
@@ -962,16 +952,9 @@ fn has_dir_node(
 
 /// Move or rename a file within a workspace.
 /// This stages the old path as "Removed" and the new path as "Added".
-pub fn mv(
-    workspace: &Workspace,
-    path: impl AsRef<Path>,
-    new_path: impl AsRef<Path>,
-) -> Result<(), OxenError> {
-    let path = path.as_ref();
-    let new_path = new_path.as_ref();
-
+pub fn mv(workspace: &Workspace, path: &Path, new_path: &Path) -> Result<(), OxenError> {
     if path == new_path {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Source and destination are the same: {path:?}"
         )));
     }
@@ -1009,7 +992,7 @@ pub fn mv(
 
     let staged_db_manager = get_staged_db_manager(workspace_repo)?;
     if staged_db_manager.read_from_staged_db(new_path)?.is_some() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Destination already staged: {new_path:?}"
         )));
     }

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -269,17 +269,17 @@ fn is_cgn_or_reserved_v4(octets: [u8; 4]) -> bool {
 async fn validate_url_target(url: &Url) -> Result<(), OxenError> {
     let host = url
         .host_str()
-        .ok_or_else(|| OxenError::file_import_error("URL has no host"))?;
+        .ok_or_else(|| OxenError::file_import_error("URL has no host".to_string()))?;
     let port = url.port_or_known_default().unwrap_or(443);
     let addr = format!("{host}:{port}");
 
     let resolved = tokio::net::lookup_host(&addr).await.map_err(|e| {
-        OxenError::file_import_error(&format!("DNS resolution failed for {host}: {e}"))
+        OxenError::file_import_error(format!("DNS resolution failed for {host}: {e}"))
     })?;
 
     for socket_addr in resolved {
         if is_private_ip(&socket_addr.ip()) {
-            return Err(OxenError::file_import_error(&format!(
+            return Err(OxenError::file_import_error(format!(
                 "URL resolves to a private/reserved IP address: {}",
                 socket_addr.ip()
             )));
@@ -336,20 +336,20 @@ pub async fn import(
     filename: Option<String>,
     workspace: &Workspace,
 ) -> Result<(), OxenError> {
-    let parsed_url = Url::parse(url)
-        .map_err(|_| OxenError::file_import_error(&format!("Invalid URL: {url}")))?;
+    let parsed_url =
+        Url::parse(url).map_err(|_| OxenError::file_import_error(format!("Invalid URL: {url}")))?;
 
     let scheme = parsed_url.scheme();
     if scheme != "http" && scheme != "https" {
         return Err(OxenError::file_import_error(
-            "Only http and https URLs are allowed",
+            "Only http and https URLs are allowed".to_string(),
         ));
     }
 
     validate_url_target(&parsed_url).await?;
 
     let auth_header_value = HeaderValue::from_str(auth)
-        .map_err(|_e| OxenError::file_import_error(&format!("Invalid header auth value {auth}")))?;
+        .map_err(|_e| OxenError::file_import_error(format!("Invalid header auth value {auth}")))?;
 
     fetch_file(
         &parsed_url,
@@ -431,7 +431,7 @@ async fn fetch_file(
     let client = Client::builder()
         .redirect(redirect::Policy::none())
         .build()
-        .map_err(|e| OxenError::file_import_error(&format!("Failed to build HTTP client: {e}")))?;
+        .map_err(|e| OxenError::file_import_error(format!("Failed to build HTTP client: {e}")))?;
 
     let mut current_url = url.clone();
     let mut response = None;
@@ -442,33 +442,38 @@ async fn fetch_file(
             req = req.header("Authorization", auth_header_value.clone());
         }
 
-        let resp = req.send().await.map_err(|e| {
-            OxenError::file_import_error(&format!("Fetch file request failed: {e}"))
-        })?;
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| OxenError::file_import_error(format!("Fetch file request failed: {e}")))?;
 
         let status = resp.status();
         if status.is_redirection() {
             if hop == MAX_REDIRECTS {
-                return Err(OxenError::file_import_error("Too many redirects (max 10)"));
+                return Err(OxenError::file_import_error(
+                    "Too many redirects (max 10)".to_string(),
+                ));
             }
             let location = resp
                 .headers()
                 .get("location")
                 .and_then(|v| v.to_str().ok())
                 .ok_or_else(|| {
-                    OxenError::file_import_error("Redirect response missing Location header")
+                    OxenError::file_import_error(
+                        "Redirect response missing Location header".to_string(),
+                    )
                 })?;
 
             // Resolve relative redirects
             let next_url = current_url
                 .join(location)
-                .map_err(|e| OxenError::file_import_error(&format!("Invalid redirect URL: {e}")))?;
+                .map_err(|e| OxenError::file_import_error(format!("Invalid redirect URL: {e}")))?;
 
             // Validate redirect target
             let scheme = next_url.scheme();
             if scheme != "http" && scheme != "https" {
                 return Err(OxenError::file_import_error(
-                    "Redirect to non-HTTP(S) URL is not allowed",
+                    "Redirect to non-HTTP(S) URL is not allowed".to_string(),
                 ));
             }
             validate_url_target(&next_url).await?;
@@ -478,7 +483,7 @@ async fn fetch_file(
         }
 
         if !status.is_success() {
-            return Err(OxenError::file_import_error(&format!(
+            return Err(OxenError::file_import_error(format!(
                 "HTTP request failed with status {status}"
             )));
         }
@@ -487,8 +492,9 @@ async fn fetch_file(
         break;
     }
 
-    let response = response
-        .ok_or_else(|| OxenError::file_import_error("Failed to get a successful response"))?;
+    let response = response.ok_or_else(|| {
+        OxenError::file_import_error("Failed to get a successful response".to_string())
+    })?;
 
     let resp_headers = response.headers();
 
@@ -501,7 +507,7 @@ async fn fetch_file(
     if let Some(content_length) = content_length
         && content_length > MAX_CONTENT_LENGTH
     {
-        return Err(OxenError::file_import_error(&format!(
+        return Err(OxenError::file_import_error(format!(
             "Content length {content_length} exceeds maximum allowed size of 1GB"
         )));
     }
@@ -519,7 +525,7 @@ async fn fetch_file(
 
     let filename = sanitize_filename(&raw_filename);
     if filename.is_empty() {
-        return Err(OxenError::file_import_error(&format!(
+        return Err(OxenError::file_import_error(format!(
             "Could not determine a valid filename for {url}"
         )));
     }
@@ -538,7 +544,8 @@ async fn fetch_file(
     let mut bytes_downloaded: u64 = 0;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|_| OxenError::file_import_error("Error reading file stream"))?;
+        let chunk = chunk
+            .map_err(|_| OxenError::file_import_error("Error reading file stream".to_string()))?;
         let processed_chunk = chunk.to_vec();
         buffer.extend_from_slice(&processed_chunk);
         bytes_downloaded += processed_chunk.len() as u64;
@@ -546,14 +553,14 @@ async fn fetch_file(
         if bytes_downloaded > MAX_CONTENT_LENGTH {
             delete_file(workspace, &filepath)?;
             return Err(OxenError::file_import_error(
-                "Content length exceeds maximum allowed size of 1GB",
+                "Content length exceeds maximum allowed size of 1GB".to_string(),
             ));
         }
         if buffer.len() > BUFFER_SIZE_THRESHOLD {
             save_path = save_stream(workspace, &filepath, buffer.split().freeze().to_vec())
                 .await
                 .map_err(|e| {
-                    OxenError::file_import_error(&format!(
+                    OxenError::file_import_error(format!(
                         "Error occurred when saving file stream: {e}"
                     ))
                 })?;
@@ -564,9 +571,7 @@ async fn fetch_file(
         save_path = save_stream(workspace, &filepath, buffer.freeze().to_vec())
             .await
             .map_err(|e| {
-                OxenError::file_import_error(&format!(
-                    "Error occurred when saving file stream: {e}"
-                ))
+                OxenError::file_import_error(format!("Error occurred when saving file stream: {e}"))
             })?;
     }
     log::debug!("workspace::files::import_file save_path is {save_path:?}");
@@ -585,7 +590,7 @@ async fn fetch_file(
 
         if bytes_written != content_length {
             return Err(OxenError::file_import_error(
-                "Content length does not match. File incomplete.",
+                "Content length does not match. File incomplete.".to_string(),
             ));
         }
     }
@@ -616,7 +621,7 @@ fn delete_file(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
 
     if full_path.exists() {
         std::fs::remove_file(&full_path).map_err(|e| {
-            OxenError::file_import_error(&format!(
+            OxenError::file_import_error(format!(
                 "Failed to remove file {}: {}",
                 full_path.display(),
                 e
@@ -662,13 +667,13 @@ pub async fn save_stream(
             .open(full_dir_cpy)
     })
     .await
-    .map_err(|e| OxenError::basic_str(&format!("spawn_blocking join error: {e}")))??;
+    .map_err(|e| OxenError::basic_str(format!("spawn_blocking join error: {e}")))??;
 
     log::debug!("liboxen::workspace::files::save_stream is writing to file: {file:?}");
 
     tokio::task::spawn_blocking(move || file.write_all(&chunk).map(|_| file))
         .await
-        .map_err(|e| OxenError::basic_str(&format!("spawn_blocking join error: {e}")))??;
+        .map_err(|e| OxenError::basic_str(format!("spawn_blocking join error: {e}")))??;
 
     Ok(full_dir)
 }
@@ -678,13 +683,13 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
     let mut files: Vec<PathBuf> = vec![];
     let file = File::open(zip_filepath)?;
     let mut archive = ZipArchive::new(file)
-        .map_err(|e| OxenError::basic_str(&format!("Failed to access zip file: {e}")))?;
+        .map_err(|e| OxenError::basic_str(format!("Failed to access zip file: {e}")))?;
 
     // Calculate total uncompressed size
     let mut total_size: u64 = 0;
     for i in 0..archive.len() {
         let zip_file = archive.by_index(i).map_err(|e| {
-            OxenError::basic_str(&format!("Failed to access zip file at index {i}: {e}"))
+            OxenError::basic_str(format!("Failed to access zip file at index {i}: {e}"))
         })?;
 
         let uncompressed_size = zip_file.size();
@@ -694,14 +699,15 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
         if compressed_size > 0 {
             let compression_ratio = uncompressed_size / compressed_size;
             if compression_ratio > MAX_COMPRESSION_RATIO {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Suspicious zip compression ratio: {compression_ratio} detected"
                 )));
             }
         } else if uncompressed_size > 0 {
             // If compressed size is 0 but uncompressed isn't, that's suspicious
             return Err(OxenError::basic_str(
-                "Suspicious zip file: compressed size is 0 but uncompressed size is not",
+                "Suspicious zip file: compressed size is 0 but uncompressed size is not"
+                    .to_string(),
             ));
         }
         // If both are 0, it's likely a directory entry, which is fine
@@ -711,7 +717,7 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
         // Check total size limit
         if total_size > MAX_DECOMPRESSED_SIZE {
             return Err(OxenError::file_import_error(
-                "Decompressed size exceeds size limit of 1GB",
+                "Decompressed size exceeds size limit of 1GB".to_string(),
             ));
         }
     }
@@ -727,7 +733,7 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
     // iterate thru zip archive and save the decompressed file
     for i in 0..archive.len() {
         let mut zip_file = archive.by_index(i).map_err(|e| {
-            OxenError::basic_str(&format!("Failed to access zip file at index {i}: {e}"))
+            OxenError::basic_str(format!("Failed to access zip file at index {i}: {e}"))
         })?;
 
         let mut zipfile_name = zip_file.mangled_name();
@@ -749,7 +755,7 @@ pub fn decompress_zip(zip_filepath: &PathBuf) -> Result<Vec<PathBuf>, OxenError>
 
         // Verify the final path is within the parent directory
         if !outpath.starts_with(&parent) {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Attempted path traversal detected: {outpath:?}"
             )));
         }
@@ -795,7 +801,7 @@ fn sanitize_path(path: &PathBuf) -> Result<PathBuf, OxenError> {
             Component::Normal(c) => components.push(c),
             Component::CurDir => {} // Skip current directory components (.)
             Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Invalid path component in zip file: {path:?}"
                 )));
             }
@@ -930,7 +936,9 @@ fn p_modify_file(
             &seen_dirs,
         )
     } else {
-        Err(OxenError::basic_str("file not found in head commit"))
+        Err(OxenError::basic_str(
+            "file not found in head commit".to_string(),
+        ))
     }
 }
 
@@ -954,7 +962,7 @@ fn has_dir_node(dir_node: &Option<MerkleTreeNode>, path: &Path) -> Result<bool, 
 /// This stages the old path as "Removed" and the new path as "Added".
 pub fn mv(workspace: &Workspace, path: &Path, new_path: &Path) -> Result<(), OxenError> {
     if path == new_path {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Source and destination are the same: {path:?}"
         )));
     }
@@ -970,7 +978,7 @@ pub fn mv(workspace: &Workspace, path: &Path, new_path: &Path) -> Result<(), Oxe
     } else {
         // File not staged, get it from the base repo
         repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
-            .ok_or_else(|| OxenError::path_does_not_exist(path))?
+            .ok_or_else(|| OxenError::path_does_not_exist(path.to_path_buf()))?
     };
 
     // Create the new file node with updated name (full path for the new location)
@@ -992,7 +1000,7 @@ pub fn mv(workspace: &Workspace, path: &Path, new_path: &Path) -> Result<(), Oxe
 
     let staged_db_manager = get_staged_db_manager(workspace_repo)?;
     if staged_db_manager.read_from_staged_db(new_path)?.is_some() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Destination already staged: {new_path:?}"
         )));
     }

--- a/crates/lib/src/core/v_latest/workspaces/status.rs
+++ b/crates/lib/src/core/v_latest/workspaces/status.rs
@@ -8,8 +8,8 @@ use crate::util;
 
 use indicatif::ProgressBar;
 
-pub fn status(workspace: &Workspace, directory: impl AsRef<Path>) -> Result<StagedData, OxenError> {
-    let dir = directory.as_ref();
+pub fn status(workspace: &Workspace, directory: &Path) -> Result<StagedData, OxenError> {
+    let dir = directory;
     let workspace_repo = &workspace.workspace_repo;
     // let opts = db::key_val::opts::default();
     let db_path = util::fs::oxen_hidden_dir(&workspace_repo.path).join(STAGED_DIR);

--- a/crates/lib/src/core/v_old/v0_19_0/entries.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/entries.rs
@@ -14,7 +14,7 @@ use crate::repositories;
 pub fn get_file(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<FileNode>, OxenError> {
     let Some(file_node) = get_file_merkle_tree_node(repo, commit, path)? else {
         return Ok(None);
@@ -30,21 +30,21 @@ pub fn get_file(
 pub fn get_file_merkle_tree_node(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
-    let parent = path.as_ref().parent().unwrap_or(Path::new(""));
+    let parent = path.parent().unwrap_or(Path::new(""));
     let parent_node = CommitMerkleTree::dir_with_children(repo, commit, parent)?;
     let Some(parent_node) = parent_node else {
-        log::debug!("path has no parent: {:?}", path.as_ref());
+        log::debug!("path has no parent: {:?}", path);
         return Ok(None);
     };
 
-    let Some(file_name) = path.as_ref().file_name() else {
-        log::debug!("path has no file name: {:?}", path.as_ref());
+    let Some(file_name) = path.file_name() else {
+        log::debug!("path has no file name: {:?}", path);
         return Ok(None);
     };
 
-    let file_node = parent_node.get_by_path(file_name)?;
+    let file_node = parent_node.get_by_path(Path::new(file_name))?;
     Ok(file_node)
 }
 
@@ -110,7 +110,7 @@ fn dir_node_to_metadata_entry(
         found_commits.entry(*dir_node.last_commit_id())
     {
         let commit = repositories::commits::get_by_hash(repo, dir_node.last_commit_id())?.ok_or(
-            OxenError::commit_id_does_not_exist(dir_node.last_commit_id().to_string()),
+            OxenError::commit_id_does_not_exist(&dir_node.last_commit_id().to_string()),
         )?;
         e.insert(commit);
     }
@@ -154,7 +154,7 @@ fn file_node_to_metadata_entry(
         found_commits.entry(*file_node.last_commit_id())
     {
         let commit = repositories::commits::get_by_hash(repo, file_node.last_commit_id())?.ok_or(
-            OxenError::commit_id_does_not_exist(file_node.last_commit_id().to_string()),
+            OxenError::commit_id_does_not_exist(&file_node.last_commit_id().to_string()),
         )?;
         e.insert(commit);
     }

--- a/crates/lib/src/core/v_old/v0_19_0/entries.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/entries.rs
@@ -88,7 +88,9 @@ pub fn get_meta_entry(
                 "get_meta_entry path not found: {:?}",
                 path.to_str().unwrap()
             );
-            Err(OxenError::resource_not_found(path.to_str().unwrap()))
+            Err(OxenError::resource_not_found(
+                path.to_str().unwrap().to_string(),
+            ))
         }
     }
 }

--- a/crates/lib/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
@@ -52,7 +52,7 @@ impl CommitMerkleTree {
         let node_hash = commit.id.parse()?;
         let root =
             CommitMerkleTree::read_node(repo, &node_hash, true)?.ok_or(OxenError::basic_str(
-                &format!("Merkle tree hash not found for commit: '{}'", commit.id),
+                format!("Merkle tree hash not found for commit: '{}'", commit.id),
             ))?;
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         Ok(Self { root, dir_hashes })
@@ -81,14 +81,14 @@ impl CommitMerkleTree {
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         let Some(node_hash) = dir_hashes.get(&node_path).cloned() else {
             log::debug!("dir_hashes {dir_hashes:?} does not contain path: {node_path:?}");
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Can only load a subtree with an existing directory path: '{}'",
                 node_path.to_str().unwrap()
             )));
         };
 
         let Some(root) = CommitMerkleTree::read_depth(repo, &node_hash, depth)? else {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Merkle tree hash not found for: '{}' hash: {:?}",
                 node_path.to_str().unwrap(),
                 node_hash
@@ -112,7 +112,7 @@ impl CommitMerkleTree {
             // We are reading a node with children
             log::debug!("Look up dir 🗂️ {node_path:?}");
             CommitMerkleTree::read_node(repo, &node_hash, load_recursive)?.ok_or(
-                OxenError::basic_str(&format!(
+                OxenError::basic_str(format!(
                     "Merkle tree hash not found for parent: '{}'",
                     node_path.to_str().unwrap()
                 )),
@@ -121,7 +121,7 @@ impl CommitMerkleTree {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
             CommitMerkleTree::read_file(repo, &dir_hashes, node_path)?.ok_or(
-                OxenError::basic_str(&format!(
+                OxenError::basic_str(format!(
                     "Merkle tree hash not found for parent: '{}'",
                     node_path.to_str().unwrap()
                 )),
@@ -258,7 +258,7 @@ impl CommitMerkleTree {
                 }
                 _ => {
                     return Err(OxenError::basic_str(
-                        "Could not read iterate over db values",
+                        "Could not read iterate over db values".to_string(),
                     ));
                 }
             }
@@ -330,7 +330,7 @@ impl CommitMerkleTree {
         let node = self
             .root
             .get_by_path(path)?
-            .ok_or(OxenError::basic_str(&format!(
+            .ok_or(OxenError::basic_str(format!(
                 "Merkle tree hash not found for parent: {path:?}"
             )))?;
         let mut children = HashSet::new();
@@ -363,7 +363,7 @@ impl CommitMerkleTree {
                 Ok(file_entries)
             }
             EMerkleTreeNode::File(file_node) => Ok(vec![file_node.clone()]),
-            _ => Err(OxenError::basic_str(&format!(
+            _ => Err(OxenError::basic_str(format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             ))),

--- a/crates/lib/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
@@ -52,7 +52,7 @@ impl CommitMerkleTree {
         let node_hash = commit.id.parse()?;
         let root =
             CommitMerkleTree::read_node(repo, &node_hash, true)?.ok_or(OxenError::basic_str(
-                format!("Merkle tree hash not found for commit: '{}'", commit.id),
+                &format!("Merkle tree hash not found for commit: '{}'", commit.id),
             ))?;
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         Ok(Self { root, dir_hashes })
@@ -61,7 +61,7 @@ impl CommitMerkleTree {
     pub fn from_path_recursive(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
     ) -> Result<Self, OxenError> {
         let load_recursive = true;
         CommitMerkleTree::from_path(repo, commit, path, load_recursive)
@@ -70,10 +70,10 @@ impl CommitMerkleTree {
     pub fn from_path_depth(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let mut node_path = path.as_ref().to_path_buf();
+        let mut node_path = path.to_path_buf();
         if node_path == Path::new(".") {
             node_path = PathBuf::from("");
         }
@@ -81,14 +81,14 @@ impl CommitMerkleTree {
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         let Some(node_hash) = dir_hashes.get(&node_path).cloned() else {
             log::debug!("dir_hashes {dir_hashes:?} does not contain path: {node_path:?}");
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Can only load a subtree with an existing directory path: '{}'",
                 node_path.to_str().unwrap()
             )));
         };
 
         let Some(root) = CommitMerkleTree::read_depth(repo, &node_hash, depth)? else {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Merkle tree hash not found for: '{}' hash: {:?}",
                 node_path.to_str().unwrap(),
                 node_hash
@@ -100,10 +100,10 @@ impl CommitMerkleTree {
     pub fn from_path(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
         load_recursive: bool,
     ) -> Result<Self, OxenError> {
-        let node_path = path.as_ref();
+        let node_path = path;
         log::debug!("Read path {node_path:?} in commit {commit:?}");
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         let node_hash: Option<MerkleHash> = dir_hashes.get(node_path).cloned();
@@ -112,7 +112,7 @@ impl CommitMerkleTree {
             // We are reading a node with children
             log::debug!("Look up dir 🗂️ {node_path:?}");
             CommitMerkleTree::read_node(repo, &node_hash, load_recursive)?.ok_or(
-                OxenError::basic_str(format!(
+                OxenError::basic_str(&format!(
                     "Merkle tree hash not found for parent: '{}'",
                     node_path.to_str().unwrap()
                 )),
@@ -121,7 +121,7 @@ impl CommitMerkleTree {
             // We are skipping to a file in the tree using the dir_hashes db
             log::debug!("Look up file 📄 {node_path:?}");
             CommitMerkleTree::read_file(repo, &dir_hashes, node_path)?.ok_or(
-                OxenError::basic_str(format!(
+                OxenError::basic_str(&format!(
                     "Merkle tree hash not found for parent: '{}'",
                     node_path.to_str().unwrap()
                 )),
@@ -134,9 +134,9 @@ impl CommitMerkleTree {
     pub fn dir_without_children(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let node_path = path.as_ref();
+        let node_path = path;
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         let node_hash: Option<MerkleHash> = dir_hashes.get(node_path).cloned();
         if let Some(node_hash) = node_hash {
@@ -151,9 +151,9 @@ impl CommitMerkleTree {
     pub fn dir_with_children(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let node_path = path.as_ref();
+        let node_path = path;
         log::debug!("Read path {node_path:?} in commit {commit:?}");
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         let node_hash: Option<MerkleHash> = dir_hashes.get(node_path).cloned();
@@ -171,9 +171,9 @@ impl CommitMerkleTree {
     pub fn dir_with_children_recursive(
         repo: &LocalRepository,
         commit: &Commit,
-        path: impl AsRef<Path>,
+        path: &Path,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let node_path = path.as_ref();
+        let node_path = path;
         log::debug!("Read path {node_path:?} in commit {commit:?}");
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         let node_hash: Option<MerkleHash> = dir_hashes.get(node_path).cloned();
@@ -299,32 +299,25 @@ impl CommitMerkleTree {
         Ok(nodes)
     }
 
-    pub fn has_dir(&self, path: impl AsRef<Path>) -> bool {
+    pub fn has_dir(&self, path: &Path) -> bool {
         // log::debug!("has_dir path: {:?}", path.as_ref());
         // log::debug!("has_dir dir_hashes: {:?}", self.dir_hashes);
-        let path = path.as_ref();
         // println!("Path for has_dir: {path:?}");
         // println!("Dir hashes: {:?}", self.dir_hashes);
         self.dir_hashes.contains_key(path)
     }
 
-    pub fn has_path(&self, path: impl AsRef<Path>) -> Result<bool, OxenError> {
-        let path = path.as_ref();
+    pub fn has_path(&self, path: &Path) -> Result<bool, OxenError> {
         let node = self.root.get_by_path(path)?;
         Ok(node.is_some())
     }
 
-    pub fn get_by_path(&self, path: impl AsRef<Path>) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let path = path.as_ref();
+    pub fn get_by_path(&self, path: &Path) -> Result<Option<MerkleTreeNode>, OxenError> {
         let node = self.root.get_by_path(path)?;
         Ok(node)
     }
 
-    pub fn get_vnodes_for_dir(
-        &self,
-        path: impl AsRef<Path>,
-    ) -> Result<Vec<MerkleTreeNode>, OxenError> {
-        let path = path.as_ref();
+    pub fn get_vnodes_for_dir(&self, path: &Path) -> Result<Vec<MerkleTreeNode>, OxenError> {
         let nodes = self.root.get_vnodes_for_dir(path)?;
         Ok(nodes)
     }
@@ -333,15 +326,11 @@ impl CommitMerkleTree {
         self.root.list_dir_paths()
     }
 
-    pub fn files_and_folders(
-        &self,
-        path: impl AsRef<Path>,
-    ) -> Result<HashSet<MerkleTreeNode>, OxenError> {
-        let path = path.as_ref();
+    pub fn files_and_folders(&self, path: &Path) -> Result<HashSet<MerkleTreeNode>, OxenError> {
         let node = self
             .root
             .get_by_path(path)?
-            .ok_or(OxenError::basic_str(format!(
+            .ok_or(OxenError::basic_str(&format!(
                 "Merkle tree hash not found for parent: {path:?}"
             )))?;
         let mut children = HashSet::new();
@@ -374,7 +363,7 @@ impl CommitMerkleTree {
                 Ok(file_entries)
             }
             EMerkleTreeNode::File(file_node) => Ok(vec![file_node.clone()]),
-            _ => Err(OxenError::basic_str(format!(
+            _ => Err(OxenError::basic_str(&format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             ))),
@@ -385,12 +374,11 @@ impl CommitMerkleTree {
     pub fn read_file(
         repo: &LocalRepository,
         dir_hashes: &HashMap<PathBuf, MerkleHash>,
-        path: impl AsRef<Path>,
+        path: &Path,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // Get the directory from the path
-        let path = path.as_ref();
         let parent_path = path.parent().unwrap();
-        let file_name = path.file_name().unwrap().to_str().unwrap();
+        let file_name = Path::new(path.file_name().unwrap().to_str().unwrap());
 
         // log::debug!(
         //     "read_file path {:?} parent_path {:?} file_name {:?}",
@@ -617,7 +605,7 @@ mod tests {
     async fn test_load_dir_nodes_v0_19_0() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let repo = repositories::init::init_with_version(dir, MinOxenVersion::V0_19_0)?;
+            let repo = repositories::init::init_with_version(&dir, MinOxenVersion::V0_19_0)?;
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;

--- a/crates/lib/src/core/versions.rs
+++ b/crates/lib/src/core/versions.rs
@@ -39,7 +39,7 @@ impl MinOxenVersion {
             "0.19.0" => Ok(MinOxenVersion::V0_19_0),
             "0.25.0" => Ok(MinOxenVersion::V0_25_0),
             "0.36.0" => Ok(MinOxenVersion::LATEST),
-            _ => Err(OxenError::invalid_version(s)),
+            _ => Err(OxenError::invalid_version(s.to_string())),
         }
     }
 

--- a/crates/lib/src/core/versions.rs
+++ b/crates/lib/src/core/versions.rs
@@ -18,7 +18,7 @@ impl MinOxenVersion {
     /// Should default to latest if none is supplied in most cases
     pub fn or_latest(s: Option<String>) -> Result<MinOxenVersion, OxenError> {
         if let Some(version) = s {
-            MinOxenVersion::from_string(version)
+            MinOxenVersion::from_string(&version)
         } else {
             Ok(MinOxenVersion::LATEST)
         }
@@ -27,19 +27,19 @@ impl MinOxenVersion {
     /// Only use this if we have no version specified in an .oxen/config.toml file
     pub fn or_earliest(s: Option<String>) -> Result<MinOxenVersion, OxenError> {
         if let Some(version) = s {
-            MinOxenVersion::from_string(version)
+            MinOxenVersion::from_string(&version)
         } else {
             Ok(MinOxenVersion::V0_10_0)
         }
     }
 
-    pub fn from_string(s: impl AsRef<str>) -> Result<MinOxenVersion, OxenError> {
-        match s.as_ref() {
+    pub fn from_string(s: &str) -> Result<MinOxenVersion, OxenError> {
+        match s {
             "0.10.0" => Ok(MinOxenVersion::V0_10_0),
             "0.19.0" => Ok(MinOxenVersion::V0_19_0),
             "0.25.0" => Ok(MinOxenVersion::V0_25_0),
             "0.36.0" => Ok(MinOxenVersion::LATEST),
-            _ => Err(OxenError::invalid_version(s.as_ref())),
+            _ => Err(OxenError::invalid_version(s)),
         }
     }
 

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -251,28 +251,28 @@ impl OxenError {
         Some(hint)
     }
 
-    pub fn basic_str(s: impl AsRef<str>) -> Self {
-        OxenError::Basic(StringError::from(s.as_ref()))
+    pub fn basic_str(s: &str) -> Self {
+        OxenError::Basic(StringError::from(s))
     }
 
-    pub fn thumbnailing_not_enabled(s: impl AsRef<str>) -> Self {
-        OxenError::ThumbnailingNotEnabled(StringError::from(s.as_ref()))
+    pub fn thumbnailing_not_enabled(s: &str) -> Self {
+        OxenError::ThumbnailingNotEnabled(StringError::from(s))
     }
 
-    pub fn authentication(s: impl AsRef<str>) -> Self {
-        OxenError::Authentication(StringError::from(s.as_ref()))
+    pub fn authentication(s: &str) -> Self {
+        OxenError::Authentication(StringError::from(s))
     }
 
-    pub fn migration_required(s: impl AsRef<str>) -> Self {
-        OxenError::MigrationRequired(StringError::from(s.as_ref()))
+    pub fn migration_required(s: &str) -> Self {
+        OxenError::MigrationRequired(StringError::from(s))
     }
 
-    pub fn invalid_version(s: impl AsRef<str>) -> Self {
-        OxenError::InvalidVersion(StringError::from(s.as_ref()))
+    pub fn invalid_version(s: &str) -> Self {
+        OxenError::InvalidVersion(StringError::from(s))
     }
 
-    pub fn oxen_update_required(s: impl AsRef<str>) -> Self {
-        OxenError::OxenUpdateRequired(StringError::from(s.as_ref()))
+    pub fn oxen_update_required(s: &str) -> Self {
+        OxenError::OxenUpdateRequired(StringError::from(s))
     }
 
     pub fn user_config_not_found(value: StringError) -> Self {
@@ -283,13 +283,12 @@ impl OxenError {
         OxenError::RepoNotFound(Box::new(repo))
     }
 
-    pub fn file_import_error(s: impl AsRef<str>) -> Self {
-        OxenError::ImportFileError(StringError::from(s.as_ref()))
+    pub fn file_import_error(s: &str) -> Self {
+        OxenError::ImportFileError(StringError::from(s))
     }
 
-    pub fn remote_not_set(name: impl AsRef<str>) -> Self {
-        let name = name.as_ref();
-        OxenError::basic_str(format!(
+    pub fn remote_not_set(name: &str) -> Self {
+        OxenError::basic_str(&format!(
             "Remote not set, you can set a remote by running:\n\noxen config --set-remote {name} <url>\n"
         ))
     }
@@ -306,8 +305,8 @@ impl OxenError {
         ))
     }
 
-    pub fn merge_conflict(desc: impl AsRef<str>) -> Self {
-        OxenError::UpstreamMergeConflict(StringError::from(desc.as_ref()))
+    pub fn merge_conflict(desc: &str) -> Self {
+        OxenError::UpstreamMergeConflict(StringError::from(desc))
     }
 
     pub fn incomplete_local_history() -> Self {
@@ -326,28 +325,28 @@ impl OxenError {
         OxenError::OperationCancelled(StringError::from("\nOperation cancelled.\n"))
     }
 
-    pub fn resource_not_found(value: impl AsRef<str>) -> Self {
-        OxenError::ResourceNotFound(StringError::from(value.as_ref()))
+    pub fn resource_not_found(value: &str) -> Self {
+        OxenError::ResourceNotFound(StringError::from(value))
     }
 
-    pub fn path_does_not_exist(path: impl AsRef<Path>) -> Self {
-        OxenError::PathDoesNotExist(Box::new(path.as_ref().into()))
+    pub fn path_does_not_exist(path: &Path) -> Self {
+        OxenError::PathDoesNotExist(Box::new(path.into()))
     }
 
-    pub fn image_metadata_error(s: impl AsRef<str>) -> Self {
-        OxenError::ImageMetadataParseError(StringError::from(s.as_ref()))
+    pub fn image_metadata_error(s: &str) -> Self {
+        OxenError::ImageMetadataParseError(StringError::from(s))
     }
 
-    pub fn sql_parse_error(s: impl AsRef<str>) -> Self {
-        OxenError::SQLParseError(StringError::from(s.as_ref()))
+    pub fn sql_parse_error(s: &str) -> Self {
+        OxenError::SQLParseError(StringError::from(s))
     }
 
     pub fn parsed_resource_not_found(resource: ParsedResource) -> Self {
         OxenError::ParsedResourceNotFound(Box::new(resource.resource.into()))
     }
 
-    pub fn invalid_repo_name(s: impl AsRef<str>) -> Self {
-        OxenError::InvalidRepoName(StringError::from(s.as_ref()))
+    pub fn invalid_repo_name(s: &str) -> Self {
+        OxenError::InvalidRepoName(StringError::from(s))
     }
 
     pub fn is_auth_error(&self) -> bool {
@@ -395,16 +394,16 @@ impl OxenError {
         OxenError::NoCommitsFound(StringError::from("\n No commits found.\n"))
     }
 
-    pub fn local_repo_not_found(dir: impl AsRef<Path>) -> OxenError {
-        OxenError::LocalRepoNotFound(Box::new(dir.as_ref().into()))
+    pub fn local_repo_not_found(dir: &Path) -> OxenError {
+        OxenError::LocalRepoNotFound(Box::new(dir.into()))
     }
 
     pub fn email_and_name_not_set() -> OxenError {
         OxenError::user_config_not_found(EMAIL_AND_NAME_NOT_FOUND.to_string().into())
     }
 
-    pub fn remote_repo_not_found(url: impl AsRef<str>) -> OxenError {
-        OxenError::RemoteRepoNotFound(Box::new(StringError::from(url.as_ref())))
+    pub fn remote_repo_not_found(url: &str) -> OxenError {
+        OxenError::RemoteRepoNotFound(Box::new(StringError::from(url)))
     }
 
     pub fn head_not_found() -> OxenError {
@@ -437,133 +436,108 @@ impl OxenError {
         )
     }
 
-    pub fn schema_does_not_exist_for_file(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("Schema does not exist for file {:?}", path.as_ref());
-        OxenError::basic_str(err)
+    pub fn schema_does_not_exist_for_file(path: &Path) -> OxenError {
+        let err = format!("Schema does not exist for file {:?}", path);
+        OxenError::basic_str(&err)
     }
 
-    pub fn schema_does_not_exist(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("Schema does not exist {:?}", path.as_ref());
-        OxenError::basic_str(err)
+    pub fn schema_does_not_exist(path: &Path) -> OxenError {
+        let err = format!("Schema does not exist {:?}", path);
+        OxenError::basic_str(&err)
     }
 
-    pub fn schema_does_not_have_field(field: impl AsRef<str>) -> OxenError {
-        let err = format!("Schema does not have field {:?}", field.as_ref());
-        OxenError::basic_str(err)
+    pub fn schema_does_not_have_field(field: &str) -> OxenError {
+        let err = format!("Schema does not have field {:?}", field);
+        OxenError::basic_str(&err)
     }
 
     pub fn schema_has_changed(old_schema: Schema, current_schema: Schema) -> OxenError {
         let err =
             format!("\nSchema has changed\n\nOld\n{old_schema}\n\nCurrent\n{current_schema}\n");
-        OxenError::basic_str(err)
+        OxenError::basic_str(&err)
     }
 
-    pub fn remote_branch_not_found(name: impl AsRef<str>) -> OxenError {
-        let err = format!("Remote branch '{}' not found", name.as_ref());
+    pub fn remote_branch_not_found(name: &str) -> OxenError {
+        let err = format!("Remote branch '{}' not found", name);
         OxenError::BranchNotFound(Box::new(StringError::from(err)))
     }
 
-    pub fn local_branch_not_found(name: impl AsRef<str>) -> OxenError {
-        let err = format!("Branch '{}' not found", name.as_ref());
+    pub fn local_branch_not_found(name: &str) -> OxenError {
+        let err = format!("Branch '{}' not found", name);
         OxenError::BranchNotFound(Box::new(StringError::from(err)))
     }
 
-    pub fn commit_db_corrupted(commit_id: impl AsRef<str>) -> OxenError {
-        let err = format!(
-            "Commit db corrupted, could not find commit: {}",
-            commit_id.as_ref()
-        );
-        OxenError::basic_str(err)
+    pub fn commit_db_corrupted(commit_id: &str) -> OxenError {
+        let err = format!("Commit db corrupted, could not find commit: {}", commit_id);
+        OxenError::basic_str(&err)
     }
 
-    pub fn commit_id_does_not_exist(commit_id: impl AsRef<str>) -> OxenError {
-        let err = format!("Could not find commit: {}", commit_id.as_ref());
-        OxenError::basic_str(err)
+    pub fn commit_id_does_not_exist(commit_id: &str) -> OxenError {
+        let err = format!("Could not find commit: {}", commit_id);
+        OxenError::basic_str(&err)
     }
 
-    pub fn local_parent_link_broken(commit_id: impl AsRef<str>) -> OxenError {
-        let err = format!("Broken link to parent commit: {}", commit_id.as_ref());
-        OxenError::basic_str(err)
+    pub fn local_parent_link_broken(commit_id: &str) -> OxenError {
+        let err = format!("Broken link to parent commit: {}", commit_id);
+        OxenError::basic_str(&err)
     }
 
-    pub fn entry_does_not_exist(path: impl AsRef<Path>) -> OxenError {
-        OxenError::ParsedResourceNotFound(Box::new(path.as_ref().into()))
+    pub fn entry_does_not_exist(path: &Path) -> OxenError {
+        OxenError::ParsedResourceNotFound(Box::new(path.into()))
     }
 
-    pub fn file_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!("File does not exist: {:?} error {:?}", path.as_ref(), error);
-        OxenError::basic_str(err)
+    pub fn file_error(path: &Path, error: std::io::Error) -> OxenError {
+        let err = format!("File does not exist: {:?} error {:?}", path, error);
+        OxenError::basic_str(&err)
     }
 
-    pub fn file_create_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!(
-            "Could not create file: {:?} error {:?}",
-            path.as_ref(),
-            error
-        );
-        OxenError::basic_str(err)
+    pub fn file_create_error(path: &Path, error: std::io::Error) -> OxenError {
+        let err = format!("Could not create file: {:?} error {:?}", path, error);
+        OxenError::basic_str(&err)
     }
 
-    pub fn dir_create_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!(
-            "Could not create directory: {:?} error {:?}",
-            path.as_ref(),
-            error
-        );
-        OxenError::basic_str(err)
+    pub fn dir_create_error(path: &Path, error: std::io::Error) -> OxenError {
+        let err = format!("Could not create directory: {:?} error {:?}", path, error);
+        OxenError::basic_str(&err)
     }
 
-    pub fn file_open_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!("Could not open file: {:?} error {:?}", path.as_ref(), error,);
-        OxenError::basic_str(err)
+    pub fn file_open_error(path: &Path, error: std::io::Error) -> OxenError {
+        let err = format!("Could not open file: {:?} error {:?}", path, error,);
+        OxenError::basic_str(&err)
     }
 
-    pub fn file_read_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!("Could not read file: {:?} error {:?}", path.as_ref(), error,);
-        OxenError::basic_str(err)
+    pub fn file_read_error(path: &Path, error: std::io::Error) -> OxenError {
+        let err = format!("Could not read file: {:?} error {:?}", path, error,);
+        OxenError::basic_str(&err)
     }
 
-    pub fn file_metadata_error(path: impl AsRef<Path>, error: std::io::Error) -> OxenError {
-        let err = format!(
-            "Could not get file metadata: {:?} error {:?}",
-            path.as_ref(),
-            error
-        );
-        OxenError::basic_str(err)
+    pub fn file_metadata_error(path: &Path, error: std::io::Error) -> OxenError {
+        let err = format!("Could not get file metadata: {:?} error {:?}", path, error);
+        OxenError::basic_str(&err)
     }
 
-    pub fn file_copy_error(
-        src: impl AsRef<Path>,
-        dst: impl AsRef<Path>,
-        err: impl std::fmt::Debug,
-    ) -> OxenError {
+    pub fn file_copy_error(src: &Path, dst: &Path, err: impl std::fmt::Debug) -> OxenError {
         let err = format!(
             "File copy error: {err:?}\nCould not copy from `{:?}` to `{:?}`",
-            src.as_ref(),
-            dst.as_ref()
+            src, dst
         );
-        OxenError::basic_str(err)
+        OxenError::basic_str(&err)
     }
 
-    pub fn file_rename_error(
-        src: impl AsRef<Path>,
-        dst: impl AsRef<Path>,
-        err: impl std::fmt::Debug,
-    ) -> OxenError {
+    pub fn file_rename_error(src: &Path, dst: &Path, err: impl std::fmt::Debug) -> OxenError {
         let err = format!(
             "File rename error: {err:?}\nCould not move from `{:?}` to `{:?}`",
-            src.as_ref(),
-            dst.as_ref()
+            src, dst
         );
-        OxenError::basic_str(err)
+        OxenError::basic_str(&err)
     }
 
-    pub fn workspace_add_file_not_in_repo(path: impl AsRef<Path>) -> OxenError {
+    pub fn workspace_add_file_not_in_repo(path: &Path) -> OxenError {
         let err = format!(
             "File is outside of the repo {:?}\n\nYou must specify a path you would like to add the file at with the -d flag.\n\n  oxen workspace add /path/to/file.png -d my-images/\n",
-            path.as_ref()
+            path
         );
-        OxenError::basic_str(err)
+        OxenError::basic_str(&err)
     }
 
     pub fn cannot_overwrite_files(paths: &[PathBuf]) -> OxenError {
@@ -573,20 +547,13 @@ impl OxenError {
             .collect::<Vec<String>>()
             .join("\n  ");
 
-        OxenError::basic_str(format!(
+        OxenError::basic_str(&format!(
             "\nError: your local changes to the following files would be overwritten. Please commit the following changes before continuing:\n\n  {paths_str}\n"
         ))
     }
 
-    pub fn entry_does_not_exist_in_commit(
-        path: impl AsRef<Path>,
-        commit_id: impl AsRef<str>,
-    ) -> OxenError {
-        let err = format!(
-            "Entry {:?} does not exist in commit {}",
-            path.as_ref(),
-            commit_id.as_ref()
-        );
+    pub fn entry_does_not_exist_in_commit(path: &Path, commit_id: &str) -> OxenError {
+        let err = format!("Entry {:?} does not exist in commit {}", path, commit_id);
         OxenError::CommitEntryNotFound(err.into())
     }
 
@@ -596,52 +563,46 @@ impl OxenError {
         )
     }
 
-    pub fn file_has_no_parent(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("File has no parent: {:?}", path.as_ref());
-        OxenError::basic_str(err)
+    pub fn file_has_no_parent(path: &Path) -> OxenError {
+        let err = format!("File has no parent: {:?}", path);
+        OxenError::basic_str(&err)
     }
 
-    pub fn file_has_no_name(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("File has no file_name: {:?}", path.as_ref());
-        OxenError::basic_str(err)
+    pub fn file_has_no_name(path: &Path) -> OxenError {
+        let err = format!("File has no file_name: {:?}", path);
+        OxenError::basic_str(&err)
     }
 
-    pub fn could_not_convert_path_to_str(path: impl AsRef<Path>) -> OxenError {
-        let err = format!("File has no name: {:?}", path.as_ref());
-        OxenError::basic_str(err)
+    pub fn could_not_convert_path_to_str(path: &Path) -> OxenError {
+        let err = format!("File has no name: {:?}", path);
+        OxenError::basic_str(&err)
     }
 
-    pub fn local_revision_not_found(name: impl AsRef<str>) -> OxenError {
-        let err = format!(
-            "Local branch or commit reference `{}` not found",
-            name.as_ref()
-        );
-        OxenError::basic_str(err)
+    pub fn local_revision_not_found(name: &str) -> OxenError {
+        let err = format!("Local branch or commit reference `{}` not found", name);
+        OxenError::basic_str(&err)
     }
 
-    pub fn could_not_find_merge_conflict(path: impl AsRef<Path>) -> OxenError {
-        let err = format!(
-            "Could not find merge conflict for path: {:?}",
-            path.as_ref()
-        );
-        OxenError::basic_str(err)
+    pub fn could_not_find_merge_conflict(path: &Path) -> OxenError {
+        let err = format!("Could not find merge conflict for path: {:?}", path);
+        OxenError::basic_str(&err)
     }
 
-    pub fn could_not_decode_value_for_key_error(key: impl AsRef<str>) -> OxenError {
-        let err = format!("Could not decode value for key: {:?}", key.as_ref());
-        OxenError::basic_str(err)
+    pub fn could_not_decode_value_for_key_error(key: &str) -> OxenError {
+        let err = format!("Could not decode value for key: {:?}", key);
+        OxenError::basic_str(&err)
     }
 
-    pub fn invalid_set_remote_url(url: impl AsRef<str>) -> OxenError {
+    pub fn invalid_set_remote_url(url: &str) -> OxenError {
         let err = format!(
             "\nRemote invalid, must be fully qualified URL, got: {:?}\n\n  oxen config --set-remote origin https://hub.oxen.ai/<namespace>/<reponame>\n",
-            url.as_ref()
+            url
         );
-        OxenError::basic_str(err)
+        OxenError::basic_str(&err)
     }
 
-    pub fn invalid_file_type(file_type: impl AsRef<str>) -> OxenError {
-        let err = format!("Invalid file type: {:?}", file_type.as_ref());
+    pub fn invalid_file_type(file_type: &str) -> OxenError {
+        let err = format!("Invalid file type: {:?}", file_type);
         OxenError::InvalidFileType(StringError::from(err))
     }
 
@@ -659,17 +620,13 @@ impl OxenError {
         OxenError::IncompatibleSchemas(Box::new(schema))
     }
 
-    pub fn parse_error(value: impl AsRef<str>) -> OxenError {
-        let err = format!("Parse error: {:?}", value.as_ref());
-        OxenError::basic_str(err)
+    pub fn parse_error(value: &str) -> OxenError {
+        let err = format!("Parse error: {:?}", value);
+        OxenError::basic_str(&err)
     }
 
-    pub fn unknown_subcommand(parent: impl AsRef<str>, name: impl AsRef<str>) -> OxenError {
-        OxenError::basic_str(format!(
-            "Unknown {} subcommand '{}'",
-            parent.as_ref(),
-            name.as_ref()
-        ))
+    pub fn unknown_subcommand(parent: &str, name: &str) -> OxenError {
+        OxenError::basic_str(&format!("Unknown {} subcommand '{}'", parent, name))
     }
 }
 
@@ -682,18 +639,18 @@ impl From<String> for OxenError {
 
 impl From<StripPrefixError> for OxenError {
     fn from(error: StripPrefixError) -> Self {
-        OxenError::basic_str(format!("Error stripping prefix: {error}"))
+        OxenError::basic_str(&format!("Error stripping prefix: {error}"))
     }
 }
 
 impl From<JoinError> for OxenError {
     fn from(error: JoinError) -> Self {
-        OxenError::basic_str(error.to_string())
+        OxenError::basic_str(&error.to_string())
     }
 }
 
 impl From<std::string::FromUtf8Error> for OxenError {
     fn from(error: std::string::FromUtf8Error) -> Self {
-        OxenError::basic_str(format!("UTF8 conversion error: {error}"))
+        OxenError::basic_str(&format!("UTF8 conversion error: {error}"))
     }
 }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -251,7 +251,7 @@ impl OxenError {
         Some(hint)
     }
 
-    pub fn basic_str(s: &str) -> Self {
+    pub fn basic_str(s: String) -> Self {
         OxenError::Basic(StringError::from(s))
     }
 
@@ -259,19 +259,19 @@ impl OxenError {
         OxenError::ThumbnailingNotEnabled(StringError::from(s))
     }
 
-    pub fn authentication(s: &str) -> Self {
+    pub fn authentication(s: String) -> Self {
         OxenError::Authentication(StringError::from(s))
     }
 
-    pub fn migration_required(s: &str) -> Self {
+    pub fn migration_required(s: String) -> Self {
         OxenError::MigrationRequired(StringError::from(s))
     }
 
-    pub fn invalid_version(s: &str) -> Self {
+    pub fn invalid_version(s: String) -> Self {
         OxenError::InvalidVersion(StringError::from(s))
     }
 
-    pub fn oxen_update_required(s: &str) -> Self {
+    pub fn oxen_update_required(s: String) -> Self {
         OxenError::OxenUpdateRequired(StringError::from(s))
     }
 
@@ -283,12 +283,12 @@ impl OxenError {
         OxenError::RepoNotFound(Box::new(repo))
     }
 
-    pub fn file_import_error(s: &str) -> Self {
+    pub fn file_import_error(s: String) -> Self {
         OxenError::ImportFileError(StringError::from(s))
     }
 
     pub fn remote_not_set(name: &str) -> Self {
-        OxenError::basic_str(&format!(
+        OxenError::basic_str(format!(
             "Remote not set, you can set a remote by running:\n\noxen config --set-remote {name} <url>\n"
         ))
     }
@@ -305,7 +305,7 @@ impl OxenError {
         ))
     }
 
-    pub fn merge_conflict(desc: &str) -> Self {
+    pub fn merge_conflict(desc: String) -> Self {
         OxenError::UpstreamMergeConflict(StringError::from(desc))
     }
 
@@ -325,19 +325,19 @@ impl OxenError {
         OxenError::OperationCancelled(StringError::from("\nOperation cancelled.\n"))
     }
 
-    pub fn resource_not_found(value: &str) -> Self {
+    pub fn resource_not_found(value: String) -> Self {
         OxenError::ResourceNotFound(StringError::from(value))
     }
 
-    pub fn path_does_not_exist(path: &Path) -> Self {
+    pub fn path_does_not_exist(path: PathBuf) -> Self {
         OxenError::PathDoesNotExist(Box::new(path.into()))
     }
 
-    pub fn image_metadata_error(s: &str) -> Self {
+    pub fn image_metadata_error(s: String) -> Self {
         OxenError::ImageMetadataParseError(StringError::from(s))
     }
 
-    pub fn sql_parse_error(s: &str) -> Self {
+    pub fn sql_parse_error(s: String) -> Self {
         OxenError::SQLParseError(StringError::from(s))
     }
 
@@ -345,7 +345,7 @@ impl OxenError {
         OxenError::ParsedResourceNotFound(Box::new(resource.resource.into()))
     }
 
-    pub fn invalid_repo_name(s: &str) -> Self {
+    pub fn invalid_repo_name(s: String) -> Self {
         OxenError::InvalidRepoName(StringError::from(s))
     }
 
@@ -394,7 +394,7 @@ impl OxenError {
         OxenError::NoCommitsFound(StringError::from("\n No commits found.\n"))
     }
 
-    pub fn local_repo_not_found(dir: &Path) -> OxenError {
+    pub fn local_repo_not_found(dir: PathBuf) -> OxenError {
         OxenError::LocalRepoNotFound(Box::new(dir.into()))
     }
 
@@ -402,7 +402,7 @@ impl OxenError {
         OxenError::user_config_not_found(EMAIL_AND_NAME_NOT_FOUND.to_string().into())
     }
 
-    pub fn remote_repo_not_found(url: &str) -> OxenError {
+    pub fn remote_repo_not_found(url: String) -> OxenError {
         OxenError::RemoteRepoNotFound(Box::new(StringError::from(url)))
     }
 
@@ -411,50 +411,50 @@ impl OxenError {
     }
 
     pub fn home_dir_not_found() -> OxenError {
-        OxenError::basic_str("Home directory not found")
+        OxenError::basic_str("Home directory not found".to_string())
     }
 
     pub fn cache_dir_not_found() -> OxenError {
-        OxenError::basic_str("Cache directory not found")
+        OxenError::basic_str("Cache directory not found".to_string())
     }
 
     pub fn must_be_on_valid_branch() -> OxenError {
         OxenError::basic_str(
-            "Repository is in a detached HEAD state, checkout a valid branch to continue.\n\n  oxen checkout <branch>\n",
+            "Repository is in a detached HEAD state, checkout a valid branch to continue.\n\n  oxen checkout <branch>\n".to_string(),
         )
     }
 
     pub fn no_schemas_staged() -> OxenError {
         OxenError::basic_str(
-            "No schemas staged\n\nAuto detect schema on file with:\n\n  oxen add path/to/file.csv\n\nOr manually add a schema override with:\n\n  oxen schemas add path/to/file.csv 'name:str, age:i32'\n",
+            "No schemas staged\n\nAuto detect schema on file with:\n\n  oxen add path/to/file.csv\n\nOr manually add a schema override with:\n\n  oxen schemas add path/to/file.csv 'name:str, age:i32'\n".to_string(),
         )
     }
 
     pub fn no_schemas_committed() -> OxenError {
         OxenError::basic_str(
-            "No schemas committed\n\nAuto detect schema on file with:\n\n  oxen add path/to/file.csv\n\nOr manually add a schema override with:\n\n  oxen schemas add path/to/file.csv 'name:str, age:i32'\n\nThen commit the schema with:\n\n  oxen commit -m 'Adding schema for path/to/file.csv'\n",
+            "No schemas committed\n\nAuto detect schema on file with:\n\n  oxen add path/to/file.csv\n\nOr manually add a schema override with:\n\n  oxen schemas add path/to/file.csv 'name:str, age:i32'\n\nThen commit the schema with:\n\n  oxen commit -m 'Adding schema for path/to/file.csv'\n".to_string(),
         )
     }
 
     pub fn schema_does_not_exist_for_file(path: &Path) -> OxenError {
         let err = format!("Schema does not exist for file {:?}", path);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn schema_does_not_exist(path: &Path) -> OxenError {
         let err = format!("Schema does not exist {:?}", path);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn schema_does_not_have_field(field: &str) -> OxenError {
         let err = format!("Schema does not have field {:?}", field);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn schema_has_changed(old_schema: Schema, current_schema: Schema) -> OxenError {
         let err =
             format!("\nSchema has changed\n\nOld\n{old_schema}\n\nCurrent\n{current_schema}\n");
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn remote_branch_not_found(name: &str) -> OxenError {
@@ -469,51 +469,51 @@ impl OxenError {
 
     pub fn commit_db_corrupted(commit_id: &str) -> OxenError {
         let err = format!("Commit db corrupted, could not find commit: {}", commit_id);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn commit_id_does_not_exist(commit_id: &str) -> OxenError {
         let err = format!("Could not find commit: {}", commit_id);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn local_parent_link_broken(commit_id: &str) -> OxenError {
         let err = format!("Broken link to parent commit: {}", commit_id);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
-    pub fn entry_does_not_exist(path: &Path) -> OxenError {
+    pub fn entry_does_not_exist(path: PathBuf) -> OxenError {
         OxenError::ParsedResourceNotFound(Box::new(path.into()))
     }
 
     pub fn file_error(path: &Path, error: std::io::Error) -> OxenError {
         let err = format!("File does not exist: {:?} error {:?}", path, error);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn file_create_error(path: &Path, error: std::io::Error) -> OxenError {
         let err = format!("Could not create file: {:?} error {:?}", path, error);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn dir_create_error(path: &Path, error: std::io::Error) -> OxenError {
         let err = format!("Could not create directory: {:?} error {:?}", path, error);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn file_open_error(path: &Path, error: std::io::Error) -> OxenError {
         let err = format!("Could not open file: {:?} error {:?}", path, error,);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn file_read_error(path: &Path, error: std::io::Error) -> OxenError {
         let err = format!("Could not read file: {:?} error {:?}", path, error,);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn file_metadata_error(path: &Path, error: std::io::Error) -> OxenError {
         let err = format!("Could not get file metadata: {:?} error {:?}", path, error);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn file_copy_error(src: &Path, dst: &Path, err: impl std::fmt::Debug) -> OxenError {
@@ -521,7 +521,7 @@ impl OxenError {
             "File copy error: {err:?}\nCould not copy from `{:?}` to `{:?}`",
             src, dst
         );
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn file_rename_error(src: &Path, dst: &Path, err: impl std::fmt::Debug) -> OxenError {
@@ -529,7 +529,7 @@ impl OxenError {
             "File rename error: {err:?}\nCould not move from `{:?}` to `{:?}`",
             src, dst
         );
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn workspace_add_file_not_in_repo(path: &Path) -> OxenError {
@@ -537,7 +537,7 @@ impl OxenError {
             "File is outside of the repo {:?}\n\nYou must specify a path you would like to add the file at with the -d flag.\n\n  oxen workspace add /path/to/file.png -d my-images/\n",
             path
         );
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn cannot_overwrite_files(paths: &[PathBuf]) -> OxenError {
@@ -547,7 +547,7 @@ impl OxenError {
             .collect::<Vec<String>>()
             .join("\n  ");
 
-        OxenError::basic_str(&format!(
+        OxenError::basic_str(format!(
             "\nError: your local changes to the following files would be overwritten. Please commit the following changes before continuing:\n\n  {paths_str}\n"
         ))
     }
@@ -559,38 +559,38 @@ impl OxenError {
 
     pub fn must_supply_valid_api_key() -> OxenError {
         OxenError::basic_str(
-            "Must supply valid API key. Create an account at https://oxen.ai and then set the API key with:\n\n  oxen config --auth hub.oxen.ai <API_KEY>\n",
+            "Must supply valid API key. Create an account at https://oxen.ai and then set the API key with:\n\n  oxen config --auth hub.oxen.ai <API_KEY>\n".to_string(),
         )
     }
 
     pub fn file_has_no_parent(path: &Path) -> OxenError {
         let err = format!("File has no parent: {:?}", path);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn file_has_no_name(path: &Path) -> OxenError {
         let err = format!("File has no file_name: {:?}", path);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn could_not_convert_path_to_str(path: &Path) -> OxenError {
         let err = format!("File has no name: {:?}", path);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn local_revision_not_found(name: &str) -> OxenError {
         let err = format!("Local branch or commit reference `{}` not found", name);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn could_not_find_merge_conflict(path: &Path) -> OxenError {
         let err = format!("Could not find merge conflict for path: {:?}", path);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn could_not_decode_value_for_key_error(key: &str) -> OxenError {
         let err = format!("Could not decode value for key: {:?}", key);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn invalid_set_remote_url(url: &str) -> OxenError {
@@ -598,7 +598,7 @@ impl OxenError {
             "\nRemote invalid, must be fully qualified URL, got: {:?}\n\n  oxen config --set-remote origin https://hub.oxen.ai/<namespace>/<reponame>\n",
             url
         );
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn invalid_file_type(file_type: &str) -> OxenError {
@@ -622,11 +622,11 @@ impl OxenError {
 
     pub fn parse_error(value: &str) -> OxenError {
         let err = format!("Parse error: {:?}", value);
-        OxenError::basic_str(&err)
+        OxenError::basic_str(err)
     }
 
     pub fn unknown_subcommand(parent: &str, name: &str) -> OxenError {
-        OxenError::basic_str(&format!("Unknown {} subcommand '{}'", parent, name))
+        OxenError::basic_str(format!("Unknown {} subcommand '{}'", parent, name))
     }
 }
 
@@ -639,18 +639,18 @@ impl From<String> for OxenError {
 
 impl From<StripPrefixError> for OxenError {
     fn from(error: StripPrefixError) -> Self {
-        OxenError::basic_str(&format!("Error stripping prefix: {error}"))
+        OxenError::basic_str(format!("Error stripping prefix: {error}"))
     }
 }
 
 impl From<JoinError> for OxenError {
     fn from(error: JoinError) -> Self {
-        OxenError::basic_str(&error.to_string())
+        OxenError::basic_str(error.to_string())
     }
 }
 
 impl From<std::string::FromUtf8Error> for OxenError {
     fn from(error: std::string::FromUtf8Error) -> Self {
-        OxenError::basic_str(&format!("UTF8 conversion error: {error}"))
+        OxenError::basic_str(format!("UTF8 conversion error: {error}"))
     }
 }

--- a/crates/lib/src/migrations.rs
+++ b/crates/lib/src/migrations.rs
@@ -17,7 +17,7 @@ pub fn list_unmigrated(
 
     if !global_last_migration.exists() {
         return Err(OxenError::basic_str(
-            "No global migration file found on server.",
+            "No global migration file found on server.".to_string(),
         ));
     }
 

--- a/crates/lib/src/model/content_type.rs
+++ b/crates/lib/src/model/content_type.rs
@@ -36,7 +36,7 @@ impl ContentType {
             "application/json" => Ok(ContentType::Json),
             "text/csv" => Ok(ContentType::Csv),
             "text/plain" => Ok(ContentType::Text),
-            _ => Err(OxenError::basic_str(format!(
+            _ => Err(OxenError::basic_str(&format!(
                 "Unsupported content-type: {s}"
             ))),
         }

--- a/crates/lib/src/model/content_type.rs
+++ b/crates/lib/src/model/content_type.rs
@@ -36,7 +36,7 @@ impl ContentType {
             "application/json" => Ok(ContentType::Json),
             "text/csv" => Ok(ContentType::Csv),
             "text/plain" => Ok(ContentType::Text),
-            _ => Err(OxenError::basic_str(&format!(
+            _ => Err(OxenError::basic_str(format!(
                 "Unsupported content-type: {s}"
             ))),
         }

--- a/crates/lib/src/model/data_frame/schema.rs
+++ b/crates/lib/src/model/data_frame/schema.rs
@@ -73,8 +73,7 @@ impl Schema {
     }
 
     /// Checks if the provided schema matches this schema given a hash or path
-    pub fn matches_ref(&self, schema_ref: impl AsRef<str>) -> bool {
-        let schema_ref = schema_ref.as_ref();
+    pub fn matches_ref(&self, schema_ref: &str) -> bool {
         self.hash == schema_ref
     }
 
@@ -155,22 +154,20 @@ impl Schema {
             .any(|f| f.name == field.name && f.dtype == field.dtype)
     }
 
-    pub fn has_field_names(&self, fields: &[impl AsRef<str>]) -> bool {
+    pub fn has_field_names(&self, fields: &[&str]) -> bool {
         fields.iter().all(|field| self.has_field_name(field))
     }
 
-    pub fn has_field_name(&self, name: impl AsRef<str>) -> bool {
-        let name = name.as_ref();
+    pub fn has_field_name(&self, name: &str) -> bool {
         self.fields.iter().any(|f| f.name == name)
     }
 
-    pub fn has_column(&self, name: impl AsRef<str>) -> bool {
-        let name = name.as_ref().to_lowercase(); // Convert the parameter to lowercase
+    pub fn has_column(&self, name: &str) -> bool {
+        let name = name.to_lowercase(); // Convert the parameter to lowercase
         self.fields.iter().any(|f| f.name.to_lowercase() == name) // Compare lowercase versions
     }
 
-    pub fn get_field(&self, name: impl AsRef<str>) -> Option<&Field> {
-        let name = name.as_ref();
+    pub fn get_field(&self, name: &str) -> Option<&Field> {
         self.fields.iter().find(|f| f.name == name)
     }
 

--- a/crates/lib/src/model/data_frame/schema/custom_data_type.rs
+++ b/crates/lib/src/model/data_frame/schema/custom_data_type.rs
@@ -16,8 +16,8 @@ impl fmt::Display for CustomDataType {
 }
 
 impl CustomDataType {
-    pub fn from_string(s: impl AsRef<str>) -> CustomDataType {
-        match s.as_ref() {
+    pub fn from_string(s: &str) -> CustomDataType {
+        match s {
             "path" => CustomDataType::Path,
             _ => CustomDataType::Unknown,
         }

--- a/crates/lib/src/model/data_frame/schema/data_type.rs
+++ b/crates/lib/src/model/data_frame/schema/data_type.rs
@@ -37,8 +37,8 @@ impl fmt::Display for DataType {
 }
 
 impl DataType {
-    pub fn from_string(s: impl AsRef<str>) -> DataType {
-        match s.as_ref() {
+    pub fn from_string(s: &str) -> DataType {
+        match s {
             "bool" => DataType::Boolean,
             "uint8" => DataType::UInt8,
             "u16" => DataType::UInt16,
@@ -256,8 +256,8 @@ impl DataType {
         }
     }
 
-    pub fn from_sql(s: impl AsRef<str>) -> Self {
-        match s.as_ref() {
+    pub fn from_sql(s: &str) -> Self {
+        match s {
             "BOOL" => DataType::Boolean,
             "UTINYINT" => DataType::UInt8, // unsigned one-byte integer
             "USMALLINT" => DataType::UInt16, // unsigned two-byte integer
@@ -308,7 +308,7 @@ impl DataType {
                     return DataType::Embedding(size.as_str().parse::<usize>().unwrap());
                 }
 
-                log::error!("TODO: from_sql unknown SQL type {}", s.as_ref());
+                log::error!("TODO: from_sql unknown SQL type {}", s);
                 DataType::Unknown
             }
         }

--- a/crates/lib/src/model/data_frame/schema/field.rs
+++ b/crates/lib/src/model/data_frame/schema/field.rs
@@ -56,7 +56,7 @@ impl Field {
         )
     }
 
-    pub fn all_fields_to_string<V: AsRef<Vec<Field>>>(fields: V) -> String {
+    pub fn all_fields_to_string(fields: &[Field]) -> String {
         let names: Vec<String> = fields.as_ref().iter().map(|f| f.name.to_owned()).collect();
 
         let combined_names = names.join(", ");
@@ -87,8 +87,7 @@ impl Field {
         fields_vec
     }
 
-    pub fn fields_to_string_with_limit<V: AsRef<Vec<Field>>>(fields: V) -> String {
-        let fields = fields.as_ref();
+    pub fn fields_to_string_with_limit(fields: &[Field]) -> String {
         let max_num = 2;
         if fields.len() > max_num {
             let name_0 = fields[0].name.to_owned();

--- a/crates/lib/src/model/diff/diff_entry.rs
+++ b/crates/lib/src/model/diff/diff_entry.rs
@@ -108,14 +108,14 @@ impl DiffEntry {
 
     pub fn from_dir_nodes(
         repo: &LocalRepository,
-        dir_path: impl AsRef<Path>,
+        dir_path: &Path,
         base_dir: Option<DirNode>,
         base_commit: &Commit,
         head_dir: Option<DirNode>,
         head_commit: &Commit,
         status: DiffEntryStatus,
     ) -> Result<DiffEntry, OxenError> {
-        let dir_path = dir_path.as_ref().to_path_buf();
+        let dir_path = dir_path.to_path_buf();
         // Need to check whether we have the head or base entry to check data about the file
         let current_dir = if let Some(dir) = &head_dir {
             dir.clone()
@@ -162,7 +162,7 @@ impl DiffEntry {
     #[allow(clippy::too_many_arguments)]
     pub async fn from_file_nodes(
         repo: &LocalRepository,
-        file_path: impl AsRef<Path>,
+        file_path: &Path,
         base_entry: Option<FileNode>,
         base_commit: &Commit, // pass in commit objects for speed so we don't have to lookup later
         head_entry: Option<FileNode>,
@@ -172,7 +172,7 @@ impl DiffEntry {
         df_opts: Option<DFOpts>, // only for tabular
     ) -> Result<DiffEntry, OxenError> {
         log::debug!("from_file_nodes: base_entry: {base_entry:?}, head_entry: {head_entry:?}");
-        let file_path = file_path.as_ref().to_path_buf();
+        let file_path = file_path.to_path_buf();
         // Need to check whether we have the head or base entry to check data about the file
         let (current_entry, data_type) = if let Some(entry) = &head_entry {
             (entry.clone(), entry.data_type().clone())
@@ -271,25 +271,22 @@ impl DiffEntry {
 
     fn resource_from_file_node(
         node: Option<FileNode>,
-        file_path: impl AsRef<Path>,
-        version: impl AsRef<str>,
+        file_path: &Path,
+        version: &str,
     ) -> Option<ParsedResource> {
-        let path = file_path.as_ref().to_path_buf();
+        let path = file_path.to_path_buf();
         node.map(|_| ParsedResource {
             commit: None,
             branch: None,
             workspace: None,
-            version: PathBuf::from(version.as_ref()),
+            version: PathBuf::from(version),
             path: path.clone(),
-            resource: PathBuf::from(version.as_ref()).join(path),
+            resource: PathBuf::from(version).join(path),
         })
     }
 
-    fn resource_from_dir_node(
-        node: Option<DirNode>,
-        dir_path: impl AsRef<Path>,
-    ) -> Option<ParsedResource> {
-        let path = dir_path.as_ref().to_path_buf();
+    fn resource_from_dir_node(node: Option<DirNode>, dir_path: &Path) -> Option<ParsedResource> {
+        let path = dir_path.to_path_buf();
         node.map(|node| ParsedResource {
             commit: None,
             branch: None,

--- a/crates/lib/src/model/diff/tabular_diff_summary.rs
+++ b/crates/lib/src/model/diff/tabular_diff_summary.rs
@@ -50,7 +50,7 @@ impl TabularDiffWrapper {
                         height: df_meta.tabular.height,
                         width: df_meta.tabular.width,
                     },
-                    _ => return Err(OxenError::basic_str("Invalid metadata type")),
+                    _ => return Err(OxenError::basic_str("Invalid metadata type".to_string())),
                 };
 
                 let head_size = match &head_entry.metadata() {
@@ -58,7 +58,7 @@ impl TabularDiffWrapper {
                         height: df_meta.tabular.height,
                         width: df_meta.tabular.width,
                     },
-                    _ => return Err(OxenError::basic_str("Invalid metadata type")),
+                    _ => return Err(OxenError::basic_str("Invalid metadata type".to_string())),
                 };
 
                 // TODO - this can be made less naive
@@ -88,7 +88,7 @@ impl TabularDiffWrapper {
                         height: df_meta.tabular.height,
                         width: df_meta.tabular.width,
                     },
-                    _ => return Err(OxenError::basic_str("Invalid metadata type")),
+                    _ => return Err(OxenError::basic_str("Invalid metadata type".to_string())),
                 };
 
                 Ok(TabularDiffWrapper {
@@ -108,7 +108,7 @@ impl TabularDiffWrapper {
                         height: df_meta.tabular.height,
                         width: df_meta.tabular.width,
                     },
-                    _ => return Err(OxenError::basic_str("Invalid metadata type")),
+                    _ => return Err(OxenError::basic_str("Invalid metadata type".to_string())),
                 };
 
                 Ok(TabularDiffWrapper {

--- a/crates/lib/src/model/diff/tabular_diff_summary.rs
+++ b/crates/lib/src/model/diff/tabular_diff_summary.rs
@@ -147,7 +147,8 @@ impl TabularDiffWrapper {
                     .get_version_path(&node.hash().to_string())
                     .await
                     .expect("invariant violation: version path not found in maybe_get_df_from_file_node");
-                tabular::read_df_with_extension(&*version_path, node.extension(), &DFOpts::empty())
+
+                tabular::read_df_with_extension(&version_path, node.extension(), &DFOpts::empty())
                     .await
                     .ok()
             }
@@ -167,7 +168,7 @@ impl TabularDiffWrapper {
                 let version_path = version_store.get_version_path(&entry.hash).await.expect(
                     "invariant violation: version path not found in maybe_get_df_from_commit_entry",
                 );
-                tabular::read_df(&*version_path, DFOpts::empty()).await.ok()
+                tabular::read_df(&version_path, DFOpts::empty()).await.ok()
             }
             None => None,
         }

--- a/crates/lib/src/model/entry/commit_entry.rs
+++ b/crates/lib/src/model/entry/commit_entry.rs
@@ -155,10 +155,10 @@ impl Hash for CommitEntry {
 
 impl CommitEntry {
     // For HashSet search purposes
-    pub fn from_path<T: AsRef<Path>>(path: T) -> CommitEntry {
+    pub fn from_path(path: &Path) -> CommitEntry {
         CommitEntry {
             commit_id: String::from(""),
-            path: path.as_ref().to_path_buf(),
+            path: path.to_path_buf(),
             hash: String::from(""),
             num_bytes: 0,
             last_modified_seconds: 0,

--- a/crates/lib/src/model/file.rs
+++ b/crates/lib/src/model/file.rs
@@ -78,18 +78,18 @@ pub struct TempFilePathNew {
 }
 
 impl FileNew {
-    pub fn new_text(path: impl AsRef<Path>, contents: impl AsRef<str>, user: User) -> FileNew {
+    pub fn new_text(path: &Path, contents: &str, user: User) -> FileNew {
         FileNew {
-            path: path.as_ref().to_path_buf(),
-            contents: FileContents::Text(contents.as_ref().to_string()),
+            path: path.to_path_buf(),
+            contents: FileContents::Text(contents.to_string()),
             user,
         }
     }
 
-    pub fn new_binary(path: impl AsRef<Path>, contents: impl AsRef<[u8]>, user: User) -> FileNew {
+    pub fn new_binary(path: &Path, contents: &[u8], user: User) -> FileNew {
         FileNew {
-            path: path.as_ref().to_path_buf(),
-            contents: FileContents::Binary(contents.as_ref().to_vec()),
+            path: path.to_path_buf(),
+            contents: FileContents::Binary(contents.to_vec()),
             user,
         }
     }

--- a/crates/lib/src/model/merkle_tree/node/commit_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/commit_node.rs
@@ -69,7 +69,7 @@ impl CommitNode {
                 }),
             }),
             _ => Err(OxenError::basic_str(
-                "CommitNode not supported in this version",
+                "CommitNode not supported in this version".to_string(),
             )),
         }
     }

--- a/crates/lib/src/model/merkle_tree/node/dir_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/dir_node.rs
@@ -86,7 +86,7 @@ impl DirNode {
                     data_type_sizes: opts.data_type_sizes,
                 }),
             }),
-            _ => Err(OxenError::basic_str(&format!(
+            _ => Err(OxenError::basic_str(format!(
                 "Unsupported DirNode version: {}",
                 repo.min_version()
             ))),

--- a/crates/lib/src/model/merkle_tree/node/dir_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/dir_node.rs
@@ -86,7 +86,7 @@ impl DirNode {
                     data_type_sizes: opts.data_type_sizes,
                 }),
             }),
-            _ => Err(OxenError::basic_str(format!(
+            _ => Err(OxenError::basic_str(&format!(
                 "Unsupported DirNode version: {}",
                 repo.min_version()
             ))),
@@ -176,8 +176,8 @@ impl DirNode {
         self.node().name()
     }
 
-    pub fn set_name(&mut self, name: impl AsRef<str>) {
-        self.mut_node().set_name(name.as_ref());
+    pub fn set_name(&mut self, name: &str) {
+        self.mut_node().set_name(name);
     }
 
     /// /// Number of files (not including directories)

--- a/crates/lib/src/model/merkle_tree/node/file_chunk_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/file_chunk_node.rs
@@ -19,7 +19,7 @@ pub struct FileChunkNode {
 impl FileChunkNode {
     pub fn deserialize(data: &[u8]) -> Result<FileChunkNode, OxenError> {
         rmp_serde::from_slice(data)
-            .map_err(|e| OxenError::basic_str(&format!("Error deserializing file chunk node: {e}")))
+            .map_err(|e| OxenError::basic_str(format!("Error deserializing file chunk node: {e}")))
     }
 }
 

--- a/crates/lib/src/model/merkle_tree/node/file_chunk_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/file_chunk_node.rs
@@ -19,7 +19,7 @@ pub struct FileChunkNode {
 impl FileChunkNode {
     pub fn deserialize(data: &[u8]) -> Result<FileChunkNode, OxenError> {
         rmp_serde::from_slice(data)
-            .map_err(|e| OxenError::basic_str(format!("Error deserializing file chunk node: {e}")))
+            .map_err(|e| OxenError::basic_str(&format!("Error deserializing file chunk node: {e}")))
     }
 }
 

--- a/crates/lib/src/model/merkle_tree/node/file_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/file_node.rs
@@ -90,7 +90,7 @@ impl FileNode {
                 })
             }
             _ => Err(OxenError::basic_str(
-                "FileNode not supported in this version",
+                "FileNode not supported in this version".to_string(),
             )),
         }
     }

--- a/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -151,10 +151,10 @@ impl MerkleTreeNode {
     }
 
     /// Create a default DirNode with the given path
-    pub fn default_dir_from_path(path: impl AsRef<Path>) -> MerkleTreeNode {
+    pub fn default_dir_from_path(path: &Path) -> MerkleTreeNode {
         let mut dir_node = DirNode::default();
-        let dir_str = path.as_ref().to_str().unwrap().to_string();
-        dir_node.set_name(dir_str);
+        let dir_str = path.to_str().unwrap().to_string();
+        dir_node.set_name(&dir_str);
         MerkleTreeNode {
             hash: MerkleHash::new(0),
             node: EMerkleTreeNode::Directory(dir_node),
@@ -212,7 +212,7 @@ impl MerkleTreeNode {
         if let EMerkleTreeNode::File(file_node) = &self.node {
             return Ok(PathBuf::from(file_node.name()));
         }
-        Err(OxenError::basic_str(format!(
+        Err(OxenError::basic_str(&format!(
             "MerkleTreeNode::maybe_path called on non-file or non-dir node: {self:?}"
         )))
     }
@@ -505,19 +505,15 @@ impl MerkleTreeNode {
     }
 
     /// Get all the vnodes for a given directory
-    pub fn get_vnodes_for_dir(
-        &self,
-        path: impl AsRef<Path>,
-    ) -> Result<Vec<MerkleTreeNode>, OxenError> {
-        let path = path.as_ref();
+    pub fn get_vnodes_for_dir(&self, path: &Path) -> Result<Vec<MerkleTreeNode>, OxenError> {
         let Some(node) = self.get_by_path(path)? else {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Merkle tree directory not found: '{path:?}'"
             )));
         };
 
         if MerkleTreeNodeType::Dir != node.node.node_type() {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "get_vnodes_for_dir Merkle tree node is not a directory: '{path:?}'"
             )));
         }
@@ -532,8 +528,7 @@ impl MerkleTreeNode {
     }
 
     /// Search for a file node by path
-    pub fn get_by_path(&self, path: impl AsRef<Path>) -> Result<Option<MerkleTreeNode>, OxenError> {
-        let path = path.as_ref();
+    pub fn get_by_path(&self, path: &Path) -> Result<Option<MerkleTreeNode>, OxenError> {
         let traversed_path = Path::new("");
         self.get_by_path_helper(traversed_path, path)
     }

--- a/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -135,7 +135,7 @@ impl MerkleTreeNode {
             EMerkleTreeNode::File(file_node) => Ok(file_node.last_commit_id()),
             EMerkleTreeNode::Directory(dir_node) => Ok(dir_node.last_commit_id()),
             _ => Err(OxenError::basic_str(
-                "MerkleTreeNode::latest_commit_id called on invalid node type",
+                "MerkleTreeNode::latest_commit_id called on invalid node type".to_string(),
             )),
         }
     }
@@ -212,7 +212,7 @@ impl MerkleTreeNode {
         if let EMerkleTreeNode::File(file_node) = &self.node {
             return Ok(PathBuf::from(file_node.name()));
         }
-        Err(OxenError::basic_str(&format!(
+        Err(OxenError::basic_str(format!(
             "MerkleTreeNode::maybe_path called on non-file or non-dir node: {self:?}"
         )))
     }
@@ -507,13 +507,13 @@ impl MerkleTreeNode {
     /// Get all the vnodes for a given directory
     pub fn get_vnodes_for_dir(&self, path: &Path) -> Result<Vec<MerkleTreeNode>, OxenError> {
         let Some(node) = self.get_by_path(path)? else {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Merkle tree directory not found: '{path:?}'"
             )));
         };
 
         if MerkleTreeNodeType::Dir != node.node.node_type() {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "get_vnodes_for_dir Merkle tree node is not a directory: '{path:?}'"
             )));
         }
@@ -698,7 +698,7 @@ impl MerkleTreeNode {
             Ok(commit_node.clone())
         } else {
             Err(OxenError::basic_str(
-                "MerkleTreeNode::commit called on non-commit node",
+                "MerkleTreeNode::commit called on non-commit node".to_string(),
             ))
         }
     }
@@ -708,7 +708,7 @@ impl MerkleTreeNode {
             Ok(vnode.clone())
         } else {
             Err(OxenError::basic_str(
-                "MerkleTreeNode::vnode called on non-vnode node",
+                "MerkleTreeNode::vnode called on non-vnode node".to_string(),
             ))
         }
     }
@@ -718,7 +718,7 @@ impl MerkleTreeNode {
             Ok(dir_node.clone())
         } else {
             Err(OxenError::basic_str(
-                "MerkleTreeNode::dir called on non-dir node",
+                "MerkleTreeNode::dir called on non-dir node".to_string(),
             ))
         }
     }
@@ -728,7 +728,7 @@ impl MerkleTreeNode {
             Ok(file_node.clone())
         } else {
             Err(OxenError::basic_str(
-                "MerkleTreeNode::file called on non-file node",
+                "MerkleTreeNode::file called on non-file node".to_string(),
             ))
         }
     }
@@ -738,7 +738,7 @@ impl MerkleTreeNode {
             Ok(file_chunk_node.clone())
         } else {
             Err(OxenError::basic_str(
-                "MerkleTreeNode::file_chunk called on non-file_chunk node",
+                "MerkleTreeNode::file_chunk called on non-file_chunk node".to_string(),
             ))
         }
     }

--- a/crates/lib/src/model/merkle_tree/node/merkle_tree_node_cache.rs
+++ b/crates/lib/src/model/merkle_tree/node/merkle_tree_node_cache.rs
@@ -232,8 +232,8 @@ pub fn cache_children(
 }
 
 /// Remove a repository's caches
-pub fn remove_from_cache(repository_path: impl AsRef<std::path::Path>) -> Result<(), OxenError> {
-    let path = repository_path.as_ref().to_path_buf();
+pub fn remove_from_cache(repository_path: &std::path::Path) -> Result<(), OxenError> {
+    let path = repository_path.to_path_buf();
 
     // Remove from node caches
     {

--- a/crates/lib/src/model/merkle_tree/node/vnode.rs
+++ b/crates/lib/src/model/merkle_tree/node/vnode.rs
@@ -53,7 +53,9 @@ impl VNode {
                     num_entries: vnode_opts.num_entries,
                 }),
             }),
-            _ => Err(OxenError::basic_str("VNode not supported in this version")),
+            _ => Err(OxenError::basic_str(
+                "VNode not supported in this version".to_string(),
+            )),
         }
     }
 

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -47,8 +47,8 @@ pub struct LocalRepositoryWithEntries {
 
 impl LocalRepository {
     /// Create a LocalRepository from a directory
-    pub fn from_dir(path: impl AsRef<Path>) -> Result<Self, OxenError> {
-        let path = path.as_ref().to_path_buf();
+    pub fn from_dir(path: &Path) -> Result<Self, OxenError> {
+        let path = path.to_path_buf();
         let config_path = util::fs::config_filepath(&path);
         let config = RepositoryConfig::from_file(&config_path)?;
 
@@ -126,11 +126,11 @@ impl LocalRepository {
     /// Note: Does not create the repository on disk, or read the config file, just instantiates the struct
     /// To load the repository, use `LocalRepository::from_dir` or `LocalRepository::from_current_dir`
     pub fn new(
-        path: impl AsRef<Path>,
+        path: &Path,
         storage_opts: Option<StorageOpts>,
     ) -> Result<LocalRepository, OxenError> {
         let mut repo = LocalRepository {
-            path: path.as_ref().to_path_buf(),
+            path: path.to_path_buf(),
             // No remotes are set yet
             remotes: vec![],
             remote_name: None,
@@ -156,15 +156,15 @@ impl LocalRepository {
 
     /// Load an older version of a repository with older oxen core logic
     pub fn new_from_version(
-        path: impl AsRef<Path>,
-        min_version: impl AsRef<str>,
+        path: &Path,
+        min_version: &str,
         storage_opts: Option<StorageOpts>,
     ) -> Result<LocalRepository, OxenError> {
         let mut repo = LocalRepository {
-            path: path.as_ref().to_path_buf(),
+            path: path.to_path_buf(),
             remotes: vec![],
             remote_name: None,
-            min_version: Some(min_version.as_ref().to_string()),
+            min_version: Some(min_version.to_string()),
             vnode_size: None,
             subtree_paths: None,
             depth: None,
@@ -232,8 +232,8 @@ impl LocalRepository {
         }
     }
 
-    pub fn set_remote_name(&mut self, name: impl AsRef<str>) {
-        self.remote_name = Some(name.as_ref().to_string());
+    pub fn set_remote_name(&mut self, name: &str) {
+        self.remote_name = Some(name.to_string());
     }
 
     pub fn set_min_version(&mut self, version: MinOxenVersion) {
@@ -315,11 +315,11 @@ impl LocalRepository {
                             OxenError::basic_str("Storage settings missing 'path' key")
                         })?;
                         let storage_path = if util::fs::is_relative_to_dir(
-                            path,
-                            util::fs::oxen_hidden_dir(&self.path),
+                            Path::new(path),
+                            &util::fs::oxen_hidden_dir(&self.path),
                         ) {
                             // If path is within .oxen (default location), use the relative path in case the repo was moved
-                            util::fs::path_relative_to_dir(path, &self.path)
+                            util::fs::path_relative_to_dir(Path::new(path), &self.path)
                                 .unwrap()
                                 .to_string_lossy()
                                 .into_owned()
@@ -358,10 +358,8 @@ impl LocalRepository {
         config.save(&config_path)
     }
 
-    pub fn set_remote(&mut self, name: impl AsRef<str>, url: impl AsRef<str>) -> Remote {
-        self.remote_name = Some(name.as_ref().to_owned());
-        let name = name.as_ref();
-        let url = url.as_ref();
+    pub fn set_remote(&mut self, name: &str, url: &str) -> Remote {
+        self.remote_name = Some(name.to_owned());
         let remote = Remote {
             name: name.to_owned(),
             url: url.to_owned(),
@@ -380,8 +378,7 @@ impl LocalRepository {
         remote
     }
 
-    pub fn delete_remote(&mut self, name: impl AsRef<str>) {
-        let name = name.as_ref();
+    pub fn delete_remote(&mut self, name: &str) {
         let mut new_remotes: Vec<Remote> = vec![];
         for i in 0..self.remotes.len() {
             if self.remotes[i].name != name {
@@ -391,8 +388,7 @@ impl LocalRepository {
         self.remotes = new_remotes;
     }
 
-    pub fn has_remote(&self, name: impl AsRef<str>) -> bool {
-        let name = name.as_ref();
+    pub fn has_remote(&self, name: &str) -> bool {
         for remote in self.remotes.iter() {
             if remote.name == name {
                 return true;
@@ -401,8 +397,7 @@ impl LocalRepository {
         false
     }
 
-    pub fn get_remote(&self, name: impl AsRef<str>) -> Option<Remote> {
-        let name = name.as_ref();
+    pub fn get_remote(&self, name: &str) -> Option<Remote> {
         log::trace!("Checking for remote {name} have {}", self.remotes.len());
         for remote in self.remotes.iter() {
             log::trace!("comparing: {name} -> {}", remote.name);
@@ -421,8 +416,8 @@ impl LocalRepository {
         }
     }
 
-    pub fn add_workspace(&mut self, name: impl AsRef<str>) {
-        let workspace_name = name.as_ref();
+    pub fn add_workspace(&mut self, name: &str) {
+        let workspace_name = name;
         let workspaces = self.workspaces.clone().unwrap_or_default();
 
         let mut new_workspaces = HashSet::new();
@@ -434,11 +429,9 @@ impl LocalRepository {
         self.workspaces = Some(new_workspaces.iter().cloned().collect());
     }
 
-    pub fn delete_workspace(&mut self, name: impl AsRef<str>) -> Result<(), OxenError> {
-        let name = name.as_ref();
-
+    pub fn delete_workspace(&mut self, name: &str) -> Result<(), OxenError> {
         if self.workspaces.is_none() {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Error: Cannot delete workspace {name:?} as it does not exist"
             )));
         }
@@ -462,8 +455,8 @@ impl LocalRepository {
         Ok(())
     }
 
-    pub fn has_workspace(&self, name: impl AsRef<str>) -> bool {
-        let workspace_name = name.as_ref();
+    pub fn has_workspace(&self, name: &str) -> bool {
+        let workspace_name = name;
         self.workspaces.is_some()
             && self
                 .workspaces
@@ -473,8 +466,8 @@ impl LocalRepository {
     }
 
     // TODO: Should we define setting a workspace that's not in the workspaces vec to be an error?
-    pub fn set_workspace(&mut self, name: impl AsRef<str>) -> Result<(), OxenError> {
-        let workspace_name = name.as_ref();
+    pub fn set_workspace(&mut self, name: &str) -> Result<(), OxenError> {
+        let workspace_name = name;
 
         if let Some(ws_name) = self
             .workspaces
@@ -567,7 +560,7 @@ mod tests {
     fn test_add_workspace() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
         let repo_path = temp_dir.path().to_path_buf();
-        let mut repo = LocalRepository::new(repo_path, None)?;
+        let mut repo = LocalRepository::new(&repo_path, None)?;
 
         let sample_name = "sample";
         repo.add_workspace(sample_name);
@@ -585,7 +578,7 @@ mod tests {
     fn test_cannot_add_repeat_workspace() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
         let repo_path = temp_dir.path().to_path_buf();
-        let mut repo = LocalRepository::new(repo_path, None)?;
+        let mut repo = LocalRepository::new(&repo_path, None)?;
 
         let sample_name = "sample";
         repo.add_workspace(sample_name);
@@ -598,7 +591,7 @@ mod tests {
     fn test_delete_workspace() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
         let repo_path = temp_dir.path().to_path_buf();
-        let mut repo = LocalRepository::new(repo_path, None)?;
+        let mut repo = LocalRepository::new(&repo_path, None)?;
 
         let sample_name = "sample";
         repo.add_workspace(sample_name);

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -82,7 +82,9 @@ impl LocalRepository {
     pub fn version_store(&self) -> Result<Arc<dyn VersionStore>, OxenError> {
         match &self.version_store {
             Some(store) => Ok(Arc::clone(store)),
-            None => Err(OxenError::basic_str("Version store not initialized")),
+            None => Err(OxenError::basic_str(
+                "Version store not initialized".to_string(),
+            )),
         }
     }
 
@@ -117,7 +119,7 @@ impl LocalRepository {
     pub fn from_current_dir() -> Result<LocalRepository, OxenError> {
         let current_dir = std::env::current_dir().map_err(OxenError::from)?;
         let repo_dir = util::fs::get_repo_root_from_current_dir()
-            .ok_or_else(|| OxenError::local_repo_not_found(&current_dir))?;
+            .ok_or_else(|| OxenError::local_repo_not_found(current_dir))?;
 
         LocalRepository::from_dir(&repo_dir)
     }
@@ -312,7 +314,7 @@ impl LocalRepository {
                 match store.storage_type() {
                     "local" => {
                         let path = settings.get("path").ok_or_else(|| {
-                            OxenError::basic_str("Storage settings missing 'path' key")
+                            OxenError::basic_str("Storage settings missing 'path' key".to_string())
                         })?;
                         let storage_path = if util::fs::is_relative_to_dir(
                             Path::new(path),
@@ -431,7 +433,7 @@ impl LocalRepository {
 
     pub fn delete_workspace(&mut self, name: &str) -> Result<(), OxenError> {
         if self.workspaces.is_none() {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Error: Cannot delete workspace {name:?} as it does not exist"
             )));
         }
@@ -440,7 +442,7 @@ impl LocalRepository {
         // This seems like an impossible scenario...
         if self.workspace_name.is_some() && name == self.workspace_name.as_ref().unwrap() {
             return Err(OxenError::basic_str(
-                "Error: Cannot delete current workspace",
+                "Error: Cannot delete current workspace".to_string(),
             ));
         }
 

--- a/crates/lib/src/model/repository/repo_new.rs
+++ b/crates/lib/src/model/repository/repo_new.rs
@@ -62,7 +62,7 @@ impl RepoNew {
     /// repo_id is the "{namespace}/{repo_name}"
     pub fn new(repo_id: String, storage_opts: Option<StorageOpts>) -> Result<RepoNew, OxenError> {
         if !repo_id.contains('/') {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Invalid repo id: {repo_id:?}"
             )));
         }
@@ -166,7 +166,7 @@ impl RepoNew {
         let mut split_path: Vec<&str> = uri.path().split('/').collect();
 
         if split_path.len() < 3 {
-            return Err(OxenError::basic_str("Invalid repo url"));
+            return Err(OxenError::basic_str("Invalid repo url".to_string()));
         }
 
         // Pop in reverse to get repo_name then namespace

--- a/crates/lib/src/model/repository/repo_new.rs
+++ b/crates/lib/src/model/repository/repo_new.rs
@@ -56,13 +56,13 @@ impl RepoNew {
     pub fn scheme(&self) -> String {
         self.scheme
             .clone()
-            .unwrap_or_else(|| RepoNew::scheme_default(self.host()))
+            .unwrap_or_else(|| RepoNew::scheme_default(&self.host()))
     }
 
     /// repo_id is the "{namespace}/{repo_name}"
     pub fn new(repo_id: String, storage_opts: Option<StorageOpts>) -> Result<RepoNew, OxenError> {
         if !repo_id.contains('/') {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Invalid repo id: {repo_id:?}"
             )));
         }
@@ -75,7 +75,7 @@ impl RepoNew {
             name: repo_name,
             is_public: None,
             host: Some(String::from(DEFAULT_HOST)),
-            scheme: Some(RepoNew::scheme_default(String::from(DEFAULT_HOST))),
+            scheme: Some(RepoNew::scheme_default(DEFAULT_HOST)),
             root_commit: None,
             description: None,
             files: None,
@@ -83,8 +83,7 @@ impl RepoNew {
         })
     }
 
-    pub fn scheme_default(host: impl AsRef<str>) -> String {
-        let host = host.as_ref();
+    pub fn scheme_default(host: &str) -> String {
         if host.contains("localhost") || host.contains("127.0.0.1") || host.contains("0.0.0.0") {
             "http".to_string()
         } else {
@@ -93,15 +92,15 @@ impl RepoNew {
     }
 
     pub fn from_namespace_name(
-        namespace: impl AsRef<str>,
-        name: impl AsRef<str>,
+        namespace: &str,
+        name: &str,
         storage_opts: Option<StorageOpts>,
     ) -> RepoNew {
         RepoNew {
-            namespace: String::from(namespace.as_ref()),
-            name: String::from(name.as_ref()),
+            namespace: String::from(namespace),
+            name: String::from(name),
             host: Some(String::from(DEFAULT_HOST)),
-            scheme: Some(RepoNew::scheme_default(String::from(DEFAULT_HOST))),
+            scheme: Some(RepoNew::scheme_default(DEFAULT_HOST)),
             is_public: None,
             root_commit: None,
             description: None,
@@ -111,16 +110,16 @@ impl RepoNew {
     }
 
     pub fn from_namespace_name_host(
-        namespace: impl AsRef<str>,
-        name: impl AsRef<str>,
-        host: impl AsRef<str>,
+        namespace: &str,
+        name: &str,
+        host: &str,
         storage_opts: Option<StorageOpts>,
     ) -> RepoNew {
         RepoNew {
-            namespace: String::from(namespace.as_ref()),
-            name: String::from(name.as_ref()),
+            namespace: String::from(namespace),
+            name: String::from(name),
             is_public: None,
-            host: Some(String::from(host.as_ref())),
+            host: Some(String::from(host)),
             scheme: Some(RepoNew::scheme_default(host)),
             root_commit: None,
             description: None,
@@ -129,17 +128,13 @@ impl RepoNew {
         }
     }
 
-    pub fn from_root_commit(
-        namespace: impl AsRef<str>,
-        name: impl AsRef<str>,
-        root_commit: Commit,
-    ) -> RepoNew {
+    pub fn from_root_commit(namespace: &str, name: &str, root_commit: Commit) -> RepoNew {
         RepoNew {
-            namespace: String::from(namespace.as_ref()),
-            name: String::from(name.as_ref()),
+            namespace: String::from(namespace),
+            name: String::from(name),
             is_public: None,
             host: Some(String::from(DEFAULT_HOST)),
-            scheme: Some(RepoNew::scheme_default(String::from(DEFAULT_HOST))),
+            scheme: Some(RepoNew::scheme_default(DEFAULT_HOST)),
             root_commit: Some(root_commit),
             description: None,
             files: None,
@@ -148,17 +143,17 @@ impl RepoNew {
     }
 
     pub fn from_files(
-        namespace: impl AsRef<str>,
-        name: impl AsRef<str>,
+        namespace: &str,
+        name: &str,
         files: Vec<FileNew>,
         storage_opts: Option<StorageOpts>,
     ) -> RepoNew {
         RepoNew {
-            namespace: String::from(namespace.as_ref()),
-            name: String::from(name.as_ref()),
+            namespace: String::from(namespace),
+            name: String::from(name),
             is_public: None,
             host: Some(String::from(DEFAULT_HOST)),
-            scheme: Some(RepoNew::scheme_default(String::from(DEFAULT_HOST))),
+            scheme: Some(RepoNew::scheme_default(DEFAULT_HOST)),
             root_commit: None,
             description: None,
             files: Some(files),

--- a/crates/lib/src/model/staged_dir_stats.rs
+++ b/crates/lib/src/model/staged_dir_stats.rs
@@ -15,9 +15,9 @@ pub struct StagedDirStats {
 }
 
 impl StagedDirStats {
-    pub fn from<T: AsRef<Path>>(path: T, status: StagedEntryStatus) -> StagedDirStats {
+    pub fn from(path: &Path, status: StagedEntryStatus) -> StagedDirStats {
         StagedDirStats {
-            path: path.as_ref().to_path_buf(),
+            path: path.to_path_buf(),
             num_files_staged: 0,
             total_files: 0,
             status,

--- a/crates/lib/src/model/staged_row_status.rs
+++ b/crates/lib/src/model/staged_row_status.rs
@@ -16,7 +16,7 @@ impl StagedRowStatus {
             "modified" => Ok(StagedRowStatus::Modified),
             "removed" => Ok(StagedRowStatus::Removed),
             "unchanged" => Ok(StagedRowStatus::Unchanged),
-            _ => Err(OxenError::basic_str("Invalid row status")),
+            _ => Err(OxenError::basic_str("Invalid row status".to_string())),
         }
     }
 }

--- a/crates/lib/src/model/workspace.rs
+++ b/crates/lib/src/model/workspace.rs
@@ -45,12 +45,12 @@ impl Workspace {
         Self::workspace_dir(&self.base_repo, &workspace_id_hash)
     }
 
-    pub fn config_path_from_dir(dir: impl AsRef<Path>) -> PathBuf {
-        dir.as_ref().join(OXEN_HIDDEN_DIR).join(WORKSPACE_CONFIG)
+    pub fn config_path_from_dir(dir: &Path) -> PathBuf {
+        dir.join(OXEN_HIDDEN_DIR).join(WORKSPACE_CONFIG)
     }
 
     pub fn config_path(&self) -> PathBuf {
-        Self::config_path_from_dir(self.dir())
+        Self::config_path_from_dir(&self.dir())
     }
 }
 

--- a/crates/lib/src/namespaces.rs
+++ b/crates/lib/src/namespaces.rs
@@ -69,7 +69,7 @@ fn get_storage_for_repo(repo: &LocalRepository) -> Result<u64, OxenError> {
             }
             repositories::size::SizeStatus::Error => {
                 log::warn!("Size calculation failed, returning 0");
-                Err(OxenError::basic_str("Size calculation failed"))
+                Err(OxenError::basic_str("Size calculation failed".to_string()))
             }
         },
         Err(e) => {

--- a/crates/lib/src/opts/clone_opts.rs
+++ b/crates/lib/src/opts/clone_opts.rs
@@ -21,25 +21,21 @@ pub struct CloneOpts {
 
 impl CloneOpts {
     /// Sets `branch` to `DEFAULT_BRANCH_NAME` and defaults `all` to `false`
-    pub fn new(url: impl AsRef<str>, dst: impl AsRef<Path>) -> CloneOpts {
+    pub fn new(url: &str, dst: &Path) -> CloneOpts {
         CloneOpts {
-            url: url.as_ref().to_string(),
-            dst: dst.as_ref().to_path_buf(),
+            url: url.to_string(),
+            dst: dst.to_path_buf(),
             fetch_opts: FetchOpts::new(),
-            storage_opts: StorageOpts::from_path(dst.as_ref(), true),
+            storage_opts: StorageOpts::from_path(dst, true),
             is_vfs: false,
             is_remote: false,
         }
     }
 
-    pub fn from_branch(
-        url: impl AsRef<str>,
-        dst: impl AsRef<Path>,
-        branch: impl AsRef<str>,
-    ) -> CloneOpts {
+    pub fn from_branch(url: &str, dst: &Path, branch: &str) -> CloneOpts {
         CloneOpts {
-            fetch_opts: FetchOpts::from_branch(branch.as_ref()),
-            storage_opts: StorageOpts::from_path(dst.as_ref(), true),
+            fetch_opts: FetchOpts::from_branch(branch),
+            storage_opts: StorageOpts::from_path(dst, true),
             is_vfs: false,
             is_remote: false,
             ..CloneOpts::new(url, dst)

--- a/crates/lib/src/opts/embedding_query_opts.rs
+++ b/crates/lib/src/opts/embedding_query_opts.rs
@@ -18,7 +18,7 @@ impl EmbeddingQueryOpts {
         let parts: Vec<&str> = self.query.split('=').collect();
         if parts.len() != 2 {
             return Err(OxenError::basic_str(
-                "Query must be in the format key=value",
+                "Query must be in the format key=value".to_string(),
             ));
         }
         Ok((parts[0].trim().to_string(), parts[1].trim().to_string()))

--- a/crates/lib/src/opts/fetch_opts.rs
+++ b/crates/lib/src/opts/fetch_opts.rs
@@ -41,9 +41,9 @@ impl FetchOpts {
         }
     }
 
-    pub fn from_branch(branch: impl AsRef<str>) -> FetchOpts {
+    pub fn from_branch(branch: &str) -> FetchOpts {
         FetchOpts {
-            branch: branch.as_ref().to_string(),
+            branch: branch.to_string(),
             ..FetchOpts::new()
         }
     }

--- a/crates/lib/src/opts/helpers.rs
+++ b/crates/lib/src/opts/helpers.rs
@@ -12,7 +12,9 @@ pub async fn remote_commit_id(
         // Fallback to main branch
         let main_branch = api::client::branches::get_by_name(repo, DEFAULT_BRANCH_NAME).await?;
         if main_branch.is_none() {
-            return Err(OxenError::basic_str("No main branch found on remote."));
+            return Err(OxenError::basic_str(
+                "No main branch found on remote.".to_string(),
+            ));
         }
         return Ok(main_branch.unwrap().commit_id);
     };
@@ -31,5 +33,7 @@ pub async fn remote_commit_id(
     }
 
     // Should not get here
-    Err(OxenError::basic_str("No remote commit specified."))
+    Err(OxenError::basic_str(
+        "No remote commit specified.".to_string(),
+    ))
 }

--- a/crates/lib/src/opts/restore_opts.rs
+++ b/crates/lib/src/opts/restore_opts.rs
@@ -10,9 +10,9 @@ pub struct RestoreOpts {
 }
 
 impl RestoreOpts {
-    pub fn from_path<P: AsRef<Path>>(path: P) -> RestoreOpts {
+    pub fn from_path(path: &Path) -> RestoreOpts {
         let mut paths = HashSet::new();
-        paths.insert(path.as_ref().to_owned());
+        paths.insert(path.to_owned());
 
         RestoreOpts {
             paths,
@@ -22,9 +22,9 @@ impl RestoreOpts {
         }
     }
 
-    pub fn from_staged_path<P: AsRef<Path>>(path: P) -> RestoreOpts {
+    pub fn from_staged_path(path: &Path) -> RestoreOpts {
         let mut paths = HashSet::new();
-        paths.insert(path.as_ref().to_owned());
+        paths.insert(path.to_owned());
 
         RestoreOpts {
             paths,
@@ -34,15 +34,15 @@ impl RestoreOpts {
         }
     }
 
-    pub fn from_path_ref<P: AsRef<Path>, S: AsRef<str>>(path: P, source_ref: S) -> RestoreOpts {
+    pub fn from_path_ref(path: &Path, source_ref: &str) -> RestoreOpts {
         let mut paths = HashSet::new();
-        paths.insert(path.as_ref().to_owned());
+        paths.insert(path.to_owned());
 
         RestoreOpts {
             paths,
             staged: false,
             is_remote: false,
-            source_ref: Some(source_ref.as_ref().to_owned()),
+            source_ref: Some(source_ref.to_owned()),
         }
     }
 }

--- a/crates/lib/src/opts/rm_opts.rs
+++ b/crates/lib/src/opts/rm_opts.rs
@@ -25,36 +25,36 @@ impl RmOpts {
     }
 
     /// Sets path and defaults all other options to false
-    pub fn from_path<P: AsRef<Path>>(path: P) -> RmOpts {
+    pub fn from_path(path: &Path) -> RmOpts {
         RmOpts {
-            path: path.as_ref().to_owned(),
+            path: path.to_owned(),
             staged: false,
             recursive: false,
         }
     }
 
     /// Sets `staged = true` to remove file from the staging index
-    pub fn from_staged_path<P: AsRef<Path>>(path: P) -> RmOpts {
+    pub fn from_staged_path(path: &Path) -> RmOpts {
         RmOpts {
-            path: path.as_ref().to_owned(),
+            path: path.to_owned(),
             staged: true,
             recursive: false,
         }
     }
 
     /// Sets `recursive = true` to remove dir
-    pub fn from_path_recursive<P: AsRef<Path>>(path: P) -> RmOpts {
+    pub fn from_path_recursive(path: &Path) -> RmOpts {
         RmOpts {
-            path: path.as_ref().to_owned(),
+            path: path.to_owned(),
             staged: false,
             recursive: true,
         }
     }
 
     /// Updates the `path` and copies values from `opts`
-    pub fn from_path_opts<P: AsRef<Path>>(path: P, opts: &RmOpts) -> RmOpts {
+    pub fn from_path_opts(path: &Path, opts: &RmOpts) -> RmOpts {
         RmOpts {
-            path: path.as_ref().to_owned(),
+            path: path.to_owned(),
             staged: opts.staged,
             recursive: opts.recursive,
         }

--- a/crates/lib/src/opts/storage_opts.rs
+++ b/crates/lib/src/opts/storage_opts.rs
@@ -47,7 +47,7 @@ impl StorageOpts {
                 let bucket = config
                     .settings
                     .get("bucket")
-                    .ok_or_else(|| OxenError::basic_str("S3 bucket not specified"))?;
+                    .ok_or_else(|| OxenError::basic_str("S3 bucket not specified".to_string()))?;
 
                 let prefix = config
                     .settings
@@ -68,7 +68,7 @@ impl StorageOpts {
                     s3_opts: Some(s3_opts),
                 })
             }
-            _ => Err(OxenError::basic_str(&format!(
+            _ => Err(OxenError::basic_str(format!(
                 "Unsupported async storage type: {}",
                 config.type_
             ))),
@@ -108,7 +108,8 @@ impl StorageOpts {
                 "local" => {
                     if storage_backend_bucket.is_some() {
                         return Err(OxenError::basic_str(
-                            "Error: storage-backend-bucket should not be set when storage-backend is local",
+                            "Error: storage-backend-bucket should not be set when storage-backend is local".to_string(),
+
                         ));
                     }
                     if let Some(storage_path) = storage_backend_path {
@@ -126,11 +127,11 @@ impl StorageOpts {
                 }
                 "s3" => {
                     let bucket = storage_backend_bucket.ok_or(OxenError::basic_str(
-                        "storage-backend-bucket is required when storage-backend is s3",
+                        "storage-backend-bucket is required when storage-backend is s3".to_string(),
                     ))?;
 
                     let prefix = storage_backend_path.ok_or(OxenError::basic_str(
-                        "storage-backend-path is required when storage-backend is s3",
+                        "storage-backend-path is required when storage-backend is s3".to_string(),
                     ))?;
 
                     Ok(Some(StorageOpts {
@@ -143,7 +144,7 @@ impl StorageOpts {
                     }))
                 }
                 _ => Err(OxenError::basic_str(
-                    "storage-backend can only be local or s3",
+                    "storage-backend can only be local or s3".to_string(),
                 )),
             }
         } else {

--- a/crates/lib/src/opts/storage_opts.rs
+++ b/crates/lib/src/opts/storage_opts.rs
@@ -68,7 +68,7 @@ impl StorageOpts {
                     s3_opts: Some(s3_opts),
                 })
             }
-            _ => Err(OxenError::basic_str(format!(
+            _ => Err(OxenError::basic_str(&format!(
                 "Unsupported async storage type: {}",
                 config.type_
             ))),

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -72,11 +72,9 @@ pub use status::status_from_dir;
 
 pub fn get_by_namespace_and_name(
     sync_dir: &Path,
-    namespace: impl AsRef<str>,
-    name: impl AsRef<str>,
+    namespace: &str,
+    name: &str,
 ) -> Result<Option<LocalRepository>, OxenError> {
-    let namespace = namespace.as_ref();
-    let name = name.as_ref();
     let repo_dir = sync_dir.join(namespace).join(name);
 
     if !repo_dir.exists() {
@@ -253,7 +251,7 @@ pub async fn create(
 
     // Create history dir
     let history_dir = util::fs::oxen_hidden_dir(&repo_dir).join(constants::HISTORY_DIR);
-    util::fs::create_dir_all(history_dir)?;
+    util::fs::create_dir_all(&history_dir)?;
 
     // Create HEAD file and point it to DEFAULT_BRANCH_NAME
     with_ref_manager(&local_repo, |manager| {
@@ -331,7 +329,7 @@ pub async fn create(
 pub fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {
     if !repo.path.exists() {
         let err = format!("Repository does not exist {:?}", repo.path);
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
     // Close DB instances before trying to delete the directory
@@ -572,9 +570,9 @@ mod tests {
             let namespace_3 = "my-namespace-3";
             let _ = sync_dir.join(namespace_3);
 
-            let _ = repositories::init(namespace_1_dir.join("testing1"))?;
-            let _ = repositories::init(namespace_1_dir.join("testing2"))?;
-            let _ = repositories::init(namespace_2_dir.join("testing3"))?;
+            let _ = repositories::init(&namespace_1_dir.join("testing1"))?;
+            let _ = repositories::init(&namespace_1_dir.join("testing2"))?;
+            let _ = repositories::init(&namespace_2_dir.join("testing3"))?;
 
             let repos = repositories::list_namespaces(sync_dir)?;
             assert_eq!(repos.len(), 2);
@@ -589,9 +587,9 @@ mod tests {
             let namespace = "my-namespace";
             let namespace_dir = sync_dir.join(namespace);
 
-            let _ = repositories::init(namespace_dir.join("testing1"))?;
-            let _ = repositories::init(namespace_dir.join("testing2"))?;
-            let _ = repositories::init(namespace_dir.join("testing3"))?;
+            let _ = repositories::init(&namespace_dir.join("testing1"))?;
+            let _ = repositories::init(&namespace_dir.join("testing2"))?;
+            let _ = repositories::init(&namespace_dir.join("testing3"))?;
 
             let repos = repositories::list_repos_in_namespace(&namespace_dir);
             assert_eq!(repos.len(), 3);

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -99,7 +99,7 @@ fn is_repo_forked(repo_dir: &Path) -> Result<Option<LocalRepository>, OxenError>
     if status_path.exists() {
         Ok(Some(LocalRepository::from_dir(repo_dir)?))
     } else {
-        Err(OxenError::local_repo_not_found(repo_dir))
+        Err(OxenError::local_repo_not_found(repo_dir.to_path_buf()))
     }
 }
 
@@ -198,7 +198,7 @@ pub fn transfer_namespace(
     match updated_repo {
         Some(new_repo) => Ok(new_repo),
         None => Err(OxenError::basic_str(
-            "Repository not found after attempted transfer",
+            "Repository not found after attempted transfer".to_string(),
         )),
     }
 }
@@ -216,12 +216,12 @@ pub async fn create(
 ) -> Result<LocalRepositoryWithEntries, OxenError> {
     // Validate repo name
     if !is_valid_repo_name(&new_repo.name) {
-        return Err(OxenError::invalid_repo_name(&new_repo.name));
+        return Err(OxenError::invalid_repo_name(new_repo.name.clone()));
     }
 
     // Validate namespace
     if !is_valid_repo_name(&new_repo.namespace) {
-        return Err(OxenError::invalid_repo_name(&new_repo.namespace));
+        return Err(OxenError::invalid_repo_name(new_repo.namespace.clone()));
     }
 
     let repo_dir = root_dir
@@ -329,7 +329,7 @@ pub async fn create(
 pub fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {
     if !repo.path.exists() {
         let err = format!("Repository does not exist {:?}", repo.path);
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     // Close DB instances before trying to delete the directory

--- a/crates/lib/src/repositories/add.rs
+++ b/crates/lib/src/repositories/add.rs
@@ -28,20 +28,20 @@ use std::path::Path;
 ///
 /// # util::fs::remove_dir_all(base_dir)?;
 /// ```
-pub async fn add(repo: &LocalRepository, path: impl AsRef<Path>) -> Result<(), OxenError> {
+pub async fn add(repo: &LocalRepository, path: &Path) -> Result<(), OxenError> {
     add_all_with_version(repo, vec![path], repo.min_version()).await
 }
 
-pub async fn add_all<T: AsRef<Path>>(
+pub async fn add_all<'a>(
     repo: &LocalRepository,
-    paths: impl IntoIterator<Item = T>,
+    paths: impl IntoIterator<Item = &'a Path>,
 ) -> Result<(), OxenError> {
     add_all_with_version(repo, paths, repo.min_version()).await
 }
 
-pub async fn add_all_with_version<T: AsRef<Path>>(
+pub async fn add_all_with_version<'a>(
     repo: &LocalRepository,
-    paths: impl IntoIterator<Item = T>,
+    paths: impl IntoIterator<Item = &'a Path>,
     version: MinOxenVersion,
 ) -> Result<(), OxenError> {
     match version {
@@ -68,7 +68,7 @@ mod tests {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![PathBuf::from("")]);
                 opts.fetch_opts.depth = Some(1);
                 let local_repo = repositories::clone::clone(&opts).await?;
@@ -103,7 +103,7 @@ mod tests {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths =
                     Some(vec![PathBuf::from("annotations").join("test")]);
                 let local_repo = repositories::clone::clone(&opts).await?;
@@ -170,14 +170,14 @@ A: Oxen.ai
             // Modify and add the file deep in a sub dir
             let one_shot_path = repo.path.join("annotations/train/one_shot.csv");
             let file_contents = "file,label\ntrain/cat_1.jpg,0";
-            test::modify_txt_file(one_shot_path, file_contents)?;
+            test::modify_txt_file(&one_shot_path, file_contents)?;
             let status = repositories::status(&repo)?;
             println!("status: {status:?}");
             status.print();
             assert_eq!(status.modified_files.len(), 1);
             // Add the top level directory, and make sure the modified file gets added
             let annotation_dir_path = repo.path.join("annotations");
-            repositories::add(&repo, annotation_dir_path).await?;
+            repositories::add(&repo, &annotation_dir_path).await?;
             let status = repositories::status(&repo)?;
             status.print();
             assert_eq!(status.staged_files.len(), 1);
@@ -311,7 +311,7 @@ A: Oxen.ai
             repositories::commit(&repo, "adding none category")?;
 
             // Add a "person" category on a the main branch
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             test::modify_txt_file(&labels_path, "cat\ndog\nperson")?;
             repositories::add(&repo, &labels_path).await?;
@@ -326,7 +326,7 @@ A: Oxen.ai
             // Assume that we fixed the conflict and added the file
             let path = status.merge_conflicts[0].base_entry.path.clone();
             let fullpath = repo.path.join(path);
-            repositories::add(&repo, fullpath).await?;
+            repositories::add(&repo, &fullpath).await?;
 
             // Adding should add to added files
             let status = repositories::status(&repo)?;
@@ -346,7 +346,7 @@ A: Oxen.ai
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             let dir = Path::new("nlp");
             let repo_dir = repo.path.join(dir);
-            repositories::add(&repo, repo_dir).await?;
+            repositories::add(&repo, &repo_dir).await?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -373,12 +373,12 @@ A: Oxen.ai
             // Modify and add the file deep in a sub dir
             let one_shot_path = repo.path.join("annotations/train/one_shot.csv");
             let file_contents = "file,label\ntrain/cat_1.jpg,0";
-            test::modify_txt_file(one_shot_path, file_contents)?;
+            test::modify_txt_file(&one_shot_path, file_contents)?;
             let status = repositories::status(&repo)?;
             assert_eq!(status.modified_files.len(), 1);
             // Add the top level directory, and make sure the modified file gets added
             let annotation_dir_path = repo.path.join("annotations/*");
-            repositories::add(&repo, annotation_dir_path).await?;
+            repositories::add(&repo, &annotation_dir_path).await?;
             let status = repositories::status(&repo)?;
             status.print();
             assert_eq!(status.staged_files.len(), 1);
@@ -396,7 +396,7 @@ A: Oxen.ai
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             let dir = Path::new("nlp");
             let repo_dir = repo.path.join(dir);
-            repositories::add(&repo, repo_dir).await?;
+            repositories::add(&repo, &repo_dir).await?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -426,7 +426,7 @@ A: Oxen.ai
             assert_eq!(status.staged_files.len(), 0);
 
             // Add the removed nlp dir with a wildcard
-            repositories::add(&repo, "nlp/*").await?;
+            repositories::add(&repo, Path::new("nlp/*")).await?;
 
             let status = repositories::status(&repo)?;
             assert_eq!(status.staged_dirs.len(), 1);
@@ -442,7 +442,7 @@ A: Oxen.ai
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             let dir = Path::new("nlp/*");
             let repo_dir = repo.path.join(dir);
-            repositories::add(&repo, repo_dir).await?;
+            repositories::add(&repo, &repo_dir).await?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -476,7 +476,7 @@ A: Oxen.ai
                 status
                     .untracked_dirs
                     .iter()
-                    .any(|(path, _)| *path == PathBuf::from("empty_dir"))
+                    .any(|(path, _)| path == Path::new("empty_dir"))
             );
 
             // Add the empty dir
@@ -615,7 +615,7 @@ A: Oxen.ai
             repositories::branches::create_checkout(&repo, branch_name)?;
 
             let file_contents = "file,label\ntrain/cat_1.jpg,0\n";
-            let one_shot_path = test::modify_txt_file(one_shot_path, file_contents)?;
+            let one_shot_path = test::modify_txt_file(&one_shot_path, file_contents)?;
             let status = repositories::status(&repo)?;
             status.print();
             assert_eq!(status.modified_files.len(), 1);
@@ -649,13 +649,13 @@ A: Oxen.ai
             // train/dog_1.jpg, train/dog_2.jpg, train/dog_3.jpg, train/dog_4.jpg
 
             // Add only the cats
-            repositories::add(&repo, "train/cat_*.jpg").await?;
+            repositories::add(&repo, Path::new("train/cat_*.jpg")).await?;
             let status = repositories::status(&repo)?;
 
             assert_eq!(status.staged_files.len(), 3);
 
             // Add the dogs
-            repositories::add(&repo, "train/dog_*.jpg").await?;
+            repositories::add(&repo, Path::new("train/dog_*.jpg")).await?;
             let status = repositories::status(&repo)?;
 
             // Should stage all 7 files now

--- a/crates/lib/src/repositories/branches.rs
+++ b/crates/lib/src/repositories/branches.rs
@@ -30,10 +30,9 @@ pub fn get_by_name(repo: &LocalRepository, name: &str) -> Result<Option<Branch>,
 /// Get branch by name or fall back the current
 pub fn get_by_name_or_current(
     repo: &LocalRepository,
-    branch_name: Option<impl AsRef<str>>,
+    branch_name: Option<&str>,
 ) -> Result<Branch, OxenError> {
     if let Some(branch_name) = branch_name {
-        let branch_name = branch_name.as_ref();
         match repositories::branches::get_by_name(repo, branch_name)? {
             Some(branch) => Ok(branch),
             None => Err(OxenError::local_branch_not_found(branch_name)),
@@ -70,24 +69,13 @@ pub fn current_branch(repo: &LocalRepository) -> Result<Option<Branch>, OxenErro
 /// # Create a new branch from the head commit
 /// This creates a new pointer to the current commit with a name,
 /// it does not switch you to this branch, you still must call `checkout_branch`
-pub fn create_from_head(
-    repo: &LocalRepository,
-    name: impl AsRef<str>,
-) -> Result<Branch, OxenError> {
-    let name = name.as_ref();
+pub fn create_from_head(repo: &LocalRepository, name: &str) -> Result<Branch, OxenError> {
     let head_commit = repositories::commits::head_commit(repo)?;
     with_ref_manager(repo, |manager| manager.create_branch(name, &head_commit.id))
 }
 
 /// # Create a local branch from a specific commit id
-pub fn create(
-    repo: &LocalRepository,
-    name: impl AsRef<str>,
-    commit_id: impl AsRef<str>,
-) -> Result<Branch, OxenError> {
-    let name = name.as_ref();
-    let commit_id = commit_id.as_ref();
-
+pub fn create(repo: &LocalRepository, name: &str, commit_id: &str) -> Result<Branch, OxenError> {
     if repositories::commits::commit_id_exists(repo, commit_id)? {
         with_ref_manager(repo, |manager| manager.create_branch(name, commit_id))
     } else {
@@ -98,27 +86,20 @@ pub fn create(
 /// # Create a branch and check it out in one go
 /// This creates a branch with name,
 /// then switches HEAD to point to the branch
-pub fn create_checkout(repo: &LocalRepository, name: impl AsRef<str>) -> Result<Branch, OxenError> {
-    let name = name.as_ref();
+pub fn create_checkout(repo: &LocalRepository, name: &str) -> Result<Branch, OxenError> {
     let name = util::fs::linux_path_str(name);
     println!("Create and checkout branch: {name}");
     let head_commit = repositories::commits::head_commit(repo)?;
 
     with_ref_manager(repo, |manager| {
         let branch = manager.create_branch(&name, &head_commit.id)?;
-        manager.set_head(name);
+        manager.set_head(&name);
         Ok(branch)
     })
 }
 
 /// Update the branch name to point to a commit id
-pub fn update(
-    repo: &LocalRepository,
-    name: impl AsRef<str>,
-    commit_id: impl AsRef<str>,
-) -> Result<Branch, OxenError> {
-    let name = name.as_ref();
-    let commit_id = commit_id.as_ref();
+pub fn update(repo: &LocalRepository, name: &str, commit_id: &str) -> Result<Branch, OxenError> {
     with_ref_manager(repo, |manager| {
         if let Some(branch) = manager.get_branch_by_name(name)? {
             // Set the branch to point to the commit
@@ -131,14 +112,13 @@ pub fn update(
 }
 
 /// Delete a local branch
-pub fn delete(repo: &LocalRepository, name: impl AsRef<str>) -> Result<Branch, OxenError> {
-    let name = name.as_ref();
+pub fn delete(repo: &LocalRepository, name: &str) -> Result<Branch, OxenError> {
     // Make sure they don't delete the current checked out branch
     if let Ok(Some(branch)) = current_branch(repo)
         && branch.name == name
     {
         let err = format!("Err: Cannot delete current checked out branch '{name}'");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
     if branch_has_been_merged(repo, name)? {
@@ -147,19 +127,18 @@ pub fn delete(repo: &LocalRepository, name: impl AsRef<str>) -> Result<Branch, O
         let err = format!(
             "Err: The branch '{name}' is not fully merged.\nIf you are sure you want to delete it, run 'oxen branch -D {name}'."
         );
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }
 
 /// # Force delete a local branch
 /// Caution! Will delete a local branch without checking if it has been merged or pushed.
-pub fn force_delete(repo: &LocalRepository, name: impl AsRef<str>) -> Result<Branch, OxenError> {
-    let name = name.as_ref();
+pub fn force_delete(repo: &LocalRepository, name: &str) -> Result<Branch, OxenError> {
     if let Ok(Some(branch)) = current_branch(repo)
         && branch.name == name
     {
         let err = format!("Err: Cannot delete current checked out branch '{name}'");
-        return Err(OxenError::basic_str(err));
+        return Err(OxenError::basic_str(&err));
     }
 
     with_ref_manager(repo, |manager| manager.delete_branch(name))
@@ -180,10 +159,9 @@ pub fn is_checked_out(repo: &LocalRepository, name: &str) -> bool {
 /// Checkout a branch
 pub async fn checkout_branch_from_commit(
     repo: &LocalRepository,
-    name: impl AsRef<str>,
+    name: &str,
     from_commit: &Option<Commit>,
 ) -> Result<(), OxenError> {
-    let name = name.as_ref();
     log::debug!("checkout_branch {name}");
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -220,8 +198,8 @@ pub async fn checkout_commit_from_commit(
     }
 }
 
-pub fn set_head(repo: &LocalRepository, value: impl AsRef<str>) -> Result<(), OxenError> {
-    log::debug!("set_head {}", value.as_ref());
+pub fn set_head(repo: &LocalRepository, value: &str) -> Result<(), OxenError> {
+    log::debug!("set_head {}", value);
     with_ref_manager(repo, |manager| {
         manager.set_head(value);
         Ok(())
@@ -246,7 +224,7 @@ fn branch_has_been_merged(repo: &LocalRepository, name: &str) -> Result<bool, Ox
             }
         } else {
             let err = format!("Err: The branch '{name}' does not exist.");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     })
 }
@@ -315,7 +293,7 @@ mod tests {
             // Make a dir
             let dir_path = Path::new("test_dir");
             let dir_repo_path = repo.path.join(dir_path);
-            util::fs::create_dir_all(dir_repo_path)?;
+            util::fs::create_dir_all(&dir_repo_path)?;
 
             // File in the dir
             let file_path = dir_path.join(Path::new("test_file.txt"));
@@ -339,7 +317,7 @@ mod tests {
             let file_path_3 = Path::new("test_file_3.txt");
             let file_repo_path_3 = repo.path.join(file_path_3);
 
-            util::fs::write_to_path(file_repo_path_3, "test 3")?;
+            util::fs::write_to_path(&file_repo_path_3, "test 3")?;
             util::fs::write_to_path(&file_repo_path_2, "something different now")?;
             util::fs::write_to_path(&file_repo_path, "something different now")?;
 
@@ -386,7 +364,7 @@ mod tests {
     async fn test_list_branch_versions_branch_off_main() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
             let dir_path = Path::new("test_dir");
-            util::fs::create_dir_all(repo.path.join(dir_path))?;
+            util::fs::create_dir_all(&repo.path.join(dir_path))?;
 
             let file_path = dir_path.join(Path::new("test_file.txt"));
             let file_repo_path = repo.path.join(&file_path);
@@ -406,7 +384,7 @@ mod tests {
             // Add an irrelevant file - aka this isn't changing for commit 3
             let file_path_2 = Path::new("test_file_2.txt");
             let file_repo_path_2 = repo.path.join(file_path_2);
-            util::fs::write_to_path(file_repo_path_2, "test")?;
+            util::fs::write_to_path(&file_repo_path_2, "test")?;
             repositories::add(&repo, &repo.path).await?;
             let _commit_3 = repositories::commit(&repo, "adding test file 3")?;
 
@@ -482,7 +460,7 @@ mod tests {
             repositories::branches::create_checkout(&repo, branch_name)?;
 
             // Must checkout main again before deleting
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             // Now we can delete
             repositories::branches::delete(&repo, branch_name)?;

--- a/crates/lib/src/repositories/branches.rs
+++ b/crates/lib/src/repositories/branches.rs
@@ -118,7 +118,7 @@ pub fn delete(repo: &LocalRepository, name: &str) -> Result<Branch, OxenError> {
         && branch.name == name
     {
         let err = format!("Err: Cannot delete current checked out branch '{name}'");
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     if branch_has_been_merged(repo, name)? {
@@ -127,7 +127,7 @@ pub fn delete(repo: &LocalRepository, name: &str) -> Result<Branch, OxenError> {
         let err = format!(
             "Err: The branch '{name}' is not fully merged.\nIf you are sure you want to delete it, run 'oxen branch -D {name}'."
         );
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 
@@ -138,7 +138,7 @@ pub fn force_delete(repo: &LocalRepository, name: &str) -> Result<Branch, OxenEr
         && branch.name == name
     {
         let err = format!("Err: Cannot delete current checked out branch '{name}'");
-        return Err(OxenError::basic_str(&err));
+        return Err(OxenError::basic_str(err));
     }
 
     with_ref_manager(repo, |manager| manager.delete_branch(name))
@@ -224,7 +224,7 @@ fn branch_has_been_merged(repo: &LocalRepository, name: &str) -> Result<bool, Ox
             }
         } else {
             let err = format!("Err: The branch '{name}' does not exist.");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     })
 }

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -14,11 +14,7 @@ use crate::{repositories, util};
 /// # Checkout a branch or commit id
 /// This switches HEAD to point to the branch name or commit id,
 /// it also updates all the local files to be from the commit that this branch references
-pub async fn checkout(
-    repo: &LocalRepository,
-    value: impl AsRef<str>,
-) -> Result<Option<Branch>, OxenError> {
-    let value = value.as_ref();
+pub async fn checkout(repo: &LocalRepository, value: &str) -> Result<Option<Branch>, OxenError> {
     log::debug!("--- CHECKOUT START {value} ----");
     if repositories::branches::exists(repo, value)? {
         if repositories::branches::is_checked_out(repo, value) {
@@ -67,26 +63,20 @@ pub async fn checkout(
 
 /// # Checkout a file and take their changes
 /// This overwrites the current file with the changes in the branch we are merging in
-pub async fn checkout_theirs(
-    repo: &LocalRepository,
-    path: impl AsRef<Path>,
-) -> Result<(), OxenError> {
+pub async fn checkout_theirs(repo: &LocalRepository, path: &Path) -> Result<(), OxenError> {
     let conflicts = repositories::merge::list_conflicts(repo)?;
     log::debug!(
         "checkout_theirs {:?} conflicts.len() {}",
-        path.as_ref(),
+        path,
         conflicts.len()
     );
 
     // find the path that matches in the conflict, throw error if !found
-    if let Some(conflict) = conflicts
-        .iter()
-        .find(|c| c.merge_entry.path == path.as_ref())
-    {
+    if let Some(conflict) = conflicts.iter().find(|c| c.merge_entry.path == path) {
         // Lookup the file for the merge commit entry and copy it over
         repositories::restore::restore(
             repo,
-            RestoreOpts::from_path_ref(path, conflict.merge_entry.commit_id.clone()),
+            RestoreOpts::from_path_ref(path, &conflict.merge_entry.commit_id.clone()),
         )
         .await
     } else {
@@ -96,26 +86,20 @@ pub async fn checkout_theirs(
 
 /// # Checkout a file and take our changes
 /// This overwrites the current file with the changes we had in our current branch
-pub async fn checkout_ours(
-    repo: &LocalRepository,
-    path: impl AsRef<Path>,
-) -> Result<(), OxenError> {
+pub async fn checkout_ours(repo: &LocalRepository, path: &Path) -> Result<(), OxenError> {
     let conflicts = repositories::merge::list_conflicts(repo)?;
     log::debug!(
         "checkout_ours {:?} conflicts.len() {}",
-        path.as_ref(),
+        path,
         conflicts.len()
     );
 
     // find the path that matches in the conflict, throw error if !found
-    if let Some(conflict) = conflicts
-        .iter()
-        .find(|c| c.merge_entry.path == path.as_ref())
-    {
+    if let Some(conflict) = conflicts.iter().find(|c| c.merge_entry.path == path) {
         // Lookup the file for the base commit entry and copy it over
         repositories::restore(
             repo,
-            RestoreOpts::from_path_ref(path, conflict.base_entry.commit_id.clone()),
+            RestoreOpts::from_path_ref(path, &conflict.base_entry.commit_id.clone()),
         )
         .await
     } else {
@@ -125,22 +109,16 @@ pub async fn checkout_ours(
 
 /// # Combine Conflicting Tabular Data Files
 /// This overwrites the current file with the changes in their file
-pub async fn checkout_combine<P: AsRef<Path>>(
-    repo: &LocalRepository,
-    path: P,
-) -> Result<(), OxenError> {
+pub async fn checkout_combine(repo: &LocalRepository, path: &Path) -> Result<(), OxenError> {
     let conflicts = repositories::merge::list_conflicts(repo)?;
 
     log::debug!(
         "checkout_combine checking path {:?} -> [{}] conflicts",
-        path.as_ref(),
+        path,
         conflicts.len()
     );
     // find the path that matches in the conflict, throw error if !found
-    if let Some(conflict) = conflicts
-        .iter()
-        .find(|c| c.merge_entry.path == path.as_ref())
-    {
+    if let Some(conflict) = conflicts.iter().find(|c| c.merge_entry.path == path) {
         if util::fs::is_tabular(&conflict.base_entry.path) {
             let version_store = repo.version_store()?;
             let df_base_path = version_store
@@ -159,7 +137,7 @@ pub async fn checkout_combine<P: AsRef<Path>>(
                 .await?;
             let df_merge = tabular::maybe_read_df_with_extension(
                 repo,
-                df_merge_path,
+                &df_merge_path,
                 &conflict.merge_entry.path,
                 &conflict.merge_entry.commit_id,
                 &DFOpts::empty(),
@@ -244,7 +222,7 @@ mod tests {
             assert!(world_file.exists());
 
             // We checkout the previous commit
-            repositories::checkout(&repo, first_commit.id).await?;
+            repositories::checkout(&repo, &first_commit.id).await?;
 
             // // Then we do not have the world file anymore
             assert!(!world_file.exists());
@@ -297,7 +275,7 @@ mod tests {
             assert!(branch_file.exists());
 
             // Checkout the previous commit
-            repositories::checkout(&repo, first_commit.id).await?;
+            repositories::checkout(&repo, &first_commit.id).await?;
 
             // Then we do not have the branch file anymore
             assert!(!branch_file.exists());
@@ -409,7 +387,7 @@ mod tests {
             assert!(world_file.exists());
 
             // Go back to the main branch
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
 
             // The world file should no longer be there
             assert!(hello_file.exists());
@@ -460,15 +438,15 @@ mod tests {
             repositories::commit(&repo, "Added world.txt")?;
 
             // Modify the hello file on the branch
-            let hello_file = test::modify_txt_file(hello_file, "Hello from branch")?;
+            let hello_file = test::modify_txt_file(&hello_file, "Hello from branch")?;
             repositories::add(&repo, &hello_file).await?;
             repositories::commit(&repo, "Changed hello.txt on branch")?;
 
             // Checkout the main branch
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
 
             // Modify the hello file on the main branch
-            let hello_file = test::modify_txt_file(hello_file, "Hello from main")?;
+            let hello_file = test::modify_txt_file(&hello_file, "Hello from main")?;
 
             // Merge the branch into main while there are conflicts
             let result = repositories::merge::merge(&repo, branch_name).await;
@@ -517,12 +495,12 @@ mod tests {
             repositories::commit(&repo, "Added world.txt")?;
 
             // Modify the hello file on the branch
-            let hello_file = test::modify_txt_file(hello_file, "Hello from branch")?;
+            let hello_file = test::modify_txt_file(&hello_file, "Hello from branch")?;
             repositories::add(&repo, &hello_file).await?;
             repositories::commit(&repo, "Changed hello.txt on branch")?;
 
             // Checkout the main branch
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
 
             // Add a new file on main
             let new_file = repo.path.join("new_file.txt");
@@ -582,7 +560,7 @@ mod tests {
             assert!(keep_file.exists());
 
             // Go back to the main branch
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
 
             // The world file should no longer be there
             assert!(hello_file.exists());
@@ -619,7 +597,7 @@ mod tests {
             repositories::branches::create_checkout(&repo, branch_name)?;
 
             // Modify the file
-            let hello_file = test::modify_txt_file(hello_file, "World")?;
+            let hello_file = test::modify_txt_file(&hello_file, "World")?;
 
             // Track & commit the change in the branch
             repositories::add(&repo, &hello_file).await?;
@@ -629,7 +607,7 @@ mod tests {
             assert_eq!(util::fs::read_from_path(&hello_file)?, "World");
 
             // Go back to the main branch
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
 
             // The file contents should be Hello, not World
             log::debug!("HELLO FILE NAME: {hello_file:?}");
@@ -661,7 +639,7 @@ mod tests {
             repositories::branches::create_checkout(&repo, branch_name)?;
 
             let file_contents = "file,label\ntrain/cat_1.jpg,0\n";
-            let one_shot_path = test::modify_txt_file(one_shot_path, file_contents)?;
+            let one_shot_path = test::modify_txt_file(&one_shot_path, file_contents)?;
             let status = repositories::status(&repo)?;
             assert_eq!(status.modified_files.len(), 1);
             status.print();
@@ -671,7 +649,7 @@ mod tests {
             repositories::commit(&repo, "Changing one shot")?;
 
             // checkout OG and make sure it reverts
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
             let updated_content = util::fs::read_from_path(&one_shot_path)?;
             assert_eq!(og_content, updated_content);
 
@@ -704,7 +682,7 @@ mod tests {
             repositories::branches::create_checkout(&repo, branch_name)?;
 
             let file_contents = "file,label\ntrain/cat_1.jpg,0\n";
-            let one_shot_path = test::modify_txt_file(one_shot_path, file_contents)?;
+            let one_shot_path = test::modify_txt_file(&one_shot_path, file_contents)?;
             let status = repositories::status(&repo)?;
             assert_eq!(status.modified_files.len(), 1);
             repositories::add(&repo, &one_shot_path).await?;
@@ -718,7 +696,7 @@ mod tests {
             repositories::commit(&repo, "Changing one shot")?;
 
             // checkout OG and make sure it reverts
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
             let updated_content = util::fs::read_from_path(&one_shot_path)?;
             assert_eq!(og_content, updated_content);
 
@@ -758,7 +736,7 @@ mod tests {
             repositories::commit(&repo, "Removing train dir")?;
 
             // checkout OG and make sure it restores the train dir
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
             assert!(dir_to_remove.exists());
             assert_eq!(util::fs::rcount_files_in_dir(&dir_to_remove), og_num_files);
 
@@ -1069,7 +1047,7 @@ mod tests {
             // Create a feature branch with modifications to world.txt and a new file
             let branch_name = "feature/new-stuff";
             repositories::branches::create_checkout(&repo, branch_name)?;
-            let world_file = test::modify_txt_file(world_file, "World modified")?;
+            let world_file = test::modify_txt_file(&world_file, "World modified")?;
             let new_file = repo.path.join("new.txt");
             util::fs::write_to_path(&new_file, "New")?;
             repositories::add(&repo, &repo.path).await?;
@@ -1114,7 +1092,7 @@ mod tests {
             // Create a feature branch that modifies hello.txt
             let branch_name = "feature/modify-hello";
             repositories::branches::create_checkout(&repo, branch_name)?;
-            test::modify_txt_file(hello_file.clone(), "Hello from feature")?;
+            test::modify_txt_file(&hello_file.clone(), "Hello from feature")?;
             repositories::add(&repo, &hello_file).await?;
             repositories::commit(&repo, "Modified hello.txt")?;
 

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -157,16 +157,16 @@ pub async fn checkout_combine(repo: &LocalRepository, path: &Path) -> Result<(),
                             let output_path = repo.path.join(&conflict.base_entry.path);
                             tabular::write_df(&mut uniq, &output_path)
                         }
-                        _ => Err(OxenError::basic_str("Could not uniq data")),
+                        _ => Err(OxenError::basic_str("Could not uniq data".to_string())),
                     }
                 }
                 _ => Err(OxenError::basic_str(
-                    "Could not combine data, make sure schema's match",
+                    "Could not combine data, make sure schema's match".to_string(),
                 )),
             }
         } else {
             Err(OxenError::basic_str(
-                "Cannot use --combine on non-tabular data file.",
+                "Cannot use --combine on non-tabular data file.".to_string(),
             ))
         }
     } else {

--- a/crates/lib/src/repositories/clone.rs
+++ b/crates/lib/src/repositories/clone.rs
@@ -18,18 +18,12 @@ pub async fn clone(opts: &CloneOpts) -> Result<LocalRepository, OxenError> {
     clone_remote(opts).await
 }
 
-pub async fn clone_url(
-    url: impl AsRef<str>,
-    dst: impl AsRef<Path>,
-) -> Result<LocalRepository, OxenError> {
+pub async fn clone_url(url: &str, dst: &Path) -> Result<LocalRepository, OxenError> {
     let fetch_opts = FetchOpts::new();
     _clone(url, dst, fetch_opts).await
 }
 
-pub async fn deep_clone_url(
-    url: impl AsRef<str>,
-    dst: impl AsRef<Path>,
-) -> Result<LocalRepository, OxenError> {
+pub async fn deep_clone_url(url: &str, dst: &Path) -> Result<LocalRepository, OxenError> {
     let fetch_opts = FetchOpts {
         all: true,
         ..FetchOpts::new()
@@ -39,15 +33,15 @@ pub async fn deep_clone_url(
 }
 
 async fn _clone(
-    url: impl AsRef<str>,
-    dst: impl AsRef<Path>,
+    url: &str,
+    dst: &Path,
     fetch_opts: FetchOpts,
 ) -> Result<LocalRepository, OxenError> {
     let opts = CloneOpts {
-        url: url.as_ref().to_string(),
-        dst: dst.as_ref().to_owned(),
+        url: url.to_string(),
+        dst: dst.to_owned(),
         fetch_opts,
-        storage_opts: StorageOpts::from_path(dst.as_ref(), true),
+        storage_opts: StorageOpts::from_path(dst, true),
         is_vfs: false,
         is_remote: false,
     };
@@ -129,7 +123,7 @@ mod tests {
             log::debug!("created the remote repo");
 
             test::run_empty_dir_test_async(|dir| async move {
-                let opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
 
                 log::debug!("about to clone the remote");
                 let local_repo = clone_remote(&opts).await?;
@@ -162,7 +156,7 @@ mod tests {
             let remote_repo = test::create_remote_repo(&local_repo).await?;
 
             test::run_empty_dir_test_async(|dir| async move {
-                let opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 let local_repo = clone_remote(&opts).await?;
 
                 api::client::repositories::delete(&remote_repo).await?;
@@ -191,7 +185,7 @@ mod tests {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![PathBuf::from(".")]);
                 opts.fetch_opts.depth = Some(1);
                 let local_repo = clone_remote(&opts).await?;
@@ -224,7 +218,7 @@ mod tests {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![PathBuf::from("annotations")]);
                 let local_repo = clone_remote(&opts).await?;
 
@@ -276,7 +270,7 @@ mod tests {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths =
                     Some(vec![PathBuf::from("annotations").join("test")]);
                 let local_repo = clone_remote(&opts).await?;
@@ -306,7 +300,7 @@ mod tests {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![
                     PathBuf::from("annotations").join("test"),
                     PathBuf::from("nlp"),
@@ -420,8 +414,8 @@ mod tests {
                 // Create a different repo
                 let repo_new = RepoNew::from_namespace_name_host(
                     constants::DEFAULT_NAMESPACE,
-                    repo_name,
-                    test::test_host(),
+                    &repo_name,
+                    &test::test_host(),
                     None,
                 );
                 api::client::repositories::create_from_local(&cloned_repo, repo_new).await?;
@@ -497,8 +491,8 @@ mod tests {
                 // Create a different repo
                 let repo_new = RepoNew::from_namespace_name_host(
                     constants::DEFAULT_NAMESPACE,
-                    repo_name,
-                    test::test_host(),
+                    &repo_name,
+                    &test::test_host(),
                     None,
                 );
                 api::client::repositories::create_empty(repo_new).await?;
@@ -614,7 +608,7 @@ mod tests {
                 // Add a file to the cloned repo
                 let new_file = "new_file.txt";
                 let new_file_path = cloned_repo.path.join(new_file);
-                let new_file_path = test::write_txt_file_to_path(new_file_path, "new file")?;
+                let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file")?;
                 repositories::add(&cloned_repo, &new_file_path).await?;
                 repositories::commit(&cloned_repo, "Adding new file path.")?;
 

--- a/crates/lib/src/repositories/commits.rs
+++ b/crates/lib/src/repositories/commits.rs
@@ -108,11 +108,7 @@ pub fn get_by_hash(repo: &LocalRepository, hash: &MerkleHash) -> Result<Option<C
 }
 
 /// Get a commit by it's string hash
-pub fn get_by_id(
-    repo: &LocalRepository,
-    commit_id: impl AsRef<str>,
-) -> Result<Option<Commit>, OxenError> {
-    let commit_id = commit_id.as_ref();
+pub fn get_by_id(repo: &LocalRepository, commit_id: &str) -> Result<Option<Commit>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::commits::get_by_id(repo, commit_id),
@@ -120,20 +116,16 @@ pub fn get_by_id(
 }
 
 /// Commit id exists
-pub fn commit_id_exists(
-    repo: &LocalRepository,
-    commit_id: impl AsRef<str>,
-) -> Result<bool, OxenError> {
-    get_by_id(repo, commit_id.as_ref()).map(|commit| commit.is_some())
+pub fn commit_id_exists(repo: &LocalRepository, commit_id: &str) -> Result<bool, OxenError> {
+    get_by_id(repo, commit_id).map(|commit| commit.is_some())
 }
 
 /// Create an empty commit off of the head commit of a branch
 pub fn create_empty_commit(
     repo: &LocalRepository,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
     commit: &Commit,
 ) -> Result<Commit, OxenError> {
-    let branch_name = branch_name.as_ref();
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("create_empty_commit not supported in v0.10.0"),
         _ => core::v_latest::commits::create_empty_commit(repo, branch_name, commit),
@@ -145,12 +137,10 @@ pub fn create_empty_commit(
 /// Returns an error if the repository already has commits.
 pub fn create_initial_commit(
     repo: &LocalRepository,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
     user: &User,
-    message: impl AsRef<str>,
+    message: &str,
 ) -> Result<Commit, OxenError> {
-    let branch_name = branch_name.as_ref();
-    let message = message.as_ref();
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("create_initial_commit not supported in v0.10.0"),
         _ => core::v_latest::commits::create_initial_commit(repo, branch_name, user, message),
@@ -184,7 +174,7 @@ pub fn list_unsynced(repo: &LocalRepository) -> Result<HashSet<Commit>, OxenErro
 /// List unsynced commits from a specific revision
 pub fn list_unsynced_from(
     repo: &LocalRepository,
-    revision: impl AsRef<str>,
+    revision: &str,
 ) -> Result<HashSet<Commit>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("list_unsynced_from not supported in v0.10.0"),
@@ -192,9 +182,9 @@ pub fn list_unsynced_from(
     }
 }
 // Source
-pub fn get_commit_or_head<S: AsRef<str> + Clone>(
+pub fn get_commit_or_head(
     repo: &LocalRepository,
-    commit_id_or_branch_name: Option<S>,
+    commit_id_or_branch_name: Option<&str>,
 ) -> Result<Commit, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => resource::get_commit_or_head(repo, commit_id_or_branch_name),
@@ -250,27 +240,19 @@ pub fn list_between(
 }
 
 /// Get a list of commits by the commit message
-pub fn get_by_message(
-    repo: &LocalRepository,
-    msg: impl AsRef<str>,
-) -> Result<Vec<Commit>, OxenError> {
+pub fn get_by_message(repo: &LocalRepository, msg: &str) -> Result<Vec<Commit>, OxenError> {
     let commits = list_all(repo)?;
     let filtered: Vec<Commit> = commits
         .into_iter()
-        .filter(|commit| commit.message == msg.as_ref())
+        .filter(|commit| commit.message == msg)
         .collect();
     Ok(filtered)
 }
 
 /// Get the most recent commit by the commit message, starting at the HEAD commit
-pub fn first_by_message(
-    repo: &LocalRepository,
-    msg: impl AsRef<str>,
-) -> Result<Option<Commit>, OxenError> {
+pub fn first_by_message(repo: &LocalRepository, msg: &str) -> Result<Option<Commit>, OxenError> {
     let commits = list(repo)?;
-    Ok(commits
-        .into_iter()
-        .find(|commit| commit.message == msg.as_ref()))
+    Ok(commits.into_iter().find(|commit| commit.message == msg))
 }
 
 /// Retrieve entries with filepaths matching a provided glob pattern
@@ -355,10 +337,7 @@ pub fn list_by_path_from_paginated(
     }
 }
 
-pub fn count_from(
-    repo: &LocalRepository,
-    revision: impl AsRef<str>,
-) -> Result<(usize, bool), OxenError> {
+pub fn count_from(repo: &LocalRepository, revision: &str) -> Result<(usize, bool), OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => Err(OxenError::basic_str("count_from not supported in v0.10.0")),
         _ => core::v_latest::commits::count_from(repo, revision),
@@ -481,7 +460,7 @@ mod tests {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             // Track the file
             let train_dir = repo.path.join("train");
-            repositories::add(&repo, train_dir).await?;
+            repositories::add(&repo, &train_dir).await?;
             // Commit the file
             let commit = repositories::commit(&repo, "Adding training data")?;
 
@@ -495,7 +474,7 @@ mod tests {
             repositories::tree::print_tree(&repo, &commit)?;
 
             let dir_node =
-                repositories::tree::get_node_by_path(&repo, &commit, PathBuf::from("train"))?;
+                repositories::tree::get_node_by_path(&repo, &commit, &PathBuf::from("train"))?;
             assert!(dir_node.is_some());
 
             let commits = repositories::commits::list(&repo)?;
@@ -511,7 +490,7 @@ mod tests {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             // Track the annotations dir, which has sub dirs
             let annotations_dir = repo.path.join("annotations");
-            repositories::add(&repo, annotations_dir).await?;
+            repositories::add(&repo, &annotations_dir).await?;
             repositories::commit(&repo, "Adding annotations data dir, which has two levels")?;
 
             let repo_status = repositories::status(&repo)?;
@@ -553,7 +532,7 @@ mod tests {
             repositories::commit(&repo, "Adding test dir")?;
 
             // checkout OG and make sure it removes the train dir
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
             assert!(!test_dir_path.exists());
 
             // checkout branch again and make sure it reverts
@@ -618,7 +597,7 @@ mod tests {
             repositories::commit(&repo, "adding none category")?;
 
             // Add a "person" category on a the main branch
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             test::modify_txt_file(&labels_path, "cat\ndog\nperson")?;
             repositories::add(&repo, &labels_path).await?;
@@ -634,7 +613,7 @@ mod tests {
             // Assume that we fixed the conflict and added the file
             let path = status.merge_conflicts[0].base_entry.path.clone();
             let fullpath = repo.path.join(path);
-            repositories::add(&repo, fullpath).await?;
+            repositories::add(&repo, &fullpath).await?;
 
             // Should commit, and then see full commit history
             repositories::commit(&repo, "merging into main")?;
@@ -822,7 +801,7 @@ mod tests {
     async fn test_commit_history_order() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             let train_dir = repo.path.join("train");
-            repositories::add(&repo, train_dir).await?;
+            repositories::add(&repo, &train_dir).await?;
             let initial_commit_message = "adding train dir";
             repositories::commit(&repo, initial_commit_message)?;
 
@@ -833,7 +812,7 @@ mod tests {
             repositories::commit(&repo, "adding text file")?;
 
             let test_dir = repo.path.join("test");
-            repositories::add(&repo, test_dir).await?;
+            repositories::add(&repo, &test_dir).await?;
             let most_recent_message = "adding test dir";
             repositories::commit(&repo, most_recent_message)?;
 
@@ -853,22 +832,22 @@ mod tests {
         test::run_training_data_repo_test_fully_committed_async(|repo| async move {
             let new_file = repo.path.join("new_1.txt");
             test::write_txt_file_to_path(&new_file, "new 1")?;
-            repositories::add(&repo, new_file).await?;
+            repositories::add(&repo, &new_file).await?;
             let base_commit = repositories::commit(&repo, "commit 1")?;
 
             let new_file = repo.path.join("new_2.txt");
             test::write_txt_file_to_path(&new_file, "new 2")?;
-            repositories::add(&repo, new_file).await?;
+            repositories::add(&repo, &new_file).await?;
             repositories::commit(&repo, "commit 2")?;
 
             let new_file = repo.path.join("new_3.txt");
             test::write_txt_file_to_path(&new_file, "new 3")?;
-            repositories::add(&repo, new_file).await?;
+            repositories::add(&repo, &new_file).await?;
             let head_commit = repositories::commit(&repo, "commit 3")?;
 
             let new_file = repo.path.join("new_4.txt");
             test::write_txt_file_to_path(&new_file, "new 4")?;
-            repositories::add(&repo, new_file).await?;
+            repositories::add(&repo, &new_file).await?;
             repositories::commit(&repo, "commit 4")?;
 
             let history = repositories::commits::list_between(&repo, &base_commit, &head_commit)?;
@@ -888,7 +867,7 @@ mod tests {
             // Make a dir
             let dir_path = Path::new("test_dir");
             let dir_repo_path = repo.path.join(dir_path);
-            util::fs::create_dir_all(dir_repo_path)?;
+            util::fs::create_dir_all(&dir_repo_path)?;
 
             // File in the dir
             let file_path = dir_path.join(Path::new("test_file.txt"));
@@ -1044,7 +1023,7 @@ mod tests {
                 status
                     .untracked_dirs
                     .iter()
-                    .any(|(path, _)| *path == PathBuf::from("empty_dir"))
+                    .any(|(path, _)| path == Path::new("empty_dir"))
             );
 
             // Add the empty dir
@@ -1057,16 +1036,16 @@ mod tests {
 
             let tree = repositories::tree::get_root_with_children(&repo, &commit)?.unwrap();
 
-            assert!(tree.get_by_path(PathBuf::from("empty_dir"))?.is_some());
+            assert!(tree.get_by_path(&PathBuf::from("empty_dir"))?.is_some());
 
             // Remove the empty dir
-            let mut rm_opts = RmOpts::from_path(PathBuf::from("empty_dir"));
+            let mut rm_opts = RmOpts::from_path(&PathBuf::from("empty_dir"));
             rm_opts.recursive = true;
             repositories::rm(&repo, &rm_opts)?;
             let commit_2 = repositories::commit(&repo, "removing empty dir")?;
 
             let tree_2 = repositories::tree::get_root_with_children(&repo, &commit_2)?.unwrap();
-            assert!(tree_2.get_by_path(PathBuf::from("empty_dir"))?.is_none());
+            assert!(tree_2.get_by_path(&PathBuf::from("empty_dir"))?.is_none());
 
             Ok(())
         })
@@ -1084,7 +1063,7 @@ mod tests {
             let commit = repositories::commit(&repo, "Adding invalid parquet file")?;
 
             let tree = repositories::tree::get_root_with_children(&repo, &commit)?.unwrap();
-            let file_node = tree.get_by_path(PathBuf::from("invalid.parquet"))?;
+            let file_node = tree.get_by_path(&PathBuf::from("invalid.parquet"))?;
             assert!(file_node.is_some());
 
             let file_entry = file_node.unwrap();
@@ -1101,7 +1080,7 @@ mod tests {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths =
                     Some(vec![PathBuf::from("annotations").join("test")]);
                 let local_repo = repositories::clone::clone(&opts).await?;
@@ -1137,7 +1116,7 @@ A: Oxen.ai
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![PathBuf::from(".")]);
                 let local_repo = repositories::clone::clone(&opts).await?;
 
@@ -1150,7 +1129,7 @@ A: Oxen.ai
                 let tree =
                     repositories::tree::get_root_with_children(&local_repo, &commit)?.unwrap();
 
-                let file_node = tree.get_by_path(PathBuf::from("empty.txt"))?;
+                let file_node = tree.get_by_path(&PathBuf::from("empty.txt"))?;
                 assert!(file_node.is_some());
                 let file_node = file_node.unwrap().file()?;
                 assert_eq!(file_node.num_bytes(), 0);
@@ -1168,7 +1147,7 @@ A: Oxen.ai
                 let tree =
                     repositories::tree::get_root_with_children(&local_repo, &commit)?.unwrap();
 
-                let file_node = tree.get_by_path(PathBuf::from("empty.txt"))?;
+                let file_node = tree.get_by_path(&PathBuf::from("empty.txt"))?;
                 assert!(file_node.is_some());
                 let file_node = file_node.unwrap().file()?;
                 assert_eq!(file_node.num_bytes(), raw_str.len() as u64);
@@ -1220,7 +1199,7 @@ A: Oxen.ai
             let head_commit = repositories::commits::head_commit(&repo)?;
             assert_eq!(head_commit.id, commit_e.id);
 
-            let expected_commits = vec![commit_e.clone(), commit_c.clone(), commit_a.clone()];
+            let expected_commits = [commit_e.clone(), commit_c.clone(), commit_a.clone()];
 
             let pagination_opts = PaginateOpts::default();
             let paginated_result = repositories::commits::list_by_path_from_paginated(

--- a/crates/lib/src/repositories/commits.rs
+++ b/crates/lib/src/repositories/commits.rs
@@ -221,7 +221,7 @@ pub fn list_from_with_depth(
 ) -> Result<HashMap<Commit, usize>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => Err(OxenError::basic_str(
-            "list_from_with_depth not supported in v0.10.0",
+            "list_from_with_depth not supported in v0.10.0".to_string(),
         )),
         _ => core::v_latest::commits::list_from_with_depth(repo, revision),
     }
@@ -339,7 +339,9 @@ pub fn list_by_path_from_paginated(
 
 pub fn count_from(repo: &LocalRepository, revision: &str) -> Result<(usize, bool), OxenError> {
     match repo.min_version() {
-        MinOxenVersion::V0_10_0 => Err(OxenError::basic_str("count_from not supported in v0.10.0")),
+        MinOxenVersion::V0_10_0 => Err(OxenError::basic_str(
+            "count_from not supported in v0.10.0".to_string(),
+        )),
         _ => core::v_latest::commits::count_from(repo, revision),
     }
 }

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -73,14 +73,14 @@ impl EntryVNode {
     }
 }
 
-pub fn commit(repo: &LocalRepository, message: impl AsRef<str>) -> Result<Commit, OxenError> {
+pub fn commit(repo: &LocalRepository, message: &str) -> Result<Commit, OxenError> {
     let cfg = UserConfig::get()?;
     commit_with_cfg(repo, message, &cfg, None)
 }
 
 pub fn commit_with_parent_ids(
     repo: &LocalRepository,
-    message: impl AsRef<str>,
+    message: &str,
     parent_ids: Vec<String>,
 ) -> Result<Commit, OxenError> {
     let cfg = UserConfig::get()?;
@@ -89,7 +89,7 @@ pub fn commit_with_parent_ids(
 
 pub fn commit_with_user(
     repo: &LocalRepository,
-    message: impl AsRef<str>,
+    message: &str,
     user: &User,
 ) -> Result<Commit, OxenError> {
     let cfg = UserConfig {
@@ -102,13 +102,12 @@ pub fn commit_with_user(
 
 pub fn commit_with_cfg(
     repo: &LocalRepository,
-    message: impl AsRef<str>,
+    message: &str,
     cfg: &UserConfig,
     parent_ids: Option<Vec<String>>,
 ) -> Result<Commit, OxenError> {
     // time the commit
     let start_time = Instant::now();
-    let message = message.as_ref();
 
     // Read the staged files from the staged db
     let opts = db::key_val::opts::default();
@@ -153,7 +152,7 @@ pub fn commit_with_cfg(
             &new_commit,
             staged_db,
             &commit_progress_bar,
-            maybe_branch_name
+            &maybe_branch_name
                 .clone()
                 .unwrap_or(DEFAULT_BRANCH_NAME.to_string()),
         )?
@@ -204,10 +203,9 @@ pub fn commit_dir_entries_with_parents(
     new_commit: &NewCommitBody,
     staged_db: DBWithThreadMode<SingleThreaded>,
     commit_progress_bar: &ProgressBar,
-    target_branch: impl AsRef<str>,
+    target_branch: &str,
 ) -> Result<Commit, OxenError> {
     let message = &new_commit.message;
-    let target_branch = target_branch.as_ref();
 
     // if the HEAD file exists, we have parents
     // otherwise this is the first commit
@@ -307,7 +305,7 @@ pub fn commit_dir_entries_with_parents(
     drop(staged_db);
 
     // Clear the staged db
-    util::fs::remove_dir_all(staged_db_path)?;
+    util::fs::remove_dir_all(&staged_db_path)?;
     Ok(node.to_commit())
 }
 
@@ -414,7 +412,7 @@ pub fn commit_dir_entries_new(
     drop(staged_db);
 
     // Clear the staged db
-    util::fs::remove_dir_all(staged_db_path)?;
+    util::fs::remove_dir_all(&staged_db_path)?;
 
     Ok(node.to_commit())
 }
@@ -423,7 +421,7 @@ pub fn commit_dir_entries(
     repo: &LocalRepository,
     dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>>,
     new_commit: &NewCommitBody,
-    target_branch: impl AsRef<str>,
+    target_branch: &str,
     commit_progress_bar: &ProgressBar,
 ) -> Result<Commit, OxenError> {
     log::debug!("commit_dir_entries got {} entries", dir_entries.len());
@@ -553,10 +551,9 @@ fn cleanup_rm_dirs(
 }
 
 fn node_data_to_staged_node(
-    base_dir: impl AsRef<Path>,
+    base_dir: &Path,
     node: &MerkleTreeNode,
 ) -> Result<Option<StagedMerkleTreeNode>, OxenError> {
-    let base_dir = base_dir.as_ref();
     match node.node.node_type() {
         MerkleTreeNodeType::Dir => {
             let mut dir_node = node.dir()?;
@@ -581,13 +578,13 @@ fn node_data_to_staged_node(
 }
 
 fn get_node_dir_children(
-    base_dir: impl AsRef<Path>,
+    base_dir: &Path,
     node: &MerkleTreeNode,
 ) -> Result<HashSet<StagedMerkleTreeNode>, OxenError> {
     let dir_children = repositories::tree::list_files_and_folders(node)?;
     let children = dir_children
         .into_iter()
-        .flat_map(|child| node_data_to_staged_node(&base_dir, &child))
+        .flat_map(|child| node_data_to_staged_node(base_dir, &child))
         .flatten()
         .collect();
 
@@ -825,7 +822,7 @@ fn write_commit_entries(
         dir_hash_db,
         dir_hashes,
         entries,
-        root_path,
+        &root_path,
         &mut total_written,
     )?;
 
@@ -840,10 +837,10 @@ fn r_create_dir_node(
     dir_hash_db: &DBWithThreadMode<SingleThreaded>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     entries: &HashMap<PathBuf, (Vec<EntryVNode>, Vec<StagedMerkleTreeNode>)>,
-    path: impl AsRef<Path>,
+    path: &Path,
     total_written: &mut u64,
 ) -> Result<(), OxenError> {
-    let path = path.as_ref().to_path_buf();
+    let path = path.to_path_buf();
 
     let keys = entries.keys();
     log::debug!("r_create_dir_node path {path:?} keys: {keys:?}");
@@ -998,7 +995,7 @@ fn r_create_dir_node(
                     // }
                 }
                 _ => {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(OxenError::basic_str(&format!(
                         "r_create_dir_node found unexpected node type: {:?}",
                         entry.node
                     )));
@@ -1014,9 +1011,9 @@ fn r_create_dir_node(
 
 fn get_children(
     entries: &HashMap<PathBuf, (Vec<EntryVNode>, Vec<StagedMerkleTreeNode>)>,
-    dir_path: impl AsRef<Path>,
+    dir_path: &Path,
 ) -> Result<Vec<PathBuf>, OxenError> {
-    let dir_path = dir_path.as_ref().to_path_buf();
+    let dir_path = dir_path.to_path_buf();
     let mut children = vec![];
 
     for (path, _) in entries.iter() {
@@ -1033,9 +1030,9 @@ fn compute_dir_node(
     commit_id: MerkleHash,
     entries: &HashMap<PathBuf, (Vec<EntryVNode>, Vec<StagedMerkleTreeNode>)>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<DirNode, OxenError> {
-    let path = path.as_ref().to_path_buf();
+    let path = path.to_path_buf();
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
     hasher.update(b"dir");
     hasher.update(path.to_str().unwrap().as_bytes());
@@ -1068,7 +1065,7 @@ fn compute_dir_node(
     for child in children.iter() {
         let Some((vnodes, removed_entries)) = entries.get(child) else {
             let err_msg = format!("compute_dir_node No entries found for directory {path:?}");
-            return Err(OxenError::basic_str(err_msg));
+            return Err(OxenError::basic_str(&err_msg));
         };
         // log::debug!(
         //     "Aggregating dir {:?} child {:?} with {} vnodes",
@@ -1123,7 +1120,7 @@ fn compute_dir_node(
                         }
                     }
                     _ => {
-                        return Err(OxenError::basic_str(format!(
+                        return Err(OxenError::basic_str(&format!(
                             "compute_dir_node found unexpected node type: {:?}",
                             entry.node
                         )));
@@ -1157,7 +1154,7 @@ fn compute_dir_node(
                     }
                 }
                 _ => {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(OxenError::basic_str(&format!(
                         "compute_dir_node found unexpected node type: {:?}",
                         entry.node
                     )));
@@ -1204,8 +1201,8 @@ fn create_merge_commit(
     let head_commit_id = util::fs::read_from_path(&orig_head_path)?;
 
     // Cleanup
-    util::fs::remove_file(merge_head_path)?;
-    util::fs::remove_file(orig_head_path)?;
+    util::fs::remove_file(&merge_head_path)?;
+    util::fs::remove_file(&orig_head_path)?;
 
     Ok(NewCommit {
         parent_ids: vec![merge_commit_id, head_commit_id],
@@ -1261,7 +1258,7 @@ mod tests {
     async fn test_first_commit() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let repo = repositories::init::init(dir)?;
+            let repo = repositories::init::init(&dir)?;
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 2).await?;
@@ -1347,7 +1344,7 @@ mod tests {
     async fn test_commit_only_dirs_at_top_level() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(async |dir| {
             // Instantiate the correct version of the repo
-            let repo = repositories::init::init(dir)?;
+            let repo = repositories::init::init(&dir)?;
 
             // Add a new file to files/dir_0/
             let new_file = repo.path.join("all_files/dir_0/new_file.txt");
@@ -1377,7 +1374,7 @@ mod tests {
     async fn test_commit_single_file_deep_in_dir() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let repo = repositories::init::init(dir)?;
+            let repo = repositories::init::init(&dir)?;
 
             // Add a new file to files/dir_0/
             let new_file = repo.path.join("files/dir_0/new_file.txt");
@@ -1407,7 +1404,7 @@ mod tests {
     async fn test_2nd_commit_keeps_num_bytes_and_data_type_counts() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let repo = repositories::init::init(dir)?;
+            let repo = repositories::init::init(&dir)?;
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;
@@ -1463,7 +1460,7 @@ mod tests {
     async fn test_second_commit() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let repo = repositories::init::init(dir)?;
+            let repo = repositories::init::init(&dir)?;
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;
@@ -1585,7 +1582,7 @@ mod tests {
     async fn test_commit_configurable_vnode_size() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let mut repo = repositories::init::init(dir)?;
+            let mut repo = repositories::init::init(&dir)?;
             // Set the vnode size to 5
             repo.set_vnode_size(5);
 
@@ -1622,7 +1619,7 @@ mod tests {
                     .join("files")
                     .join(format!("dir_{dir_num}"))
                     .join(format!("new_file_{i}.txt"));
-                util::fs::write_to_path(&new_file, format!("New fileeeee {i}"))?;
+                util::fs::write_to_path(&new_file, &format!("New fileeeee {i}"))?;
                 repositories::add(&repo, &new_file).await?;
             }
 
@@ -1664,7 +1661,7 @@ mod tests {
     async fn test_commit_20_files_6_vnode_size() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let mut repo = repositories::init::init(dir)?;
+            let mut repo = repositories::init::init(&dir)?;
             // Set the vnode size to 6
             repo.set_vnode_size(6);
 
@@ -1734,7 +1731,7 @@ mod tests {
     async fn test_third_commit() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {
             // Instantiate the correct version of the repo
-            let repo = repositories::init::init(dir)?;
+            let repo = repositories::init::init(&dir)?;
 
             // Write data to the repo
             add_n_files_m_dirs(&repo, 10, 3).await?;
@@ -1828,8 +1825,8 @@ mod tests {
             let first_root_dir_node = first_tree.get_by_path(Path::new(""))?.unwrap();
 
             // add the data
-            repositories::add(&repo, repo.path.join("train")).await?;
-            repositories::add(&repo, repo.path.join("test")).await?;
+            repositories::add(&repo, &repo.path.join("train")).await?;
+            repositories::add(&repo, &repo.path.join("test")).await?;
             let second_commit = super::commit(&repo, "Adding the data")?;
 
             let second_tree = CommitMerkleTree::from_commit(&repo, &second_commit)?;

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -128,7 +128,7 @@ pub fn commit_with_cfg(
     log::debug!("got dir entries: {:?}", dir_entries.len());
 
     if dir_entries.is_empty() {
-        return Err(OxenError::basic_str("No changes to commit"));
+        return Err(OxenError::basic_str("No changes to commit".to_string()));
     }
 
     // let mut dir_tree = entries_to_dir_tree(&dir_entries)?;
@@ -436,7 +436,7 @@ pub fn commit_dir_entries(
     }
 
     if dir_entries.is_empty() {
-        return Err(OxenError::basic_str("No changes to commit"));
+        return Err(OxenError::basic_str("No changes to commit".to_string()));
     }
 
     let message = &new_commit.message;
@@ -995,7 +995,7 @@ fn r_create_dir_node(
                     // }
                 }
                 _ => {
-                    return Err(OxenError::basic_str(&format!(
+                    return Err(OxenError::basic_str(format!(
                         "r_create_dir_node found unexpected node type: {:?}",
                         entry.node
                     )));
@@ -1065,7 +1065,7 @@ fn compute_dir_node(
     for child in children.iter() {
         let Some((vnodes, removed_entries)) = entries.get(child) else {
             let err_msg = format!("compute_dir_node No entries found for directory {path:?}");
-            return Err(OxenError::basic_str(&err_msg));
+            return Err(OxenError::basic_str(err_msg));
         };
         // log::debug!(
         //     "Aggregating dir {:?} child {:?} with {} vnodes",
@@ -1120,7 +1120,7 @@ fn compute_dir_node(
                         }
                     }
                     _ => {
-                        return Err(OxenError::basic_str(&format!(
+                        return Err(OxenError::basic_str(format!(
                             "compute_dir_node found unexpected node type: {:?}",
                             entry.node
                         )));
@@ -1154,7 +1154,7 @@ fn compute_dir_node(
                     }
                 }
                 _ => {
-                    return Err(OxenError::basic_str(&format!(
+                    return Err(OxenError::basic_str(format!(
                         "compute_dir_node found unexpected node type: {:?}",
                         entry.node
                     )));

--- a/crates/lib/src/repositories/data_frames.rs
+++ b/crates/lib/src/repositories/data_frames.rs
@@ -12,7 +12,7 @@ pub mod schemas;
 pub async fn get_slice(
     repo: &LocalRepository,
     resource: &ParsedResource,
-    path: impl AsRef<Path>,
+    path: &Path,
     opts: &DFOpts,
 ) -> Result<DataFrameSlice, OxenError> {
     match repo.min_version() {

--- a/crates/lib/src/repositories/data_frames/schemas.rs
+++ b/crates/lib/src/repositories/data_frames/schemas.rs
@@ -65,7 +65,9 @@ pub fn restore_schema(
     after_column: &str,
 ) -> Result<(), OxenError> {
     match repo.min_version() {
-        MinOxenVersion::V0_10_0 => Err(OxenError::basic_str("Not implemented for v0.10.0")),
+        MinOxenVersion::V0_10_0 => Err(OxenError::basic_str(
+            "Not implemented for v0.10.0".to_string(),
+        )),
         _ => core::v_latest::data_frames::schemas::restore_schema(
             repo,
             path,

--- a/crates/lib/src/repositories/data_frames/schemas.rs
+++ b/crates/lib/src/repositories/data_frames/schemas.rs
@@ -28,7 +28,7 @@ pub fn list(
 pub fn get_by_path(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<Schema>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -37,10 +37,7 @@ pub fn get_by_path(
 }
 
 /// Get a staged schema
-pub fn get_staged(
-    repo: &LocalRepository,
-    path: impl AsRef<Path>,
-) -> Result<Option<Schema>, OxenError> {
+pub fn get_staged(repo: &LocalRepository, path: &Path) -> Result<Option<Schema>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::data_frames::schemas::get_staged(repo, path),
@@ -50,7 +47,7 @@ pub fn get_staged(
 /// Get staged schema for workspace
 pub fn get_staged_schema_with_staged_db_manager(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<Schema>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -62,7 +59,7 @@ pub fn get_staged_schema_with_staged_db_manager(
 
 pub fn restore_schema(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
     og_schema: &Schema,
     before_column: &str,
     after_column: &str,
@@ -90,11 +87,10 @@ pub fn list_staged(repo: &LocalRepository) -> Result<HashMap<PathBuf, Schema>, O
 /// Get a string representation of the schema given a schema ref
 pub fn show(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
     staged: bool,
     verbose: bool,
 ) -> Result<String, OxenError> {
-    let path = path.as_ref();
     let schema = if staged {
         get_staged(repo, path)?
     } else {
@@ -130,7 +126,7 @@ pub fn show(
 }
 
 /// Remove a schema override from the staging area, TODO: Currently undefined behavior for non-staged schemas
-pub fn rm(repo: &LocalRepository, path: impl AsRef<Path>, staged: bool) -> Result<(), OxenError> {
+pub fn rm(repo: &LocalRepository, path: &Path, staged: bool) -> Result<(), OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::data_frames::schemas::rm(repo, path, staged),
@@ -140,7 +136,7 @@ pub fn rm(repo: &LocalRepository, path: impl AsRef<Path>, staged: bool) -> Resul
 /// Add metadata to the schema
 pub fn add_schema_metadata(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     match repo.min_version() {
@@ -152,8 +148,8 @@ pub fn add_schema_metadata(
 /// Add metadata to a specific column
 pub fn add_column_metadata(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
-    column: impl AsRef<str>,
+    path: &Path,
+    column: &str,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     match repo.min_version() {
@@ -222,7 +218,7 @@ mod tests {
                 .join("train")
                 .join("bounding_box.csv");
             let bbox_file = repo.path.join(bbox_filename);
-            repositories::add(&repo, bbox_file).await?;
+            repositories::add(&repo, &bbox_file).await?;
 
             // Make sure it is staged
             let status = repositories::status(&repo)?;
@@ -276,7 +272,7 @@ mod tests {
                 .join("train")
                 .join("bounding_box.csv");
             let bbox_file = repo.path.join(&bbox_filename);
-            repositories::add(&repo, bbox_file).await?;
+            repositories::add(&repo, &bbox_file).await?;
 
             // Make sure it is staged
             let status = repositories::status(&repo)?;
@@ -291,8 +287,8 @@ mod tests {
             // Write a new commit that is modifies any file
             let readme_filename = Path::new("README.md");
             let readme_file = repo.path.join(readme_filename);
-            util::fs::write(&readme_file, "Changing the README")?;
-            repositories::add(&repo, readme_file).await?;
+            util::fs::write(&readme_file, "Changing the README".as_bytes())?;
+            repositories::add(&repo, &readme_file).await?;
             let commit = repositories::commit(&repo, "Changing the README")?;
 
             // Fetch schema from HEAD commit, it should still be there in all it's glory
@@ -413,19 +409,21 @@ mod tests {
             repositories::add(&repo, &bbox_path).await?;
             repositories::data_frames::schemas::add_column_metadata(
                 &repo,
-                schema_ref,
+                Path::new(schema_ref),
                 "min_x",
                 &min_x_meta,
             )?;
 
-            let schema = repositories::data_frames::schemas::get_staged(&repo, schema_ref)?;
+            let schema =
+                repositories::data_frames::schemas::get_staged(&repo, Path::new(schema_ref))?;
             assert!(schema.is_some());
 
             // Remove the schema
-            repositories::data_frames::schemas::rm(&repo, schema_ref, true)?;
+            repositories::data_frames::schemas::rm(&repo, Path::new(schema_ref), true)?;
 
             // Make sure none are left
-            let schema = repositories::data_frames::schemas::get_staged(&repo, schema_ref)?;
+            let schema =
+                repositories::data_frames::schemas::get_staged(&repo, Path::new(schema_ref))?;
             assert!(schema.is_none());
 
             Ok(())
@@ -497,7 +495,7 @@ mod tests {
             repositories::data_frames::schemas::add_column_metadata(
                 &repo,
                 &bbox_file,
-                column_name,
+                &column_name,
                 &column_metadata,
             )?;
 

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -88,7 +88,7 @@ pub async fn diff(opts: DiffOpts) -> Result<Vec<DiffResult>, OxenError> {
             let path_1 = opts.path_1;
             let Some(path_2) = opts.path_2 else {
                 return Err(OxenError::basic_str(
-                    "Error: `oxen diff` requires a repo or file paths",
+                    "Error: `oxen diff` requires a repo or file paths".to_string(),
                 ));
             };
 
@@ -158,7 +158,7 @@ pub async fn diff(opts: DiffOpts) -> Result<Vec<DiffResult>, OxenError> {
         }
 
         _ => Err(OxenError::basic_str(
-            "Single file comparison mode not supported",
+            "Single file comparison mode not supported".to_string(),
         )),
     }
 }
@@ -451,7 +451,7 @@ pub async fn diff_path(
         _ => {
             println!("Unable to compare directory and file");
             Err(OxenError::basic_str(
-                "Cannot compare a directory with a file",
+                "Cannot compare a directory with a file".to_string(),
             ))
         }
     }
@@ -638,7 +638,7 @@ pub async fn diff_file_nodes(
             ))),
         },
         (None, None) => Err(OxenError::basic_str(
-            "Could not find one or both of the files to compare",
+            "Could not find one or both of the files to compare".to_string(),
         )),
     }
 }
@@ -749,7 +749,7 @@ pub async fn diff_tabular_file_nodes(
             diff_dfs(&df_1, &df_2, keys, targets, display)
         }
         _ => Err(OxenError::basic_str(
-            "Could not find one or both of the files to compare",
+            "Could not find one or both of the files to compare".to_string(),
         )),
     }
 }
@@ -817,7 +817,7 @@ pub async fn diff_text_file_nodes(
             )
         }
         (None, None) => Err(OxenError::basic_str(
-            "Could not find one or both of the files to compare",
+            "Could not find one or both of the files to compare".to_string(),
         )),
     }
 }
@@ -850,7 +850,7 @@ async fn read_version_file_to_string(
             Err(_) => {
                 let err = format!("could not decode version {} as UTF-8", hash);
                 log::warn!("{err}");
-                Err(OxenError::basic_str(&err))
+                Err(OxenError::basic_str(err))
             }
         },
         Err(err) => Err(err),
@@ -970,7 +970,7 @@ fn get_keys_targets_smart_defaults(
             Ok((keys, filled_targets))
         }
         (false, true) => Err(OxenError::basic_str(
-            "Must specify at least one key column if specifying target columns.",
+            "Must specify at least one key column if specifying target columns.".to_string(),
         )),
         (false, false) => {
             let filled_keys = schema_diff.unchanged_cols.to_vec();

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -54,11 +54,11 @@ const TARGETS_HASH_COL: &str = "_targets_hash";
 const KEYS_HASH_COL: &str = "_keys_hash";
 const DUPES_PATH: &str = "dupes.json";
 
-fn is_files_tabular(file_1: impl AsRef<Path>, file_2: impl AsRef<Path>) -> bool {
-    util::fs::is_tabular(file_1.as_ref()) && util::fs::is_tabular(file_2.as_ref())
+fn is_files_tabular(file_1: &Path, file_2: &Path) -> bool {
+    util::fs::is_tabular(file_1) && util::fs::is_tabular(file_2)
 }
-fn is_files_utf8(file_1: impl AsRef<Path>, file_2: impl AsRef<Path>) -> bool {
-    util::fs::is_utf8(file_1.as_ref()) && util::fs::is_utf8(file_2.as_ref())
+fn is_files_utf8(file_1: &Path, file_2: &Path) -> bool {
+    util::fs::is_utf8(file_1) && util::fs::is_utf8(file_2)
 }
 
 pub async fn diff(opts: DiffOpts) -> Result<Vec<DiffResult>, OxenError> {
@@ -93,8 +93,8 @@ pub async fn diff(opts: DiffOpts) -> Result<Vec<DiffResult>, OxenError> {
             };
 
             let result = diff_files(
-                path_1,
-                path_2,
+                &path_1,
+                &path_2,
                 opts.keys.clone(),
                 opts.targets.clone(),
                 vec![],
@@ -146,7 +146,7 @@ pub async fn diff(opts: DiffOpts) -> Result<Vec<DiffResult>, OxenError> {
             // Direct file comparison mode
 
             let result = diff_files(
-                opts.path_1,
+                &opts.path_1,
                 path_2,
                 opts.keys.clone(),
                 opts.targets.clone(),
@@ -404,22 +404,22 @@ pub async fn diff_path(
     repo: &LocalRepository,
     base_commit: &Commit,
     head_commit: &Commit,
-    base_path: impl AsRef<Path>,
-    head_path: impl AsRef<Path>,
+    base_path: &Path,
+    head_path: &Path,
     opts: &DiffOpts,
 ) -> Result<DiffEntriesCounts, OxenError> {
-    match (base_path.as_ref().is_file(), head_path.as_ref().is_file()) {
+    match (base_path.is_file(), head_path.is_file()) {
         (true, true) => {
             let diff_entry = DiffEntry {
-                filename: head_path.as_ref().to_string_lossy().to_string(),
+                filename: head_path.to_string_lossy().to_string(),
                 head_resource: Some(ParsedResource {
                     commit: Some(head_commit.clone()),
-                    path: head_path.as_ref().to_path_buf(),
+                    path: head_path.to_path_buf(),
                     ..ParsedResource::default() //TODO: Fill in other fields as well
                 }),
                 base_resource: Some(ParsedResource {
                     commit: Some(base_commit.clone()),
-                    path: base_path.as_ref().to_path_buf(),
+                    path: base_path.to_path_buf(),
                     ..ParsedResource::default() //TODO: Fill in other fields as well
                 }),
                 ..DiffEntry::default()
@@ -441,8 +441,8 @@ pub async fn diff_path(
                 repo,
                 base_commit,
                 head_commit,
-                base_path.as_ref().to_path_buf(),
-                head_path.as_ref().to_path_buf(),
+                base_path.to_path_buf(),
+                head_path.to_path_buf(),
                 opts.page,
                 opts.page_size,
             )
@@ -458,35 +458,30 @@ pub async fn diff_path(
 }
 
 pub async fn diff_files(
-    path_1: impl AsRef<Path>,
-    path_2: impl AsRef<Path>,
+    path_1: &Path,
+    path_2: &Path,
     keys: Vec<String>,
     targets: Vec<String>,
     display: Vec<String>,
 ) -> Result<DiffResult, OxenError> {
-    log::debug!(
-        "Compare command called with: {:?} and {:?}",
-        path_1.as_ref(),
-        path_2.as_ref()
-    );
-    if is_files_tabular(&path_1, &path_2) {
+    log::debug!("Compare command called with: {:?} and {:?}", path_1, path_2);
+    if is_files_tabular(path_1, path_2) {
         let result = tabular(path_1, path_2, keys, targets, display).await?;
         Ok(DiffResult::Tabular(result))
-    } else if is_files_utf8(&path_1, &path_2) {
-        let file_content_1 = util::fs::read_file(Some(&path_1))?;
-        let file_content_2 = util::fs::read_file(Some(&path_2))?;
+    } else if is_files_utf8(path_1, path_2) {
+        let file_content_1 = util::fs::read_file(Some(path_1))?;
+        let file_content_2 = util::fs::read_file(Some(path_2))?;
         let result = utf8_diff::diff(
             Some(file_content_1),
-            Some(path_1.as_ref().to_path_buf()),
+            Some(path_1.to_path_buf()),
             Some(file_content_2),
-            Some(path_2.as_ref().to_path_buf()),
+            Some(path_2.to_path_buf()),
         )?;
         Ok(DiffResult::Text(result))
     } else {
-        Err(OxenError::invalid_file_type(format!(
+        Err(OxenError::invalid_file_type(&format!(
             "Compare not supported for files, found {:?} and {:?}",
-            path_1.as_ref(),
-            path_2.as_ref()
+            path_1, path_2
         )))
     }
 }
@@ -495,7 +490,7 @@ pub async fn diff_files(
 pub async fn diff_file_and_node(
     repo: &LocalRepository,
     file_node: Option<FileNode>,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     keys: Vec<String>,
     targets: Vec<String>,
     display: Vec<String>,
@@ -517,7 +512,7 @@ pub async fn diff_file_and_node(
             EntryDataType::Text => {
                 log::debug!(
                     "diff_file_and_node: diffing text files {:?} and {:?}",
-                    file_path.as_ref(),
+                    file_path,
                     file_node.hash().to_string()
                 );
                 let result = diff_text_file_and_node(repo, Some(&file_node), file_path).await?;
@@ -528,16 +523,16 @@ pub async fn diff_file_and_node(
                 );
                 Ok(result)
             }
-            _ => Err(OxenError::invalid_file_type(format!(
+            _ => Err(OxenError::invalid_file_type(&format!(
                 "Compare not supported for files, found {:?} and {:?}",
-                file_path.as_ref(),
+                file_path,
                 file_node.hash().to_string()
             ))),
         },
         None => {
             //we didn't get the file node, so we are comparing to a new file
 
-            let file_type = util::fs::file_data_type(file_path.as_ref());
+            let file_type = util::fs::file_data_type(file_path);
             match file_type {
                 EntryDataType::Tabular => {
                     let result = diff_tabular_file_and_file_node(
@@ -548,17 +543,14 @@ pub async fn diff_file_and_node(
                     Ok(DiffResult::Tabular(result))
                 }
                 EntryDataType::Text => {
-                    log::debug!(
-                        "diff_file_and_node: diffing text files {:?}",
-                        file_path.as_ref()
-                    );
+                    log::debug!("diff_file_and_node: diffing text files {:?}", file_path);
                     let result = diff_text_file_and_node(repo, None, file_path).await?;
                     log::debug!("diff_file_and_node: diffing text files {result:?}");
                     Ok(result)
                 }
-                _ => Err(OxenError::invalid_file_type(format!(
+                _ => Err(OxenError::invalid_file_type(&format!(
                     "Compare not supported for files, found {:?}",
-                    file_path.as_ref(),
+                    file_path,
                 ))),
             }
         }
@@ -604,7 +596,7 @@ pub async fn diff_file_nodes(
                     result.filename2 = Some(file_2.name().to_string());
                     Ok(DiffResult::Text(result))
                 }
-                _ => Err(OxenError::invalid_file_type(format!(
+                _ => Err(OxenError::invalid_file_type(&format!(
                     "Compare not supported for files, found {:?} and {:?}",
                     file_1.data_type(),
                     file_2.data_type()
@@ -624,7 +616,7 @@ pub async fn diff_file_nodes(
                 result.filename1 = Some(file_1.name().to_string());
                 Ok(DiffResult::Text(result))
             }
-            _ => Err(OxenError::invalid_file_type(format!(
+            _ => Err(OxenError::invalid_file_type(&format!(
                 "Compare not supported for files, found {:?}",
                 file_1.data_type()
             ))),
@@ -640,7 +632,7 @@ pub async fn diff_file_nodes(
                 let result = diff_text_file_nodes(repo, None, Some(&file_2)).await?;
                 Ok(DiffResult::Text(result))
             }
-            _ => Err(OxenError::invalid_file_type(format!(
+            _ => Err(OxenError::invalid_file_type(&format!(
                 "Compare not supported for files, found {:?}",
                 file_2.data_type()
             ))),
@@ -654,7 +646,7 @@ pub async fn diff_file_nodes(
 pub async fn diff_tabular_file_and_file_node(
     repo: &LocalRepository,
     file_node: Option<&FileNode>,
-    file_1_path: impl AsRef<Path>,
+    file_1_path: &Path,
     keys: Vec<String>,
     targets: Vec<String>,
     display: Vec<String>,
@@ -666,7 +658,7 @@ pub async fn diff_tabular_file_and_file_node(
                 .get_version_path(&file_node.hash().to_string())
                 .await?;
             let df_1 = tabular::read_df_with_extension(
-                file_node_path,
+                &file_node_path,
                 file_node.extension(),
                 &DFOpts::empty(),
             )
@@ -707,13 +699,13 @@ pub async fn diff_tabular_file_nodes(
                 .get_version_path(&file_2.hash().to_string())
                 .await?;
             let df_1 = tabular::read_df_with_extension(
-                version_path_1,
+                &version_path_1,
                 file_1.extension(),
                 &DFOpts::empty(),
             )
             .await?;
             let df_2 = tabular::read_df_with_extension(
-                version_path_2,
+                &version_path_2,
                 file_2.extension(),
                 &DFOpts::empty(),
             )
@@ -729,7 +721,7 @@ pub async fn diff_tabular_file_nodes(
                 .get_version_path(&file_1.hash().to_string())
                 .await?;
             let df_1 = tabular::read_df_with_extension(
-                version_path_1,
+                &version_path_1,
                 file_1.extension(),
                 &DFOpts::empty(),
             )
@@ -747,7 +739,7 @@ pub async fn diff_tabular_file_nodes(
                 .await?;
             let df_1 = tabular::new_df();
             let df_2 = tabular::read_df_with_extension(
-                version_path_2,
+                &version_path_2,
                 file_2.extension(),
                 &DFOpts::empty(),
             )
@@ -765,7 +757,7 @@ pub async fn diff_tabular_file_nodes(
 pub async fn diff_text_file_and_node(
     repo: &LocalRepository,
     file_node: Option<&FileNode>,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
 ) -> Result<DiffResult, OxenError> {
     let version_store = repo.version_store()?;
     let file_node_content = if let Some(node) = file_node {
@@ -775,12 +767,12 @@ pub async fn diff_text_file_and_node(
         None
     };
 
-    let file_path_content = util::fs::read_file(Some(&file_path))?;
+    let file_path_content = util::fs::read_file(Some(file_path))?;
     let result = utf8_diff::diff(
         file_node_content,
-        Some(file_path.as_ref().to_path_buf()), // The display path for the file node is the same as the locally-changed file
+        Some(file_path.to_path_buf()), // The display path for the file node is the same as the locally-changed file
         Some(file_path_content),
-        Some(file_path.as_ref().to_path_buf()),
+        Some(file_path.to_path_buf()),
     )?;
     Ok(DiffResult::Text(result))
 }
@@ -831,8 +823,8 @@ pub async fn diff_text_file_nodes(
 }
 
 pub async fn tabular(
-    file_1: impl AsRef<Path>,
-    file_2: impl AsRef<Path>,
+    file_1: &Path,
+    file_2: &Path,
     keys: Vec<String>,
     targets: Vec<String>,
     display: Vec<String>,
@@ -850,13 +842,13 @@ pub async fn tabular(
 
 async fn read_version_file_to_string(
     version_store: &Arc<dyn VersionStore>,
-    hash: impl AsRef<str>,
+    hash: &str,
 ) -> Result<String, OxenError> {
     match version_store.get_version(hash.as_ref()).await {
         Ok(bytes) => match String::from_utf8(bytes) {
             Ok(s) => Ok(s),
             Err(_) => {
-                let err = format!("could not decode version {} as UTF-8", hash.as_ref());
+                let err = format!("could not decode version {} as UTF-8", hash);
                 log::warn!("{err}");
                 Err(OxenError::basic_str(&err))
             }
@@ -870,12 +862,13 @@ fn validate_required_fields(
     keys: Vec<String>,
     targets: Vec<String>,
 ) -> Result<(), OxenError> {
+    let keys_str: Vec<&str> = keys.iter().map(String::as_str).collect();
     // Keys must be in both dfs
-    if !schema_1.has_field_names(&keys) {
+    if !schema_1.has_field_names(&keys_str) {
         return Err(OxenError::incompatible_schemas(schema_1.clone()));
     };
 
-    if !schema_2.has_field_names(&keys) {
+    if !schema_2.has_field_names(&keys_str) {
         return Err(OxenError::incompatible_schemas(schema_2));
     };
 
@@ -906,7 +899,17 @@ pub fn diff_dfs(
 
     let (df_1, df_2) = hash_dfs(df_1.clone(), df_2.clone(), &keys, &targets)?;
 
-    let compare = join_diff::diff(&df_1, &df_2, schema_diff, &keys, &targets, &display)?;
+    let keys_str: Vec<&str> = keys.iter().map(String::as_str).collect();
+    let targets_str: Vec<&str> = targets.iter().map(String::as_str).collect();
+    let display_str: Vec<&str> = display.iter().map(String::as_str).collect();
+    let compare = join_diff::diff(
+        &df_1,
+        &df_2,
+        schema_diff,
+        &keys_str,
+        &targets_str,
+        &display_str,
+    )?;
 
     Ok(compare)
 }
@@ -1280,7 +1283,7 @@ pub async fn compute_new_columns_from_dfs(
 
 pub async fn diff_entries(
     repo: &LocalRepository,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     base_entry: Option<FileNode>,
     base_commit: &Commit,
     head_entry: Option<FileNode>,
@@ -1387,25 +1390,25 @@ pub async fn get_cached_diff(
     // TODO this should be cached
     let left_version_path = repositories::revisions::get_version_file_from_commit_id(
         repo,
-        left_entry.commit_id,
+        &left_entry.commit_id,
         &left_entry.path,
     )
     .await?;
-    let left_full_df = tabular::read_df(&*left_version_path, DFOpts::empty()).await?;
+    let left_full_df = tabular::read_df(&left_version_path, DFOpts::empty()).await?;
     let right_version_path = repositories::revisions::get_version_file_from_commit_id(
         repo,
-        right_entry.commit_id,
+        &right_entry.commit_id,
         &right_entry.path,
     )
     .await?;
-    let right_full_df = tabular::read_df(&*right_version_path, DFOpts::empty()).await?;
+    let right_full_df = tabular::read_df(&right_version_path, DFOpts::empty()).await?;
 
     let schema_diff = TabularSchemaDiff::from_schemas(
         &Schema::from_polars(left_full_df.schema()),
         &Schema::from_polars(right_full_df.schema()),
     )?;
 
-    let diff_df = tabular::read_df(get_diff_cache_path(repo, compare_id), DFOpts::empty()).await?;
+    let diff_df = tabular::read_df(&get_diff_cache_path(repo, compare_id), DFOpts::empty()).await?;
 
     let schemas = TabularDiffSchemas {
         left: Schema::from_polars(left_full_df.schema()),
@@ -1649,7 +1652,7 @@ mod tests {
 
             // Remove a row
             let bbox_file = test::modify_txt_file(
-                bbox_file,
+                &bbox_file,
                 r"
 file,label,min_x,min_y,width,height
 train/dog_1.jpg,dog,101.5,32.0,385,330
@@ -1658,7 +1661,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
 ",
             )?;
 
-            repositories::add(&repo, bbox_file).await?;
+            repositories::add(&repo, &bbox_file).await?;
             let head_commit = repositories::commit(&repo, "Removing a row from train bbox data")?;
 
             let entries = repositories::diffs::list_diff_entries(
@@ -1698,7 +1701,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             let base_commit = repositories::commits::head_commit(&repo)?;
 
             // Remove the file
-            util::fs::remove_file(bbox_file)?;
+            util::fs::remove_file(&bbox_file)?;
 
             let opts = RmOpts::from_path(&bbox_filename);
             repositories::rm(&repo, &opts)?;
@@ -1785,7 +1788,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             let bbox_file = repo.path.join(&bbox_filename);
 
             // Remove the file
-            util::fs::remove_file(bbox_file)?;
+            util::fs::remove_file(&bbox_file)?;
 
             let opts = RmOpts::from_path(&bbox_filename);
             repositories::rm(&repo, &opts)?;
@@ -1842,19 +1845,22 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             let add_root_dir = PathBuf::from("not_annotations");
             let add_root_dir_added_file = PathBuf::from("not_annotations").join("added_file.txt");
 
-            util::fs::create_dir_all(repo.path.join(add_dir))?;
-            util::fs::create_dir_all(repo.path.join(add_root_dir))?;
+            util::fs::create_dir_all(&repo.path.join(add_dir))?;
+            util::fs::create_dir_all(&repo.path.join(add_root_dir))?;
 
             test::write_txt_file_to_path(&new_root_file, "Hello,world")?;
             test::write_txt_file_to_path(&new_bbox_file, "Hello,world")?;
-            test::write_txt_file_to_path(repo.path.join(add_dir_added_file), "Hello,world!!")?;
-            test::write_txt_file_to_path(repo.path.join(add_root_dir_added_file), "Hello,world!!")?;
+            test::write_txt_file_to_path(&repo.path.join(add_dir_added_file), "Hello,world!!")?;
+            test::write_txt_file_to_path(
+                &repo.path.join(add_root_dir_added_file),
+                "Hello,world!!",
+            )?;
 
             // get og commit
             let base_commit = repositories::commits::head_commit(&repo)?;
 
             // Remove the file
-            util::fs::remove_file(bbox_file)?;
+            util::fs::remove_file(&bbox_file)?;
 
             let opts = RmOpts::from_path(&bbox_filename);
             repositories::rm(&repo, &opts)?;
@@ -1949,7 +1955,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             let base_commit = repositories::commits::head_commit(&repo)?;
 
             // Remove the file
-            util::fs::remove_file(bbox_file)?;
+            util::fs::remove_file(&bbox_file)?;
 
             let opts = RmOpts::from_path(&bbox_filename);
             repositories::rm(&repo, &opts)?;
@@ -2060,7 +2066,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             tokio::fs::write(repo.path.join(&path_1), csv1).await?;
             tokio::fs::write(repo.path.join(&path_2), csv2).await?;
 
-            repositories::add(&repo, repo.path.clone()).await?;
+            repositories::add(&repo, &repo.path.clone()).await?;
 
             let commit = repositories::commit(&repo, "two files")?;
 
@@ -2121,7 +2127,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             tokio::fs::write(repo.path.join(&path_1), csv1).await?;
             tokio::fs::write(repo.path.join(&path_2), csv2).await?;
 
-            repositories::add(&repo, repo.path.clone()).await?;
+            repositories::add(&repo, &repo.path.clone()).await?;
 
             let commit = repositories::commit(&repo, "two files")?;
 
@@ -2193,7 +2199,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             tokio::fs::write(repo.path.join(&path_1), csv1).await?;
             tokio::fs::write(repo.path.join(&path_2), csv2).await?;
 
-            repositories::add(&repo, repo.path.clone()).await?;
+            repositories::add(&repo, &repo.path.clone()).await?;
 
             let commit = repositories::commit(&repo, "two files")?;
 
@@ -2265,7 +2271,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             tokio::fs::write(repo.path.join(&path_1), csv1).await?;
             tokio::fs::write(repo.path.join(&path_2), csv2).await?;
 
-            repositories::add(&repo, repo.path.clone()).await?;
+            repositories::add(&repo, &repo.path.clone()).await?;
 
             let commit = repositories::commit(&repo, "two files")?;
 
@@ -2336,7 +2342,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             tokio::fs::write(repo.path.join(&path_1), csv1).await?;
             tokio::fs::write(repo.path.join(&path_2), csv2).await?;
 
-            repositories::add(&repo, repo.path.clone()).await?;
+            repositories::add(&repo, &repo.path.clone()).await?;
 
             let commit = repositories::commit(&repo, "two files")?;
 
@@ -2401,7 +2407,7 @@ train/cat_2.jpg,cat,30.5,44.0,333,396
             tokio::fs::write(repo.path.join(&path_1), csv1).await?;
             tokio::fs::write(repo.path.join(&path_2), csv2).await?;
 
-            repositories::add(&repo, repo.path.clone()).await?;
+            repositories::add(&repo, &repo.path.clone()).await?;
 
             let commit = repositories::commit(&repo, "two files")?;
 

--- a/crates/lib/src/repositories/diffs/join_diff.rs
+++ b/crates/lib/src/repositories/diffs/join_diff.rs
@@ -45,7 +45,7 @@ pub fn diff(
 ) -> Result<TabularDiff, OxenError> {
     if !targets.is_empty() && keys.is_empty() {
         let targets = targets.iter().map(|k| k.as_ref()).collect::<Vec<&str>>();
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Must specify at least one key column if specifying target columns. Targets: {targets:?}"
         )));
     }

--- a/crates/lib/src/repositories/diffs/join_diff.rs
+++ b/crates/lib/src/repositories/diffs/join_diff.rs
@@ -39,13 +39,13 @@ pub fn diff(
     df_1: &DataFrame,
     df_2: &DataFrame,
     schema_diff: SchemaDiff,
-    keys: &[impl AsRef<str>],
-    targets: &[impl AsRef<str>],
-    display: &[impl AsRef<str>],
+    keys: &[&str],
+    targets: &[&str],
+    display: &[&str],
 ) -> Result<TabularDiff, OxenError> {
     if !targets.is_empty() && keys.is_empty() {
         let targets = targets.iter().map(|k| k.as_ref()).collect::<Vec<&str>>();
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Must specify at least one key column if specifying target columns. Targets: {targets:?}"
         )));
     }

--- a/crates/lib/src/repositories/download.rs
+++ b/crates/lib/src/repositories/download.rs
@@ -15,19 +15,13 @@ use crate::repositories::LocalRepository;
 
 pub async fn download(
     repo: &RemoteRepository,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    remote_path: &Path,
+    local_path: &Path,
+    revision: &str,
 ) -> Result<(), OxenError> {
     // Ping server telling it we are about to download
     api::client::repositories::pre_download(repo).await?;
-    api::client::entries::download_entry(
-        repo,
-        remote_path.as_ref(),
-        local_path.as_ref(),
-        revision.as_ref(),
-    )
-    .await?;
+    api::client::entries::download_entry(repo, remote_path, local_path, revision).await?;
     // Ping server telling it we finished downloading
     api::client::repositories::post_download(repo).await?;
     Ok(())
@@ -36,8 +30,8 @@ pub async fn download(
 pub async fn download_dir(
     remote_repo: &RemoteRepository,
     entry: &MetadataEntry,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
+    remote_path: &Path,
+    local_path: &Path,
 ) -> Result<(), OxenError> {
     match remote_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -54,8 +48,8 @@ pub async fn download_dir_to_repo(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
     entry: &MetadataEntry,
-    remote_path: impl AsRef<Path>,
-    local_path: impl AsRef<Path>,
+    remote_path: &Path,
+    local_path: &Path,
 ) -> Result<(), OxenError> {
     match remote_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -97,7 +91,7 @@ mod tests {
             let num_files = 33;
             for i in 0..num_files {
                 let path = dir.join(format!("file_{i}.txt"));
-                util::fs::write_to_path(&path, format!("lol hi {i}"))?;
+                util::fs::write_to_path(&path, &format!("lol hi {i}"))?;
             }
             repositories::add(&repo, &dir).await?;
             repositories::commit(&repo, "adding text files")?;
@@ -118,7 +112,7 @@ mod tests {
 
             // Download the directory
             let output_dir = repo.path.join("output");
-            download(&remote_repo, &dir, &output_dir, &branch.name).await?;
+            download(&remote_repo, dir, &output_dir, &branch.name).await?;
 
             // Check that the files are there
             for i in 0..num_files {
@@ -190,7 +184,7 @@ mod tests {
             let num_files = 33;
             for i in 0..num_files {
                 let path = dir.join(format!("file_{i}.txt"));
-                util::fs::write_to_path(&path, format!("lol hi {i}"))?;
+                util::fs::write_to_path(&path, &format!("lol hi {i}"))?;
             }
             repositories::add(&repo, &dir).await?;
             repositories::commit(&repo, "adding text files")?;
@@ -211,7 +205,7 @@ mod tests {
 
             // Download the directory
             let output_dir = Path::new("output");
-            repositories::download(&remote_repo, &dir, &output_dir, &branch.name).await?;
+            repositories::download(&remote_repo, dir, output_dir, &branch.name).await?;
 
             // Check that the files are there
             for i in 0..num_files {
@@ -245,7 +239,7 @@ mod tests {
                 let local_path = repo_dir.join("new_name.txt");
                 let revision = DEFAULT_BRANCH_NAME;
 
-                download(&remote_repo, file_path, &local_path, revision).await?;
+                download(&remote_repo, Path::new(file_path), &local_path, revision).await?;
 
                 assert!(local_path.exists());
                 assert_eq!(util::fs::read_from_path(&local_path)?, file_contents);
@@ -273,7 +267,7 @@ mod tests {
                 let dst_path = repo_dir.join("images");
                 let revision = DEFAULT_BRANCH_NAME;
 
-                download(&remote_repo, src_path, &dst_path, revision).await?;
+                download(&remote_repo, Path::new(src_path), &dst_path, revision).await?;
 
                 assert!(dst_path.exists());
                 let result_dir = &dst_path.join(src_path);

--- a/crates/lib/src/repositories/entries.rs
+++ b/crates/lib/src/repositories/entries.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 pub fn get_directory(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<DirNode>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 is no longer supported"),
@@ -36,7 +36,7 @@ pub fn get_directory(
 pub fn get_file(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<FileNode>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 is no longer supported"),
@@ -48,17 +48,23 @@ pub fn get_file(
 /// List all the entries within a commit
 pub fn list_commit_entries(
     repo: &LocalRepository,
-    revision: impl AsRef<str>,
+    revision: &str,
     paginate_opts: &PaginateOpts,
 ) -> Result<PaginatedDirEntries, OxenError> {
-    list_directory_w_version(repo, ROOT_PATH, revision, paginate_opts, repo.min_version())
+    list_directory_w_version(
+        repo,
+        Path::new(ROOT_PATH),
+        revision,
+        paginate_opts,
+        repo.min_version(),
+    )
 }
 
 /// List all the entries within a directory given a specific commit
 pub fn list_directory(
     repo: &LocalRepository,
-    directory: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    directory: &Path,
+    revision: &str,
     paginate_opts: &PaginateOpts,
 ) -> Result<PaginatedDirEntries, OxenError> {
     list_directory_w_version(repo, directory, revision, paginate_opts, repo.min_version())
@@ -67,24 +73,24 @@ pub fn list_directory(
 /// Force a version when listing a repo
 pub fn list_directory_w_version(
     repo: &LocalRepository,
-    directory: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    directory: &Path,
+    revision: &str,
     paginate_opts: &PaginateOpts,
     version: MinOxenVersion,
 ) -> Result<PaginatedDirEntries, OxenError> {
     match version {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => {
-            let revision_str = revision.as_ref().to_string();
+            let revision_str = revision.to_string();
             let branch = repositories::branches::get_by_name(repo, &revision_str)?;
             let commit = repositories::revisions::get(repo, &revision_str)?;
             let parsed_resource = ParsedResource {
-                path: directory.as_ref().to_path_buf(),
+                path: directory.to_path_buf(),
                 commit,
                 workspace: None,
                 branch,
                 version: PathBuf::from(&revision_str),
-                resource: PathBuf::from(&revision_str).join(directory.as_ref()),
+                resource: PathBuf::from(&revision_str).join(directory),
             };
             core::v_latest::entries::list_directory(
                 repo,
@@ -98,8 +104,8 @@ pub fn list_directory_w_version(
 
 pub fn list_directory_w_workspace(
     repo: &LocalRepository,
-    directory: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    directory: &Path,
+    revision: &str,
     workspace: Option<Workspace>,
     paginate_opts: &PaginateOpts,
     version: MinOxenVersion,
@@ -117,8 +123,8 @@ pub fn list_directory_w_workspace(
 
 pub fn list_directory_w_workspace_depth(
     repo: &LocalRepository,
-    directory: impl AsRef<Path>,
-    revision: impl AsRef<str>,
+    directory: &Path,
+    revision: &str,
     workspace: Option<Workspace>,
     paginate_opts: &PaginateOpts,
     version: MinOxenVersion,
@@ -130,7 +136,7 @@ pub fn list_directory_w_workspace_depth(
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => {
             let _perf_setup = crate::perf_guard!("entries::list_directory_w_workspace_setup");
-            let revision_str = revision.as_ref().to_string();
+            let revision_str = revision.to_string();
             let version_str = if let Some(workspace) = workspace.clone() {
                 workspace.id.clone()
             } else {
@@ -140,12 +146,12 @@ pub fn list_directory_w_workspace_depth(
             let branch = repositories::branches::get_by_name(repo, &revision_str)?;
             let commit = repositories::revisions::get(repo, &revision_str)?;
             let parsed_resource = ParsedResource {
-                path: directory.as_ref().to_path_buf(),
+                path: directory.to_path_buf(),
                 commit,
                 workspace,
                 branch,
                 version: PathBuf::from(&version_str),
-                resource: PathBuf::from(&version_str).join(directory.as_ref()),
+                resource: PathBuf::from(&version_str).join(directory),
             };
             drop(_perf_setup);
 
@@ -160,7 +166,7 @@ pub fn list_directory_w_workspace_depth(
     }
 }
 
-pub fn update_metadata(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<(), OxenError> {
+pub fn update_metadata(repo: &LocalRepository, revision: &str) -> Result<(), OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => {
             panic!("update_metadata not implemented for oxen v0.10.0")
@@ -175,9 +181,8 @@ pub fn update_metadata(repo: &LocalRepository, revision: impl AsRef<str>) -> Res
 pub fn get_meta_entry(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<MetadataEntry, OxenError> {
-    let path = path.as_ref();
     let parsed_resource = ParsedResource {
         path: path.to_path_buf(),
         commit: Some(commit.clone()),
@@ -409,7 +414,7 @@ mod tests {
             let file_to_add = repo.path.join("labels.txt");
 
             // Commit the file
-            repositories::add(&repo, file_to_add).await?;
+            repositories::add(&repo, &file_to_add).await?;
             let commit = repositories::commit(&repo, "Adding labels file")?;
 
             let entries = repositories::entries::list_for_commit(&repo, &commit)?;
@@ -427,7 +432,7 @@ mod tests {
             let file_to_add = repo.path.join("labels.txt");
 
             // Commit the file
-            repositories::add(&repo, file_to_add).await?;
+            repositories::add(&repo, &file_to_add).await?;
             let commit = repositories::commit(&repo, "Adding labels file")?;
 
             let count = repositories::entries::count_for_commit(&repo, &commit)?;
@@ -644,16 +649,16 @@ mod tests {
                 util::fs::create_dir_all(&dir_path)?;
                 let filename = "data.txt";
                 let filepath = dir_path.join(filename);
-                util::fs::write(&filepath, format!("Hi {n}"))?;
+                util::fs::write(&filepath, format!("Hi {n}").as_bytes())?;
             }
             // Create 2 files
             let filename = "labels.txt";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "hello world")?;
+            util::fs::write(&filepath, "hello world".as_bytes())?;
 
             let filename = "README.md";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "readme....")?;
+            util::fs::write(&filepath, "readme....".as_bytes())?;
 
             // Add and commit all the dirs and files
             repositories::add(&repo, &repo.path).await?;
@@ -690,7 +695,7 @@ mod tests {
                 util::fs::create_dir_all(&dir_path)?;
                 let filename = "data.txt";
                 let filepath = dir_path.join(filename);
-                util::fs::write(&filepath, format!("Hi {n}"))?;
+                util::fs::write(&filepath, format!("Hi {n}").as_bytes())?;
             }
 
             // Add and commit all the dirs and files
@@ -736,7 +741,7 @@ mod tests {
                 util::fs::create_dir_all(&dir_path)?;
                 let filename = "data.txt";
                 let filepath = dir_path.join(filename);
-                util::fs::write(&filepath, format!("Hi {n}"))?;
+                util::fs::write(&filepath, format!("Hi {n}").as_bytes())?;
             }
 
             // Add and commit all the dirs and files
@@ -782,16 +787,16 @@ mod tests {
                 util::fs::create_dir_all(&dir_path)?;
                 let filename = "data.txt";
                 let filepath = dir_path.join(filename);
-                util::fs::write(&filepath, format!("Hi {n}"))?;
+                util::fs::write(&filepath, format!("Hi {n}").as_bytes())?;
             }
             // Create 2 files
             let filename = "labels.txt";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "hello world")?;
+            util::fs::write(&filepath, "hello world".as_bytes())?;
 
             let filename = "README.md";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "readme....")?;
+            util::fs::write(&filepath, "readme....".as_bytes())?;
 
             // Add and commit all the dirs and files
             repositories::add(&repo, &repo.path).await?;
@@ -828,16 +833,16 @@ mod tests {
                 util::fs::create_dir_all(&dir_path)?;
                 let filename = "data.txt";
                 let filepath = dir_path.join(filename);
-                util::fs::write(&filepath, format!("Hi {n}"))?;
+                util::fs::write(&filepath, format!("Hi {n}").as_bytes())?;
             }
             // Create 2 files
             let filename = "labels.txt";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "hello world")?;
+            util::fs::write(&filepath, "hello world".as_bytes())?;
 
             let filename = "README.md";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "readme....")?;
+            util::fs::write(&filepath, "readme....".as_bytes())?;
 
             // Add and commit all the dirs and files
             repositories::add(&repo, &repo.path).await?;
@@ -874,16 +879,16 @@ mod tests {
                 util::fs::create_dir_all(&dir_path)?;
                 let filename = "data.txt";
                 let filepath = dir_path.join(filename);
-                util::fs::write(&filepath, format!("Hi {n}"))?;
+                util::fs::write(&filepath, format!("Hi {n}").as_bytes())?;
             }
             // Create 2 files
             let filename = "labels.txt";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "hello world")?;
+            util::fs::write(&filepath, "hello world".as_bytes())?;
 
             let filename = "README.md";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "readme....")?;
+            util::fs::write(&filepath, "readme....".as_bytes())?;
 
             // Add and commit all the dirs and files
             repositories::add(&repo, &repo.path).await?;
@@ -921,7 +926,7 @@ mod tests {
                 util::fs::create_dir_all(&dir_path)?;
                 let filename = "data.txt";
                 let filepath = dir_path.join(filename);
-                util::fs::write(&filepath, format!("Hi {n}"))?;
+                util::fs::write(&filepath, format!("Hi {n}").as_bytes())?;
             }
 
             // Create many files
@@ -929,7 +934,7 @@ mod tests {
             for n in 0..num_files {
                 let filename = format!("file_{n}.txt");
                 let filepath = repo.path.join(filename);
-                util::fs::write(filepath, format!("helloooo {n}"))?;
+                util::fs::write(&filepath, format!("helloooo {n}").as_bytes())?;
             }
 
             // Add and commit all the dirs and files
@@ -965,14 +970,14 @@ mod tests {
             util::fs::create_dir_all(&dir_path)?;
             let filename = "data.txt";
             let filepath = dir_path.join(filename);
-            util::fs::write(filepath, "All the lonely directories")?;
+            util::fs::write(&filepath, "All the lonely directories".as_bytes())?;
 
             // Create many files
             let num_files = 45;
             for n in 0..num_files {
                 let filename = format!("file_{n}.txt");
                 let filepath = repo.path.join(filename);
-                util::fs::write(filepath, format!("helloooo {n}"))?;
+                util::fs::write(&filepath, format!("helloooo {n}").as_bytes())?;
             }
 
             // Add and commit all the dirs and files
@@ -1012,7 +1017,7 @@ mod tests {
                 util::fs::create_dir_all(&dir_path)?;
                 let filename = "data.txt";
                 let filepath = dir_path.join(filename);
-                util::fs::write(&filepath, format!("Hi {n}"))?;
+                util::fs::write(&filepath, format!("Hi {n}").as_bytes())?;
             }
 
             // Create many files
@@ -1020,7 +1025,7 @@ mod tests {
             for n in 0..num_files {
                 let filename = format!("file_{n}.txt");
                 let filepath = repo.path.join(filename);
-                util::fs::write(filepath, format!("helloooo {n}"))?;
+                util::fs::write(&filepath, format!("helloooo {n}").as_bytes())?;
             }
 
             // Add and commit all the dirs and files
@@ -1069,11 +1074,11 @@ mod tests {
             // Add two tabular files to it
             let filename_1 = "cats.tsv";
             let filepath_1 = dir_path.join(filename_1);
-            util::fs::write(filepath_1, "1\t2\t3\nhello\tworld\tsup\n")?;
+            util::fs::write(&filepath_1, "1\t2\t3\nhello\tworld\tsup\n".as_bytes())?;
 
             let filename_2 = "dogs.csv";
             let filepath_2 = dir_path.join(filename_2);
-            util::fs::write(filepath_2, "1,2,3\nhello,world,sup\n")?;
+            util::fs::write(&filepath_2, "1,2,3\nhello,world,sup\n".as_bytes())?;
 
             let path_1 = PathBuf::from("data")
                 .join("train")
@@ -1090,7 +1095,7 @@ mod tests {
             // And write a file in the same dir that is not tabular
             let filename = "README.md";
             let filepath = dir_path.join(filename);
-            util::fs::write(filepath, "readme....")?;
+            util::fs::write(&filepath, "readme....".as_bytes())?;
 
             // Add and commit all
             repositories::add(&repo, &repo.path).await?;
@@ -1108,7 +1113,7 @@ mod tests {
 
             // Now index df2
             let workspace_id = Uuid::new_v4().to_string();
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, false)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, false)?;
             repositories::workspaces::data_frames::index(&repo, &workspace, &entry2.path).await?;
 
             // Now get the metadata entries for the two dataframes
@@ -1144,10 +1149,10 @@ mod tests {
             util::fs::create_dir_all(&dir_a_subdir)?;
             util::fs::create_dir_all(&dir_b)?;
 
-            util::fs::write(repo.path.join("root_file.txt"), "root content")?;
-            util::fs::write(dir_a.join("file_a1.txt"), "a1 content")?;
-            util::fs::write(dir_a_subdir.join("file_sub.txt"), "sub content")?;
-            util::fs::write(dir_b.join("file_b1.txt"), "b1 content")?;
+            util::fs::write(&repo.path.join("root_file.txt"), "root content".as_bytes())?;
+            util::fs::write(&dir_a.join("file_a1.txt"), "a1 content".as_bytes())?;
+            util::fs::write(&dir_a_subdir.join("file_sub.txt"), "sub content".as_bytes())?;
+            util::fs::write(&dir_b.join("file_b1.txt"), "b1 content".as_bytes())?;
 
             repositories::add(&repo, &repo.path).await?;
             let commit = repositories::commit(&repo, "Adding nested structure")?;

--- a/crates/lib/src/repositories/fetch.rs
+++ b/crates/lib/src/repositories/fetch.rs
@@ -19,7 +19,7 @@ pub async fn fetch_all(
 ) -> Result<Vec<Branch>, OxenError> {
     let remote = repo
         .get_remote(&fetch_opts.remote)
-        .ok_or(OxenError::remote_not_set(fetch_opts.remote.clone()))?;
+        .ok_or(OxenError::remote_not_set(&fetch_opts.remote.clone()))?;
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
     api::client::repositories::pre_fetch(&remote_repo).await?;
@@ -87,7 +87,7 @@ pub async fn fetch_branch(
 ) -> Result<Branch, OxenError> {
     let remote = repo
         .get_remote(&fetch_opts.remote)
-        .ok_or(OxenError::remote_not_set(fetch_opts.remote.clone()))?;
+        .ok_or(OxenError::remote_not_set(&fetch_opts.remote.clone()))?;
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
 
     api::client::repositories::pre_fetch(&remote_repo).await?;
@@ -141,7 +141,7 @@ mod tests {
             for branch in branches.iter() {
                 repositories::branches::create_checkout(&repo, branch)?;
                 let filepath = repo.path.join(format!("file_{branch}.txt"));
-                test::write_txt_file_to_path(&filepath, format!("a file on {branch}"))?;
+                test::write_txt_file_to_path(&filepath, &format!("a file on {branch}"))?;
                 repositories::add(&repo, &filepath).await?;
                 repositories::commit(&repo, &format!("Adding file on {branch}"))?;
                 repositories::push(&repo).await?;

--- a/crates/lib/src/repositories/fork.rs
+++ b/crates/lib/src/repositories/fork.rs
@@ -28,7 +28,7 @@ fn read_status(repo_path: &Path) -> Result<Option<ForkStatus>, OxenError> {
     let content = fs::read_to_string(&status_path)?;
     let status_file: ForkStatusFile = toml::from_str(&content).map_err(|e| {
         log::error!("Failed to parse fork status on file: {status_path:?} error: {e}");
-        OxenError::basic_str(format!("Failed to parse fork status on file: {e}"))
+        OxenError::basic_str(&format!("Failed to parse fork status on file: {e}"))
     })?;
 
     let status = &status_file.status;
@@ -51,7 +51,7 @@ pub fn start_fork(
     new_path: PathBuf,
 ) -> Result<ForkStartResponse, OxenError> {
     if new_path.exists() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "A file already exists at the destination path: {}",
             new_path.to_string_lossy()
         )));

--- a/crates/lib/src/repositories/fork.rs
+++ b/crates/lib/src/repositories/fork.rs
@@ -28,7 +28,7 @@ fn read_status(repo_path: &Path) -> Result<Option<ForkStatus>, OxenError> {
     let content = fs::read_to_string(&status_path)?;
     let status_file: ForkStatusFile = toml::from_str(&content).map_err(|e| {
         log::error!("Failed to parse fork status on file: {status_path:?} error: {e}");
-        OxenError::basic_str(&format!("Failed to parse fork status on file: {e}"))
+        OxenError::basic_str(format!("Failed to parse fork status on file: {e}"))
     })?;
 
     let status = &status_file.status;
@@ -51,7 +51,7 @@ pub fn start_fork(
     new_path: PathBuf,
 ) -> Result<ForkStartResponse, OxenError> {
     if new_path.exists() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "A file already exists at the destination path: {}",
             new_path.to_string_lossy()
         )));

--- a/crates/lib/src/repositories/init.rs
+++ b/crates/lib/src/repositories/init.rs
@@ -21,15 +21,14 @@ use crate::opts::StorageOpts;
 /// let repo = repositories::init(base_dir)?;
 /// assert!(base_dir.join(".oxen").exists());
 /// ```
-pub fn init(path: impl AsRef<Path>) -> Result<LocalRepository, OxenError> {
+pub fn init(path: &Path) -> Result<LocalRepository, OxenError> {
     init_with_version(path, MIN_OXEN_VERSION)
 }
 
 pub fn init_with_version(
-    path: impl AsRef<Path>,
+    path: &Path,
     version: MinOxenVersion,
 ) -> Result<LocalRepository, OxenError> {
-    let path = path.as_ref();
     match version {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::init_with_version_default(path, version),
@@ -37,18 +36,17 @@ pub fn init_with_version(
 }
 
 pub async fn init_with_storage_opts(
-    path: impl AsRef<Path>,
+    path: &Path,
     storage_opts: Option<StorageOpts>,
 ) -> Result<LocalRepository, OxenError> {
     init_with_version_and_storage_opts(path, MIN_OXEN_VERSION, storage_opts).await
 }
 
 pub async fn init_with_version_and_storage_opts(
-    path: impl AsRef<Path>,
+    path: &Path,
     version: MinOxenVersion,
     storage_opts: Option<StorageOpts>,
 ) -> Result<LocalRepository, OxenError> {
-    let path = path.as_ref();
     match version {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::init_with_version_and_storage_opts(path, version, storage_opts).await,

--- a/crates/lib/src/repositories/load.rs
+++ b/crates/lib/src/repositories/load.rs
@@ -16,7 +16,7 @@ pub async fn load(
     let dest_path = if dest_path.exists() {
         if dest_path.is_file() {
             return Err(OxenError::basic_str(
-                "Destination path is a file, must be a directory",
+                "Destination path is a file, must be a directory".to_string(),
             ));
         }
         dest_path.to_path_buf()

--- a/crates/lib/src/repositories/load.rs
+++ b/crates/lib/src/repositories/load.rs
@@ -78,7 +78,7 @@ mod tests {
             assert!(save_path.exists());
 
             // Cleanup tarball
-            util::fs::remove_file(save_path)?;
+            util::fs::remove_file(&save_path)?;
 
             Ok(())
         })
@@ -108,7 +108,7 @@ mod tests {
                 assert!(hydrated_repo.path.join("hello.txt").exists());
 
                 // Cleanup tarball
-                util::fs::remove_file(save_path)?;
+                util::fs::remove_file(&save_path)?;
 
                 Ok(())
             })
@@ -146,7 +146,7 @@ mod tests {
                 assert_eq!(status.removed_files.len(), 1);
 
                 // Cleanup tarball
-                util::fs::remove_file(save_path)?;
+                util::fs::remove_file(&save_path)?;
 
                 Ok(())
             })
@@ -209,7 +209,7 @@ mod tests {
                 assert!(!hydrated_repo.path.join("goodbye.txt").exists());
 
                 // Cleanup tarball
-                util::fs::remove_file(save_path)?;
+                util::fs::remove_file(&save_path)?;
 
                 Ok(())
             })

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -123,10 +123,7 @@ pub async fn merge_into_base(
     }
 }
 
-pub async fn merge(
-    repo: &LocalRepository,
-    branch_name: impl AsRef<str>,
-) -> Result<Option<Commit>, OxenError> {
+pub async fn merge(repo: &LocalRepository, branch_name: &str) -> Result<Option<Commit>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::merge::merge(repo, branch_name).await,
@@ -178,9 +175,9 @@ pub fn remove_conflict_path(repo: &LocalRepository, path: &Path) -> Result<(), O
     }
 }
 
-pub fn find_merge_commits<S: AsRef<str>>(
+pub fn find_merge_commits(
     repo: &LocalRepository,
-    branch_name: S,
+    branch_name: &str,
 ) -> Result<MergeCommits, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -232,7 +229,7 @@ mod tests {
         let a_branch = repositories::branches::current_branch(repo)?.unwrap();
         let a_path = repo.path.join("a.txt");
         util::fs::write_to_path(&a_path, "a")?;
-        repositories::add(repo, a_path).await?;
+        repositories::add(repo, &a_path).await?;
         // Return the lowest common ancestor for the tests
         let lca = repositories::commit(repo, "Committing a.txt file")?;
 
@@ -240,19 +237,19 @@ mod tests {
         repositories::branches::create_checkout(repo, merge_branch_name)?;
         let b_path = repo.path.join("b.txt");
         util::fs::write_to_path(&b_path, "b")?;
-        repositories::add(repo, b_path).await?;
+        repositories::add(repo, &b_path).await?;
         repositories::commit(repo, "Committing b.txt file")?;
 
         // Checkout A again to make another change
         repositories::checkout(repo, &a_branch.name).await?;
         let c_path = repo.path.join("c.txt");
         util::fs::write_to_path(&c_path, "c")?;
-        repositories::add(repo, c_path).await?;
+        repositories::add(repo, &c_path).await?;
         repositories::commit(repo, "Committing c.txt file")?;
 
         let d_path = repo.path.join("d.txt");
         util::fs::write_to_path(&d_path, "d")?;
-        repositories::add(repo, d_path).await?;
+        repositories::add(repo, &d_path).await?;
         repositories::commit(repo, "Committing d.txt file")?;
 
         // Checkout merge branch (B) to make another change
@@ -260,7 +257,7 @@ mod tests {
 
         let e_path = repo.path.join("e.txt");
         util::fs::write_to_path(&e_path, "e")?;
-        repositories::add(repo, e_path).await?;
+        repositories::add(repo, &e_path).await?;
         repositories::commit(repo, "Committing e.txt file")?;
 
         // Checkout the OG branch again so that we can merge into it
@@ -276,7 +273,7 @@ mod tests {
             let og_branch = repositories::branches::current_branch(&repo)?.unwrap();
             let hello_file = repo.path.join("hello.txt");
             util::fs::write_to_path(&hello_file, "Hello")?;
-            repositories::add(&repo, hello_file).await?;
+            repositories::add(&repo, &hello_file).await?;
             repositories::commit(&repo, "Adding hello file")?;
 
             // Branch to add world
@@ -320,7 +317,7 @@ mod tests {
             let og_branch = repositories::branches::current_branch(&repo)?.unwrap();
             let hello_file = repo.path.join("hello.txt");
             util::fs::write_to_path(&hello_file, "Hello")?;
-            repositories::add(&repo, hello_file).await?;
+            repositories::add(&repo, &hello_file).await?;
 
             // Write and add world file
             let world_file = repo.path.join("world.txt");
@@ -369,7 +366,7 @@ mod tests {
             let og_branch = repositories::branches::current_branch(&repo)?.unwrap();
             let hello_file = repo.path.join("hello.txt");
             util::fs::write_to_path(&hello_file, "Hello")?;
-            repositories::add(&repo, hello_file).await?;
+            repositories::add(&repo, &hello_file).await?;
 
             // Write and add world file
             let world_file = repo.path.join("world.txt");
@@ -386,7 +383,7 @@ mod tests {
 
             // Modify the file
             let new_contents = "Around the world";
-            let world_file = test::modify_txt_file(world_file, new_contents)?;
+            let world_file = test::modify_txt_file(&world_file, new_contents)?;
 
             // Commit the removal
             repositories::add(&repo, &world_file).await?;
@@ -584,7 +581,7 @@ mod tests {
             // Add a fish label to the file on a branch
             let fish_branch_name = "add-fish-label";
             repositories::branches::create_checkout(&repo, fish_branch_name)?;
-            let labels_path = test::modify_txt_file(labels_path, "cat\ndog\nfish")?;
+            let labels_path = test::modify_txt_file(&labels_path, "cat\ndog\nfish")?;
             repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "Adding fish to labels.txt file")?;
 
@@ -592,8 +589,8 @@ mod tests {
             repositories::checkout(&repo, &og_branch.name).await?;
             let human_branch_name = "add-human-label";
             repositories::branches::create_checkout(&repo, human_branch_name)?;
-            let labels_path = test::modify_txt_file(labels_path, "cat\ndog\nhuman")?;
-            repositories::add(&repo, labels_path).await?;
+            let labels_path = test::modify_txt_file(&labels_path, "cat\ndog\nhuman")?;
+            repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "Adding human to labels.txt file")?;
 
             // Checkout main again
@@ -634,7 +631,7 @@ mod tests {
             // Add a fish label to the file on a branch
             let fish_branch_name = "add-fish-label";
             repositories::branches::create_checkout(&repo, fish_branch_name)?;
-            let labels_path = test::modify_txt_file(labels_path, "cat\ndog\nfish")?;
+            let labels_path = test::modify_txt_file(&labels_path, "cat\ndog\nfish")?;
             repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "Adding fish to labels.txt file")?;
 
@@ -642,8 +639,8 @@ mod tests {
             repositories::checkout(&repo, &og_branch.name).await?;
             let human_branch_name = "add-human-label";
             repositories::branches::create_checkout(&repo, human_branch_name)?;
-            let labels_path = test::modify_txt_file(labels_path, "cat\ndog\nhuman")?;
-            repositories::add(&repo, labels_path).await?;
+            let labels_path = test::modify_txt_file(&labels_path, "cat\ndog\nhuman")?;
+            repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "Adding human to labels.txt file")?;
 
             // Checkout main again
@@ -685,7 +682,7 @@ mod tests {
             // Add a fish label to the file on a branch
             let fish_branch_name = "add-fish-label";
             repositories::branches::create_checkout(&repo, fish_branch_name)?;
-            let labels_path = test::modify_txt_file(labels_path, "cat\ndog\nfish")?;
+            let labels_path = test::modify_txt_file(&labels_path, "cat\ndog\nfish")?;
             repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "Adding fish to labels.txt file")?;
 
@@ -693,8 +690,8 @@ mod tests {
             repositories::checkout(&repo, &og_branch.name).await?;
             let human_branch_name = "add-human-label";
             repositories::branches::create_checkout(&repo, human_branch_name)?;
-            let labels_path = test::modify_txt_file(labels_path, "cat\ndog\nhuman")?;
-            repositories::add(&repo, labels_path).await?;
+            let labels_path = test::modify_txt_file(&labels_path, "cat\ndog\nhuman")?;
+            repositories::add(&repo, &labels_path).await?;
             let human_commit = repositories::commit(&repo, "Adding human to labels.txt file")?;
 
             // Checkout main again
@@ -735,17 +732,17 @@ mod tests {
                 .join("bounding_box.csv");
             let bbox_file = repo.path.join(&bbox_filename);
             let bbox_file =
-                test::append_line_txt_file(bbox_file, "train/cat_3.jpg,cat,41.0,31.5,410,427")?;
+                test::append_line_txt_file(&bbox_file, "train/cat_3.jpg,cat,41.0,31.5,410,427")?;
             let their_branch_contents = util::fs::read_from_path(&bbox_file)?;
 
             repositories::add(&repo, &bbox_file).await?;
             repositories::commit(&repo, "Adding new annotation as an Ox on a branch.")?;
 
             // Add a more rows on the main branch
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             let bbox_file =
-                test::append_line_txt_file(bbox_file, "train/dog_4.jpg,dog,52.0,62.5,256,429")?;
+                test::append_line_txt_file(&bbox_file, "train/dog_4.jpg,dog,52.0,62.5,256,429")?;
 
             repositories::add(&repo, &bbox_file).await?;
             repositories::commit(&repo, "Adding new annotation on main branch")?;
@@ -787,17 +784,17 @@ mod tests {
 
             // Add in a line in this branch
             let row_from_branch = "train/cat_3.jpg,cat,41.0,31.5,410,427";
-            let bbox_file = test::append_line_txt_file(bbox_file, row_from_branch)?;
+            let bbox_file = test::append_line_txt_file(&bbox_file, row_from_branch)?;
 
             // Add the changes
             repositories::add(&repo, &bbox_file).await?;
             repositories::commit(&repo, "Adding new annotation as an Ox on a branch.")?;
 
             // Add a more rows on the main branch
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             let row_from_main = "train/dog_4.jpg,dog,52.0,62.5,256,429";
-            let bbox_file = test::append_line_txt_file(bbox_file, row_from_main)?;
+            let bbox_file = test::append_line_txt_file(&bbox_file, row_from_main)?;
 
             repositories::add(&repo, &bbox_file).await?;
             repositories::commit(&repo, "Adding new annotation on main branch")?;
@@ -810,7 +807,7 @@ mod tests {
             assert_eq!(status.merge_conflicts.len(), 1);
 
             // Run repositories::checkout::checkout_theirs() and make sure their changes get kept
-            repositories::checkout::checkout_combine(&repo, bbox_filename).await?;
+            repositories::checkout::checkout_combine(&repo, &bbox_filename).await?;
             let df = tabular::read_df(&bbox_file, DFOpts::empty()).await?;
 
             // This doesn't guarantee order, but let's make sure we have 7 annotations now
@@ -847,12 +844,12 @@ mod tests {
             repositories::commit(&repo, "Adding new column as an Ox on a branch.")?;
 
             // Add a more rows on the main branch
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             let row_from_main = "train/dog_4.jpg,dog,52.0,62.5,256,429";
-            let bbox_file = test::append_line_txt_file(bbox_file, row_from_main)?;
+            let bbox_file = test::append_line_txt_file(&bbox_file, row_from_main)?;
 
-            repositories::add(&repo, bbox_file).await?;
+            repositories::add(&repo, &bbox_file).await?;
             repositories::commit(&repo, "Adding new row on main branch")?;
 
             // Try to merge in the changes
@@ -863,7 +860,7 @@ mod tests {
             assert_eq!(status.merge_conflicts.len(), 1);
 
             // Run repositories::checkout::checkout_theirs() and make sure we cannot
-            let result = repositories::checkout::checkout_combine(&repo, bbox_filename).await;
+            let result = repositories::checkout::checkout_combine(&repo, &bbox_filename).await;
             println!("{result:?}");
             assert!(result.is_err());
 
@@ -906,7 +903,7 @@ mod tests {
                     let bbox_file = cloned_repo_a.path.join(&bbox_filename);
                     let og_df = tabular::read_df(&bbox_file, DFOpts::empty()).await?;
                     let bbox_file = test::append_line_txt_file(
-                        bbox_file,
+                        &bbox_file,
                         "train/cat_3.jpg,cat,41.0,31.5,410,427",
                     )?;
                     repositories::add(&cloned_repo_a, &bbox_file).await?;
@@ -929,7 +926,7 @@ mod tests {
                         .join("bounding_box.csv");
                     let bbox_file = cloned_repo_a.path.join(&bbox_filename);
                     let bbox_file = test::append_line_txt_file(
-                        bbox_file,
+                        &bbox_file,
                         "train/cat_13.jpg,cat,41.0,31.5,410,427",
                     )?;
                     repositories::add(&cloned_repo_a, &bbox_file).await?;
@@ -974,7 +971,7 @@ mod tests {
             repositories::branches::create_checkout(&repo, new_branch_name)?;
 
             // 3. Commit something in new branch
-            let labels_path = test::modify_txt_file(labels_path, "cat\ndog\nfish")?;
+            let labels_path = test::modify_txt_file(&labels_path, "cat\ndog\nfish")?;
             repositories::add(&repo, &labels_path).await?;
             repositories::commit(&repo, "Adding fish to labels.txt file")?;
 
@@ -1084,7 +1081,7 @@ mod tests {
             let _new_branch = repositories::branches::create_checkout(&repo, new_branch_name)?;
 
             // 4. merge main onto new branch
-            let commit = repositories::merge::merge(&repo, og_branch.name).await?;
+            let commit = repositories::merge::merge(&repo, &og_branch.name).await?;
 
             // 5. There should be no commit
             assert!(commit.is_none());

--- a/crates/lib/src/repositories/metadata.rs
+++ b/crates/lib/src/repositories/metadata.rs
@@ -21,8 +21,7 @@ pub mod text;
 pub mod video;
 
 /// Returns the metadata given a file path
-pub fn get(path: impl AsRef<Path>) -> Result<MetadataEntry, OxenError> {
-    let path = path.as_ref();
+pub fn get(path: &Path) -> Result<MetadataEntry, OxenError> {
     let base_name = path.file_name().ok_or(OxenError::file_has_no_name(path))?;
     let size = get_file_size(path)?;
     let mime_type = util::fs::file_mime_type(path);
@@ -47,8 +46,7 @@ pub fn get(path: impl AsRef<Path>) -> Result<MetadataEntry, OxenError> {
 }
 
 /// Returns the metadata given a file path
-pub fn from_path(path: impl AsRef<Path>) -> Result<MetadataEntry, OxenError> {
-    let path = path.as_ref();
+pub fn from_path(path: &Path) -> Result<MetadataEntry, OxenError> {
     let base_name = path.file_name().ok_or(OxenError::file_has_no_name(path))?;
     let size = get_file_size(path)?;
     let mime_type = util::fs::file_mime_type(path);
@@ -126,8 +124,8 @@ pub fn from_dir_node(
 /// Returns metadata with latest commit information. Less efficient than get().
 pub fn get_cli(
     repo: &LocalRepository,
-    entry_path: impl AsRef<Path>,
-    data_path: impl AsRef<Path>,
+    entry_path: &Path,
+    data_path: &Path,
 ) -> Result<CLIMetadataEntry, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -136,13 +134,13 @@ pub fn get_cli(
 }
 
 /// Returns the file size in bytes.
-pub fn get_file_size(path: impl AsRef<Path>) -> Result<u64, OxenError> {
-    let metadata = util::fs::metadata(path.as_ref())?;
+pub fn get_file_size(path: &Path) -> Result<u64, OxenError> {
+    let metadata = util::fs::metadata(path)?;
     Ok(metadata.len())
 }
 
 pub fn get_file_metadata_with_extension(
-    path: impl AsRef<Path>,
+    path: &Path,
     data_type: &EntryDataType,
     extension: &str,
 ) -> Result<Option<GenericMetadata>, OxenError> {
@@ -190,10 +188,9 @@ pub fn get_file_metadata_with_extension(
 
 /// Returns metadata based on data_type
 pub fn get_file_metadata(
-    path: impl AsRef<Path>,
+    path: &Path,
     data_type: &EntryDataType,
 ) -> Result<Option<GenericMetadata>, OxenError> {
-    let path = path.as_ref();
     get_file_metadata_with_extension(path, data_type, &util::fs::file_extension(path))
 }
 
@@ -206,7 +203,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_metadata_audio_flac() {
         let file = test::test_audio_file_with_name("121-121726-0005.flac");
-        let metadata = repositories::metadata::get(file).unwrap();
+        let metadata = repositories::metadata::get(&file).unwrap();
 
         println!("metadata: {metadata:?}");
 

--- a/crates/lib/src/repositories/metadata/audio.rs
+++ b/crates/lib/src/repositories/metadata/audio.rs
@@ -8,8 +8,7 @@ use lofty::probe::Probe;
 use std::path::Path;
 
 /// Detects the audio metadata for the given file.
-pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataAudio, OxenError> {
-    let path = path.as_ref();
+pub fn get_metadata(path: &Path) -> Result<MetadataAudio, OxenError> {
     match Probe::open(path) {
         Ok(tagged_file) => match tagged_file.read() {
             Ok(tagged_file) => {
@@ -27,12 +26,12 @@ pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataAudio, OxenError> 
             }
             Err(err) => {
                 let error_str = format!("Could not read audio stream from {path:?} {err}");
-                Err(OxenError::basic_str(error_str))
+                Err(OxenError::basic_str(&error_str))
             }
         },
         Err(err) => {
             let error_str = format!("Could not probe audio stream from {path:?}: {err}");
-            Err(OxenError::basic_str(error_str))
+            Err(OxenError::basic_str(&error_str))
         }
     }
 }
@@ -50,7 +49,7 @@ mod tests {
     #[test]
     fn test_get_metadata_audio_flac() {
         let file = test::test_audio_file_with_name("121-121726-0005.flac");
-        let metadata = repositories::metadata::get(file).unwrap();
+        let metadata = repositories::metadata::get(&file).unwrap();
 
         println!("metadata: {metadata:?}");
 
@@ -72,7 +71,7 @@ mod tests {
     #[test]
     fn test_get_metadata_audio_wav() {
         let file = test::test_audio_file_with_name("121-121726-0005.wav");
-        let metadata = repositories::metadata::get(file).unwrap();
+        let metadata = repositories::metadata::get(&file).unwrap();
 
         println!("metadata: {metadata:?}");
 

--- a/crates/lib/src/repositories/metadata/audio.rs
+++ b/crates/lib/src/repositories/metadata/audio.rs
@@ -26,12 +26,12 @@ pub fn get_metadata(path: &Path) -> Result<MetadataAudio, OxenError> {
             }
             Err(err) => {
                 let error_str = format!("Could not read audio stream from {path:?} {err}");
-                Err(OxenError::basic_str(&error_str))
+                Err(OxenError::basic_str(error_str))
             }
         },
         Err(err) => {
             let error_str = format!("Could not probe audio stream from {path:?}: {err}");
-            Err(OxenError::basic_str(&error_str))
+            Err(OxenError::basic_str(error_str))
         }
     }
 }

--- a/crates/lib/src/repositories/metadata/image.rs
+++ b/crates/lib/src/repositories/metadata/image.rs
@@ -11,7 +11,7 @@ use std::io::BufReader;
 use std::path::Path;
 
 /// Detects the image metadata for the given file.
-pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataImage, OxenError> {
+pub fn get_metadata(path: &Path) -> Result<MetadataImage, OxenError> {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
     let reader = ImageReader::new(reader).with_guessed_format()?;
@@ -38,7 +38,7 @@ mod tests {
     fn test_get_metadata_img_rgb() {
         let file = test::test_img_file_with_name("cat_1.jpg");
 
-        let data = repositories::metadata::get(file).unwrap();
+        let data = repositories::metadata::get(&file).unwrap();
 
         assert_eq!(data.data_type, EntryDataType::Image);
         assert_eq!(data.mime_type, "image/jpeg");
@@ -56,7 +56,7 @@ mod tests {
     #[test]
     fn test_get_metadata_img_rgba() {
         let file = test::test_img_file_with_name("cat_rgba.png");
-        let data = repositories::metadata::get(file).unwrap();
+        let data = repositories::metadata::get(&file).unwrap();
 
         assert_eq!(data.data_type, EntryDataType::Image);
         assert_eq!(data.mime_type, "image/png");
@@ -75,7 +75,7 @@ mod tests {
     fn test_get_metadata_img_grayscale() {
         let file = test::test_img_file_with_name("cat_grayscale.jpg");
 
-        let data = repositories::metadata::get(file).unwrap();
+        let data = repositories::metadata::get(&file).unwrap();
 
         assert_eq!(data.data_type, EntryDataType::Image);
         assert_eq!(data.mime_type, "image/jpeg");
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn test_get_metadata_img_mnist() {
         let file = test::test_img_file_with_name("mnist_7.png");
-        let data = repositories::metadata::get(file).unwrap();
+        let data = repositories::metadata::get(&file).unwrap();
 
         assert_eq!(data.data_type, EntryDataType::Image);
         assert_eq!(data.mime_type, "image/png");

--- a/crates/lib/src/repositories/metadata/image.rs
+++ b/crates/lib/src/repositories/metadata/image.rs
@@ -20,7 +20,9 @@ pub fn get_metadata(path: &Path) -> Result<MetadataImage, OxenError> {
         Ok((width, height)) => Ok(MetadataImage::new(width, height)),
         Err(e) => {
             log::debug!("Could not get image metadata {e:?}");
-            Err(OxenError::basic_str("Could not get image metadata"))
+            Err(OxenError::basic_str(
+                "Could not get image metadata".to_string(),
+            ))
         }
     }
 }

--- a/crates/lib/src/repositories/metadata/tabular.rs
+++ b/crates/lib/src/repositories/metadata/tabular.rs
@@ -8,18 +8,16 @@ use crate::model::metadata::MetadataTabular;
 use std::path::Path;
 
 /// Detects the tabular metadata for the given file.
-pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataTabular, OxenError> {
-    let path = path.as_ref();
+pub fn get_metadata(path: &Path) -> Result<MetadataTabular, OxenError> {
     let size = tabular::get_size(path)?;
     let schema = tabular::get_schema(path)?;
     Ok(MetadataTabular::new(size.width, size.height, schema))
 }
 
 pub fn get_metadata_with_extension(
-    path: impl AsRef<Path>,
+    path: &Path,
     extension: &str,
 ) -> Result<MetadataTabular, OxenError> {
-    let path = path.as_ref();
     let size = tabular::get_size_with_extension(path, Some(extension))?;
     let schema = tabular::get_schema_with_extension(path, Some(extension))?;
     Ok(MetadataTabular::new(size.width, size.height, schema))
@@ -36,7 +34,7 @@ mod tests {
     #[test]
     fn test_get_metadata_tabular() {
         let file = test::test_text_file_with_name("celeb_a_200k.csv");
-        let metadata = repositories::metadata::get(file).unwrap();
+        let metadata = repositories::metadata::get(&file).unwrap();
 
         assert!(metadata.size >= 9604701); // not sure why different on windows
         assert_eq!(metadata.data_type, EntryDataType::Tabular);

--- a/crates/lib/src/repositories/metadata/text.rs
+++ b/crates/lib/src/repositories/metadata/text.rs
@@ -9,7 +9,7 @@ use crate::util;
 use std::path::Path;
 
 /// Detects the text metadata for the given file.
-pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataText, OxenError> {
+pub fn get_metadata(path: &Path) -> Result<MetadataText, OxenError> {
     let mut opts = CountLinesOpts::empty();
     opts.with_chars = true;
 
@@ -30,7 +30,7 @@ mod tests {
     #[test]
     fn test_get_metadata_text_readme() {
         let file = test::test_text_file_with_name("README");
-        let metadata = repositories::metadata::get(file).unwrap();
+        let metadata = repositories::metadata::get(&file).unwrap();
 
         assert!(metadata.size >= 44); // not sure why 46 on windows
         assert_eq!(metadata.data_type, EntryDataType::Text);
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn test_get_metadata_text_readme_md() {
         let file = test::test_text_file_with_name("README.md");
-        let metadata = repositories::metadata::get(file).unwrap();
+        let metadata = repositories::metadata::get(&file).unwrap();
 
         assert!(metadata.size >= 50); // not sure why 53 on windows
         assert_eq!(metadata.data_type, EntryDataType::Text);

--- a/crates/lib/src/repositories/metadata/video.rs
+++ b/crates/lib/src/repositories/metadata/video.rs
@@ -28,15 +28,15 @@ pub fn get_metadata(path: &Path) -> Result<MetadataVideo, OxenError> {
                 .filter_map(|t| match t.track_type() {
                     Ok(TrackType::Video) => Some(Ok(t)),
                     Ok(_) => None,
-                    Err(e) => Some(Err(OxenError::basic_str(&format!(
+                    Err(e) => Some(Err(OxenError::basic_str(format!(
                         "Could not get track type: {e:?}"
                     )))),
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
-            let video = video_tracks
-                .first()
-                .ok_or(OxenError::basic_str("Could not get video track"))?;
+            let video = video_tracks.first().ok_or(OxenError::basic_str(
+                "Could not get video track".to_string(),
+            ))?;
 
             Ok(MetadataVideo::new(
                 duration,
@@ -46,7 +46,7 @@ pub fn get_metadata(path: &Path) -> Result<MetadataVideo, OxenError> {
         }
         Err(err) => {
             let err = format!("Could not get video metadata {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }

--- a/crates/lib/src/repositories/metadata/video.rs
+++ b/crates/lib/src/repositories/metadata/video.rs
@@ -9,8 +9,7 @@ use std::io::BufReader;
 use std::path::Path;
 
 /// Detects the video metadata for the given file.
-pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataVideo, OxenError> {
-    let path = path.as_ref();
+pub fn get_metadata(path: &Path) -> Result<MetadataVideo, OxenError> {
     let f = match File::open(path) {
         Ok(f) => f,
         Err(e) => return Err(OxenError::file_error(path, e)),
@@ -29,7 +28,7 @@ pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataVideo, OxenError> 
                 .filter_map(|t| match t.track_type() {
                     Ok(TrackType::Video) => Some(Ok(t)),
                     Ok(_) => None,
-                    Err(e) => Some(Err(OxenError::basic_str(format!(
+                    Err(e) => Some(Err(OxenError::basic_str(&format!(
                         "Could not get track type: {e:?}"
                     )))),
                 })
@@ -47,7 +46,7 @@ pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataVideo, OxenError> 
         }
         Err(err) => {
             let err = format!("Could not get video metadata {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -65,7 +64,7 @@ mod tests {
     #[test]
     fn test_get_metadata_video_mp4() {
         let file = test::test_video_file_with_name("basketball.mp4");
-        let metadata = repositories::metadata::get(file).unwrap();
+        let metadata = repositories::metadata::get(&file).unwrap();
         println!("metadata: {metadata:?}");
 
         assert_eq!(metadata.size, 23599);
@@ -85,7 +84,7 @@ mod tests {
     #[test]
     fn test_get_metadata_video_mov() {
         let file = test::test_video_file_with_name("dog_skatez.mov");
-        let metadata = repositories::metadata::get(file).unwrap();
+        let metadata = repositories::metadata::get(&file).unwrap();
         println!("metadata: {metadata:?}");
 
         assert_eq!(metadata.size, 11657299);

--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -301,7 +301,7 @@ mod tests {
                 // Track some more data in the cloned repo
                 let hotdog_path = test::test_hotdog_1();
                 let new_file_path = cloned_repo.path.join("train").join("hotdog_1.jpg");
-                util::fs::copy(hotdog_path, &new_file_path)?;
+                util::fs::copy(&hotdog_path, &new_file_path)?;
                 repositories::add(&cloned_repo, &new_file_path).await?;
                 repositories::commit(&cloned_repo, "Adding one file to train dir")?;
                 let opts = PushOpts {
@@ -329,7 +329,7 @@ mod tests {
                 // Add another file on the OG side, and push it back
                 let hotdog_path = test::test_hotdog_2();
                 let new_file_path = train_path.join("hotdog_2.jpg");
-                util::fs::copy(hotdog_path, &new_file_path)?;
+                util::fs::copy(&hotdog_path, &new_file_path)?;
                 repositories::add(&repo, &train_path).await?;
                 repositories::commit(&repo, "Adding next file to train dir")?;
                 let opts = PushOpts {
@@ -380,8 +380,8 @@ mod tests {
             util::fs::create_dir_all(&train_dir)?;
             for path in train_paths.iter() {
                 util::fs::copy(
-                    test::REPO_ROOT.join(path),
-                    train_dir.join(path.file_name().unwrap()),
+                    &test::REPO_ROOT.join(path),
+                    &train_dir.join(path.file_name().unwrap()),
                 )?;
             }
 
@@ -417,7 +417,7 @@ mod tests {
                 // Track some more data in the cloned repo
                 let hotdog_path = test::test_hotdog_1();
                 let new_file_path = cloned_repo.path.join("train").join("hotdog_1.jpg");
-                util::fs::copy(hotdog_path, &new_file_path)?;
+                util::fs::copy(&hotdog_path, &new_file_path)?;
                 repositories::add(&cloned_repo, &new_file_path).await?;
                 repositories::commit(&cloned_repo, "Adding one file to train dir")?;
                 let opts = PushOpts {
@@ -460,7 +460,7 @@ mod tests {
             let og_content = "I am the License.";
             test::write_txt_file_to_path(&filepath, og_content)?;
 
-            repositories::add(&repo, filepath).await?;
+            repositories::add(&repo, &filepath).await?;
             let commit = repositories::commit(&repo, "Adding file without extension");
 
             assert!(commit.is_ok());
@@ -567,7 +567,7 @@ mod tests {
                 // Clone the branch
                 let opts = CloneOpts::from_branch(
                     remote_repo.url(),
-                    new_repo_dir.join("new_repo"),
+                    &new_repo_dir.join("new_repo"),
                     branch_name,
                 );
                 let cloned_repo = repositories::clone(&opts).await?;
@@ -645,7 +645,7 @@ mod tests {
             // run another test with a new repo dir that we are going to sync to
             test::run_empty_dir_test_async(|new_repo_dir| async move {
                 // Clone the branch
-                let opts = CloneOpts::new(remote_repo.url(), new_repo_dir.join("new_repo"));
+                let opts = CloneOpts::new(remote_repo.url(), &new_repo_dir.join("new_repo"));
                 let cloned_repo = repositories::clone(&opts).await?;
 
                 // Make sure we have all the files from the branch
@@ -685,7 +685,7 @@ mod tests {
 
             let new_path = &local_repo.path.join("newfolder").join("a.txt");
 
-            util::fs::create_dir_all(local_repo.path.join("newfolder"))?;
+            util::fs::create_dir_all(&local_repo.path.join("newfolder"))?;
             test::write_txt_file_to_path(new_path, contents)?;
             repositories::add(&local_repo, new_path).await?;
 
@@ -808,7 +808,7 @@ mod tests {
                     .join("classification")
                     .join("new_data.tsv");
                 let new_file_path = user_a_repo.path.join(&new_file);
-                let new_file_path = test::write_txt_file_to_path(new_file_path, "image\tlabel")?;
+                let new_file_path = test::write_txt_file_to_path(&new_file_path, "image\tlabel")?;
                 repositories::add(&user_a_repo, &new_file_path).await?;
                 repositories::commit(&user_a_repo, "User A adding new data.")?;
                 repositories::push(&user_a_repo).await?;
@@ -816,7 +816,7 @@ mod tests {
                 // User B adds the same file and pushes
                 let new_file_path = user_b_repo.path.join(&new_file);
                 let new_file_path =
-                    test::write_txt_file_to_path(new_file_path, "I am user B, try to stop me")?;
+                    test::write_txt_file_to_path(&new_file_path, "I am user B, try to stop me")?;
                 repositories::add(&user_b_repo, &new_file_path).await?;
                 repositories::commit(&user_b_repo, "User B adding the same file.")?;
 
@@ -843,7 +843,7 @@ mod tests {
                 status.print();
 
                 // Checkout your version and add the changes
-                repositories::checkout::checkout_ours(&user_b_repo, new_file).await?;
+                repositories::checkout::checkout_ours(&user_b_repo, &new_file).await?;
                 repositories::add(&user_b_repo, &new_file_path).await?;
                 // Commit the changes
                 repositories::commit(&user_b_repo, "Taking my changes")?;
@@ -894,7 +894,8 @@ mod tests {
                 // User A adds a file and pushes
                 let new_file = PathBuf::from("README.md");
                 let new_file_path = user_a_repo.path.join(&new_file);
-                let new_file_path = test::write_txt_file_to_path(new_file_path, "User A's README")?;
+                let new_file_path =
+                    test::write_txt_file_to_path(&new_file_path, "User A's README")?;
                 repositories::add(&user_a_repo, &new_file_path).await?;
                 repositories::commit(&user_a_repo, "User A adding new data.")?;
                 repositories::push(&user_a_repo).await?;
@@ -902,7 +903,7 @@ mod tests {
                 // User B adds the same file and pushes
                 let new_file_path = user_b_repo.path.join(&new_file);
                 let new_file_path =
-                    test::write_txt_file_to_path(new_file_path, "I am user B, try to stop me")?;
+                    test::write_txt_file_to_path(&new_file_path, "I am user B, try to stop me")?;
                 repositories::add(&user_b_repo, &new_file_path).await?;
                 repositories::commit(&user_b_repo, "User B adding the same README.")?;
 
@@ -930,7 +931,7 @@ mod tests {
                 assert_eq!(status.removed_files.len(), 0);
 
                 // Checkout your version and add the changes
-                repositories::checkout::checkout_ours(&user_b_repo, new_file).await?;
+                repositories::checkout::checkout_ours(&user_b_repo, &new_file).await?;
                 repositories::add(&user_b_repo, &new_file_path).await?;
                 // Commit the changes
                 repositories::commit(&user_b_repo, "Taking my changes")?;
@@ -977,15 +978,17 @@ mod tests {
                     // User A adds a file and pushes
                     let new_file = "new_file.txt";
                     let new_file_path = user_a_repo.path.join(new_file);
-                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file")?;
+                    let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file")?;
                     repositories::add(&user_a_repo, &new_file_path).await?;
                     repositories::commit(&user_a_repo, "User A changing file.")?;
                     repositories::push(&user_a_repo).await?;
 
                     // User B changes the same file and pushes
                     let new_file_path = user_b_repo.path.join(new_file);
-                    let new_file_path =
-                        test::write_txt_file_to_path(new_file_path, "I am user B, try to stop me")?;
+                    let new_file_path = test::write_txt_file_to_path(
+                        &new_file_path,
+                        "I am user B, try to stop me",
+                    )?;
                     repositories::add(&user_b_repo, &new_file_path).await?;
                     repositories::commit(&user_b_repo, "User B changing file.")?;
 
@@ -1003,7 +1006,8 @@ mod tests {
                     status.print();
 
                     // Checkout your version and add the changes
-                    repositories::checkout::checkout_ours(&user_b_repo, new_file).await?;
+                    repositories::checkout::checkout_ours(&user_b_repo, Path::new(new_file))
+                        .await?;
                     repositories::add(&user_b_repo, &new_file_path).await?;
                     // Commit the changes
                     repositories::commit(&user_b_repo, "Taking my changes")?;
@@ -1045,12 +1049,12 @@ mod tests {
 
                     // Add file_1 and file_2 to user A repo
                     let file_1 = "file_1.txt";
-                    test::write_txt_file_to_path(user_a_repo.path.join(file_1), "File 1")?;
+                    test::write_txt_file_to_path(&user_a_repo.path.join(file_1), "File 1")?;
                     let file_2 = "file_2.txt";
-                    test::write_txt_file_to_path(user_a_repo.path.join(file_2), "File 2")?;
+                    test::write_txt_file_to_path(&user_a_repo.path.join(file_2), "File 2")?;
 
-                    repositories::add(&user_a_repo, user_a_repo.path.join(file_1)).await?;
-                    repositories::add(&user_a_repo, user_a_repo.path.join(file_2)).await?;
+                    repositories::add(&user_a_repo, &user_a_repo.path.join(file_1)).await?;
+                    repositories::add(&user_a_repo, &user_a_repo.path.join(file_2)).await?;
 
                     repositories::commit(&user_a_repo, "Adding file_1 and file_2")?;
 
@@ -1059,9 +1063,9 @@ mod tests {
 
                     // Add file_3 to user B repo
                     let file_3 = "file_3.txt";
-                    test::write_txt_file_to_path(user_b_repo.path.join(file_3), "File 3")?;
+                    test::write_txt_file_to_path(&user_b_repo.path.join(file_3), "File 3")?;
 
-                    repositories::add(&user_b_repo, user_b_repo.path.join(file_3)).await?;
+                    repositories::add(&user_b_repo, &user_b_repo.path.join(file_3)).await?;
                     repositories::commit(&user_b_repo, "Adding file_3")?;
 
                     // Pull changes without pushing first - fine since no conflict
@@ -1108,12 +1112,12 @@ mod tests {
 
                     // Add file_1 and file_2 to user A repo
                     let file_1 = "file_1.txt";
-                    test::write_txt_file_to_path(user_a_repo.path.join(file_1), "File 1")?;
+                    test::write_txt_file_to_path(&user_a_repo.path.join(file_1), "File 1")?;
                     let file_2 = "file_2.txt";
-                    test::write_txt_file_to_path(user_a_repo.path.join(file_2), "File 2")?;
+                    test::write_txt_file_to_path(&user_a_repo.path.join(file_2), "File 2")?;
 
-                    repositories::add(&user_a_repo, user_a_repo.path.join(file_1)).await?;
-                    repositories::add(&user_a_repo, user_a_repo.path.join(file_2)).await?;
+                    repositories::add(&user_a_repo, &user_a_repo.path.join(file_1)).await?;
+                    repositories::add(&user_a_repo, &user_a_repo.path.join(file_2)).await?;
 
                     repositories::commit(&user_a_repo, "Adding file_1 and file_2")?;
 
@@ -1122,13 +1126,13 @@ mod tests {
 
                     let local_file_2 = "file_2.txt";
                     test::write_txt_file_to_path(
-                        user_b_repo.path.join(local_file_2),
+                        &user_b_repo.path.join(local_file_2),
                         "wrong not correct content",
                     )?;
 
                     // Add file_3 to user B repo
                     let file_3 = "file_3.txt";
-                    test::write_txt_file_to_path(user_b_repo.path.join(file_3), "File 3")?;
+                    test::write_txt_file_to_path(&user_b_repo.path.join(file_3), "File 3")?;
 
                     // Make a dir
                     let dir_1 = "dir_1";
@@ -1141,22 +1145,22 @@ mod tests {
                     // Add files in dir_2
                     let file_4 = "file_4.txt";
                     test::write_txt_file_to_path(
-                        user_b_repo.path.join(dir_2).join(file_4),
+                        &user_b_repo.path.join(dir_2).join(file_4),
                         "File 4",
                     )?;
                     let file_5 = "file_5.txt";
                     test::write_txt_file_to_path(
-                        user_b_repo.path.join(dir_2).join(file_5),
+                        &user_b_repo.path.join(dir_2).join(file_5),
                         "File 5",
                     )?;
 
                     let dir_3 = "dir_3";
                     let subdir = "subdir";
-                    util::fs::create_dir_all(user_b_repo.path.join(dir_3).join(subdir))?;
+                    util::fs::create_dir_all(&user_b_repo.path.join(dir_3).join(subdir))?;
 
                     let subfile = "subfile.txt";
                     test::write_txt_file_to_path(
-                        user_b_repo.path.join(dir_3).join(subdir).join(subfile),
+                        &user_b_repo.path.join(dir_3).join(subdir).join(subfile),
                         "Subfile",
                     )?;
 
@@ -1167,7 +1171,7 @@ mod tests {
                     assert!(result.is_err());
 
                     // Remove the file that is causing the conflict
-                    util::fs::remove_file(user_b_repo.path.join(local_file_2))?;
+                    util::fs::remove_file(&user_b_repo.path.join(local_file_2))?;
 
                     // Pull again should succeed
                     repositories::pull(&user_b_repo).await?;
@@ -1525,7 +1529,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|new_repo_dir| async move {
                 let mut opts =
-                    CloneOpts::new(&remote_repo.remote.url, new_repo_dir.join("new_repo"));
+                    CloneOpts::new(&remote_repo.remote.url, &new_repo_dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![PathBuf::from("test")]);
                 opts.fetch_opts.depth = Some(1);
 
@@ -1967,7 +1971,7 @@ mod tests {
             let remote_repo_clone = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
                 // Create an empty repo locally
-                let mut local_repo = LocalRepository::new(dir, None)?;
+                let mut local_repo = LocalRepository::new(&dir, None)?;
 
                 // Add and commit a new file
                 let hello_file = local_repo.path.join("dir").join("hello.txt");

--- a/crates/lib/src/repositories/push.rs
+++ b/crates/lib/src/repositories/push.rs
@@ -71,6 +71,7 @@ mod tests {
     use crate::view::entries::EMetadataEntry;
     use futures::future;
     use std::collections::HashSet;
+    use std::path::Path;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -86,7 +87,7 @@ mod tests {
 
             // Write a README.md file
             let readme_path = repo.path.join("README.md");
-            let readme_path = test::write_txt_file_to_path(readme_path, "Ready to train 🏋️‍♂️")?;
+            let readme_path = test::write_txt_file_to_path(&readme_path, "Ready to train 🏋️‍♂️")?;
             repositories::add(&repo, &readme_path).await?;
 
             // Commit the train dir
@@ -104,17 +105,27 @@ mod tests {
 
             let page_num = 1;
             let page_size = num_files + 10;
-            let entries =
-                api::client::dir::list(&remote_repo, &commit.id, "train", page_num, page_size)
-                    .await?;
+            let entries = api::client::dir::list(
+                &remote_repo,
+                &commit.id,
+                Path::new("train"),
+                page_num,
+                page_size,
+            )
+            .await?;
             assert_eq!(entries.total_entries, num_files);
             assert_eq!(entries.entries.len(), num_files);
 
             // Make sure we can download the file
             let readme_path = repo.path.join("README.md");
             let download_path = repo.path.join("README_2.md");
-            api::client::entries::download_entry(&remote_repo, "README.md", &download_path, "main")
-                .await?;
+            api::client::entries::download_entry(
+                &remote_repo,
+                Path::new("README.md"),
+                &download_path,
+                "main",
+            )
+            .await?;
 
             // Make sure the file is the same
             let readme_1_contents = util::fs::read_from_path(&download_path)?;
@@ -159,12 +170,22 @@ mod tests {
 
             let page_num = 1;
             let page_size = num_train_files + num_test_files + 5;
-            let train_entries =
-                api::client::dir::list(&remote_repo, &commit.id, "/train", page_num, page_size)
-                    .await?;
-            let test_entries =
-                api::client::dir::list(&remote_repo, &commit.id, "/test", page_num, page_size)
-                    .await?;
+            let train_entries = api::client::dir::list(
+                &remote_repo,
+                &commit.id,
+                Path::new("/train"),
+                page_num,
+                page_size,
+            )
+            .await?;
+            let test_entries = api::client::dir::list(
+                &remote_repo,
+                &commit.id,
+                Path::new("/test"),
+                page_num,
+                page_size,
+            )
+            .await?;
             assert_eq!(
                 train_entries.total_entries + test_entries.total_entries,
                 num_train_files + num_test_files
@@ -212,14 +233,20 @@ mod tests {
 
             let page_num = 1;
             let entries =
-                api::client::dir::list(&remote_repo, &commit.id, ".", page_num, 10).await?;
+                api::client::dir::list(&remote_repo, &commit.id, Path::new("."), page_num, 10)
+                    .await?;
             assert_eq!(entries.total_entries, 2);
             assert_eq!(entries.entries.len(), 2);
 
             let page_size = num_test_files + 10;
-            let entries =
-                api::client::dir::list(&remote_repo, &commit.id, "test", page_num, page_size)
-                    .await?;
+            let entries = api::client::dir::list(
+                &remote_repo,
+                &commit.id,
+                Path::new("test"),
+                page_num,
+                page_size,
+            )
+            .await?;
             assert_eq!(entries.total_entries, num_test_files);
             assert_eq!(entries.entries.len(), num_test_files);
 
@@ -257,7 +284,7 @@ mod tests {
 
             // Create README
             let readme_path = repo.path.join("README.md");
-            let readme_path = test::write_txt_file_to_path(readme_path, "README")?;
+            let readme_path = test::write_txt_file_to_path(&readme_path, "README")?;
             repositories::add(&repo, &readme_path).await?;
             let first_commit_id = repositories::commit(&repo, "Adding README")?;
 
@@ -271,14 +298,14 @@ mod tests {
                 let dir_path = data_dir.join(format!("{i}"));
                 util::fs::create_dir_all(&dir_path)?;
                 let file_path = dir_path.join("file.txt");
-                let file_path = test::write_txt_file_to_path(file_path, format!("file -> {i}"))?;
+                let file_path = test::write_txt_file_to_path(&file_path, &format!("file -> {i}"))?;
                 repositories::add(&repo, &file_path).await?;
                 repositories::commit(&repo, &format!("Adding file -> data/{i}/file.txt"))?;
             }
 
             // modify the 3rd file
             let file_path = data_dir.join("2").join("file.txt");
-            let file_path = test::write_txt_file_to_path(file_path, "modified file")?;
+            let file_path = test::write_txt_file_to_path(&file_path, "modified file")?;
             repositories::add(&repo, &file_path).await?;
             let last_commit = repositories::commit(&repo, "Modifying file again")?;
 
@@ -295,7 +322,8 @@ mod tests {
             // Make sure we get the correct latest commit messages
             let page_num = 1;
             let entries =
-                api::client::dir::list(&remote_repo, &last_commit.id, ".", page_num, 10).await?;
+                api::client::dir::list(&remote_repo, &last_commit.id, Path::new("."), page_num, 10)
+                    .await?;
             assert_eq!(entries.total_entries, 2);
             assert_eq!(entries.entries.len(), 2);
 
@@ -321,9 +349,14 @@ mod tests {
 
             // Check the latest commit in a subdir
             let page_num = 1;
-            let entries =
-                api::client::dir::list(&remote_repo, &last_commit.id, "data/3", page_num, 10)
-                    .await?;
+            let entries = api::client::dir::list(
+                &remote_repo,
+                &last_commit.id,
+                Path::new("data/3"),
+                page_num,
+                10,
+            )
+            .await?;
             assert_eq!(entries.total_entries, 1);
             assert_eq!(entries.entries.len(), 1);
 
@@ -373,8 +406,14 @@ mod tests {
 
             let page_num = 1;
             let page_size = num_files + 10;
-            let entries =
-                api::client::dir::list(&remote_repo, &commit.id, ".", page_num, page_size).await?;
+            let entries = api::client::dir::list(
+                &remote_repo,
+                &commit.id,
+                Path::new("."),
+                page_num,
+                page_size,
+            )
+            .await?;
             assert_eq!(entries.total_entries, num_files);
             assert_eq!(entries.entries.len(), num_files);
 
@@ -468,7 +507,7 @@ mod tests {
                     // Add to the first repo, after we have the second repo cloned
                     let new_file = "new_file.txt";
                     let new_file_path = first_cloned_repo.path.join(new_file);
-                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file")?;
+                    let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file")?;
                     repositories::add(&first_cloned_repo, &new_file_path).await?;
                     repositories::commit(&first_cloned_repo, "Adding first file path.")?;
                     repositories::push(&first_cloned_repo).await?;
@@ -477,13 +516,13 @@ mod tests {
                     // Adding two commits to have a longer history that also should fail
                     let new_file = "new_file_2.txt";
                     let new_file_path = second_cloned_repo.path.join(new_file);
-                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 2")?;
+                    let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file 2")?;
                     repositories::add(&second_cloned_repo, &new_file_path).await?;
                     repositories::commit(&second_cloned_repo, "Adding second file path.")?;
 
                     let new_file = "new_file_3.txt";
                     let new_file_path = second_cloned_repo.path.join(new_file);
-                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 3")?;
+                    let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file 3")?;
                     repositories::add(&second_cloned_repo, &new_file_path).await?;
                     repositories::commit(&second_cloned_repo, "Adding third file path.")?;
 
@@ -516,7 +555,7 @@ mod tests {
                 // Add to the first repo
                 let new_file = "new_file.txt";
                 let new_file_path = repo_1.path.join(new_file);
-                let new_file_path = test::write_txt_file_to_path(new_file_path, "new file")?;
+                let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file")?;
                 repositories::add(&repo_1, &new_file_path).await?;
                 repositories::commit(&repo_1, "Adding first file path.")?;
                 // Set/create the proper remote
@@ -528,13 +567,13 @@ mod tests {
                 // Adding two commits to have a longer history that also should fail
                 let new_file = "new_file_2.txt";
                 let new_file_path = repo_2.path.join(new_file);
-                let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 2")?;
+                let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file 2")?;
                 repositories::add(&repo_2, &new_file_path).await?;
                 repositories::commit(&repo_2, "Adding second file path.")?;
 
                 let new_file = "new_file_3.txt";
                 let new_file_path = repo_2.path.join(new_file);
-                let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 3")?;
+                let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file 3")?;
                 repositories::add(&repo_2, &new_file_path).await?;
                 repositories::commit(&repo_2, "Adding third file path.")?;
 
@@ -593,7 +632,7 @@ mod tests {
             // New commit
             let new_file = "new_file.txt";
             let new_file_path = local_repo.path.join(new_file);
-            let new_file_path = test::write_txt_file_to_path(new_file_path, "new file")?;
+            let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file")?;
             repositories::add(&local_repo, &new_file_path).await?;
             repositories::commit(&local_repo, "Adding first file path.")?;
 
@@ -659,7 +698,7 @@ mod tests {
                     // Add to the first repo, after we have the second repo cloned
                     let new_file = "new_file.txt";
                     let new_file_path = first_cloned_repo.path.join(new_file);
-                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file")?;
+                    let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file")?;
                     repositories::add(&first_cloned_repo, &new_file_path).await?;
                     repositories::commit(&first_cloned_repo, "Adding first file path.")?;
                     repositories::push(&first_cloned_repo).await?;
@@ -668,13 +707,13 @@ mod tests {
                     // Adding two commits to have a longer history that also should fail
                     let new_file = "new_file_2.txt";
                     let new_file_path = second_cloned_repo.path.join(new_file);
-                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 2")?;
+                    let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file 2")?;
                     repositories::add(&second_cloned_repo, &new_file_path).await?;
                     repositories::commit(&second_cloned_repo, "Adding second file path.")?;
 
                     let new_file = "new_file_3.txt";
                     let new_file_path = second_cloned_repo.path.join(new_file);
-                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 3")?;
+                    let new_file_path = test::write_txt_file_to_path(&new_file_path, "new file 3")?;
                     repositories::add(&second_cloned_repo, &new_file_path).await?;
                     repositories::commit(&second_cloned_repo, "Adding third file path.")?;
 
@@ -729,7 +768,7 @@ mod tests {
                         let new_file = "new_file.txt";
                         let new_file_path = first_cloned_repo.path.join(new_file);
                         let new_file_path =
-                            test::write_txt_file_to_path(new_file_path, "new file")?;
+                            test::write_txt_file_to_path(&new_file_path, "new file")?;
                         repositories::add(&first_cloned_repo, &new_file_path).await?;
                         repositories::commit(&first_cloned_repo, "Adding first file path.")?;
                         repositories::push(&first_cloned_repo).await?;
@@ -746,14 +785,14 @@ mod tests {
                         let new_file = "new_file_2.txt";
                         let new_file_path = second_cloned_repo.path.join(new_file);
                         let new_file_path =
-                            test::write_txt_file_to_path(new_file_path, "new file 2")?;
+                            test::write_txt_file_to_path(&new_file_path, "new file 2")?;
                         repositories::add(&second_cloned_repo, &new_file_path).await?;
                         repositories::commit(&second_cloned_repo, "Adding second file path.")?;
 
                         let new_file = "new_file_3.txt";
                         let new_file_path = second_cloned_repo.path.join(new_file);
                         let new_file_path =
-                            test::write_txt_file_to_path(new_file_path, "new file 3")?;
+                            test::write_txt_file_to_path(&new_file_path, "new file 3")?;
                         repositories::add(&second_cloned_repo, &new_file_path).await?;
                         repositories::commit(&second_cloned_repo, "Adding third file path.")?;
 
@@ -813,7 +852,7 @@ mod tests {
                     let mod_file = "README.md";
                     let a_mod_file_path = user_a_repo.path.join(mod_file);
                     let a_mod_file_path =
-                        test::write_txt_file_to_path(a_mod_file_path, "I am the README now")?;
+                        test::write_txt_file_to_path(&a_mod_file_path, "I am the README now")?;
                     repositories::add(&user_a_repo, &a_mod_file_path).await?;
                     let commit_a =
                         repositories::commit(&user_a_repo, "User A modifying the README.")?;
@@ -823,7 +862,7 @@ mod tests {
                     // User B tries to modify the same README.md and push
                     let b_mod_file_path = user_b_repo.path.join(mod_file);
                     let b_mod_file_path =
-                        test::write_txt_file_to_path(b_mod_file_path, "I be the README now.")?;
+                        test::write_txt_file_to_path(&b_mod_file_path, "I be the README now.")?;
                     repositories::add(&user_b_repo, &b_mod_file_path).await?;
                     let commit_b =
                         repositories::commit(&user_b_repo, "User B modifying the README.")?;
@@ -847,7 +886,7 @@ mod tests {
                     // User B resolves conflicts
                     let b_mod_file_path = user_b_repo.path.join(mod_file);
                     let b_mod_file_path = test::write_txt_file_to_path(
-                        b_mod_file_path,
+                        &b_mod_file_path,
                         "No for real. I be the README now.",
                     )?;
                     println!("passed write_txt_file_to_path");
@@ -1026,7 +1065,7 @@ mod tests {
                     log::debug!("b head before is {head:?}");
 
                     let maybe_b_entry = pre_b.get_by_path(
-                        PathBuf::from("annotations")
+                        &PathBuf::from("annotations")
                             .join("train")
                             .join("annotations.txt"),
                     )?;
@@ -1040,7 +1079,7 @@ mod tests {
                     let post_b =
                         repositories::tree::get_root_with_children(&user_b_repo, &head)?.unwrap();
                     let maybe_b_entry = post_b.get_by_path(
-                        PathBuf::from("annotations")
+                        &PathBuf::from("annotations")
                             .join("train")
                             .join("annotations.txt"),
                     )?;
@@ -1084,11 +1123,11 @@ mod tests {
             // Move the README to a new file name
             let train_images = local_repo.path.join("train");
             let new_path = local_repo.path.join("images").join("train");
-            util::fs::create_dir_all(local_repo.path.join("images"))?;
+            util::fs::create_dir_all(&local_repo.path.join("images"))?;
             util::fs::rename(&train_images, &new_path)?;
 
-            repositories::add(&local_repo, new_path).await?;
-            let mut rm_opts = RmOpts::from_path("train");
+            repositories::add(&local_repo, &new_path).await?;
+            let mut rm_opts = RmOpts::from_path(Path::new("train"));
             rm_opts.recursive = true;
             repositories::rm(&local_repo, &rm_opts)?;
             let commit =
@@ -1116,8 +1155,8 @@ mod tests {
 
             // Add a single new file
             let new_file = local_repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
-            repositories::add(&local_repo, new_file).await?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
+            repositories::add(&local_repo, &new_file).await?;
             let commit = repositories::commit(&local_repo, "Added a new file")?;
             repositories::push(&local_repo).await?;
 
@@ -1144,8 +1183,8 @@ mod tests {
             let new_path = local_repo.path.join("README2.md");
             util::fs::rename(&readme_path, &new_path)?;
 
-            repositories::add(&local_repo, new_path).await?;
-            let rm_opts = RmOpts::from_path("README.md");
+            repositories::add(&local_repo, &new_path).await?;
+            let rm_opts = RmOpts::from_path(Path::new("README.md"));
             repositories::rm(&local_repo, &rm_opts)?;
             let commit = repositories::commit(&local_repo, "Moved the readme")?;
             repositories::push(&local_repo).await?;
@@ -1178,7 +1217,7 @@ mod tests {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths = Some(vec![PathBuf::from(".")]);
                 opts.fetch_opts.depth = Some(1);
                 let local_repo = repositories::clone::clone(&opts).await?;
@@ -1225,7 +1264,7 @@ A: Oxen.ai is a great tool for this! It can handle any size dataset, and is opti
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let cloned_remote = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.fetch_opts.subtree_paths =
                     Some(vec![PathBuf::from("annotations").join("test")]);
                 let local_repo = repositories::clone::clone(&opts).await?;
@@ -1299,7 +1338,7 @@ A: Checkout Oxen.ai
                     .join("classification")
                     .join("new_data.tsv");
                 let new_file_path = user_a_repo.path.join(&new_file);
-                let new_file_path = test::write_txt_file_to_path(new_file_path, "image\tlabel")?;
+                let new_file_path = test::write_txt_file_to_path(&new_file_path, "image\tlabel")?;
                 repositories::add(&user_a_repo, &new_file_path).await?;
                 let commit =
                     repositories::commit(&user_a_repo, "Adding nlp/classification/new_data.tsv")?;
@@ -1367,7 +1406,7 @@ A: Checkout Oxen.ai
                     .join("new_partial_data_1.tsv");
                 let new_file_path_1 = user_a_repo.path.join(&new_file_1);
                 let new_file_path_1 =
-                    test::write_txt_file_to_path(new_file_path_1, "image\tlabel1")?;
+                    test::write_txt_file_to_path(&new_file_path_1, "image\tlabel1")?;
                 repositories::add(&user_a_repo, &new_file_path_1).await?;
 
                 let new_file_2 = PathBuf::from("nlp")
@@ -1375,7 +1414,7 @@ A: Checkout Oxen.ai
                     .join("new_partial_data_2.tsv");
                 let new_file_path_2 = user_a_repo.path.join(&new_file_2);
                 let new_file_path_2 =
-                    test::write_txt_file_to_path(new_file_path_2, "image\tlabel2")?;
+                    test::write_txt_file_to_path(&new_file_path_2, "image\tlabel2")?;
                 repositories::add(&user_a_repo, &new_file_path_2).await?;
 
                 // Modify an existing file
@@ -1383,7 +1422,7 @@ A: Checkout Oxen.ai
                     .path
                     .join("nlp/classification/existing_file.tsv");
                 let modified_file_path =
-                    test::write_txt_file_to_path(existing_file_path, "image\tmodified_label")?;
+                    test::write_txt_file_to_path(&existing_file_path, "image\tmodified_label")?;
                 repositories::add(&user_a_repo, &modified_file_path).await?;
 
                 // Commit changes
@@ -1537,7 +1576,7 @@ A: Checkout Oxen.ai
                 // Download the file from the remote repository
                 repositories::download(
                     &remote_repo_clone,
-                    "exact_chunk_size_file.bin",
+                    Path::new("exact_chunk_size_file.bin"),
                     &download_path,
                     &branch.name,
                 )
@@ -1586,7 +1625,7 @@ A: Checkout Oxen.ai
             let dir1_path = original_repo.path.join("dir1");
             util::fs::create_dir_all(&dir1_path)?;
             let file1_path = dir1_path.join("file1.txt");
-            util::fs::write(&file1_path, "Original content")?;
+            util::fs::write(&file1_path, "Original content".as_bytes())?;
             repositories::add(&original_repo, &file1_path).await?;
             repositories::commit(&original_repo, "Add dir1/file1.txt")?;
             repositories::push(&original_repo).await?;
@@ -1599,14 +1638,17 @@ A: Checkout Oxen.ai
 
                 // Modify dir1/file1.txt in the clone
                 let clone_file1_path = clone_repo.path.join("dir1").join("file1.txt");
-                util::fs::write(&clone_file1_path, "Clone modified content")?;
+                util::fs::write(&clone_file1_path, "Clone modified content".as_bytes())?;
                 repositories::add(&clone_repo, &clone_file1_path).await?;
                 repositories::commit(&clone_repo, "Modify file1.txt in clone")?;
                 repositories::push(&clone_repo).await?;
 
                 // Modify dir1/file1.txt in the original repo (different content)
                 let original_file1_path = original_repo.path.join("dir1").join("file1.txt");
-                util::fs::write(&original_file1_path, "Original repo modified content")?;
+                util::fs::write(
+                    &original_file1_path,
+                    "Original repo modified content".as_bytes(),
+                )?;
                 repositories::add(&original_repo, &original_file1_path).await?;
                 repositories::commit(&original_repo, "Modify file1.txt in original")?;
 
@@ -1652,7 +1694,7 @@ A: Checkout Oxen.ai
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
             // Add a single new file
             let new_file = local_repo.path.join("new_file.txt");
-            util::fs::write(&new_file, "I am a new file")?;
+            util::fs::write(&new_file, "I am a new file".as_bytes())?;
             repositories::add(&local_repo, &new_file).await?;
             let commit = repositories::commit(&local_repo, "Added a new file")?;
 

--- a/crates/lib/src/repositories/remote_mode.rs
+++ b/crates/lib/src/repositories/remote_mode.rs
@@ -23,6 +23,7 @@ pub use status::status;
 #[cfg(test)]
 mod tests {
 
+    use std::path::Path;
     use std::path::PathBuf;
 
     use crate::api;
@@ -47,7 +48,7 @@ mod tests {
             test::run_empty_dir_test_async(|repo_dir| async move {
                 // Clone repo in remote mode
                 let mut clone_opts =
-                    CloneOpts::new(&remote_repo.remote.url, repo_dir.join("new_repo"));
+                    CloneOpts::new(&remote_repo.remote.url, &repo_dir.join("new_repo"));
                 clone_opts.is_remote = true;
 
                 let remote_mode_repo = repositories::clone(&clone_opts).await?;
@@ -98,13 +99,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let remote_mode_repo = repositories::clone(&opts).await?;
                 assert!(remote_mode_repo.is_remote_mode());
 
                 let workspace_identifier = remote_mode_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Create a deeply nested directory
                 let dir_path = remote_mode_repo
@@ -117,20 +118,20 @@ mod tests {
 
                 // Add two tabular files
                 let cats_tsv = dir_path.join("cats.tsv");
-                util::fs::write(&cats_tsv, "1\t2\t3\nhello\tworld\tsup\n")?;
+                util::fs::write(&cats_tsv, "1\t2\t3\nhello\tworld\tsup\n".as_bytes())?;
                 let dogs_csv = dir_path.join("dogs.csv");
-                util::fs::write(&dogs_csv, "1,2,3\nhello,world,sup\n")?;
+                util::fs::write(&dogs_csv, "1,2,3\nhello,world,sup\n".as_bytes())?;
 
                 // Add a non-tabular file
                 let readme_md = dir_path.join("README.md");
-                util::fs::write(&readme_md, "readme....")?;
+                util::fs::write(&readme_md, "readme....".as_bytes())?;
 
                 // Add and commit all
                 let files_to_add = vec![cats_tsv, dogs_csv, readme_md];
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     files_to_add,
                     &Some(remote_mode_repo.clone()),
                 )
@@ -170,13 +171,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let remote_mode_repo = repositories::clone(&opts).await?;
                 assert!(remote_mode_repo.is_remote_mode());
 
                 let workspace_identifier = remote_mode_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 let p1 = PathBuf::from("hi.txt");
                 let p2 = PathBuf::from("bye.txt");
@@ -191,7 +192,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![p1.clone(), p2.clone()],
                     &Some(remote_mode_repo.clone()),
                 )
@@ -203,7 +204,7 @@ mod tests {
                     &remote_mode_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -225,12 +226,12 @@ mod tests {
                 assert!(repositories::tree::has_path(
                     &remote_mode_repo,
                     &commit,
-                    p1.clone()
+                    &p1.clone()
                 )?);
                 assert!(repositories::tree::has_path(
                     &remote_mode_repo,
                     &head_commit,
-                    p2.clone()
+                    &p2.clone()
                 )?);
 
                 // Pull with the original repo and verify it also contains both paths
@@ -240,12 +241,12 @@ mod tests {
                 assert!(repositories::tree::has_path(
                     &local_repo,
                     &local_repo_head,
-                    p1.clone()
+                    &p1.clone()
                 )?);
                 assert!(repositories::tree::has_path(
                     &local_repo,
                     &local_repo_head,
-                    p2.clone()
+                    &p2.clone()
                 )?);
 
                 Ok(())

--- a/crates/lib/src/repositories/remote_mode/add.rs
+++ b/crates/lib/src/repositories/remote_mode/add.rs
@@ -4,6 +4,7 @@
 #[cfg(test)]
 mod tests {
 
+    use std::path::Path;
     use std::path::PathBuf;
 
     use crate::config::UserConfig;
@@ -24,7 +25,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -34,14 +35,14 @@ mod tests {
 
                 // Get status, should show untracked file
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -53,7 +54,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![file_path],
                     &Some(cloned_repo.clone()),
                 )
@@ -64,7 +65,7 @@ mod tests {
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -88,7 +89,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -98,15 +99,15 @@ mod tests {
 
                 // Get relative path
                 let relative_path =
-                    util::fs::path_relative_to_dir(&file_path, cloned_repo.path.clone())?;
+                    util::fs::path_relative_to_dir(&file_path, &cloned_repo.path.clone())?;
 
                 // Add file with full path
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![relative_path],
                     &Some(cloned_repo.clone()),
                 )
@@ -114,12 +115,12 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -143,7 +144,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -156,11 +157,11 @@ mod tests {
 
                 // Add file with full path
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![canon_path],
                     &Some(cloned_repo.clone()),
                 )
@@ -168,12 +169,12 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -197,7 +198,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
 
                 let cloned_repo = repositories::clone(&opts).await?;
@@ -216,13 +217,13 @@ mod tests {
 
                 // Status displays only the untracked file and dirs
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
-                let directory = String::from(".");
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
+                let directory_name = ".";
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &PathBuf::from("."),
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -238,7 +239,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![full_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -246,12 +247,12 @@ mod tests {
 
                 // Status displays only the staged file and dirs
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -272,7 +273,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![full_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -280,12 +281,12 @@ mod tests {
 
                 // Status now displays the modified as well as the staged entries
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -305,7 +306,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![full_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -313,12 +314,12 @@ mod tests {
 
                 // Status again displays only the staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -347,13 +348,13 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Write three files to a subdirectory
                 let training_data_dir = PathBuf::from("training_data");
@@ -366,12 +367,12 @@ mod tests {
 
                 // Get status, should show untracked files
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -383,7 +384,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![sub_file_1, sub_file_2, sub_file_3],
                     &Some(cloned_repo.clone()),
                 )
@@ -394,7 +395,7 @@ mod tests {
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -418,13 +419,13 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Write three files to the root dir
                 let repo_dir = cloned_repo.path.clone();
@@ -446,7 +447,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![glob_path],
                     &Some(cloned_repo.clone()),
                 )
@@ -454,12 +455,12 @@ mod tests {
 
                 // Status should now show the files as staged
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -497,7 +498,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![glob_path2],
                     &Some(cloned_repo.clone()),
                 )
@@ -505,12 +506,12 @@ mod tests {
 
                 // Verify new paths were added
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -539,13 +540,13 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Create a directory with a nested structure
                 let new_dir = cloned_repo.path.join("new");
@@ -565,7 +566,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![new_dir.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -573,12 +574,12 @@ mod tests {
 
                 // Check status for all staged files
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -602,13 +603,13 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Create a file, add it, and commit it
                 let dir_path = cloned_repo.path.join("dir");
@@ -618,7 +619,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![hello_file_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -635,7 +636,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![hello_file_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -643,12 +644,12 @@ mod tests {
 
                 // Verify repo is still clean
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;

--- a/crates/lib/src/repositories/remote_mode/checkout.rs
+++ b/crates/lib/src/repositories/remote_mode/checkout.rs
@@ -87,7 +87,7 @@ pub async fn create_checkout_branch(
     let workspace_name = format!("{branch_name}: {workspace_id}");
     let Some(remote) = repo.remote() else {
         return Err(OxenError::basic_str(
-            "Error: local repository has no remote",
+            "Error: local repository has no remote".to_string(),
         ));
     };
     let remote_repo = api::client::repositories::get_by_remote(&remote).await?;
@@ -120,7 +120,7 @@ pub async fn create_checkout_branch(
                 workspace_id.clone()
             );
             println!("{}", err_msg.yellow().bold());
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Error: Remote-mode repo already exists for workspace {workspace_id}"
             )));
         }

--- a/crates/lib/src/repositories/remote_mode/checkout.rs
+++ b/crates/lib/src/repositories/remote_mode/checkout.rs
@@ -11,7 +11,7 @@ pub async fn checkout(repo: &mut LocalRepository, name: &str) -> Result<(), Oxen
     match repositories::checkout(repo, name).await {
         Ok(Some(branch)) => {
             // Change current workspace name
-            repo.set_workspace(branch.name.clone())?;
+            repo.set_workspace(&branch.name.clone())?;
             repo.save()?;
         }
         // TODO: This should create a workspace on this commit
@@ -94,11 +94,11 @@ pub async fn create_checkout_branch(
 
     // Create the remote branch from the commit
     let head_commit = repositories::commits::head_commit(repo)?;
-    api::client::branches::create_from_commit(&remote_repo, &branch_name, &head_commit).await?;
+    api::client::branches::create_from_commit(&remote_repo, branch_name, &head_commit).await?;
 
     let workspace = api::client::workspaces::create_with_path(
         &remote_repo,
-        &branch_name,
+        branch_name,
         &workspace_id,
         Path::new("/"),
         Some(workspace_name.clone()),
@@ -120,7 +120,7 @@ pub async fn create_checkout_branch(
                 workspace_id.clone()
             );
             println!("{}", err_msg.yellow().bold());
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Error: Remote-mode repo already exists for workspace {workspace_id}"
             )));
         }
@@ -138,6 +138,8 @@ pub async fn create_checkout_branch(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use crate::error::OxenError;
     use crate::{api, repositories, test, util};
 
@@ -167,7 +169,7 @@ mod tests {
                 let remote_repo_copy = remote_repo.clone();
 
                 test::run_empty_dir_test_async(|dir| async move {
-                    let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                    let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                     opts.is_remote = true;
                     let mut cloned_repo = repositories::clone(&opts).await?;
                     assert!(cloned_repo.is_remote_mode());
@@ -199,7 +201,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let mut cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -246,7 +248,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let mut cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -286,7 +288,7 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let mut cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -299,12 +301,12 @@ mod tests {
 
                 util::fs::write_to_path(&hello_file, file_contents)?;
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![hello_file.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -328,7 +330,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &current_workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![world_file.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -368,7 +370,7 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let mut cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -381,11 +383,11 @@ mod tests {
                 util::fs::write_to_path(&hello_file, file_contents)?;
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![hello_file.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -412,7 +414,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &current_workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![world_file.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -455,7 +457,7 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let mut cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -466,11 +468,11 @@ mod tests {
                 let hello_file = cloned_repo.path.join("hello.txt");
                 util::fs::write_to_path(&hello_file, "Hello")?;
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![hello_file.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -489,7 +491,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &current_workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![feature_file.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -528,7 +530,7 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let mut cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -542,12 +544,12 @@ mod tests {
                 util::fs::write_to_path(&hello_file, initial_content)?;
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![hello_file.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -571,7 +573,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &current_workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![hello_file.clone()],
                     &Some(cloned_repo.clone()),
                 )

--- a/crates/lib/src/repositories/remote_mode/commit.rs
+++ b/crates/lib/src/repositories/remote_mode/commit.rs
@@ -14,7 +14,7 @@ pub async fn commit(
         &local_repo.workspace_name.clone().unwrap()
     } else {
         return Err(OxenError::basic_str(
-            "Error: Cannot run remote mode commands outside remote mode repo",
+            "Error: Cannot run remote mode commands outside remote mode repo".to_string(),
         ));
     };
 

--- a/crates/lib/src/repositories/remote_mode/commit.rs
+++ b/crates/lib/src/repositories/remote_mode/commit.rs
@@ -64,7 +64,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -74,11 +74,11 @@ mod tests {
 
                 // Add file
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![file_path],
                     &Some(cloned_repo.clone()),
                 )
@@ -96,12 +96,12 @@ mod tests {
 
                 // Verify repo is clean
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -127,13 +127,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 let commit_root =
@@ -157,19 +157,20 @@ mod tests {
                     api::client::workspaces::files::add(
                         &remote_repo,
                         &workspace_id,
-                        &directory,
+                        Path::new(directory_name),
                         vec![file_path.clone()],
                         &Some(cloned_repo.clone()),
                     )
                     .await?;
 
-                    let status_opts =
-                        StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    let status_opts = StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(
+                        &cloned_repo.path,
+                    ));
                     let status = repositories::remote_mode::status(
                         &cloned_repo,
                         &remote_repo,
                         &workspace_id,
-                        &directory,
+                        Path::new(directory_name),
                         &status_opts,
                     )
                     .await?;
@@ -196,7 +197,7 @@ mod tests {
                     assert!(repositories::tree::has_path(
                         &cloned_repo,
                         &new_head_commit,
-                        file_path
+                        &file_path
                     )?);
 
                     previous_head_commit = new_head_commit;
@@ -230,7 +231,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone an empty repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -240,21 +241,21 @@ mod tests {
                 let annotations_dir = PathBuf::from("annotations");
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[annotations_dir.clone()],
+                    std::slice::from_ref(&annotations_dir),
                     &head_commit.id,
                 )
                 .await?;
 
                 // Verify bounding_box.csv and its parent dirs are no longer unsynced
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -276,7 +277,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![full_path],
                     &Some(cloned_repo.clone()),
                 )
@@ -295,7 +296,7 @@ mod tests {
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -324,7 +325,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -367,13 +368,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Create a file locally
                 let hello_file_path = PathBuf::from("hello.txt");
@@ -384,7 +385,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![hello_file_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -435,13 +436,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Create a directory with files
                 let dir_to_remove = PathBuf::from("train");
@@ -455,7 +456,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![dir_to_remove.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -483,12 +484,12 @@ mod tests {
                 )
                 .await?;
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory.clone())]);
+                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory_name)]);
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -519,13 +520,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Create an invalid parquet file locally
                 let invalid_parquet_file = test::test_invalid_parquet_file();
@@ -536,7 +537,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![file_path.clone()],
                     &Some(cloned_repo.clone()),
                 )

--- a/crates/lib/src/repositories/remote_mode/restore.rs
+++ b/crates/lib/src/repositories/remote_mode/restore.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 pub async fn restore(
     repo: &LocalRepository,
     paths: &[PathBuf],
-    revision: &String,
+    revision: &str,
 ) -> Result<(), OxenError> {
     let mut paths_to_download: Vec<(PathBuf, PathBuf)> = vec![];
     let remote_repo = api::client::repositories::get_default_remote(repo).await?;
@@ -35,7 +35,7 @@ pub async fn restore(
         repo,
         &remote_repo,
         &paths_to_download,
-        &revision,
+        revision,
     )
     .await?;
 
@@ -45,6 +45,7 @@ pub async fn restore(
 #[cfg(test)]
 mod tests {
 
+    use std::path::Path;
     use std::path::PathBuf;
 
     use crate::error::OxenError;
@@ -59,19 +60,19 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
 
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory.clone())]);
+                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory_name)]);
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -81,7 +82,7 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[readme_path.clone()],
+                    std::slice::from_ref(&readme_path),
                     &head_commit.id,
                 )
                 .await?;
@@ -107,19 +108,19 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
 
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory.clone())]);
+                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory_name)]);
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -130,7 +131,7 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[full_path.clone()],
+                    std::slice::from_ref(&full_path),
                     &head_commit.id,
                 )
                 .await?;
@@ -156,19 +157,19 @@ mod tests {
                 let remote_repo_copy = remote_repo.clone();
 
                 test::run_empty_dir_test_async(|dir| async move {
-                    let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                    let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                     opts.is_remote = true;
                     let cloned_repo = repositories::clone(&opts).await?;
 
                     let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                    let directory = ".".to_string();
+                    let directory_name = ".";
                     let status_opts =
-                        StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory.clone())]);
+                        StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory_name)]);
                     let status = repositories::remote_mode::status(
                         &cloned_repo,
                         &remote_repo,
                         &workspace_identifier,
-                        &directory,
+                        Path::new(directory_name),
                         &status_opts,
                     )
                     .await?;
@@ -180,7 +181,7 @@ mod tests {
                     let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                     repositories::remote_mode::restore(
                         &cloned_repo,
-                        &[file_path.clone()],
+                        std::slice::from_ref(&file_path),
                         &head_commit.id,
                     )
                     .await?;
@@ -217,20 +218,20 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 let repo_path = cloned_repo.path.clone();
 
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory.clone())]);
+                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory_name)]);
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -240,17 +241,18 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[annotations_path.clone()],
+                    std::slice::from_ref(&annotations_path),
                     &head_commit.id,
                 )
                 .await?;
 
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let status_opts =
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;

--- a/crates/lib/src/repositories/remote_mode/rm.rs
+++ b/crates/lib/src/repositories/remote_mode/rm.rs
@@ -4,6 +4,7 @@
 #[cfg(test)]
 mod tests {
 
+    use std::path::Path;
     use std::path::PathBuf;
 
     use crate::api;
@@ -25,7 +26,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone a repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -35,14 +36,14 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[file_path.clone()],
+                    std::slice::from_ref(&file_path),
                     &head_commit.id,
                 )
                 .await?;
 
                 // Remove the README file
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::rm_files(
                     &cloned_repo,
                     &remote_repo,
@@ -53,12 +54,12 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -83,7 +84,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone a repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -93,7 +94,7 @@ mod tests {
 
                 // Add file with full path
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::rm_files(
                     &cloned_repo,
                     &remote_repo,
@@ -104,12 +105,12 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -134,7 +135,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone a repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -146,7 +147,7 @@ mod tests {
 
                 // Remove the file
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::rm_files(
                     &cloned_repo,
                     &remote_repo,
@@ -157,12 +158,12 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -187,7 +188,7 @@ mod tests {
 
             test::run_empty_dir_test_async(|dir| async move {
                 // Clone a repo in remote mode
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -198,7 +199,7 @@ mod tests {
 
                 // Add file with full path
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 api::client::workspaces::files::rm_files(
                     &cloned_repo,
                     &remote_repo,
@@ -209,12 +210,12 @@ mod tests {
 
                 // Get status, should show staged file
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -239,7 +240,7 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -276,13 +277,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let file_path = PathBuf::from("README.md");
                 let full_path = cloned_repo.path.join(&file_path);
 
@@ -291,7 +292,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     vec![file_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -299,12 +300,12 @@ mod tests {
 
                 // Check status to confirm it's staged
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -325,7 +326,7 @@ mod tests {
                     &cloned_repo,
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -347,13 +348,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 // Create a directory with multiple files and commit it
                 let images_dir = PathBuf::from("images");
@@ -363,9 +364,9 @@ mod tests {
                 let file2 = images_dir.join("dog_2.txt");
                 let file3 = images_dir.join("cat_1.txt");
 
-                test::write_txt_file_to_path(cloned_repo.path.join(&file1), "dog")?;
-                test::write_txt_file_to_path(cloned_repo.path.join(&file2), "dog")?;
-                test::write_txt_file_to_path(cloned_repo.path.join(&file3), "cat")?;
+                test::write_txt_file_to_path(&cloned_repo.path.join(&file1), "dog")?;
+                test::write_txt_file_to_path(&cloned_repo.path.join(&file2), "dog")?;
+                test::write_txt_file_to_path(&cloned_repo.path.join(&file3), "cat")?;
 
                 println!(
                     "File 1: {file1:?}; exists? {:?}; clone repo path: {:?}; exist? {:?}",
@@ -379,7 +380,7 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     files_to_add,
                     &Some(cloned_repo.clone()),
                 )
@@ -407,12 +408,12 @@ mod tests {
 
                 // Check status: only one file should be staged for removal
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -453,7 +454,7 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
@@ -470,7 +471,7 @@ mod tests {
                 let prev_dirs = dirs_in_tree.len();
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let path_with_asterisk = PathBuf::from("annotations").join("*");
 
                 // Remove the directory using a path with a trailing slash
@@ -485,12 +486,12 @@ mod tests {
 
                 // Check status to verify files are staged for removal
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -534,13 +535,13 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let workspace_id = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let path_with_slash = PathBuf::from("annotations").join("t*");
 
                 // Remove the directory using a path with a trailing slash
@@ -555,12 +556,12 @@ mod tests {
 
                 // Check status to verify files are staged for removal
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[cloned_repo.path.clone()]);
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&cloned_repo.path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_id,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;

--- a/crates/lib/src/repositories/remote_mode/status.rs
+++ b/crates/lib/src/repositories/remote_mode/status.rs
@@ -16,7 +16,7 @@ pub async fn status(
     local_repository: &LocalRepository,
     remote_repo: &RemoteRepository,
     workspace_identifier: &str,
-    directory: impl AsRef<Path>,
+    directory: &Path,
     opts: &StagedDataOpts,
 ) -> Result<StagedData, OxenError> {
     let page_size = opts.limit;
@@ -80,6 +80,7 @@ pub async fn status(
 #[cfg(test)]
 mod tests {
 
+    use std::path::Path;
     use std::path::PathBuf;
 
     use crate::error::OxenError;
@@ -125,19 +126,19 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
 
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
                 let status_opts =
-                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory.clone())]);
+                    StagedDataOpts::from_paths_remote_mode(&[PathBuf::from(directory_name)]);
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -164,21 +165,22 @@ mod tests {
             let remote_repo_copy = remote_repo.clone();
 
             test::run_empty_dir_test_async(|dir| async move {
-                let mut opts = CloneOpts::new(&remote_repo.remote.url, dir.join("new_repo"));
+                let mut opts = CloneOpts::new(&remote_repo.remote.url, &dir.join("new_repo"));
                 opts.is_remote = true;
                 let cloned_repo = repositories::clone(&opts).await?;
                 assert!(cloned_repo.is_remote_mode());
 
                 let repo_path = cloned_repo.path.clone();
 
-                let directory = ".".to_string();
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let directory_name = ".";
+                let status_opts =
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -197,34 +199,34 @@ mod tests {
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[one_shot_path.clone()],
+                    std::slice::from_ref(&one_shot_path),
                     &head_commit.id,
                 )
                 .await?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[two_shot_path.clone()],
+                    std::slice::from_ref(&two_shot_path),
                     &head_commit.id,
                 )
                 .await?;
                 repositories::remote_mode::restore(
                     &cloned_repo,
-                    &[bounding_box_path.clone()],
+                    std::slice::from_ref(&bounding_box_path),
                     &head_commit.id,
                 )
                 .await?;
 
                 // Modify one_shot.csv
                 let new_content = "new content coming in hot";
-                test::modify_txt_file(cloned_repo.path.join(&one_shot_path), new_content)?;
+                test::modify_txt_file(&cloned_repo.path.join(&one_shot_path), new_content)?;
 
                 // Modify and add two_shot.csv
                 let new_content = "new content coming in even hotter!";
-                test::modify_txt_file(cloned_repo.path.join(&two_shot_path), new_content)?;
+                test::modify_txt_file(&cloned_repo.path.join(&two_shot_path), new_content)?;
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![two_shot_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
@@ -240,13 +242,14 @@ mod tests {
                 .await?;
 
                 // Check status for corresponding changes
-                let directory = ".".to_string();
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let directory_name = ".";
+                let status_opts =
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -267,20 +270,21 @@ mod tests {
                 api::client::workspaces::files::add(
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     vec![subdir_path.clone()],
                     &Some(cloned_repo.clone()),
                 )
                 .await?;
 
                 // Re-check status
-                let directory = ".".to_string();
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
+                let directory_name = ".";
+                let status_opts =
+                    StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
                 let status = repositories::remote_mode::status(
                     &cloned_repo,
                     &remote_repo,
                     &workspace_identifier,
-                    &directory,
+                    Path::new(directory_name),
                     &status_opts,
                 )
                 .await?;
@@ -320,7 +324,7 @@ mod tests {
                 let repo_path = cloned_repo.path.clone();
                 log::debug!("Cloned repo path: {:?}", cloned_repo.path.canonicalize());
                 let workspace_identifier = cloned_repo.workspace_name.clone().unwrap();
-                let directory = ".".to_string();
+                let directory_name = ".";
 
                 let head_commit = repositories::commits::head_commit(&cloned_repo)?;
 
@@ -334,8 +338,8 @@ mod tests {
                 util::fs::rename(&og_file, &new_file)?;
 
                 // Status before adding should show 4 unsynced files (README.md,  LICENSE, prompts.jsonl, labels.txt) and an untracked file
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
-                let status = repositories::remote_mode::status(&cloned_repo, &remote_repo, &workspace_identifier, &directory, &status_opts).await?;
+                let status_opts = StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
+                let status = repositories::remote_mode::status(&cloned_repo, &remote_repo, &workspace_identifier, Path::new(directory), &status_opts).await?;
                 status.print();
                 assert_eq!(status.moved_files.len(), 0);
                 assert_eq!(status.unsynced_files.len(), 4);
@@ -343,8 +347,8 @@ mod tests {
 
                 // Remove the previous file
                 api::client::workspaces::files::rm_files(&cloned_repo, &remote_repo, &workspace_identifier, vec![og_basename.clone()]).await?;
-                let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path.clone()]);
-                let status = repositories::remote_mode::status(&cloned_repo, &remote_repo, &workspace_identifier, &directory, &status_opts).await?;
+                let status_opts = StagedDataOpts::from_paths_remote_mode(std::slice::from_ref(&repo_path));
+                let status = repositories::remote_mode::status(&cloned_repo, &remote_repo, &workspace_identifier, Path::new(directory), &status_opts).await?;
                 status.print();
                 assert_eq!(status.moved_files.len(), 0);
                 assert_eq!(status.staged_files.len(), 1);
@@ -353,7 +357,7 @@ mod tests {
                 // Add the new file to complete the pair
                 api::client::workspaces::files::add(&cloned_repo, &remote_repo, &workspace_identifier, &directory, vec![new_basename.clone()]).await?;
                 let status_opts = StagedDataOpts::from_paths_remote_mode(&[repo_path]);
-                let status = repositories::remote_mode::status(&cloned_repo, &remote_repo, &workspace_identifier, &directory, &status_opts).await?;
+                let status = repositories::remote_mode::status(&cloned_repo, &remote_repo, &workspace_identifier, Path::new(directory), &status_opts).await?;
                 status.print();
                 assert_eq!(status.moved_files.len(), 1);
                 assert_eq!(status.staged_files.len(), 2);

--- a/crates/lib/src/repositories/restore.rs
+++ b/crates/lib/src/repositories/restore.rs
@@ -80,7 +80,11 @@ mod tests {
             assert!(!hello_file.exists());
             // Restore takes the filename not the full path to the test repo
             // ie: "hello.txt" instead of data/test/runs/repo_data/test/runs_fc1544ab-cd55-4344-aa13-5360dc91d0fe/hello.txt
-            repositories::restore::restore(&repo, RestoreOpts::from_path(hello_filename)).await?;
+            repositories::restore::restore(
+                &repo,
+                RestoreOpts::from_path(Path::new(hello_filename)),
+            )
+            .await?;
             assert!(hello_file.exists());
 
             Ok(())
@@ -103,20 +107,20 @@ mod tests {
 
             // Modify the file once
             let first_modification = "Hola Mundo";
-            let hello_file = test::modify_txt_file(hello_file, first_modification)?;
+            let hello_file = test::modify_txt_file(&hello_file, first_modification)?;
             repositories::add(&repo, &hello_file).await?;
             let first_mod_commit = repositories::commit(&repo, "Changing to spanish")?;
 
             // Modify again
             let second_modification = "Bonjour le monde";
-            let hello_file = test::modify_txt_file(hello_file, second_modification)?;
+            let hello_file = test::modify_txt_file(&hello_file, second_modification)?;
             repositories::add(&repo, &hello_file).await?;
             repositories::commit(&repo, "Changing to french")?;
 
             // Restore from the first commit
             repositories::restore::restore(
                 &repo,
-                RestoreOpts::from_path_ref(hello_filename, first_mod_commit.id),
+                RestoreOpts::from_path_ref(Path::new(hello_filename), &first_mod_commit.id),
             )
             .await?;
             let content = util::fs::read_from_path(&hello_file)?;
@@ -142,7 +146,7 @@ mod tests {
             let orig_branch = repositories::branches::current_branch(&repo)?.unwrap();
 
             let train_dir = repo.path.join("train");
-            repositories::add(&repo, train_dir).await?;
+            repositories::add(&repo, &train_dir).await?;
             repositories::commit(&repo, "Adding train dir")?;
 
             // Branch
@@ -163,7 +167,7 @@ mod tests {
             assert!(!file_to_remove.exists());
 
             // Switch back to main branch
-            repositories::checkout(&repo, orig_branch.name).await?;
+            repositories::checkout(&repo, &orig_branch.name).await?;
             // Make sure we restore file
             assert!(file_to_remove.exists());
 
@@ -193,12 +197,12 @@ mod tests {
             let readme_path = repo.path.join(readme_file);
             let og_readme_contents = util::fs::read_from_path(&readme_path)?;
 
-            let readme_path = test::append_line_txt_file(readme_path, "Adding s'more")?;
+            let readme_path = test::append_line_txt_file(&readme_path, "Adding s'more")?;
 
             // Restore the directory
             repositories::restore::restore(
                 &repo,
-                RestoreOpts::from_path_ref(annotations_dir, last_commit.id.clone()),
+                RestoreOpts::from_path_ref(annotations_dir, &last_commit.id.clone()),
             )
             .await?;
 
@@ -207,7 +211,7 @@ mod tests {
             assert_eq!(og_bbox_contents, restored_contents);
 
             // Make sure the modified file is restored
-            let restored_contents = util::fs::read_from_path(readme_path)?;
+            let restored_contents = util::fs::read_from_path(&readme_path)?;
             assert_eq!(og_readme_contents, restored_contents);
 
             Ok(())
@@ -233,7 +237,7 @@ mod tests {
 
             repositories::restore::restore(
                 &repo,
-                RestoreOpts::from_path_ref(bbox_file, last_commit.id.clone()),
+                RestoreOpts::from_path_ref(&bbox_file, &last_commit.id),
             )
             .await?;
             let restored_contents = util::fs::read_from_path(&bbox_path)?;
@@ -264,7 +268,7 @@ mod tests {
 
             repositories::restore::restore(
                 &repo,
-                RestoreOpts::from_path_ref(bbox_file, last_commit.id.clone()),
+                RestoreOpts::from_path_ref(&bbox_file, &last_commit.id),
             ).await?;
             let restored_contents = util::fs::read_from_path(&bbox_path)?;
             assert_eq!(og_contents, restored_contents);
@@ -290,11 +294,11 @@ mod tests {
 
             let og_contents = util::fs::read_from_path(&bbox_path)?;
             let new_contents = format!("{og_contents}\nnew 0");
-            util::fs::write_to_path(&bbox_path, new_contents)?;
+            util::fs::write_to_path(&bbox_path, &new_contents)?;
 
             repositories::restore::restore(
                 &repo,
-                RestoreOpts::from_path_ref(bbox_file, last_commit.id.clone()),
+                RestoreOpts::from_path_ref(&bbox_file, &last_commit.id),
             )
             .await?;
             let restored_contents = util::fs::read_from_path(&bbox_path)?;
@@ -318,7 +322,7 @@ mod tests {
             let bbox_path = repo.path.join(&bbox_file);
 
             // Stage file
-            repositories::add(&repo, bbox_path).await?;
+            repositories::add(&repo, &bbox_path).await?;
 
             // Make sure is staged
             let status = repositories::status(&repo)?;
@@ -326,7 +330,8 @@ mod tests {
             status.print();
 
             // Remove from staged
-            repositories::restore::restore(&repo, RestoreOpts::from_staged_path(bbox_file)).await?;
+            repositories::restore::restore(&repo, RestoreOpts::from_staged_path(&bbox_file))
+                .await?;
 
             // Make sure is unstaged
             let status = repositories::status(&repo)?;
@@ -359,8 +364,11 @@ mod tests {
             util::fs::remove_file(&ann_path)?;
 
             // Restore from commit
-            repositories::restore::restore(&repo, RestoreOpts::from_path_ref(ann_file, commit.id))
-                .await?;
+            repositories::restore::restore(
+                &repo,
+                RestoreOpts::from_path_ref(&ann_file, &commit.id),
+            )
+            .await?;
 
             // Make sure is same size
             let restored_df = tabular::read_df(&ann_path, DFOpts::empty()).await?;
@@ -399,8 +407,11 @@ mod tests {
             util::fs::remove_file(&ann_path)?;
 
             // Restore from commit
-            repositories::restore::restore(&repo, RestoreOpts::from_path_ref(ann_file, commit.id))
-                .await?;
+            repositories::restore::restore(
+                &repo,
+                RestoreOpts::from_path_ref(&ann_file, &commit.id),
+            )
+            .await?;
 
             // Make sure is same size
             let restored_df = tabular::read_df(&ann_path, DFOpts::empty()).await?;
@@ -423,7 +434,7 @@ mod tests {
             let annotations_dir = repo.path.join(relative_path);
 
             // Stage file
-            repositories::add(&repo, annotations_dir).await?;
+            repositories::add(&repo, &annotations_dir).await?;
 
             // Make sure is staged
             let status = repositories::status(&repo)?;
@@ -450,7 +461,7 @@ mod tests {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             let dir = Path::new("nlp");
             let repo_dir = repo.path.join(dir);
-            repositories::add(&repo, repo_dir).await?;
+            repositories::add(&repo, &repo_dir).await?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -484,7 +495,7 @@ mod tests {
             assert_eq!(status.removed_files.len(), 1);
             assert_eq!(status.staged_files.len(), 0);
             // Add the removed nlp dir with a wildcard
-            repositories::add(&repo, "nlp/*").await?;
+            repositories::add(&repo, Path::new("nlp/*")).await?;
 
             let status = repositories::status(&repo)?;
             assert_eq!(status.staged_dirs.len(), 1);
@@ -632,8 +643,8 @@ mod tests {
 
             // Copy bbox and one_shot to new_annotations
             util::fs::create_dir_all(&new_annotations_dir)?;
-            util::fs::copy(bbox_path, new_annotations_dir.join("bounding_box.csv"))?;
-            util::fs::copy(one_shot_path, new_annotations_dir.join("one_shot.csv"))?;
+            util::fs::copy(&bbox_path, &new_annotations_dir.join("bounding_box.csv"))?;
+            util::fs::copy(&one_shot_path, &new_annotations_dir.join("one_shot.csv"))?;
 
             // Get file names for these copied files
             new_annotations_dir

--- a/crates/lib/src/repositories/revisions.rs
+++ b/crates/lib/src/repositories/revisions.rs
@@ -11,8 +11,7 @@ use crate::storage::LocalFilePath;
 
 /// Get a commit object from a commit id or branch name
 /// Returns Ok(None) if the revision does not exist
-pub fn get(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<Option<Commit>, OxenError> {
-    let revision = revision.as_ref();
+pub fn get(repo: &LocalRepository, revision: &str) -> Result<Option<Commit>, OxenError> {
     if revision == "HEAD" {
         let commit = repositories::commits::head_commit(repo)?;
         return Ok(Some(commit));
@@ -34,8 +33,8 @@ pub fn get(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<Option<C
 /// Get the version file path from a commit id
 pub async fn get_version_file_from_commit_id(
     repo: &LocalRepository,
-    commit_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    commit_id: &str,
+    path: &Path,
 ) -> Result<LocalFilePath, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),

--- a/crates/lib/src/repositories/rm.rs
+++ b/crates/lib/src/repositories/rm.rs
@@ -154,35 +154,35 @@ mod tests {
             util::fs::create_dir_all(&gemma_dir)?;
 
             let chat_file = gemma_dir.join("chat.py");
-            util::fs::write(chat_file, "print('Hello, Gemma!')")?;
+            util::fs::write(&chat_file, "print('Hello, Gemma!')".as_bytes())?;
 
             let mistral_dir = repo.path.join("mistral-small-3-1");
             util::fs::create_dir_all(&mistral_dir)?;
 
             let chat_file = mistral_dir.join("chat.py");
-            util::fs::write(chat_file, "print('Hello, Mistral!')")?;
+            util::fs::write(&chat_file, "print('Hello, Mistral!')".as_bytes())?;
 
             let phi_dir = repo.path.join("phi-4");
             util::fs::create_dir_all(&phi_dir)?;
 
             let chat_file = phi_dir.join("chat.py");
-            util::fs::write(chat_file, "print('Hello, Phi!')")?;
+            util::fs::write(&chat_file, "print('Hello, Phi!')".as_bytes())?;
 
             let phi_multimodal_dir = repo.path.join("phi-4-multimodal");
             util::fs::create_dir_all(&phi_multimodal_dir)?;
 
             let chat_file = phi_multimodal_dir.join("chat.py");
-            util::fs::write(chat_file, "print('Hello, Phi Multimodal!')")?;
+            util::fs::write(&chat_file, "print('Hello, Phi Multimodal!')".as_bytes())?;
 
             let ocr_bench_dir = phi_multimodal_dir.join("eval");
             util::fs::create_dir_all(&ocr_bench_dir)?;
 
             let ocr_file = ocr_bench_dir.join("ocr-bench-v2.py");
-            util::fs::write(ocr_file, "print('Hello, Phi OCR Bench!')")?;
+            util::fs::write(&ocr_file, "print('Hello, Phi OCR Bench!')".as_bytes())?;
 
             // Write a README.md file
             let readme_file = repo.path.join("README.md");
-            util::fs::write(readme_file, "Hello, world!")?;
+            util::fs::write(&readme_file, "Hello, world!".as_bytes())?;
 
             // Add and commit the files
             repositories::add(&repo, &repo.path).await?;
@@ -207,16 +207,16 @@ mod tests {
             // add data via a workspace
             let workspace_id = "my_workspace";
             let workspace =
-                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_id)
+                api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                     .await?;
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_csv_file_with_name("emojis.csv");
             let directory_name = "phi-4";
-            let result = api::client::workspaces::files::upload_single_file(
+            let result = &api::client::workspaces::files::upload_single_file(
                 &remote_repo,
-                &workspace_id,
-                directory_name,
-                file_to_post,
+                workspace_id,
+                Path::new(directory_name),
+                &file_to_post,
             )
             .await;
             assert!(result.is_ok());
@@ -508,14 +508,14 @@ mod tests {
             // Remove one of the dogs
             let repo_filepath = PathBuf::from("images").join("dog_1.jpg");
 
-            let rm_opts = RmOpts::from_path(repo_filepath);
+            let rm_opts = RmOpts::from_path(&repo_filepath);
             repositories::rm(&repo, &rm_opts)?;
             let _commit = repositories::commit(&repo, "Removing dog")?;
 
             // Add dwight howard and vince carter
             let test_file = test::test_img_file_with_name("dwight_vince.jpeg");
             let repo_filepath = images_dir.join(test_file.file_name().unwrap());
-            util::fs::copy(&test_file, repo_filepath)?;
+            util::fs::copy(&test_file, &repo_filepath)?;
             repositories::add(&repo, &images_dir).await?;
             let commit = repositories::commit(&repo, "Adding dwight and vince")?;
 
@@ -544,7 +544,7 @@ mod tests {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             let dir = Path::new("nlp");
             let repo_dir = repo.path.join(dir);
-            repositories::add(&repo, repo_dir).await?;
+            repositories::add(&repo, &repo_dir).await?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -576,7 +576,7 @@ mod tests {
             status.print();
 
             // Add the removed nlp dir with a wildcard
-            repositories::add(&repo, "nlp/*").await?;
+            repositories::add(&repo, Path::new("nlp/*")).await?;
             status.print();
 
             let status = repositories::status(&repo)?;
@@ -674,7 +674,7 @@ mod tests {
             // add a new file in a directory
             let path = Path::new("dir").join("new_file.txt");
 
-            util::fs::write_to_path(repo.path.join(&path), "this is a new file")?;
+            util::fs::write_to_path(&repo.path.join(&path), "this is a new file")?;
             repositories::add(&repo, &path).await?;
             repositories::commit(&repo, "first_commit")?;
 
@@ -697,7 +697,7 @@ mod tests {
         test::run_select_data_repo_test_no_commits_async("README", |repo| async move {
             // Stage a file in a directory
             let path = Path::new("README.md");
-            repositories::add(&repo, repo.path.join(path)).await?;
+            repositories::add(&repo, &repo.path.join(path)).await?;
 
             let status = repositories::status(&repo)?;
             assert_eq!(status.staged_files.len(), 1);
@@ -719,7 +719,7 @@ mod tests {
         test::run_select_data_repo_test_no_commits_async("train", |repo| async move {
             // Stage the data
             let path = Path::new("train");
-            repositories::add(&repo, repo.path.join(path)).await?;
+            repositories::add(&repo, &repo.path.join(path)).await?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -744,7 +744,7 @@ mod tests {
         test::run_select_data_repo_test_no_commits_async("annotations", |repo| async move {
             // Stage the data
             let path = Path::new("annotations").join("train");
-            repositories::add(&repo, repo.path.join(&path)).await?;
+            repositories::add(&repo, &repo.path.join(&path)).await?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -774,7 +774,7 @@ mod tests {
         test::run_select_data_repo_test_no_commits_async("train", |repo| async move {
             // Stage the data
             let path = Path::new("train");
-            repositories::add(&repo, repo.path.join(path)).await?;
+            repositories::add(&repo, &repo.path.join(path)).await?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -804,7 +804,7 @@ mod tests {
         test::run_select_data_repo_test_no_commits_async("train", |repo| async move {
             // Stage the data
             let path = Path::new("train/");
-            repositories::add(&repo, repo.path.join(path)).await?;
+            repositories::add(&repo, &repo.path.join(path)).await?;
 
             let status = repositories::status(&repo)?;
             // 1: train dir
@@ -911,12 +911,12 @@ mod tests {
 
             // copy a cat into the dog image
             util::fs::copy(
-                test::REPO_ROOT
+                &test::REPO_ROOT
                     .join("data")
                     .join("test")
                     .join("images")
                     .join("cat_1.jpg"),
-                repo.path.join(train_dir.join("dog_1.jpg")),
+                &repo.path.join(train_dir.join("dog_1.jpg")),
             )?;
 
             // There should be one modified file

--- a/crates/lib/src/repositories/save.rs
+++ b/crates/lib/src/repositories/save.rs
@@ -15,7 +15,7 @@ pub fn save(repo: &LocalRepository, dst_path: &Path) -> Result<(), OxenError> {
         match (dst_path.is_file(), dst_path.is_dir()) {
             (true, false) => dst_path.to_path_buf(),
             (false, true) => dst_path.join("oxen-archive.tar.gz"),
-            _ => return Err(OxenError::basic_str(dst_path.to_str().unwrap())),
+            _ => return Err(OxenError::basic_str(dst_path.to_str().unwrap().to_string())),
         }
     };
 

--- a/crates/lib/src/repositories/size.rs
+++ b/crates/lib/src/repositories/size.rs
@@ -46,7 +46,7 @@ pub fn update_size(repo: &LocalRepository) -> Result<(), OxenError> {
                 size: parsed.size,
             },
             Err(e) => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Failed to parse size file: {e}"
                 )));
             }

--- a/crates/lib/src/repositories/size.rs
+++ b/crates/lib/src/repositories/size.rs
@@ -46,7 +46,7 @@ pub fn update_size(repo: &LocalRepository) -> Result<(), OxenError> {
                 size: parsed.size,
             },
             Err(e) => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Failed to parse size file: {e}"
                 )));
             }
@@ -61,7 +61,7 @@ pub fn update_size(repo: &LocalRepository) -> Result<(), OxenError> {
         }
     };
 
-    util::fs::write_to_path(&path, size.to_string())?;
+    util::fs::write_to_path(&path, &size.to_string())?;
 
     let repo_path = repo.path.clone();
     let path_clone = path.clone();
@@ -75,7 +75,7 @@ pub fn update_size(repo: &LocalRepository) -> Result<(), OxenError> {
                     status: SizeStatus::Done,
                     size: calculated_size,
                 };
-                if let Err(e) = util::fs::write_to_path(&path_clone, size.to_string()) {
+                if let Err(e) = util::fs::write_to_path(&path_clone, &size.to_string()) {
                     log::error!("Failed to write size result: {e}");
                 }
             }
@@ -85,7 +85,7 @@ pub fn update_size(repo: &LocalRepository) -> Result<(), OxenError> {
                     status: SizeStatus::Error,
                     size: 0,
                 };
-                let _ = util::fs::write_to_path(&path_clone, size.to_string());
+                let _ = util::fs::write_to_path(&path_clone, &size.to_string());
             }
         }
     });

--- a/crates/lib/src/repositories/status.rs
+++ b/crates/lib/src/repositories/status.rs
@@ -64,10 +64,7 @@ pub fn status_from_opts(
     }
 }
 
-pub fn status_from_dir(
-    repo: &LocalRepository,
-    dir: impl AsRef<Path>,
-) -> Result<StagedData, OxenError> {
+pub fn status_from_dir(repo: &LocalRepository, dir: &Path) -> Result<StagedData, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::status::status_from_dir(repo, dir),
@@ -130,7 +127,7 @@ mod tests {
     #[tokio::test]
     async fn test_command_add_one_file_top_level() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
-            repositories::add(&repo, repo.path.join(Path::new("labels.txt"))).await?;
+            repositories::add(&repo, &repo.path.join(Path::new("labels.txt"))).await?;
 
             let repo_status = repositories::status(&repo)?;
             repo_status.print();
@@ -163,7 +160,7 @@ mod tests {
             // Add a deep file
             repositories::add(
                 &repo,
-                repo.path.join(Path::new("annotations/train/one_shot.csv")),
+                &repo.path.join(Path::new("annotations/train/one_shot.csv")),
             )
             .await?;
 
@@ -385,7 +382,7 @@ mod tests {
             let initial_len = commits.len();
 
             let labels_path = repo.path.join("labels.txt");
-            util::fs::write_to_path(labels_path, "changing this guy, but not committing")?;
+            util::fs::write_to_path(&labels_path, "changing this guy, but not committing")?;
 
             let result = repositories::commit(&repo, "Should not work");
             assert!(result.is_err());
@@ -402,7 +399,7 @@ mod tests {
         test::run_empty_local_repo_test(|repo| {
             // Write to file
             let hello_file = repo.path.join("hello.txt");
-            util::fs::write_to_path(hello_file, "Hello World")?;
+            util::fs::write_to_path(&hello_file, "Hello World")?;
 
             // Get status
             let repo_status = repositories::status(&repo)?;
@@ -433,7 +430,7 @@ mod tests {
             repositories::commit(&repo, "adding none category")?;
 
             // Add a "person" category on a the main branch
-            repositories::checkout(&repo, og_branch.name).await?;
+            repositories::checkout(&repo, &og_branch.name).await?;
 
             test::modify_txt_file(&labels_path, "cat\ndog\nperson")?;
             repositories::add(&repo, &labels_path).await?;
@@ -460,7 +457,7 @@ mod tests {
             // Move the file to a new name
             let og_basename = PathBuf::from("README.md");
             let og_file = repo.path.join(&og_basename);
-            util::fs::remove_file(og_file)?;
+            util::fs::remove_file(&og_file)?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -489,7 +486,7 @@ mod tests {
             // Move the file to a new name
             let og_basename = PathBuf::from("README.md");
             let og_file = repo.path.join(&og_basename);
-            util::fs::remove_file(og_file)?;
+            util::fs::remove_file(&og_file)?;
 
             let status = repositories::status(&repo)?;
             status.print();
@@ -544,7 +541,7 @@ mod tests {
             assert_eq!(status.staged_files.len(), 2); // Staged files still operates on the addition + removal
 
             // Restore one file and break the pair
-            repositories::restore(&repo, RestoreOpts::from_staged_path(og_basename)).await?;
+            repositories::restore(&repo, RestoreOpts::from_staged_path(&og_basename)).await?;
 
             // Pair is broken; no more "moved"
             let status = repositories::status(&repo)?;
@@ -705,7 +702,7 @@ mod tests {
                 .join("one_shot.csv");
 
             // Modify the committed file
-            let one_shot_file = test::modify_txt_file(one_shot_file, "new content coming in hot")?;
+            let one_shot_file = test::modify_txt_file(&one_shot_file, "new content coming in hot")?;
 
             // List modified
             let status = repositories::status(&repo)?;
@@ -716,7 +713,7 @@ mod tests {
             assert_eq!(files.len(), 1);
 
             // And it is
-            let relative_path = util::fs::path_relative_to_dir(one_shot_file, repo_path)?;
+            let relative_path = util::fs::path_relative_to_dir(&one_shot_file, repo_path)?;
             assert!(files.contains(&relative_path));
 
             Ok(())
@@ -822,14 +819,14 @@ mod tests {
             assert_eq!(mod_files.len(), 0);
 
             // modify the file
-            let hello_file = test::modify_txt_file(hello_file, "Hello 2")?;
+            let hello_file = test::modify_txt_file(&hello_file, "Hello 2")?;
 
             // List files
             let status = repositories::status(&repo)?;
             status.print();
             let mod_files = status.modified_files;
             assert_eq!(mod_files.len(), 1);
-            let relative_path = util::fs::path_relative_to_dir(hello_file, repo_path)?;
+            let relative_path = util::fs::path_relative_to_dir(&hello_file, repo_path)?;
             assert!(mod_files.contains(&relative_path));
 
             Ok(())
@@ -849,7 +846,7 @@ mod tests {
             repositories::branches::create_checkout(&repo, branch_name)?;
 
             let file_contents = "file,label\ntrain/cat_1.jpg,0\n";
-            test::modify_txt_file(one_shot_path, file_contents)?;
+            test::modify_txt_file(&one_shot_path, file_contents)?;
             let status = repositories::status(&repo)?;
             status.print();
             assert_eq!(status.modified_files.len(), 1);

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -103,7 +103,7 @@ pub fn get_root_with_children_and_partial_nodes(
 /// Will error if the node is not a commit node, because only CommitNodes have a root directory
 pub fn get_root_dir(node: &MerkleTreeNode) -> Result<&MerkleTreeNode, OxenError> {
     if node.node.node_type() != MerkleTreeNodeType::Commit {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Expected a commit node, but got: '{:?}'",
             node.node.node_type()
         )));
@@ -111,7 +111,7 @@ pub fn get_root_dir(node: &MerkleTreeNode) -> Result<&MerkleTreeNode, OxenError>
 
     // A commit node should have exactly one child, which is the root directory
     if node.children.len() != 1 {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Commit node should have exactly one child (root directory) but got: {} from {}",
             node.children.len(),
             node
@@ -120,7 +120,7 @@ pub fn get_root_dir(node: &MerkleTreeNode) -> Result<&MerkleTreeNode, OxenError>
 
     let root_dir = &node.children[0];
     if root_dir.node.node_type() != MerkleTreeNodeType::Dir {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "The child of a commit node should be a directory, but got: '{:?}'",
             root_dir.node.node_type()
         )));
@@ -168,21 +168,12 @@ pub fn get_commit_node_version(
     Ok(commit_node.version())
 }
 
-pub fn has_dir(
-    repo: &LocalRepository,
-    commit: &Commit,
-    path: impl AsRef<Path>,
-) -> Result<bool, OxenError> {
+pub fn has_dir(repo: &LocalRepository, commit: &Commit, path: &Path) -> Result<bool, OxenError> {
     let dir_hashes = CommitMerkleTreeLatest::dir_hashes(repo, commit)?;
-    Ok(dir_hashes.contains_key(path.as_ref()))
+    Ok(dir_hashes.contains_key(path))
 }
 
-pub fn has_path(
-    repo: &LocalRepository,
-    commit: &Commit,
-    path: impl AsRef<Path>,
-) -> Result<bool, OxenError> {
-    let path = path.as_ref();
+pub fn has_path(repo: &LocalRepository, commit: &Commit, path: &Path) -> Result<bool, OxenError> {
     let dir_hashes = CommitMerkleTreeLatest::dir_hashes(repo, commit)?;
     match dir_hashes.get(path) {
         Some(dir_hash) => {
@@ -204,7 +195,7 @@ pub fn has_path(
 pub fn get_node_by_path(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
     let load_recursive = false;
     match repo.min_version() {
@@ -230,7 +221,7 @@ pub fn get_node_by_path(
 pub fn get_node_by_path_with_children(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
     let load_recursive = true;
     let node = match repo.min_version() {
@@ -246,9 +237,9 @@ pub fn get_node_by_path_with_children(
 pub fn get_file_by_path(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Option<FileNode>, OxenError> {
-    let Some(root) = get_node_by_path(repo, commit, &path)? else {
+    let Some(root) = get_node_by_path(repo, commit, path)? else {
         return Ok(None);
     };
     match root.node {
@@ -260,7 +251,7 @@ pub fn get_file_by_path(
 pub fn get_dir_with_children(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
     dir_hashes: Option<&HashMap<PathBuf, MerkleHash>>,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
     let _perf = crate::perf_guard!("tree::get_dir_with_children");
@@ -274,7 +265,7 @@ pub fn get_dir_with_children(
 pub fn get_dir_without_children(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
     dir_hashes: Option<&HashMap<PathBuf, MerkleHash>>,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
     match repo.min_version() {
@@ -288,7 +279,7 @@ pub fn get_dir_without_children(
 pub fn get_dir_with_children_recursive(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
     dir_hashes: Option<&HashMap<PathBuf, MerkleHash>>,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
     match repo.min_version() {
@@ -302,7 +293,7 @@ pub fn get_dir_with_children_recursive(
 pub fn get_dir_with_unique_children(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
     base_hashes: &HashSet<MerkleHash>,
     unique_hashes: &mut HashSet<MerkleHash>,
     dir_hashes: Option<&HashMap<PathBuf, MerkleHash>>,
@@ -342,7 +333,7 @@ pub fn get_subtree(
         }
         (None, Some(depth)) => {
             log::debug!("Getting tree from root with depth {depth} for commit {commit}");
-            get_subtree_by_depth(repo, commit, PathBuf::from("."), *depth)
+            get_subtree_by_depth(repo, commit, &PathBuf::from("."), *depth)
         }
         _ => {
             log::debug!("Getting full tree for commit {commit}");
@@ -354,7 +345,7 @@ pub fn get_subtree(
 pub fn get_subtree_by_depth(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
     depth: i32,
 ) -> Result<Option<MerkleTreeNode>, OxenError> {
     match repo.min_version() {
@@ -368,7 +359,7 @@ pub fn get_subtree_by_depth(
 pub fn get_subtree_by_depth_with_unique_children(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
     base_hashes: Option<&HashSet<MerkleHash>>,
     unique_hashes: Option<&mut HashSet<MerkleHash>>,
     shared_hashes: Option<&mut HashSet<MerkleHash>>,
@@ -405,7 +396,7 @@ pub fn list_nodes_from_paths(
 /// List the files and folders given a directory node
 pub fn list_files_and_folders(node: &MerkleTreeNode) -> Result<Vec<MerkleTreeNode>, OxenError> {
     if MerkleTreeNodeType::Dir != node.node.node_type() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "list_files_and_folders Merkle tree node is not a directory: '{:?}'",
             node.node.node_type()
         )));
@@ -426,7 +417,7 @@ pub fn list_files_and_folders_set(
     node: &MerkleTreeNode,
 ) -> Result<HashSet<MerkleTreeNode>, OxenError> {
     if MerkleTreeNodeType::Dir != node.node.node_type() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "list_files_and_folders Merkle tree node is not a directory: '{:?}'",
             node.node.node_type()
         )));
@@ -447,7 +438,7 @@ pub fn list_files_and_folders_map(
     node: &MerkleTreeNode,
 ) -> Result<HashMap<PathBuf, MerkleTreeNode>, OxenError> {
     if MerkleTreeNodeType::Dir != node.node.node_type() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "list_files_and_folders_map Merkle tree node is not a directory: '{:?}'",
             node.node.node_type()
         )));
@@ -521,12 +512,12 @@ pub async fn list_missing_file_hashes(
 ) -> Result<HashSet<MerkleHash>, OxenError> {
     if repo.min_version() == MinOxenVersion::V0_19_0 {
         let Some(node) = CommitMerkleTreeV0_19_0::read_depth(repo, hash, 1)? else {
-            return Err(OxenError::basic_str(format!("Node {hash} not found")));
+            return Err(OxenError::basic_str(&format!("Node {hash} not found")));
         };
         node.list_missing_file_hashes(repo).await
     } else {
         let Some(node) = CommitMerkleTreeLatest::read_depth(repo, hash, 1)? else {
-            return Err(OxenError::basic_str(format!("Node {hash} not found")));
+            return Err(OxenError::basic_str(&format!("Node {hash} not found")));
         };
         node.list_missing_file_hashes(repo).await
     }
@@ -617,7 +608,7 @@ pub fn dir_entries_with_paths(
         }
         EMerkleTreeNode::File(_) => {}
         _ => {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             )));
@@ -661,7 +652,7 @@ pub fn unique_dir_entries(
         }
         EMerkleTreeNode::File(_) => {}
         _ => {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             )));
@@ -703,7 +694,7 @@ async fn list_missing_file_hashes_from_hashes(
 
 pub fn list_all_files(
     node: &MerkleTreeNode,
-    subtree_path: &PathBuf,
+    subtree_path: &Path,
 ) -> Result<HashSet<FileNodeWithDir>, OxenError> {
     let mut file_nodes = HashSet::new();
     r_list_all_files(node, subtree_path, &mut file_nodes)?;
@@ -712,10 +703,9 @@ pub fn list_all_files(
 
 fn r_list_all_files(
     node: &MerkleTreeNode,
-    traversed_path: impl AsRef<Path>,
+    traversed_path: &Path,
     file_nodes: &mut HashSet<FileNodeWithDir>,
 ) -> Result<(), OxenError> {
-    let traversed_path = traversed_path.as_ref();
     for child in &node.children {
         match &child.node {
             EMerkleTreeNode::File(file_node) => {
@@ -726,7 +716,7 @@ fn r_list_all_files(
             }
             EMerkleTreeNode::Directory(dir_node) => {
                 let new_path = traversed_path.join(dir_node.name());
-                r_list_all_files(child, new_path, file_nodes)?;
+                r_list_all_files(child, &new_path, file_nodes)?;
             }
             EMerkleTreeNode::VNode(_) => {
                 r_list_all_files(child, traversed_path, file_nodes)?;
@@ -740,16 +730,15 @@ fn r_list_all_files(
 /// Collect MerkleTree into Directories
 pub fn list_all_dirs(node: &MerkleTreeNode) -> Result<HashSet<DirNodeWithPath>, OxenError> {
     let mut dir_nodes = HashSet::new();
-    r_list_all_dirs(node, PathBuf::from(""), &mut dir_nodes)?;
+    r_list_all_dirs(node, &PathBuf::from(""), &mut dir_nodes)?;
     Ok(dir_nodes)
 }
 
 fn r_list_all_dirs(
     node: &MerkleTreeNode,
-    traversed_path: impl AsRef<Path>,
+    traversed_path: &Path,
     dir_nodes: &mut HashSet<DirNodeWithPath>,
 ) -> Result<(), OxenError> {
-    let traversed_path = traversed_path.as_ref();
     for child in &node.children {
         // log::debug!("Found child: {child}");
         match &child.node {
@@ -759,7 +748,7 @@ fn r_list_all_dirs(
                     dir_node: dir_node.to_owned(),
                     path: new_path.to_owned(),
                 });
-                r_list_all_dirs(child, new_path, dir_nodes)?;
+                r_list_all_dirs(child, &new_path, dir_nodes)?;
             }
             EMerkleTreeNode::VNode(_) => {
                 r_list_all_dirs(child, traversed_path, dir_nodes)?;
@@ -776,18 +765,16 @@ pub fn list_files_and_dirs(
 ) -> Result<(HashSet<FileNodeWithDir>, HashSet<DirNodeWithPath>), OxenError> {
     let mut file_nodes = HashSet::new();
     let mut dir_nodes = HashSet::new();
-    r_list_files_and_dirs(root, PathBuf::new(), &mut file_nodes, &mut dir_nodes)?;
+    r_list_files_and_dirs(root, &PathBuf::new(), &mut file_nodes, &mut dir_nodes)?;
     Ok((file_nodes, dir_nodes))
 }
 
 fn r_list_files_and_dirs(
     node: &MerkleTreeNode,
-    traversed_path: impl AsRef<Path>,
+    traversed_path: &Path,
     file_nodes: &mut HashSet<FileNodeWithDir>,
     dir_nodes: &mut HashSet<DirNodeWithPath>,
 ) -> Result<(), OxenError> {
-    let traversed_path = traversed_path.as_ref();
-
     if let EMerkleTreeNode::File(file_node) = &node.node {
         file_nodes.insert(FileNodeWithDir {
             file_node: file_node.to_owned(),
@@ -813,7 +800,7 @@ fn r_list_files_and_dirs(
                         path: new_path.to_owned(),
                     });
                 }
-                r_list_files_and_dirs(child, new_path, file_nodes, dir_nodes)?;
+                r_list_files_and_dirs(child, &new_path, file_nodes, dir_nodes)?;
             }
             EMerkleTreeNode::VNode(_) => {
                 r_list_files_and_dirs(child, traversed_path, file_nodes, dir_nodes)?;
@@ -842,7 +829,7 @@ pub fn list_files_by_type(
         log::warn!("get_root_with_children returned None for commit: {commit:?}");
         return Ok(file_nodes);
     };
-    r_list_files_by_type(&tree, data_type, &mut file_nodes, PathBuf::new())?;
+    r_list_files_by_type(&tree, data_type, &mut file_nodes, &PathBuf::new())?;
     Ok(file_nodes)
 }
 
@@ -850,9 +837,8 @@ fn r_list_files_by_type(
     node: &MerkleTreeNode,
     data_type: &EntryDataType,
     file_nodes: &mut HashSet<FileNode>,
-    traversed_path: impl AsRef<Path>,
+    traversed_path: &Path,
 ) -> Result<(), OxenError> {
-    let traversed_path = traversed_path.as_ref();
     for child in &node.children {
         match &child.node {
             EMerkleTreeNode::File(file_node) => {
@@ -865,7 +851,7 @@ fn r_list_files_by_type(
             }
             EMerkleTreeNode::Directory(dir_node) => {
                 let full_path = traversed_path.join(dir_node.name());
-                r_list_files_by_type(child, data_type, file_nodes, full_path)?;
+                r_list_files_by_type(child, data_type, file_nodes, &full_path)?;
             }
             EMerkleTreeNode::VNode(_) => {
                 r_list_files_by_type(child, data_type, file_nodes, traversed_path)?;
@@ -885,7 +871,7 @@ pub fn cp_dir_hashes_to(
         CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &original_commit_id.to_string());
     let new_dir_hashes_path =
         CommitMerkleTree::dir_hash_db_path_from_commit_id(repo, &new_commit_id.to_string());
-    util::fs::copy_dir_all(original_dir_hashes_path, new_dir_hashes_path)?;
+    util::fs::copy_dir_all(&original_dir_hashes_path, &new_dir_hashes_path)?;
 
     Ok(())
 }
@@ -1285,7 +1271,7 @@ fn get_node_hashes_for_subtree(
     let Ok(Some(_)) = CommitMerkleTreeLatest::read_depth_from_path_and_collect_hashes(
         repository,
         commit,
-        subtree_path.clone().unwrap_or(PathBuf::from(".")),
+        &subtree_path.clone().unwrap_or(PathBuf::from(".")),
         Some(base_hashes),
         Some(&mut unique_hashes),
         None,
@@ -1311,7 +1297,7 @@ pub fn populate_starting_hashes(
     let Ok(Some(_)) = CommitMerkleTreeLatest::read_depth_from_path_and_collect_hashes(
         repository,
         commit,
-        subtree_path.clone().unwrap_or(PathBuf::from(".")),
+        &subtree_path.clone().unwrap_or(PathBuf::from(".")),
         None,
         Some(unique_hashes),
         None,
@@ -1343,7 +1329,7 @@ pub fn get_ancestor_nodes(
                     let Some(node) =
                         repositories::tree::get_node_by_path_with_children(repo, commit, ancestor)?
                     else {
-                        return Err(OxenError::basic_str(format!(
+                        return Err(OxenError::basic_str(&format!(
                             "Ancestor {ancestor:?} for subtree path {subtree_path:?} not found in merkle tree"
                         )));
                     };
@@ -1385,7 +1371,7 @@ pub fn print_tree_depth_subtree(
     repo: &LocalRepository,
     commit: &Commit,
     depth: i32,
-    subtree: &PathBuf,
+    subtree: &Path,
 ) -> Result<(), OxenError> {
     let tree = get_subtree_by_depth(repo, commit, subtree, depth)?.unwrap();
     match repo.min_version() {
@@ -1402,7 +1388,7 @@ pub fn print_tree_depth_subtree(
 pub fn print_tree_path(
     repo: &LocalRepository,
     commit: &Commit,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<(), OxenError> {
     let tree = get_node_by_path_with_children(repo, commit, path)?.unwrap();
     match repo.min_version() {
@@ -1458,26 +1444,26 @@ mod tests {
             // Add two tabular files to it
             let filename = "cats.tsv";
             let filepath = dir_path.join(filename);
-            util::fs::write(filepath, "1\t2\t3\nhello\tworld\tsup\n")?;
+            util::fs::write(&filepath, "1\t2\t3\nhello\tworld\tsup\n".as_bytes())?;
 
             let filename = "dogs.csv";
             let filepath = dir_path.join(filename);
-            util::fs::write(filepath, "1,2,3\nhello,world,sup\n")?;
+            util::fs::write(&filepath, "1,2,3\nhello,world,sup\n".as_bytes())?;
 
             // And write a file in the same dir that is not tabular
             let filename = "README.md";
             let filepath = dir_path.join(filename);
-            util::fs::write(filepath, "readme....")?;
+            util::fs::write(&filepath, "readme....".as_bytes())?;
 
             // And write a tabular file to the root dir
             let filename = "labels.tsv";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "1\t2\t3\nhello\tworld\tsup\n")?;
+            util::fs::write(&filepath, "1\t2\t3\nhello\tworld\tsup\n".as_bytes())?;
 
             // And write a non tabular file to the root dir
             let filename = "labels.txt";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "1\t2\t3\nhello\tworld\tsup\n")?;
+            util::fs::write(&filepath, "1\t2\t3\nhello\tworld\tsup\n".as_bytes())?;
 
             // Add and commit all
             repositories::add(&repo, &repo.path).await?;
@@ -1491,7 +1477,7 @@ mod tests {
             // Add another tabular file
             let filename = "dogs.tsv";
             let filepath = repo.path.join(filename);
-            util::fs::write(filepath, "1\t2\t3\nhello\tworld\tsup\n")?;
+            util::fs::write(&filepath, "1\t2\t3\nhello\tworld\tsup\n".as_bytes())?;
 
             // Add and commit all
             repositories::add(&repo, &repo.path).await?;
@@ -1504,7 +1490,7 @@ mod tests {
             // Remove the deeply nested dir
             util::fs::remove_dir_all(&dir_path)?;
 
-            let mut opts = RmOpts::from_path(dir_path);
+            let mut opts = RmOpts::from_path(&dir_path);
             opts.recursive = true;
             repositories::rm(&repo, &opts)?;
             let commit = repositories::commit(&repo, "Removing dir")?;
@@ -1547,12 +1533,12 @@ mod tests {
             assert!(repositories::tree::has_path(
                 &local_repo,
                 &commit,
-                PathBuf::from(p1)
+                &PathBuf::from(p1)
             )?);
             assert!(repositories::tree::has_path(
                 &local_repo,
                 &commit,
-                PathBuf::from(p2)
+                &PathBuf::from(p2)
             )?);
 
             Ok(())
@@ -1572,8 +1558,8 @@ mod tests {
             let new_file2 = repo.path.join("new_dir1").join("new_file2.txt");
             util::fs::create_dir_all(new_file2.parent().unwrap())?;
 
-            util::fs::write(&new_file1, "This is new file 1 content")?;
-            util::fs::write(&new_file2, "This is new file 2 content")?;
+            util::fs::write(&new_file1, "This is new file 1 content".as_bytes())?;
+            util::fs::write(&new_file2, "This is new file 2 content".as_bytes())?;
 
             repositories::add(&repo, &new_file1).await?;
             repositories::add(&repo, &new_file2).await?;
@@ -1582,7 +1568,7 @@ mod tests {
             // Add more files and make second new commit
             let new_file3 = repo.path.join("new_dir2").join("new_file3.csv");
             util::fs::create_dir_all(new_file3.parent().unwrap())?;
-            util::fs::write(&new_file3, "col1,col2,col3\nval1,val2,val3\n")?;
+            util::fs::write(&new_file3, "col1,col2,col3\nval1,val2,val3\n".as_bytes())?;
 
             repositories::add(&repo, &new_file3).await?;
             let commit2 = repositories::commit(&repo, "Add second batch of new files")?;

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -103,7 +103,7 @@ pub fn get_root_with_children_and_partial_nodes(
 /// Will error if the node is not a commit node, because only CommitNodes have a root directory
 pub fn get_root_dir(node: &MerkleTreeNode) -> Result<&MerkleTreeNode, OxenError> {
     if node.node.node_type() != MerkleTreeNodeType::Commit {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Expected a commit node, but got: '{:?}'",
             node.node.node_type()
         )));
@@ -111,7 +111,7 @@ pub fn get_root_dir(node: &MerkleTreeNode) -> Result<&MerkleTreeNode, OxenError>
 
     // A commit node should have exactly one child, which is the root directory
     if node.children.len() != 1 {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Commit node should have exactly one child (root directory) but got: {} from {}",
             node.children.len(),
             node
@@ -120,7 +120,7 @@ pub fn get_root_dir(node: &MerkleTreeNode) -> Result<&MerkleTreeNode, OxenError>
 
     let root_dir = &node.children[0];
     if root_dir.node.node_type() != MerkleTreeNodeType::Dir {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "The child of a commit node should be a directory, but got: '{:?}'",
             root_dir.node.node_type()
         )));
@@ -396,7 +396,7 @@ pub fn list_nodes_from_paths(
 /// List the files and folders given a directory node
 pub fn list_files_and_folders(node: &MerkleTreeNode) -> Result<Vec<MerkleTreeNode>, OxenError> {
     if MerkleTreeNodeType::Dir != node.node.node_type() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "list_files_and_folders Merkle tree node is not a directory: '{:?}'",
             node.node.node_type()
         )));
@@ -417,7 +417,7 @@ pub fn list_files_and_folders_set(
     node: &MerkleTreeNode,
 ) -> Result<HashSet<MerkleTreeNode>, OxenError> {
     if MerkleTreeNodeType::Dir != node.node.node_type() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "list_files_and_folders Merkle tree node is not a directory: '{:?}'",
             node.node.node_type()
         )));
@@ -438,7 +438,7 @@ pub fn list_files_and_folders_map(
     node: &MerkleTreeNode,
 ) -> Result<HashMap<PathBuf, MerkleTreeNode>, OxenError> {
     if MerkleTreeNodeType::Dir != node.node.node_type() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "list_files_and_folders_map Merkle tree node is not a directory: '{:?}'",
             node.node.node_type()
         )));
@@ -476,9 +476,9 @@ pub fn collect_nodes_along_path(
     // Grab the first path or error if empty
     let root_path = paths
         .first()
-        .ok_or(OxenError::basic_str("No paths provided"))?;
+        .ok_or(OxenError::basic_str("No paths provided".to_string()))?;
     let node = get_node_by_path_with_children(repo, commit, root_path)?
-        .ok_or(OxenError::basic_str("Node not found"))?;
+        .ok_or(OxenError::basic_str("Node not found".to_string()))?;
 
     let (_root_node, nodes) = node.get_nodes_along_paths(paths)?;
 
@@ -512,12 +512,12 @@ pub async fn list_missing_file_hashes(
 ) -> Result<HashSet<MerkleHash>, OxenError> {
     if repo.min_version() == MinOxenVersion::V0_19_0 {
         let Some(node) = CommitMerkleTreeV0_19_0::read_depth(repo, hash, 1)? else {
-            return Err(OxenError::basic_str(&format!("Node {hash} not found")));
+            return Err(OxenError::basic_str(format!("Node {hash} not found")));
         };
         node.list_missing_file_hashes(repo).await
     } else {
         let Some(node) = CommitMerkleTreeLatest::read_depth(repo, hash, 1)? else {
-            return Err(OxenError::basic_str(&format!("Node {hash} not found")));
+            return Err(OxenError::basic_str(format!("Node {hash} not found")));
         };
         node.list_missing_file_hashes(repo).await
     }
@@ -608,7 +608,7 @@ pub fn dir_entries_with_paths(
         }
         EMerkleTreeNode::File(_) => {}
         _ => {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             )));
@@ -652,7 +652,7 @@ pub fn unique_dir_entries(
         }
         EMerkleTreeNode::File(_) => {}
         _ => {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Unexpected node type: {:?}",
                 node.node.node_type()
             )));
@@ -1013,7 +1013,7 @@ pub fn unpack_nodes(
     log::debug!("Archive created");
     let Ok(entries) = archive.entries() else {
         return Err(OxenError::basic_str(
-            "Could not unpack tree database from archive",
+            "Could not unpack tree database from archive".to_string(),
         ));
     };
     log::debug!("Extracting entries...");
@@ -1056,7 +1056,7 @@ pub fn unpack_nodes(
 /// Write a node to disk
 pub fn write_tree(repo: &LocalRepository, node: &MerkleTreeNode) -> Result<(), OxenError> {
     let EMerkleTreeNode::Commit(commit_node) = &node.node else {
-        return Err(OxenError::basic_str("Expected commit node"));
+        return Err(OxenError::basic_str("Expected commit node".to_string()));
     };
     let commit_node = CommitNode::new(repo, commit_node.get_opts())?;
     p_write_tree(repo, node, &commit_node)?;
@@ -1143,9 +1143,9 @@ pub fn get_node_hashes_between_commits(
         commits.len(),
         maybe_subtrees
     );
-    let (first_commit, new_commits) = commits
-        .split_first()
-        .ok_or(OxenError::basic_str("Must provide at least one commit"))?;
+    let (first_commit, new_commits) = commits.split_first().ok_or(OxenError::basic_str(
+        "Must provide at least one commit".to_string(),
+    ))?;
 
     let mut starting_node_hashes = HashSet::new();
 
@@ -1329,7 +1329,7 @@ pub fn get_ancestor_nodes(
                     let Some(node) =
                         repositories::tree::get_node_by_path_with_children(repo, commit, ancestor)?
                     else {
-                        return Err(OxenError::basic_str(&format!(
+                        return Err(OxenError::basic_str(format!(
                             "Ancestor {ancestor:?} for subtree path {subtree_path:?} not found in merkle tree"
                         )));
                     };

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -33,11 +33,7 @@ use uuid::Uuid;
 /// Loads a workspace from the filesystem. Must call create() first to create the workspace.
 ///
 /// Returns an None if the workspace does not exist
-pub fn get(
-    repo: &LocalRepository,
-    workspace_id: impl AsRef<str>,
-) -> Result<Option<Workspace>, OxenError> {
-    let workspace_id = workspace_id.as_ref();
+pub fn get(repo: &LocalRepository, workspace_id: &str) -> Result<Option<Workspace>, OxenError> {
     let workspace_id_hash = util::hasher::hash_str_sha256(workspace_id);
     log::debug!("workspace::get workspace_id: {workspace_id:?} hash: {workspace_id_hash:?}");
 
@@ -46,11 +42,11 @@ pub fn get(
 
     log::debug!("workspace::get directory: {workspace_dir:?}");
     if config_path.exists() {
-        get_by_dir(repo, workspace_dir)
+        get_by_dir(repo, &workspace_dir)
     } else if let Some(workspace) = get_by_name(repo, workspace_id)? {
         let workspace_id = util::hasher::hash_str_sha256(&workspace.id);
         let workspace_dir = Workspace::workspace_dir(repo, &workspace_id);
-        get_by_dir(repo, workspace_dir)
+        get_by_dir(repo, &workspace_dir)
     } else {
         Ok(None)
     }
@@ -58,9 +54,8 @@ pub fn get(
 
 pub fn get_by_dir(
     repo: &LocalRepository,
-    workspace_dir: impl AsRef<Path>,
+    workspace_dir: &Path,
 ) -> Result<Option<Workspace>, OxenError> {
-    let workspace_dir = workspace_dir.as_ref();
     let workspace_id = workspace_dir.file_name().unwrap().to_str().unwrap();
     let config_path = Workspace::config_path_from_dir(workspace_dir);
 
@@ -71,10 +66,10 @@ pub fn get_by_dir(
 
     let config_contents = util::fs::read_from_path(&config_path)?;
     let config: WorkspaceConfig = toml::from_str(&config_contents)
-        .map_err(|e| OxenError::basic_str(format!("Failed to parse workspace config: {e}")))?;
+        .map_err(|e| OxenError::basic_str(&format!("Failed to parse workspace config: {e}")))?;
 
     let Some(commit) = repositories::commits::get_by_id(repo, &config.workspace_commit_id)? else {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Workspace {} has invalid commit_id {}",
             workspace_id, config.workspace_commit_id
         )));
@@ -100,12 +95,12 @@ pub fn get_by_dir(
 
 pub fn get_by_name(
     repo: &LocalRepository,
-    workspace_name: impl AsRef<str>,
+    workspace_name: &str,
 ) -> Result<Option<Workspace>, OxenError> {
-    let workspace_name = workspace_name.as_ref();
     for workspace in iter_workspaces(repo)? {
         if let Some(workspace) = workspace?
-            && workspace.name.as_deref() == Some(workspace_name)
+            && let Some(other_workspace_name) = workspace.name.as_deref()
+            && other_workspace_name == workspace_name
         {
             return Ok(Some(workspace));
         }
@@ -117,7 +112,7 @@ pub fn get_by_name(
 pub fn create(
     base_repo: &LocalRepository,
     commit: &Commit,
-    workspace_id: impl AsRef<str>,
+    workspace_id: &str,
     is_editable: bool,
 ) -> Result<Workspace, OxenError> {
     create_with_name(base_repo, commit, workspace_id, None, is_editable)
@@ -126,11 +121,10 @@ pub fn create(
 pub fn create_with_name(
     base_repo: &LocalRepository,
     commit: &Commit,
-    workspace_id: impl AsRef<str>,
+    workspace_id: &str,
     workspace_name: Option<String>,
     is_editable: bool,
 ) -> Result<Workspace, OxenError> {
-    let workspace_id = workspace_id.as_ref();
     let workspace_id_hash = util::hasher::hash_str_sha256(workspace_id);
     let workspace_dir = Workspace::workspace_dir(base_repo, &workspace_id_hash);
     let oxen_dir = workspace_dir.join(OXEN_HIDDEN_DIR);
@@ -139,7 +133,7 @@ pub fn create_with_name(
 
     if oxen_dir.exists() {
         log::debug!("index::workspaces::create already have oxen repo directory {oxen_dir:?}");
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Workspace {workspace_id} already exists"
         )));
     }
@@ -170,7 +164,7 @@ pub fn create_with_name(
     let toml_string = match toml::to_string(&workspace_config) {
         Ok(s) => s,
         Err(e) => {
-            return Err(OxenError::basic_str(format!(
+            return Err(OxenError::basic_str(&format!(
                 "Failed to serialize workspace config to TOML: {e}"
             )));
         }
@@ -179,7 +173,7 @@ pub fn create_with_name(
     // Write the TOML string to WORKSPACE_CONFIG
     let workspace_config_path = Workspace::config_path_from_dir(&workspace_dir);
     log::debug!("index::workspaces::create writing workspace config to: {workspace_config_path:?}");
-    util::fs::write_to_path(&workspace_config_path, toml_string)?;
+    util::fs::write_to_path(&workspace_config_path, &toml_string)?;
 
     Ok(Workspace {
         id: workspace_id.to_owned(),
@@ -226,13 +220,13 @@ pub fn create_temporary(
 ) -> Result<TemporaryWorkspace, OxenError> {
     let workspace_id = Uuid::new_v4().to_string();
     let workspace_name = format!("temporary-{workspace_id}");
-    let workspace = create_with_name(base_repo, commit, workspace_id, Some(workspace_name), true)?;
+    let workspace = create_with_name(base_repo, commit, &workspace_id, Some(workspace_name), true)?;
     Ok(TemporaryWorkspace { workspace })
 }
 
 fn check_non_editable_workspace(workspace: &Workspace, commit: &Commit) -> Result<(), OxenError> {
     if workspace.commit.id == commit.id && !workspace.is_editable {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "A non-editable workspace already exists for commit {}",
             commit.id
         )));
@@ -245,7 +239,7 @@ fn check_existing_workspace_name(
     workspace_name: &str,
 ) -> Result<(), OxenError> {
     if workspace.name == Some(workspace_name.to_string()) || *workspace_name == workspace.id {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "A workspace with the name {workspace_name} already exists"
         )));
     }
@@ -262,7 +256,7 @@ fn iter_workspaces(
 
     let workspace_hashes = if workspaces_dir.exists() {
         util::fs::list_dirs_in_dir(&workspaces_dir).map_err(|e| {
-            OxenError::basic_str(format!("Error listing workspace directories: {e}"))
+            OxenError::basic_str(&format!("Error listing workspace directories: {e}"))
         })?
     } else {
         Vec::new()
@@ -290,11 +284,11 @@ pub fn list(repo: &LocalRepository) -> Result<Vec<Workspace>, OxenError> {
 
 pub fn get_non_editable_by_commit_id(
     repo: &LocalRepository,
-    commit_id: impl AsRef<str>,
+    commit_id: &str,
 ) -> Result<Workspace, OxenError> {
     let workspaces = list(repo)?;
     for workspace in workspaces {
-        if workspace.commit.id == commit_id.as_ref() && !workspace.is_editable {
+        if workspace.commit.id == commit_id && !workspace.is_editable {
             return Ok(workspace);
         }
     }
@@ -344,7 +338,7 @@ pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), O
     let config_contents = util::fs::read_from_path(&config_path)?;
     let mut config: WorkspaceConfig = toml::from_str(&config_contents).map_err(|e| {
         log::error!("Failed to parse workspace config: {config_path:?}, err: {e}");
-        OxenError::basic_str(format!("Failed to parse workspace config: {e}"))
+        OxenError::basic_str(&format!("Failed to parse workspace config: {e}"))
     })?;
 
     log::debug!(
@@ -357,10 +351,12 @@ pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), O
 
     let toml_string = toml::to_string(&config).map_err(|e| {
         log::error!("Failed to serialize workspace config to TOML: {config_path:?}, err: {e}");
-        OxenError::basic_str(format!("Failed to serialize workspace config to TOML: {e}"))
+        OxenError::basic_str(&format!(
+            "Failed to serialize workspace config to TOML: {e}"
+        ))
     })?;
 
-    util::fs::write_to_path(&config_path, toml_string)?;
+    util::fs::write_to_path(&config_path, &toml_string)?;
 
     Ok(())
 }
@@ -368,7 +364,7 @@ pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), O
 pub async fn commit(
     workspace: &Workspace,
     new_commit: &NewCommitBody,
-    branch_name: impl AsRef<str>,
+    branch_name: &str,
 ) -> Result<Commit, OxenError> {
     match workspace.workspace_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -376,10 +372,7 @@ pub async fn commit(
     }
 }
 
-pub fn mergeability(
-    workspace: &Workspace,
-    branch_name: impl AsRef<str>,
-) -> Result<Mergeable, OxenError> {
+pub fn mergeability(workspace: &Workspace, branch_name: &str) -> Result<Mergeable, OxenError> {
     match workspace.workspace_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::commit::mergeability(workspace, branch_name),
@@ -388,9 +381,8 @@ pub fn mergeability(
 
 fn init_workspace_repo(
     repo: &LocalRepository,
-    workspace_dir: impl AsRef<Path>,
+    workspace_dir: &Path,
 ) -> Result<LocalRepository, OxenError> {
-    let workspace_dir = workspace_dir.as_ref();
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::init_workspace_repo(repo, workspace_dir),
@@ -430,9 +422,9 @@ pub fn populate_entries_with_workspace_data(
     for (file_path, status) in additions_map.iter() {
         if *status == StagedEntryStatus::Added {
             let staged_node = get_staged_db_manager(&workspace.workspace_repo)?
-                .read_from_staged_db(file_path)?
+                .read_from_staged_db(Path::new(file_path))?
                 .ok_or_else(|| {
-                    OxenError::basic_str(format!(
+                    OxenError::basic_str(&format!(
                         "Staged entry disappeared while resolving workspace metadata: {file_path:?}"
                     ))
                 })?;
@@ -609,7 +601,8 @@ mod tests {
                 // Update the hello file in the temporary workspace
                 let workspace_hello_file = temp_workspace.dir().join("hello.txt");
                 util::fs::write_to_path(&workspace_hello_file, "Hello again")?;
-                repositories::workspaces::files::add(&temp_workspace, workspace_hello_file).await?;
+                repositories::workspaces::files::add(&temp_workspace, &workspace_hello_file)
+                    .await?;
                 // Commit the changes to the "main" branch
                 repositories::workspaces::commit(
                     &temp_workspace,
@@ -630,7 +623,7 @@ mod tests {
                 // Update the goodbye file in the temporary workspace
                 let workspace_goodbye_file = temp_workspace.dir().join("goodbye.txt");
                 util::fs::write_to_path(&workspace_goodbye_file, "Goodbye again")?;
-                repositories::workspaces::files::add(&temp_workspace, workspace_goodbye_file)
+                repositories::workspaces::files::add(&temp_workspace, &workspace_goodbye_file)
                     .await?;
                 // Commit the changes to the "main" branch
                 repositories::workspaces::commit(
@@ -667,7 +660,8 @@ mod tests {
                 // Update the hello file in the temporary workspace
                 let workspace_hello_file = temp_workspace.dir().join("greetings").join("hello.txt");
                 util::fs::write_to_path(&workspace_hello_file, "Hello again")?;
-                repositories::workspaces::files::add(&temp_workspace, workspace_hello_file).await?;
+                repositories::workspaces::files::add(&temp_workspace, &workspace_hello_file)
+                    .await?;
                 // Commit the changes to the "main" branch
                 repositories::workspaces::commit(
                     &temp_workspace,
@@ -688,7 +682,8 @@ mod tests {
                 // Update the hello file in the temporary workspace
                 let workspace_hello_file = temp_workspace.dir().join("greetings").join("hello.txt");
                 util::fs::write_to_path(&workspace_hello_file, "Hello again")?;
-                repositories::workspaces::files::add(&temp_workspace, workspace_hello_file).await?;
+                repositories::workspaces::files::add(&temp_workspace, &workspace_hello_file)
+                    .await?;
                 // Commit the changes to the "main" branch
                 let result = repositories::workspaces::commit(
                     &temp_workspace,
@@ -730,7 +725,8 @@ mod tests {
                 // Update the hello file in the temporary workspace
                 let workspace_hello_file = temp_workspace.dir().join("greetings").join("hello.txt");
                 util::fs::write_to_path(&workspace_hello_file, "Hello again")?;
-                repositories::workspaces::files::add(&temp_workspace, workspace_hello_file).await?;
+                repositories::workspaces::files::add(&temp_workspace, &workspace_hello_file)
+                    .await?;
                 // Commit the changes to the "main" branch
                 repositories::workspaces::commit(
                     &temp_workspace,
@@ -752,7 +748,7 @@ mod tests {
                 let workspace_goodbye_file =
                     temp_workspace.dir().join("greetings").join("goodbye.txt");
                 util::fs::write_to_path(&workspace_goodbye_file, "Goodbye again")?;
-                repositories::workspaces::files::add(&temp_workspace, workspace_goodbye_file)
+                repositories::workspaces::files::add(&temp_workspace, &workspace_goodbye_file)
                     .await?;
                 // Commit the changes to the "main" branch
                 repositories::workspaces::commit(
@@ -837,15 +833,15 @@ mod tests {
             api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace1.id,
-                "dir1",
-                file1,
+                Path::new("dir1"),
+                &file1,
             )
             .await?;
             api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace2.id,
-                "dir2",
-                file2,
+                Path::new("dir2"),
+                &file2,
             )
             .await?;
 
@@ -931,12 +927,12 @@ mod tests {
 
                     // Add a unique file
                     let file_path = repo.path.join(format!("file-{i}.txt"));
-                    util::fs::write_to_path(&file_path, format!("content {i}"))?;
+                    util::fs::write_to_path(&file_path, &format!("content {i}"))?;
                     api::client::workspaces::files::upload_single_file(
                         &remote_repo,
                         &workspace.id,
-                        "",
-                        file_path,
+                        Path::new(""),
+                        &file_path,
                     )
                     .await?;
 
@@ -964,7 +960,7 @@ mod tests {
             for handle in handles {
                 handle
                     .await
-                    .map_err(|e| OxenError::basic_str(format!("Task error: {e}")))??;
+                    .map_err(|e| OxenError::basic_str(&format!("Task error: {e}")))??;
             }
 
             Ok(remote_repo)

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -66,10 +66,10 @@ pub fn get_by_dir(
 
     let config_contents = util::fs::read_from_path(&config_path)?;
     let config: WorkspaceConfig = toml::from_str(&config_contents)
-        .map_err(|e| OxenError::basic_str(&format!("Failed to parse workspace config: {e}")))?;
+        .map_err(|e| OxenError::basic_str(format!("Failed to parse workspace config: {e}")))?;
 
     let Some(commit) = repositories::commits::get_by_id(repo, &config.workspace_commit_id)? else {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Workspace {} has invalid commit_id {}",
             workspace_id, config.workspace_commit_id
         )));
@@ -133,7 +133,7 @@ pub fn create_with_name(
 
     if oxen_dir.exists() {
         log::debug!("index::workspaces::create already have oxen repo directory {oxen_dir:?}");
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Workspace {workspace_id} already exists"
         )));
     }
@@ -164,7 +164,7 @@ pub fn create_with_name(
     let toml_string = match toml::to_string(&workspace_config) {
         Ok(s) => s,
         Err(e) => {
-            return Err(OxenError::basic_str(&format!(
+            return Err(OxenError::basic_str(format!(
                 "Failed to serialize workspace config to TOML: {e}"
             )));
         }
@@ -226,7 +226,7 @@ pub fn create_temporary(
 
 fn check_non_editable_workspace(workspace: &Workspace, commit: &Commit) -> Result<(), OxenError> {
     if workspace.commit.id == commit.id && !workspace.is_editable {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "A non-editable workspace already exists for commit {}",
             commit.id
         )));
@@ -239,7 +239,7 @@ fn check_existing_workspace_name(
     workspace_name: &str,
 ) -> Result<(), OxenError> {
     if workspace.name == Some(workspace_name.to_string()) || *workspace_name == workspace.id {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "A workspace with the name {workspace_name} already exists"
         )));
     }
@@ -256,7 +256,7 @@ fn iter_workspaces(
 
     let workspace_hashes = if workspaces_dir.exists() {
         util::fs::list_dirs_in_dir(&workspaces_dir).map_err(|e| {
-            OxenError::basic_str(&format!("Error listing workspace directories: {e}"))
+            OxenError::basic_str(format!("Error listing workspace directories: {e}"))
         })?
     } else {
         Vec::new()
@@ -293,7 +293,7 @@ pub fn get_non_editable_by_commit_id(
         }
     }
     Err(OxenError::basic_str(
-        "No non-editable workspace found for the given commit ID",
+        "No non-editable workspace found for the given commit ID".to_string(),
     ))
 }
 
@@ -338,7 +338,7 @@ pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), O
     let config_contents = util::fs::read_from_path(&config_path)?;
     let mut config: WorkspaceConfig = toml::from_str(&config_contents).map_err(|e| {
         log::error!("Failed to parse workspace config: {config_path:?}, err: {e}");
-        OxenError::basic_str(&format!("Failed to parse workspace config: {e}"))
+        OxenError::basic_str(format!("Failed to parse workspace config: {e}"))
     })?;
 
     log::debug!(
@@ -351,9 +351,7 @@ pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), O
 
     let toml_string = toml::to_string(&config).map_err(|e| {
         log::error!("Failed to serialize workspace config to TOML: {config_path:?}, err: {e}");
-        OxenError::basic_str(&format!(
-            "Failed to serialize workspace config to TOML: {e}"
-        ))
+        OxenError::basic_str(format!("Failed to serialize workspace config to TOML: {e}"))
     })?;
 
     util::fs::write_to_path(&config_path, &toml_string)?;
@@ -424,7 +422,7 @@ pub fn populate_entries_with_workspace_data(
             let staged_node = get_staged_db_manager(&workspace.workspace_repo)?
                 .read_from_staged_db(Path::new(file_path))?
                 .ok_or_else(|| {
-                    OxenError::basic_str(&format!(
+                    OxenError::basic_str(format!(
                         "Staged entry disappeared while resolving workspace metadata: {file_path:?}"
                     ))
                 })?;
@@ -438,7 +436,7 @@ pub fn populate_entries_with_workspace_data(
                 }
                 _ => {
                     return Err(OxenError::basic_str(
-                        "Unexpected node type found in staged db",
+                        "Unexpected node type found in staged db".to_string(),
                     ));
                 }
             };
@@ -484,7 +482,7 @@ pub fn get_added_entry(
     if let Some(status) = additions_map.get(file_path.to_str().unwrap()).cloned() {
         if status != StagedEntryStatus::Added {
             return Err(OxenError::basic_str(
-                "Entry is not in the workspace's staged database",
+                "Entry is not in the workspace's staged database".to_string(),
             ));
         }
 
@@ -501,7 +499,7 @@ pub fn get_added_entry(
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Unexpected node type found in staged db",
+                    "Unexpected node type found in staged db".to_string(),
                 ));
             }
         };
@@ -514,7 +512,7 @@ pub fn get_added_entry(
         Ok(EMetadataEntry::WorkspaceMetadataEntry(ws_entry))
     } else {
         Err(OxenError::basic_str(
-            "Entry is not in the workspace's staged database",
+            "Entry is not in the workspace's staged database".to_string(),
         ))
     }
 }
@@ -960,7 +958,7 @@ mod tests {
             for handle in handles {
                 handle
                     .await
-                    .map_err(|e| OxenError::basic_str(&format!("Task error: {e}")))??;
+                    .map_err(|e| OxenError::basic_str(format!("Task error: {e}")))??;
             }
 
             Ok(remote_repo)

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -99,7 +99,7 @@ pub async fn rename(
 ) -> Result<PathBuf, OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => Err(OxenError::basic_str(
-            "rename is not supported for this version of oxen",
+            "rename is not supported for this version of oxen".to_string(),
         )),
         _ => core::v_latest::workspaces::data_frames::rename(workspace, path, new_path).await,
     }
@@ -228,7 +228,7 @@ pub fn full_diff(workspace: &Workspace, path: &Path) -> Result<DiffResult, OxenE
     log::debug!("diff_workspace_df got repo at path {:?}", repo.path);
 
     if !is_indexed(workspace, path)? {
-        return Err(OxenError::basic_str("Dataset is not indexed"));
+        return Err(OxenError::basic_str("Dataset is not indexed".to_string()));
     };
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
@@ -287,7 +287,7 @@ pub async fn from_directory(
 ) -> Result<Commit, OxenError> {
     let has_dir = repositories::tree::has_dir(repo, &workspace.commit, path)?;
     if !has_dir {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Directory not found: {:?}",
             path
         )));
@@ -516,13 +516,13 @@ fn add_exclude_to_sql(sql: &str) -> Result<String, OxenError> {
     let select_idx = sql
         .to_lowercase()
         .find("select")
-        .ok_or_else(|| OxenError::basic_str("No SELECT found in query"))?;
+        .ok_or_else(|| OxenError::basic_str("No SELECT found in query".to_string()))?;
 
     // Find the first FROM after SELECT (case insensitive)
     let from_idx = sql[select_idx..]
         .to_lowercase()
         .find("from")
-        .ok_or_else(|| OxenError::basic_str("No FROM found in query"))?;
+        .ok_or_else(|| OxenError::basic_str("No FROM found in query".to_string()))?;
 
     // Split into parts
     let before_from = &sql[..select_idx + from_idx];

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -33,19 +33,18 @@ pub mod embeddings;
 pub mod rows;
 pub mod schemas;
 
-pub fn is_behind(workspace: &Workspace, path: impl AsRef<Path>) -> Result<bool, OxenError> {
+pub fn is_behind(workspace: &Workspace, path: &Path) -> Result<bool, OxenError> {
     let commit_path = previous_commit_ref_path(workspace, path);
-    let commit_id = util::fs::read_from_path(commit_path)?;
+    let commit_id = util::fs::read_from_path(&commit_path)?;
     Ok(commit_id != workspace.commit.id)
 }
 
-pub fn is_indexed(workspace: &Workspace, path: impl AsRef<Path>) -> Result<bool, OxenError> {
-    let path = path.as_ref();
+pub fn is_indexed(workspace: &Workspace, path: &Path) -> Result<bool, OxenError> {
     log::debug!("checking dataset is indexed for {path:?}");
     let db_path = duckdb_path(workspace, path);
     log::debug!("getting conn at path {db_path:?}");
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let table_exists = df_db::table_exists(conn, TABLE_NAME)?;
             log::debug!("dataset_is_indexed() got table_exists: {table_exists:?}");
@@ -56,7 +55,7 @@ pub fn is_indexed(workspace: &Workspace, path: impl AsRef<Path>) -> Result<bool,
 
 pub fn is_queryable_data_frame_indexed(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
     commit: &Commit,
 ) -> Result<bool, OxenError> {
     match repo.min_version() {
@@ -69,7 +68,7 @@ pub fn is_queryable_data_frame_indexed(
 
 pub fn get_queryable_data_frame_workspace(
     repo: &LocalRepository,
-    path: impl AsRef<Path>,
+    path: &Path,
     commit: &Commit,
 ) -> Result<Workspace, OxenError> {
     match repo.min_version() {
@@ -85,18 +84,18 @@ pub fn get_queryable_data_frame_workspace(
 pub async fn index(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<(), OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::workspaces::data_frames::index(workspace, path.as_ref()).await,
+        _ => core::v_latest::workspaces::data_frames::index(workspace, path).await,
     }
 }
 
 pub async fn rename(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    new_path: impl AsRef<Path>,
+    path: &Path,
+    new_path: &Path,
 ) -> Result<PathBuf, OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => Err(OxenError::basic_str(
@@ -106,11 +105,10 @@ pub async fn rename(
     }
 }
 
-pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), OxenError> {
-    let path = path.as_ref();
+pub fn unindex(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             df_db::drop_table(conn, TABLE_NAME)?;
             Ok(())
@@ -121,21 +119,21 @@ pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), Oxen
 pub async fn restore(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<(), OxenError> {
     // Unstage and then restage the df
-    unindex(workspace, &path)?;
+    unindex(workspace, path)?;
 
     // TODO: we could do this more granularly without a full reset
-    index(repo, workspace, path.as_ref()).await?;
+    index(repo, workspace, path).await?;
 
     Ok(())
 }
 
-pub fn count(workspace: &Workspace, path: impl AsRef<Path>) -> Result<usize, OxenError> {
+pub fn count(workspace: &Workspace, path: &Path) -> Result<usize, OxenError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let count = df_db::count(conn, TABLE_NAME)?;
             Ok(count)
@@ -143,17 +141,12 @@ pub fn count(workspace: &Workspace, path: impl AsRef<Path>) -> Result<usize, Oxe
     })
 }
 
-pub fn query(
-    workspace: &Workspace,
-    path: impl AsRef<Path>,
-    opts: &DFOpts,
-) -> Result<DataFrame, OxenError> {
-    let path = path.as_ref();
+pub fn query(workspace: &Workspace, path: &Path, opts: &DFOpts) -> Result<DataFrame, OxenError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("query_staged_df() got db_path: {db_path:?}");
     log::debug!("query() opts: {opts:?}");
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn_mut(|conn| {
             // Get the schema of this commit entry
             let schema = df_db::get_schema(conn, TABLE_NAME)?;
@@ -184,15 +177,14 @@ pub fn query(
 
 pub fn export(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     opts: &DFOpts,
-    temp_file: impl AsRef<Path>,
+    temp_file: &Path,
 ) -> Result<(), OxenError> {
-    let path = path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("export() got db_path: {db_path:?}");
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let sql = if let Some(embedding_opts) = opts.get_sort_by_embedding_query() {
                 let exclude_cols = true;
@@ -218,11 +210,11 @@ pub fn export(
     })
 }
 
-pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DataFrame, OxenError> {
-    let file_path = path.as_ref();
+pub fn diff(workspace: &Workspace, path: &Path) -> Result<DataFrame, OxenError> {
+    let file_path = path;
     let staged_db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
 
-    with_df_db_manager(staged_db_path, |manager| {
+    with_df_db_manager(&staged_db_path, |manager| {
         manager.with_conn(|conn| {
             let diff_df = workspace_df_db::df_diff(conn)?;
             Ok(diff_df)
@@ -230,9 +222,8 @@ pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DataFrame, 
     })
 }
 
-pub fn full_diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffResult, OxenError> {
+pub fn full_diff(workspace: &Workspace, path: &Path) -> Result<DiffResult, OxenError> {
     let repo = &workspace.base_repo;
-    let path = path.as_ref();
     // Get commit for the branch head
     log::debug!("diff_workspace_df got repo at path {:?}", repo.path);
 
@@ -242,7 +233,7 @@ pub fn full_diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffRe
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let diff_df = workspace_df_db::df_diff(conn)?;
             log::debug!("full_diff() diff_df: {diff_df:?}");
@@ -287,18 +278,18 @@ pub fn full_diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffRe
 pub async fn from_directory(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    output_path: impl AsRef<Path>,
+    path: &Path,
+    output_path: &Path,
     extra_columns: &[NewColumn],
     recursive: bool,
     new_commit: &NewCommitBody,
     branch: &Branch,
 ) -> Result<Commit, OxenError> {
-    let has_dir = repositories::tree::has_dir(repo, &workspace.commit, path.as_ref())?;
+    let has_dir = repositories::tree::has_dir(repo, &workspace.commit, path)?;
     if !has_dir {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Directory not found: {:?}",
-            path.as_ref()
+            path
         )));
     }
 
@@ -307,12 +298,11 @@ pub async fn from_directory(
     let subtree = repositories::tree::get_subtree(
         repo,
         &workspace.commit,
-        &Some(path.as_ref().to_path_buf()),
+        &Some(path.to_path_buf()),
         &Some(depth),
     )?;
 
-    let files =
-        repositories::tree::list_all_files(&subtree.unwrap(), &path.as_ref().to_path_buf())?;
+    let files = repositories::tree::list_all_files(&subtree.unwrap(), path)?;
 
     // Extract file paths from FileNodeWithDir
     let file_paths: Vec<String> = files
@@ -440,7 +430,7 @@ pub async fn set_media_render_metadata_if_applicable(
     repo: &LocalRepository,
     workspace: &Workspace,
     files: &[FileNodeWithDir],
-    output_path: impl AsRef<Path>,
+    output_path: &Path,
 ) -> Result<(), OxenError> {
     if let Some(render_func) = get_uniform_media_type(files) {
         let render_metadata = serde_json::json!({
@@ -454,7 +444,7 @@ pub async fn set_media_render_metadata_if_applicable(
         repositories::workspaces::data_frames::columns::add_column_metadata(
             repo,
             workspace,
-            output_path.as_ref().to_path_buf(),
+            output_path.to_path_buf(),
             "file_path".to_string(),
             &render_metadata,
         )?;
@@ -463,14 +453,14 @@ pub async fn set_media_render_metadata_if_applicable(
     Ok(())
 }
 
-pub fn duckdb_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {
-    let path = util::fs::linux_path(path.as_ref());
+pub fn duckdb_path(workspace: &Workspace, path: &Path) -> PathBuf {
+    let path = util::fs::linux_path(path);
     log::debug!(
         "duckdb_path path: {:?} workspace: {:?}",
         path,
         workspace.dir()
     );
-    let path_hash = util::hasher::hash_str(path.to_string_lossy());
+    let path_hash = util::hasher::hash_str(path.to_string_lossy().as_ref());
     workspace
         .dir()
         .join(OXEN_HIDDEN_DIR)
@@ -480,8 +470,8 @@ pub fn duckdb_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {
         .join("db")
 }
 
-pub fn previous_commit_ref_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {
-    let path_hash = util::hasher::hash_str(path.as_ref().to_string_lossy());
+pub fn previous_commit_ref_path(workspace: &Workspace, path: &Path) -> PathBuf {
+    let path_hash = util::hasher::hash_str(path.to_string_lossy().as_ref());
     workspace
         .dir()
         .join(OXEN_HIDDEN_DIR)
@@ -491,8 +481,8 @@ pub fn previous_commit_ref_path(workspace: &Workspace, path: impl AsRef<Path>) -
         .join("COMMIT_ID")
 }
 
-pub fn column_changes_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {
-    let path_hash = util::hasher::hash_str(path.as_ref().to_string_lossy());
+pub fn column_changes_path(workspace: &Workspace, path: &Path) -> PathBuf {
+    let path_hash = util::hasher::hash_str(path.to_string_lossy().as_ref());
     workspace
         .dir()
         .join(OXEN_HIDDEN_DIR)
@@ -502,8 +492,8 @@ pub fn column_changes_path(workspace: &Workspace, path: impl AsRef<Path>) -> Pat
         .join("column_changes")
 }
 
-pub fn row_changes_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {
-    let path_hash = util::hasher::hash_str(path.as_ref().to_string_lossy());
+pub fn row_changes_path(workspace: &Workspace, path: &Path) -> PathBuf {
+    let path_hash = util::hasher::hash_str(path.to_string_lossy().as_ref());
     workspace
         .dir()
         .join(OXEN_HIDDEN_DIR)
@@ -587,7 +577,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -634,7 +624,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -713,7 +703,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -802,7 +792,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -859,7 +849,7 @@ mod tests {
 
             let file_2 = repositories::revisions::get_version_file_from_commit_id(
                 &repo,
-                commit_2.id,
+                &commit_2.id,
                 &file_path,
             )
             .await?;
@@ -867,7 +857,7 @@ mod tests {
             util::fs::copy(&*file_2, &file_2_csv)?;
             log::debug!("copied file 2 to {file_2_csv:?}");
             let diff_result =
-                repositories::diffs::diff_files(file_1_csv, file_2_csv, vec![], vec![], vec![])
+                &repositories::diffs::diff_files(&file_1_csv, &file_2_csv, vec![], vec![], vec![])
                     .await?;
 
             log::debug!("diff result is {diff_result:?}");
@@ -894,7 +884,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -970,7 +960,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -1035,7 +1025,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -1121,7 +1111,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -1208,7 +1198,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             let file_path = Path::new("annotations")
                 .join("train")
                 .join("bounding_box.csv");
@@ -1284,7 +1274,7 @@ mod tests {
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
 
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
             workspaces::data_frames::index(&repo, &workspace, &path).await?;
             let json_data = json!({"NOT_REAL_COLUMN": "images/test.jpg"});
             let result = workspaces::data_frames::rows::add(&repo, &workspace, &path, &json_data);
@@ -1312,7 +1302,7 @@ mod tests {
             let commit = repositories::commits::head_commit(&repo)?;
             let user = UserConfig::get()?.to_user();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
 
             workspaces::data_frames::index(&repo, &workspace, &path).await?;
             let json_data = json!({"file": "images/test.jpg", "label": "dog", "min_x": 2.0, "min_y": 3.0, "width": 100, "height": 120});
@@ -1331,7 +1321,7 @@ mod tests {
             let version_file = version_store.get_version_path(&entry.hash).await?;
             let extension = entry.path.extension().unwrap().to_str().unwrap();
             let data_frame =
-                df::tabular::read_df_with_extension(version_file, extension, &DFOpts::empty()).await?;
+                df::tabular::read_df_with_extension(&version_file, extension, &DFOpts::empty()).await?;
             println!("{data_frame}");
             assert_eq!(
                 format!("{data_frame}"),

--- a/crates/lib/src/repositories/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/columns.rs
@@ -79,7 +79,7 @@ pub fn add_column_metadata(
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     match repo.min_version() {
-        MinOxenVersion::V0_10_0 => Err(OxenError::basic_str("Not implemented")),
+        MinOxenVersion::V0_10_0 => Err(OxenError::basic_str("Not implemented".to_string())),
         _ => core::v_latest::workspaces::data_frames::columns::add_column_metadata(
             repo, workspace, &file_path, &column, metadata,
         ),
@@ -157,7 +157,9 @@ pub fn decorate_fields_with_column_diffs(
                             }
                             Ok(())
                         }
-                        Err(_) => Err(OxenError::basic_str("Error deserializing value")),
+                        Err(_) => Err(OxenError::basic_str(
+                            "Error deserializing value".to_string(),
+                        )),
                     }
                 }
                 Ok(None) => Ok(()),
@@ -183,7 +185,9 @@ pub fn decorate_fields_with_column_diffs(
                             }
                             Ok(())
                         }
-                        Err(_) => Err(OxenError::basic_str("Error deserializing value")),
+                        Err(_) => Err(OxenError::basic_str(
+                            "Error deserializing value".to_string(),
+                        )),
                     }
                 }
                 Ok(None) => Ok(()),
@@ -208,13 +212,13 @@ pub fn handle_data_frame_column_change(
         })),
         "modified" => {
             let column_before = change.column_before.ok_or(OxenError::basic_str(
-                "A modified column needs to have a column before value",
+                "A modified column needs to have a column before value".to_string(),
             ))?;
 
             let previous_field = PreviousField {
                 name: column_before.column_name.clone(),
                 dtype: column_before.column_data_type.ok_or(OxenError::basic_str(
-                    "A modified column needs to have a before datatype value",
+                    "A modified column needs to have a before datatype value".to_string(),
                 ))?,
                 metadata: None,
             };
@@ -238,19 +242,19 @@ pub fn reinsert_deleted_columns_into_schema(
         match item {
             Ok((_key, value_bytes)) => {
                 let column_change: DataFrameColumnChange = serde_json::from_slice(&value_bytes)
-                    .map_err(|_| OxenError::basic_str("Error deserializing value"))?;
+                    .map_err(|_| OxenError::basic_str("Error deserializing value".to_string()))?;
 
                 if column_change.operation == "deleted" {
                     deleted_columns.push(column_change.column_before);
                 }
             }
-            Err(_) => return Err(OxenError::basic_str("Error reading from db")),
+            Err(_) => return Err(OxenError::basic_str("Error reading from db".to_string())),
         }
     }
 
     for deleted_column in &deleted_columns {
         let before_column = deleted_column.clone().ok_or(OxenError::basic_str(
-            "A deleted column needs to have a column before value",
+            "A deleted column needs to have a column before value".to_string(),
         ))?;
 
         df_views.source.schema.fields.push(Field {
@@ -259,7 +263,7 @@ pub fn reinsert_deleted_columns_into_schema(
                 .column_data_type
                 .clone()
                 .ok_or(OxenError::basic_str(
-                    "A deleted column needs to have a before datatype value",
+                    "A deleted column needs to have a before datatype value".to_string(),
                 ))?
                 .clone(),
             metadata: None,
@@ -271,7 +275,7 @@ pub fn reinsert_deleted_columns_into_schema(
             dtype: before_column
                 .column_data_type
                 .ok_or(OxenError::basic_str(
-                    "A deleted column needs to have a before datatype value",
+                    "A deleted column needs to have a before datatype value".to_string(),
                 ))?
                 .clone(),
             metadata: None,

--- a/crates/lib/src/repositories/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/columns.rs
@@ -25,23 +25,21 @@ use crate::model::data_frame::schema::field::{Changes, PreviousField};
 pub fn add(
     repo: &LocalRepository,
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     new_column: &NewColumn,
 ) -> Result<DataFrame, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::workspaces::data_frames::columns::add(
-            workspace,
-            file_path.as_ref(),
-            new_column,
-        ),
+        _ => {
+            core::v_latest::workspaces::data_frames::columns::add(workspace, file_path, new_column)
+        }
     }
 }
 
 pub async fn update(
     repo: &LocalRepository,
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     column_to_update: &ColumnToUpdate,
 ) -> Result<DataFrame, OxenError> {
     match repo.min_version() {
@@ -49,7 +47,7 @@ pub async fn update(
         _ => {
             core::v_latest::workspaces::data_frames::columns::update(
                 workspace,
-                file_path.as_ref(),
+                file_path,
                 column_to_update,
             )
             .await
@@ -60,14 +58,14 @@ pub async fn update(
 pub fn delete(
     repo: &LocalRepository,
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     column_to_delete: &ColumnToDelete,
 ) -> Result<DataFrame, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::data_frames::columns::delete(
             workspace,
-            file_path.as_ref(),
+            file_path,
             column_to_delete,
         ),
     }
@@ -83,7 +81,7 @@ pub fn add_column_metadata(
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => Err(OxenError::basic_str("Not implemented")),
         _ => core::v_latest::workspaces::data_frames::columns::add_column_metadata(
-            repo, workspace, file_path, column, metadata,
+            repo, workspace, &file_path, &column, metadata,
         ),
     }
 }
@@ -91,7 +89,7 @@ pub fn add_column_metadata(
 pub async fn restore(
     repo: &LocalRepository,
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     column_to_restore: &ColumnToRestore,
 ) -> Result<DataFrame, OxenError> {
     match repo.min_version() {
@@ -99,7 +97,7 @@ pub async fn restore(
         _ => {
             core::v_latest::workspaces::data_frames::columns::restore(
                 workspace,
-                file_path.as_ref(),
+                file_path,
                 column_to_restore,
             )
             .await
@@ -109,7 +107,7 @@ pub async fn restore(
 
 pub fn get_column_diff(
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
 ) -> Result<Vec<DataFrameColumnChange>, OxenError> {
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
@@ -123,11 +121,11 @@ pub fn get_column_diff(
 
 pub fn decorate_fields_with_column_diffs(
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     df_views: &mut JsonDataFrameViews,
 ) -> Result<(), OxenError> {
     let column_changes_path =
-        repositories::workspaces::data_frames::column_changes_path(workspace, file_path.as_ref());
+        repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
     let opts = db::key_val::opts::default();
     let db_open_result = DB::open_for_read_only(
         &opts,

--- a/crates/lib/src/repositories/workspaces/data_frames/embeddings.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/embeddings.rs
@@ -166,7 +166,7 @@ fn get_embedding_length(
         })
     })?;
     let Some(item) = result_set.first() else {
-        return Err(OxenError::basic_str("No items found"));
+        return Err(OxenError::basic_str("No items found".to_string()));
     };
     let first_column = item.column(0);
     log::debug!("First column: {first_column:?}");
@@ -178,12 +178,14 @@ fn get_embedding_length(
                 let array = first_column
                     .as_any()
                     .downcast_ref::<ListArray>()
-                    .ok_or_else(|| OxenError::basic_str("Failed to downcast to ListArray"))?;
+                    .ok_or_else(|| {
+                        OxenError::basic_str("Failed to downcast to ListArray".to_string())
+                    })?;
                 if let Some(first_value) = array.value(0).as_any().downcast_ref::<Float32Array>() {
                     first_value.len()
                 } else {
                     return Err(OxenError::basic_str(
-                        "Expected Float32Array inside ListArray",
+                        "Expected Float32Array inside ListArray".to_string(),
                     ));
                 }
             }
@@ -191,18 +193,20 @@ fn get_embedding_length(
                 let array = first_column
                     .as_any()
                     .downcast_ref::<ListArray>()
-                    .ok_or_else(|| OxenError::basic_str("Failed to downcast to ListArray"))?;
+                    .ok_or_else(|| {
+                        OxenError::basic_str("Failed to downcast to ListArray".to_string())
+                    })?;
                 if let Some(first_value) = array.value(0).as_any().downcast_ref::<Float64Array>() {
                     first_value.len()
                 } else {
                     return Err(OxenError::basic_str(
-                        "Expected Float64Array inside ListArray",
+                        "Expected Float64Array inside ListArray".to_string(),
                     ));
                 }
             }
             _ => {
                 return Err(OxenError::basic_str(
-                    "Column must be a list of float32 or float64",
+                    "Column must be a list of float32 or float64".to_string(),
                 ));
             }
         },
@@ -210,11 +214,15 @@ fn get_embedding_length(
             arrow::datatypes::DataType::Float32 => *size as usize,
             _ => {
                 return Err(OxenError::basic_str(
-                    "Column FixedSizeList must be a float32 type",
+                    "Column FixedSizeList must be a float32 type".to_string(),
                 ));
             }
         },
-        _ => return Err(OxenError::basic_str("Column must be a list type")),
+        _ => {
+            return Err(OxenError::basic_str(
+                "Column must be a list type".to_string(),
+            ));
+        }
     };
 
     log::debug!("Vector length: {vector_length}");
@@ -239,7 +247,7 @@ pub fn embedding_from_query(
     // Read the vector length from the file we wrote in the index function
     let Ok(config) = embedding_config(workspace, path) else {
         return Err(OxenError::basic_str(
-            "Must index embeddings before querying",
+            "Must index embeddings before querying".to_string(),
         ));
     };
     let vector_length = config.columns[&column].vector_length;
@@ -494,37 +502,8 @@ fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError
                     let array = first_column
                         .as_any()
                         .downcast_ref::<ListArray>()
-                        .ok_or_else(|| OxenError::basic_str("Failed to downcast to ListArray"))?;
-                    if let Some(first_value) =
-                        array.value(0).as_any().downcast_ref::<Float32Array>()
-                    {
-                        embeddings.push(first_value.values().to_vec());
-                        if vector_length == 0 {
-                            vector_length = first_value.len();
-                        } else if first_value.len() != vector_length {
-                            return Err(OxenError::basic_str(
-                                "All embeddings must be the same length",
-                            ));
-                        }
-                    } else {
-                        return Err(OxenError::basic_str(
-                            "Expected Float32Array inside ListArray",
-                        ));
-                    }
-                }
-                _ => {
-                    return Err(OxenError::basic_str(
-                        "Expected arrow::datatypes::DataType::Float32 inside List",
-                    ));
-                }
-            },
-            arrow::datatypes::DataType::FixedSizeList(field, _) => match field.data_type() {
-                arrow::datatypes::DataType::Float32 => {
-                    let array = first_column
-                        .as_any()
-                        .downcast_ref::<FixedSizeListArray>()
                         .ok_or_else(|| {
-                            OxenError::basic_str("Failed to downcast to FixedSizeListArray")
+                            OxenError::basic_str("Failed to downcast to ListArray".to_string())
                         })?;
                     if let Some(first_value) =
                         array.value(0).as_any().downcast_ref::<Float32Array>()
@@ -534,20 +513,53 @@ fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError
                             vector_length = first_value.len();
                         } else if first_value.len() != vector_length {
                             return Err(OxenError::basic_str(
-                                "All embeddings must be the same length",
+                                "All embeddings must be the same length".to_string(),
+                            ));
+                        }
+                    } else {
+                        return Err(OxenError::basic_str(
+                            "Expected Float32Array inside ListArray".to_string(),
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(OxenError::basic_str(
+                        "Expected arrow::datatypes::DataType::Float32 inside List".to_string(),
+                    ));
+                }
+            },
+            arrow::datatypes::DataType::FixedSizeList(field, _) => match field.data_type() {
+                arrow::datatypes::DataType::Float32 => {
+                    let array = first_column
+                        .as_any()
+                        .downcast_ref::<FixedSizeListArray>()
+                        .ok_or_else(|| {
+                            OxenError::basic_str(
+                                "Failed to downcast to FixedSizeListArray".to_string(),
+                            )
+                        })?;
+                    if let Some(first_value) =
+                        array.value(0).as_any().downcast_ref::<Float32Array>()
+                    {
+                        embeddings.push(first_value.values().to_vec());
+                        if vector_length == 0 {
+                            vector_length = first_value.len();
+                        } else if first_value.len() != vector_length {
+                            return Err(OxenError::basic_str(
+                                "All embeddings must be the same length".to_string(),
                             ));
                         }
                     }
                 }
                 _ => {
                     return Err(OxenError::basic_str(
-                        "Column FixedSizeList must be a float32 type",
+                        "Column FixedSizeList must be a float32 type".to_string(),
                     ));
                 }
             },
             _ => {
                 return Err(OxenError::basic_str(
-                    "Expected arrow::datatypes::DataType::List inside as data type",
+                    "Expected arrow::datatypes::DataType::List inside as data type".to_string(),
                 ));
             }
         }
@@ -559,7 +571,7 @@ fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError
 
     if vector_length == 0 {
         return Err(OxenError::basic_str(
-            "Vector's must have a length greater than 0",
+            "Vector's must have a length greater than 0".to_string(),
         ));
     }
 

--- a/crates/lib/src/repositories/workspaces/data_frames/embeddings.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/embeddings.rs
@@ -17,16 +17,13 @@ use crate::{repositories, util};
 use std::path::Path;
 use std::path::PathBuf;
 
-fn embedding_config_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {
+fn embedding_config_path(workspace: &Workspace, path: &Path) -> PathBuf {
     let path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let parent = path.parent().unwrap();
     parent.join(EMBEDDING_CONFIG_FILENAME)
 }
 
-fn embedding_config(
-    workspace: &Workspace,
-    path: impl AsRef<Path>,
-) -> Result<EmbeddingConfig, OxenError> {
+fn embedding_config(workspace: &Workspace, path: &Path) -> Result<EmbeddingConfig, OxenError> {
     let embedding_config = embedding_config_path(workspace, path);
     let config_data = util::fs::read_from_path(&embedding_config)?;
     Ok(toml::from_str(&config_data)?)
@@ -34,8 +31,8 @@ fn embedding_config(
 
 fn write_embedding_size_to_config(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column_name: impl AsRef<str>,
+    path: &Path,
+    column_name: &str,
     vector_length: usize,
 ) -> Result<(), OxenError> {
     let embedding_config = embedding_config_path(workspace, path);
@@ -49,14 +46,12 @@ fn write_embedding_size_to_config(
     };
 
     let column = EmbeddingColumn {
-        name: column_name.as_ref().to_string(),
+        name: column_name.to_string(),
         vector_length,
         status: EmbeddingStatus::InProgress,
     };
 
-    config
-        .columns
-        .insert(column_name.as_ref().to_string(), column);
+    config.columns.insert(column_name.to_string(), column);
 
     let config_str = toml::to_string(&config)?;
     std::fs::write(embedding_config, config_str)?;
@@ -65,14 +60,14 @@ fn write_embedding_size_to_config(
 
 fn update_embedding_status(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column_name: impl AsRef<str>,
+    path: &Path,
+    column_name: &str,
     status: EmbeddingStatus,
 ) -> Result<(), OxenError> {
     let embedding_config = embedding_config_path(workspace, path);
     let config_data = util::fs::read_from_path(&embedding_config)?;
     let mut config: EmbeddingConfig = toml::from_str(&config_data)?;
-    config.columns.get_mut(column_name.as_ref()).unwrap().status = status;
+    config.columns.get_mut(column_name).unwrap().status = status;
     let config_str = toml::to_string(&config)?;
     std::fs::write(embedding_config, config_str)?;
     Ok(())
@@ -80,7 +75,7 @@ fn update_embedding_status(
 
 pub fn list_indexed_columns(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<Vec<EmbeddingColumn>, OxenError> {
     let Ok(config) = embedding_config(workspace, path) else {
         return Ok(vec![]);
@@ -90,11 +85,11 @@ pub fn list_indexed_columns(
 
 fn perform_indexing(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     column_name: String,
     vector_length: usize,
 ) -> Result<(), OxenError> {
-    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, &path);
+    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             // Execute VSS commands separately
@@ -114,21 +109,20 @@ fn perform_indexing(
     log::debug!(
         "Completed indexing embeddings for column `{}` on {}",
         column_name,
-        path.as_ref().display()
+        path.display()
     );
-    update_embedding_status(workspace, path, column_name, EmbeddingStatus::Complete)?;
+    update_embedding_status(workspace, path, &column_name, EmbeddingStatus::Complete)?;
 
     Ok(())
 }
 
 pub fn index(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column: impl AsRef<str>,
+    path: &Path,
+    column: &str,
     use_background_thread: bool,
 ) -> Result<(), OxenError> {
-    let path = path.as_ref().to_path_buf();
-    let column = column.as_ref();
+    let path = path.to_path_buf();
 
     let column_name = column.to_string();
     log::debug!(
@@ -145,12 +139,12 @@ pub fn index(
 
         // Spawn background thread for VSS setup
         std::thread::spawn(move || {
-            if let Err(e) = perform_indexing(&workspace, path, column_name, vector_length) {
+            if let Err(e) = perform_indexing(&workspace, &path, column_name, vector_length) {
                 log::error!("Error in background indexing thread: {e}");
             }
         });
     } else {
-        perform_indexing(workspace, path, column_name, vector_length)?;
+        perform_indexing(workspace, &path, column_name, vector_length)?;
     }
 
     Ok(())
@@ -158,11 +152,9 @@ pub fn index(
 
 fn get_embedding_length(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column: impl AsRef<str>,
+    path: &Path,
+    column: &str,
 ) -> Result<usize, OxenError> {
-    let path = path.as_ref();
-    let column = column.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("Embedding index DB Path: {db_path:?}");
     let result_set = with_df_db_manager(&db_path, |manager| {
@@ -234,10 +226,9 @@ fn get_embedding_length(
 pub fn embedding_from_query(
     conn: &duckdb::Connection,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     query: &EmbeddingQueryOpts,
 ) -> Result<(Vec<f32>, usize), OxenError> {
-    let path = path.as_ref();
     let column = query.column.clone();
     let query = query.query.clone();
     let sql = format!("SELECT {column} FROM df WHERE {query};");
@@ -302,7 +293,7 @@ pub fn similarity_query(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, &path);
     log::debug!("Embedding query DB Path: {db_path:?}");
     let (avg_embedding, vector_length) = with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| embedding_from_query(conn, workspace, path.clone(), opts))
+        manager.with_conn(|conn| embedding_from_query(conn, workspace, &path.clone(), opts))
     })?;
 
     let schema = with_df_db_manager(&db_path, |manager| {
@@ -330,7 +321,8 @@ pub fn similarity_query_with_conn(
     let path = opts.path.clone();
     let similarity_column = opts.name.clone();
 
-    let (avg_embedding, vector_length) = embedding_from_query(conn, workspace, path.clone(), opts)?;
+    let (avg_embedding, vector_length) =
+        embedding_from_query(conn, workspace, &path.clone(), opts)?;
     let schema = df_db::get_schema(conn, TABLE_NAME)?;
 
     build_similarity_query_sql(
@@ -345,17 +337,16 @@ pub fn similarity_query_with_conn(
 
 pub fn nearest_neighbors(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column: impl AsRef<str>,
+    path: &Path,
+    column: &str,
     embedding: Vec<f32>,
     pagination: &PaginateOpts,
     exclude_cols: bool,
 ) -> Result<DataFrame, OxenError> {
     // Time the query
     let start = std::time::Instant::now();
-    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, &path);
+    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    let column = column.as_ref();
     let vector_length = embedding.len();
     let similarity_column = "similarity";
     let (result_set, mut schema) = with_df_db_manager(&db_path, |manager| {

--- a/crates/lib/src/repositories/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/rows.rs
@@ -26,20 +26,18 @@ use std::path::Path;
 pub fn add(
     repo: &LocalRepository,
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
     data: &serde_json::Value,
 ) -> Result<DataFrame, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => {
-            core::v_latest::workspaces::data_frames::rows::add(workspace, file_path.as_ref(), data)
-        }
+        _ => core::v_latest::workspaces::data_frames::rows::add(workspace, file_path, data),
     }
 }
 
 pub fn get_row_diff(
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
 ) -> Result<Vec<DataFrameRowChange>, OxenError> {
     let row_changes_path =
         repositories::workspaces::data_frames::row_changes_path(workspace, file_path);
@@ -51,73 +49,53 @@ pub fn get_row_diff(
 pub fn update(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     row_id: &str,
     data: &serde_json::Value,
 ) -> Result<DataFrame, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::workspaces::data_frames::rows::update(
-            workspace,
-            path.as_ref(),
-            row_id,
-            data,
-        ),
+        _ => core::v_latest::workspaces::data_frames::rows::update(workspace, path, row_id, data),
     }
 }
 
 pub fn batch_update(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     data: &serde_json::Value,
 ) -> Result<Vec<UpdateResult>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::workspaces::data_frames::rows::batch_update(
-            workspace,
-            path.as_ref(),
-            data,
-        ),
+        _ => core::v_latest::workspaces::data_frames::rows::batch_update(workspace, path, data),
     }
 }
 
 pub fn delete(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     row_id: &str,
 ) -> Result<DataFrame, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => {
-            core::v_latest::workspaces::data_frames::rows::delete(workspace, path.as_ref(), row_id)
-        }
+        _ => core::v_latest::workspaces::data_frames::rows::delete(workspace, path, row_id),
     }
 }
 
 pub async fn restore(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    row_id: impl AsRef<str>,
+    path: &Path,
+    row_id: &str,
 ) -> Result<DataFrame, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => {
-            core::v_latest::workspaces::data_frames::rows::restore(workspace, path.as_ref(), row_id)
-                .await
-        }
+        _ => core::v_latest::workspaces::data_frames::rows::restore(workspace, path, row_id).await,
     }
 }
 
-pub fn get_by_id(
-    workspace: &Workspace,
-    path: impl AsRef<Path>,
-    row_id: impl AsRef<str>,
-) -> Result<DataFrame, OxenError> {
-    let path = path.as_ref();
-    let row_id = row_id.as_ref();
+pub fn get_by_id(workspace: &Workspace, path: &Path, row_id: &str) -> Result<DataFrame, OxenError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("get_row_by_id() got db_path: {db_path:?}");
     let data = with_df_db_manager(&db_path, |manager| {

--- a/crates/lib/src/repositories/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/rows.rs
@@ -131,7 +131,7 @@ pub fn get_row_status(row_df: &DataFrame) -> Result<Option<StagedRowStatus>, Oxe
         let anyval_status = row_df.column(DIFF_STATUS_COL).unwrap().get(0)?;
         let str_status = anyval_status
             .get_str()
-            .ok_or_else(|| OxenError::basic_str("Row status not found"))?;
+            .ok_or_else(|| OxenError::basic_str("Row status not found".to_string()))?;
         let status = StagedRowStatus::from_string(str_status)?;
         Ok(Some(status))
     } else {

--- a/crates/lib/src/repositories/workspaces/data_frames/schemas.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/schemas.rs
@@ -7,8 +7,8 @@ use crate::repositories;
 
 use std::path::Path;
 
-pub fn get_by_path(workspace: &Workspace, path: impl AsRef<Path>) -> Result<Schema, OxenError> {
-    let file_path = path.as_ref();
+pub fn get_by_path(workspace: &Workspace, path: &Path) -> Result<Schema, OxenError> {
+    let file_path = path;
     let staged_db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     let df_schema = with_df_db_manager(&staged_db_path, |manager| {
         manager.with_conn(|conn| df_db::get_schema(conn, TABLE_NAME))
@@ -18,7 +18,7 @@ pub fn get_by_path(workspace: &Workspace, path: impl AsRef<Path>) -> Result<Sche
 
 pub fn update_schema(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     og_schema: &Schema,
     before_column: &str,
     after_column: &str,

--- a/crates/lib/src/repositories/workspaces/df.rs
+++ b/crates/lib/src/repositories/workspaces/df.rs
@@ -64,7 +64,9 @@ fn handle_unindexed_error() -> Result<DataFrame, OxenError> {
     println!(
         "Dataset not indexed for remote editing. Use `oxen df --index <path>` to index it, or `oxen df <path> --committed` to view the committed resource in view-only mode.\n"
     );
-    Err(OxenError::basic_str("No dataset staged for this resource."))
+    Err(OxenError::basic_str(
+        "No dataset staged for this resource.".to_string(),
+    ))
 }
 
 // TODO: Only difference between this and `df` is for `get` operations - everything above
@@ -107,7 +109,9 @@ pub async fn staged_df(
         println!(
             "Dataset not indexed for remote editing. Use `oxen df --index <path>` to index it, or `oxen df <path> --committed` to view the committed resource in view-only mode.\n"
         );
-        Err(OxenError::basic_str("No dataset staged for this resource."))
+        Err(OxenError::basic_str(
+            "No dataset staged for this resource.".to_string(),
+        ))
     }
 }
 

--- a/crates/lib/src/repositories/workspaces/df.rs
+++ b/crates/lib/src/repositories/workspaces/df.rs
@@ -20,12 +20,12 @@ use crate::view::StatusMessage;
 pub async fn df(
     repo: &LocalRepository,
     workspace_id: &str,
-    input: impl AsRef<Path>,
+    input: &Path,
     opts: DFOpts,
 ) -> Result<DataFrame, OxenError> {
     // Special case where we are writing data
     if let Some(row) = &opts.add_row {
-        add_row(repo, workspace_id, input.as_ref(), row).await
+        add_row(repo, workspace_id, input, row).await
     } else if let Some(uuid) = &opts.delete_row {
         delete_row(repo, workspace_id, input, uuid).await
     } else {
@@ -33,7 +33,7 @@ pub async fn df(
         let output = opts.output.clone();
         let workspace_id = UserConfig::identifier()?;
         let val =
-            api::client::workspaces::data_frames::get(&remote_repo, workspace_id, input, &opts)
+            api::client::workspaces::data_frames::get(&remote_repo, &workspace_id, input, &opts)
                 .await;
 
         match val {
@@ -42,7 +42,7 @@ pub async fn df(
                     let mut df = data_frame.view.to_df().await;
                     if let Some(output) = output {
                         println!("Writing {output:?}");
-                        tabular::write_df(&mut df, output)?;
+                        tabular::write_df(&mut df, &output)?;
                     }
 
                     println!(
@@ -69,22 +69,22 @@ fn handle_unindexed_error() -> Result<DataFrame, OxenError> {
 
 // TODO: Only difference between this and `df` is for `get` operations - everything above
 // the "else" can be factored into a shared method
-pub async fn staged_df<P: AsRef<Path>>(
+pub async fn staged_df(
     repo: &LocalRepository,
     workspace_id: &str,
-    input: P,
+    input: &Path,
     opts: DFOpts,
 ) -> Result<DataFrame, OxenError> {
     // Special case where we are writing data
     if let Some(row) = &opts.add_row {
-        add_row(repo, workspace_id, input.as_ref(), row).await
+        add_row(repo, workspace_id, input, row).await
     } else if let Some(uuid) = &opts.delete_row {
         delete_row(repo, workspace_id, input, uuid).await
     } else {
         let remote_repo = api::client::repositories::get_default_remote(repo).await?;
         let output = opts.output.clone();
         let val =
-            api::client::workspaces::data_frames::get(&remote_repo, &workspace_id, input, &opts)
+            api::client::workspaces::data_frames::get(&remote_repo, workspace_id, input, &opts)
                 .await;
 
         if let Ok(val) = val
@@ -93,7 +93,7 @@ pub async fn staged_df<P: AsRef<Path>>(
             let mut df = data_frame.view.to_df().await;
             if let Some(output) = output {
                 println!("Writing {output:?}");
-                tabular::write_df(&mut df, output)?;
+                tabular::write_df(&mut df, &output)?;
             }
 
             println!(
@@ -136,14 +136,14 @@ pub async fn add_row(
 pub async fn delete_row(
     repository: &LocalRepository,
     workspace_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
     row_id: &str,
 ) -> Result<DataFrame, OxenError> {
     let remote_repo = api::client::repositories::get_default_remote(repository).await?;
     let df = api::client::workspaces::data_frames::rows::delete(
         &remote_repo,
         workspace_id,
-        path.as_ref(),
+        path,
         row_id,
     )
     .await?;
@@ -153,17 +153,13 @@ pub async fn delete_row(
 pub async fn get_row(
     repository: &LocalRepository,
     workspace_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
     row_id: &str,
 ) -> Result<DataFrame, OxenError> {
     let remote_repo = api::client::repositories::get_default_remote(repository).await?;
-    let df_json = api::client::workspaces::data_frames::rows::get(
-        &remote_repo,
-        workspace_id,
-        path.as_ref(),
-        row_id,
-    )
-    .await?;
+    let df_json =
+        api::client::workspaces::data_frames::rows::get(&remote_repo, workspace_id, path, row_id)
+            .await?;
     let df = df_json.data_frame.view.to_df().await;
     println!("{df:?}");
     Ok(df)
@@ -172,8 +168,8 @@ pub async fn get_row(
 pub async fn index(
     repository: &LocalRepository,
     workspace_id: &str,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<StatusMessage, OxenError> {
     let remote_repo = api::client::repositories::get_default_remote(repository).await?;
-    api::client::workspaces::data_frames::index(&remote_repo, workspace_id, path.as_ref()).await
+    api::client::workspaces::data_frames::index(&remote_repo, workspace_id, path).await
 }

--- a/crates/lib/src/repositories/workspaces/diff.rs
+++ b/crates/lib/src/repositories/workspaces/diff.rs
@@ -15,7 +15,7 @@ use crate::model::diff::DiffResult;
 pub fn diff(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
 ) -> Result<DiffResult, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),

--- a/crates/lib/src/repositories/workspaces/files.rs
+++ b/crates/lib/src/repositories/workspaces/files.rs
@@ -9,31 +9,28 @@ use crate::view::ErrorFileInfo;
 
 use std::path::{Path, PathBuf};
 
-pub fn exists(workspace: &Workspace, path: impl AsRef<Path>) -> Result<bool, OxenError> {
+pub fn exists(workspace: &Workspace, path: &Path) -> Result<bool, OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::files::exists(workspace, path),
     }
 }
 
-pub async fn add(workspace: &Workspace, path: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
+pub async fn add(workspace: &Workspace, path: &Path) -> Result<PathBuf, OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::files::add(workspace, path).await,
     }
 }
 
-pub async fn rm(
-    workspace: &Workspace,
-    path: impl AsRef<Path>,
-) -> Result<Vec<ErrorFileInfo>, OxenError> {
+pub async fn rm(workspace: &Workspace, path: &Path) -> Result<Vec<ErrorFileInfo>, OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::files::rm(workspace, path).await,
     }
 }
 
-pub fn unstage(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), OxenError> {
+pub fn unstage(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::files::unstage(workspace, path),
@@ -79,11 +76,7 @@ pub async fn upload_zip(
     }
 }
 
-pub fn mv(
-    workspace: &Workspace,
-    path: impl AsRef<Path>,
-    new_path: impl AsRef<Path>,
-) -> Result<(), OxenError> {
+pub fn mv(workspace: &Workspace, path: &Path, new_path: &Path) -> Result<(), OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::files::mv(workspace, path, new_path),
@@ -112,7 +105,7 @@ mod tests {
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
-            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let workspace = repositories::workspaces::create(&repo, &commit, &workspace_id, true)?;
 
             // Original file path that exists in the repo
             let original_path = Path::new("annotations")
@@ -161,8 +154,7 @@ mod tests {
                 email: user.email.clone(),
                 message: "Moved file to new location".to_string(),
             };
-            let commit =
-                workspaces::commit(&workspace, &new_commit, branch_name.to_string()).await?;
+            let commit = workspaces::commit(&workspace, &new_commit, branch_name).await?;
 
             // Verify the file exists at the new path in the commit
             let new_file = repositories::tree::get_file_by_path(&repo, &commit, &new_path)?;

--- a/crates/lib/src/repositories/workspaces/status.rs
+++ b/crates/lib/src/repositories/workspaces/status.rs
@@ -15,10 +15,7 @@ pub fn status(workspace: &Workspace) -> Result<StagedData, OxenError> {
     status_from_dir(workspace, Path::new(""))
 }
 
-pub fn status_from_dir(
-    workspace: &Workspace,
-    directory: impl AsRef<Path>,
-) -> Result<StagedData, OxenError> {
+pub fn status_from_dir(workspace: &Workspace, directory: &Path) -> Result<StagedData, OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::workspaces::status::status(workspace, directory),

--- a/crates/lib/src/repositories/workspaces/upload.rs
+++ b/crates/lib/src/repositories/workspaces/upload.rs
@@ -40,7 +40,7 @@ mod tests {
             let num_files = 33;
             for i in 0..num_files {
                 let path = dir.join(format!("file_{i}.txt"));
-                util::fs::write_to_path(&path, format!("lol hi {i}"))?;
+                util::fs::write_to_path(&path, &format!("lol hi {i}"))?;
             }
             repositories::add(&repo, &dir).await?;
             repositories::commit(&repo, "adding text files")?;
@@ -99,7 +99,7 @@ mod tests {
             let num_files = 5;
             for i in 0..num_files {
                 let path = dir.join(format!("file_{i}.txt"));
-                util::fs::write_to_path(&path, format!("lol hi {i}"))?;
+                util::fs::write_to_path(&path, &format!("lol hi {i}"))?;
             }
             repositories::add(&repo, &dir).await?;
             repositories::commit(&repo, "adding text files")?;
@@ -141,7 +141,7 @@ mod tests {
             assert_eq!(1, new_entries.entries.len());
 
             let file_path = "test/ing/data/new_file.jsonl";
-            let entry = api::client::entries::get_entry(&remote_repo, file_path, &branch.name).await?;
+            let entry = api::client::entries::get_entry(&remote_repo, Path::new(file_path), &branch.name).await?;
             assert!(entry.is_some());
             let entry = entry.unwrap();
             assert_eq!(entry.filename(), "new_file.jsonl");
@@ -161,7 +161,7 @@ mod tests {
             let num_files = 5;
             for i in 0..num_files {
                 let path = dir.join(format!("file_{i}.txt"));
-                util::fs::write_to_path(&path, format!("lol hi {i}"))?;
+                util::fs::write_to_path(&path, &format!("lol hi {i}"))?;
             }
             repositories::add(&repo, &dir).await?;
             repositories::commit(&repo, "adding text files")?;

--- a/crates/lib/src/resource.rs
+++ b/crates/lib/src/resource.rs
@@ -19,42 +19,42 @@ pub fn parse_resource_from_path(
 }
 
 /// Pass in a branch name and maybe get a commit id back
-pub fn maybe_get_commit_id_from_branch_name<S: AsRef<str>>(
+pub fn maybe_get_commit_id_from_branch_name(
     repo: &LocalRepository,
-    commit_id_or_branch_name: S,
+    commit_id_or_branch_name: &str,
 ) -> Result<Option<String>, OxenError> {
     with_ref_manager(repo, |manager| {
-        manager.get_commit_id_for_branch(commit_id_or_branch_name.as_ref())
+        manager.get_commit_id_for_branch(commit_id_or_branch_name)
     })
 }
 
 /// Pass in a commit id or a branch name and resolve it to a
-pub fn maybe_get_commit<S: AsRef<str>>(
+pub fn maybe_get_commit(
     repo: &LocalRepository,
-    commit_id_or_branch_name: S,
+    commit_id_or_branch_name: &str,
 ) -> Result<Option<Commit>, OxenError> {
-    if let Some(commit) = repositories::commits::get_by_id(repo, &commit_id_or_branch_name)? {
+    if let Some(commit) = repositories::commits::get_by_id(repo, commit_id_or_branch_name)? {
         return Ok(Some(commit));
     }
 
-    match maybe_get_commit_id_from_branch_name(repo, &commit_id_or_branch_name) {
+    match maybe_get_commit_id_from_branch_name(repo, commit_id_or_branch_name) {
         Ok(Some(commit_id)) => repositories::commits::get_by_id(repo, &commit_id),
         Ok(None) => Err(OxenError::local_revision_not_found(
-            commit_id_or_branch_name.as_ref(),
+            commit_id_or_branch_name,
         )),
         Err(err) => Err(err),
     }
 }
 
-pub fn get_commit_or_head<S: AsRef<str>>(
+pub fn get_commit_or_head(
     repo: &LocalRepository,
-    commit_id_or_branch_name: Option<S>,
+    commit_id_or_branch_name: Option<&str>,
 ) -> Result<Commit, OxenError> {
     if commit_id_or_branch_name.is_none() {
         return repositories::commits::head_commit(repo);
     }
 
-    match maybe_get_commit(repo, commit_id_or_branch_name.unwrap().as_ref()) {
+    match maybe_get_commit(repo, commit_id_or_branch_name.unwrap()) {
         Ok(Some(commit)) => Ok(commit),
         _ => repositories::commits::head_commit(repo),
     }

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -34,9 +34,9 @@ impl LocalVersionStore {
     ///
     /// # Arguments
     /// * `root_path` - Base directory for version storage
-    pub fn new(root_path: impl AsRef<Path>) -> Self {
+    pub fn new(root_path: &Path) -> Self {
         Self {
-            root_path: root_path.as_ref().to_path_buf(),
+            root_path: root_path.to_path_buf(),
         }
     }
 

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -310,7 +310,9 @@ impl VersionStore for LocalVersionStore {
 
         let read_len = std::cmp::min(size, file_len - offset);
         if read_len > usize::MAX as u64 {
-            return Err(OxenError::basic_str("requested chunk too large"));
+            return Err(OxenError::basic_str(
+                "requested chunk too large".to_string(),
+            ));
         }
 
         use tokio::io::{AsyncSeekExt, SeekFrom};

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -60,7 +60,7 @@ impl S3VersionStore {
                     .send()
                     .await
                     .map_err(|err| {
-                        OxenError::basic_str(&format!("Failed to get bucket location: {err:?}"))
+                        OxenError::basic_str(format!("Failed to get bucket location: {err:?}"))
                     })?
                     .location_constraint()
                     .map(|loc| loc.as_str().to_string())
@@ -78,7 +78,7 @@ impl S3VersionStore {
 
         match result_ref {
             Ok(client) => Ok(client.clone()),
-            Err(e) => Err(OxenError::basic_str(&format!("{e:?}"))),
+            Err(e) => Err(OxenError::basic_str(format!("{e:?}"))),
         }
     }
 
@@ -123,19 +123,19 @@ impl VersionStore for S3VersionStore {
                             .send()
                             .await
                             .map_err(|err| {
-                                OxenError::basic_str(&format!(
+                                OxenError::basic_str(format!(
                                     "Failed to delete _permission_check: {err}"
                                 ))
                             })?;
                         Ok(())
                     }
                     // Surface the error from S3
-                    Err(err) => Err(OxenError::basic_str(&format!(
+                    Err(err) => Err(OxenError::basic_str(format!(
                         "S3 write permission check failed: {err}",
                     ))),
                 }
             }
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "Cannot access S3 bucket '{}': {err}",
                 self.bucket
             ))),
@@ -147,12 +147,12 @@ impl VersionStore for S3VersionStore {
         let client = self.init_client().await?;
         // get file content from the path
         let mut file = std::fs::File::open(file_path).map_err(|e| {
-            OxenError::basic_str(&format!("Failed to open file {}: {e}", file_path.display()))
+            OxenError::basic_str(format!("Failed to open file {}: {e}", file_path.display()))
         })?;
 
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer).map_err(|e| {
-            OxenError::basic_str(&format!("Failed to read file {}: {e}", file_path.display()))
+            OxenError::basic_str(format!("Failed to read file {}: {e}", file_path.display()))
         })?;
 
         let key = self.generate_key(hash);
@@ -164,7 +164,7 @@ impl VersionStore for S3VersionStore {
             .body(body)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(&format!("Failed to store version in S3: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("Failed to store version in S3: {e}")))?;
 
         Ok(())
     }
@@ -176,7 +176,7 @@ impl VersionStore for S3VersionStore {
     ) -> Result<(), OxenError> {
         // TODO: Implement S3 version storage from reader
         Err(OxenError::basic_str(
-            "S3VersionStore store_version_from_reader not yet implemented",
+            "S3VersionStore store_version_from_reader not yet implemented".to_string(),
         ))
     }
 
@@ -215,7 +215,7 @@ impl VersionStore for S3VersionStore {
             .send()
             .await
             .map_err(|e| {
-                OxenError::basic_str(&format!("failed to store derived version file in S3: {e}"))
+                OxenError::basic_str(format!("failed to store derived version file in S3: {e}"))
             })?;
         log::debug!("Saved derived version file {key}");
 
@@ -232,11 +232,11 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(&format!("S3 head_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("S3 head_object failed: {e}")))?;
 
         let size = resp
             .content_length()
-            .ok_or_else(|| OxenError::basic_str("S3 object missing content_length"))?
+            .ok_or_else(|| OxenError::basic_str("S3 object missing content_length".to_string()))?
             as u64;
         Ok(size)
     }
@@ -251,13 +251,13 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(&format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
 
         let data = resp
             .body
             .collect()
             .await
-            .map_err(|e| OxenError::basic_str(&format!("S3 read body failed: {e}")))?
+            .map_err(|e| OxenError::basic_str(format!("S3 read body failed: {e}")))?
             .into_bytes()
             .to_vec();
 
@@ -278,11 +278,11 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(&format!("S3 head_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("S3 head_object failed: {e}")))?;
 
         let size = resp
             .content_length()
-            .ok_or_else(|| OxenError::basic_str("S3 object missing content_length"))?
+            .ok_or_else(|| OxenError::basic_str("S3 object missing content_length".to_string()))?
             as u64;
         Ok(size)
     }
@@ -301,7 +301,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(&format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
 
         let adapter = ByteStreamAdapter { inner: resp.body };
 
@@ -323,7 +323,7 @@ impl VersionStore for S3VersionStore {
             .key(key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(&format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
 
         let adapter = ByteStreamAdapter { inner: resp.body };
         Ok(Box::new(adapter) as Box<_>)
@@ -348,12 +348,12 @@ impl VersionStore for S3VersionStore {
 
             Err(SdkError::ServiceError(err)) => match err.err() {
                 HeadObjectError::NotFound(_) => Ok(false),
-                err => Err(OxenError::basic_str(&format!(
+                err => Err(OxenError::basic_str(format!(
                     "derived_exists failed with S3 head_object error: {err:?}"
                 ))),
             },
 
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "derived_exists failed with S3 head_object error: {err:?}"
             ))),
         }
@@ -364,10 +364,10 @@ impl VersionStore for S3VersionStore {
         let data = self.get_version(hash).await?;
         let mut tmp = TempFile::new()
             .await
-            .map_err(|e| OxenError::basic_str(&format!("Failed to create temp file: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("Failed to create temp file: {e}")))?;
         tmp.write_all(&data)
             .await
-            .map_err(|e| OxenError::basic_str(&format!("Failed to write temp file: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("Failed to write temp file: {e}")))?;
         Ok(LocalFilePath::Temp(tmp))
     }
 
@@ -377,11 +377,11 @@ impl VersionStore for S3VersionStore {
         if let Some(parent) = dest_path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
-                .map_err(|e| OxenError::basic_str(&format!("Failed to create parent dirs: {e}")))?;
+                .map_err(|e| OxenError::basic_str(format!("Failed to create parent dirs: {e}")))?;
         }
         tokio::fs::write(dest_path, &data)
             .await
-            .map_err(|e| OxenError::basic_str(&format!("Failed to write file: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("Failed to write file: {e}")))?;
         Ok(())
     }
 
@@ -393,7 +393,7 @@ impl VersionStore for S3VersionStore {
     ) -> Result<(), OxenError> {
         // TODO: Implement S3 version chunk storage
         Err(OxenError::basic_str(
-            "S3VersionStore store_version_chunk not yet implemented",
+            "S3VersionStore store_version_chunk not yet implemented".to_string(),
         ))
     }
 
@@ -404,7 +404,7 @@ impl VersionStore for S3VersionStore {
     ) -> Result<Box<dyn tokio::io::AsyncWrite + Send + Unpin>, OxenError> {
         // TODO: Implement S3 version chunk stream storage
         Err(OxenError::basic_str(
-            "S3VersionStore get_version_chunk_writer not yet implemented",
+            "S3VersionStore get_version_chunk_writer not yet implemented".to_string(),
         ))
     }
 
@@ -416,14 +416,14 @@ impl VersionStore for S3VersionStore {
     ) -> Result<Vec<u8>, OxenError> {
         // TODO: Implement S3 version chunk retrieval
         Err(OxenError::basic_str(
-            "S3VersionStore get_version_chunk not yet implemented",
+            "S3VersionStore get_version_chunk not yet implemented".to_string(),
         ))
     }
 
     async fn list_version_chunks(&self, _hash: &str) -> Result<Vec<u64>, OxenError> {
         // TODO: Implement S3 version chunk listing
         Err(OxenError::basic_str(
-            "S3VersionStore list_version_chunks not yet implemented",
+            "S3VersionStore list_version_chunks not yet implemented".to_string(),
         ))
     }
 
@@ -442,12 +442,12 @@ impl VersionStore for S3VersionStore {
 
             Err(SdkError::ServiceError(err)) => match err.err() {
                 HeadObjectError::NotFound(_) => Ok(false),
-                err => Err(OxenError::basic_str(&format!(
+                err => Err(OxenError::basic_str(format!(
                     "version_exists failed with S3 head_object error: {err:?}"
                 ))),
             },
 
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "version_exists failed with S3 head_object error: {err:?}"
             ))),
         }
@@ -456,14 +456,14 @@ impl VersionStore for S3VersionStore {
     async fn delete_version(&self, _hash: &str) -> Result<(), OxenError> {
         // TODO: Implement S3 version deletion
         Err(OxenError::basic_str(
-            "S3VersionStore delete_version not yet implemented",
+            "S3VersionStore delete_version not yet implemented".to_string(),
         ))
     }
 
     async fn list_versions(&self) -> Result<Vec<String>, OxenError> {
         // TODO: Implement S3 version listing
         Err(OxenError::basic_str(
-            "S3VersionStore list_versions not yet implemented",
+            "S3VersionStore list_versions not yet implemented".to_string(),
         ))
     }
 
@@ -474,7 +474,7 @@ impl VersionStore for S3VersionStore {
     ) -> Result<PathBuf, OxenError> {
         // TODO: Implement S3 version chunk combination
         Err(OxenError::basic_str(
-            "S3VersionStore combine_version_chunks not yet implemented",
+            "S3VersionStore combine_version_chunks not yet implemented".to_string(),
         ))
     }
 
@@ -484,7 +484,7 @@ impl VersionStore for S3VersionStore {
     ) -> Result<CleanCorruptedVersionsResult, OxenError> {
         // TODO: Implement S3 version chunk combination
         Err(OxenError::basic_str(
-            "S3VersionStore clean_corrupted_versions not yet implemented",
+            "S3VersionStore clean_corrupted_versions not yet implemented".to_string(),
         ))
     }
 

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -60,7 +60,7 @@ impl S3VersionStore {
                     .send()
                     .await
                     .map_err(|err| {
-                        OxenError::basic_str(format!("Failed to get bucket location: {err:?}"))
+                        OxenError::basic_str(&format!("Failed to get bucket location: {err:?}"))
                     })?
                     .location_constraint()
                     .map(|loc| loc.as_str().to_string())
@@ -78,7 +78,7 @@ impl S3VersionStore {
 
         match result_ref {
             Ok(client) => Ok(client.clone()),
-            Err(e) => Err(OxenError::basic_str(format!("{e:?}"))),
+            Err(e) => Err(OxenError::basic_str(&format!("{e:?}"))),
         }
     }
 
@@ -123,19 +123,19 @@ impl VersionStore for S3VersionStore {
                             .send()
                             .await
                             .map_err(|err| {
-                                OxenError::basic_str(format!(
+                                OxenError::basic_str(&format!(
                                     "Failed to delete _permission_check: {err}"
                                 ))
                             })?;
                         Ok(())
                     }
                     // Surface the error from S3
-                    Err(err) => Err(OxenError::basic_str(format!(
+                    Err(err) => Err(OxenError::basic_str(&format!(
                         "S3 write permission check failed: {err}",
                     ))),
                 }
             }
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "Cannot access S3 bucket '{}': {err}",
                 self.bucket
             ))),
@@ -147,12 +147,12 @@ impl VersionStore for S3VersionStore {
         let client = self.init_client().await?;
         // get file content from the path
         let mut file = std::fs::File::open(file_path).map_err(|e| {
-            OxenError::basic_str(format!("Failed to open file {}: {e}", file_path.display()))
+            OxenError::basic_str(&format!("Failed to open file {}: {e}", file_path.display()))
         })?;
 
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer).map_err(|e| {
-            OxenError::basic_str(format!("Failed to read file {}: {e}", file_path.display()))
+            OxenError::basic_str(&format!("Failed to read file {}: {e}", file_path.display()))
         })?;
 
         let key = self.generate_key(hash);
@@ -164,7 +164,7 @@ impl VersionStore for S3VersionStore {
             .body(body)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("Failed to store version in S3: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("Failed to store version in S3: {e}")))?;
 
         Ok(())
     }
@@ -215,7 +215,7 @@ impl VersionStore for S3VersionStore {
             .send()
             .await
             .map_err(|e| {
-                OxenError::basic_str(format!("failed to store derived version file in S3: {e}"))
+                OxenError::basic_str(&format!("failed to store derived version file in S3: {e}"))
             })?;
         log::debug!("Saved derived version file {key}");
 
@@ -232,7 +232,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 head_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("S3 head_object failed: {e}")))?;
 
         let size = resp
             .content_length()
@@ -251,13 +251,13 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("S3 get_object failed: {e}")))?;
 
         let data = resp
             .body
             .collect()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 read body failed: {e}")))?
+            .map_err(|e| OxenError::basic_str(&format!("S3 read body failed: {e}")))?
             .into_bytes()
             .to_vec();
 
@@ -278,7 +278,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 head_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("S3 head_object failed: {e}")))?;
 
         let size = resp
             .content_length()
@@ -301,7 +301,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("S3 get_object failed: {e}")))?;
 
         let adapter = ByteStreamAdapter { inner: resp.body };
 
@@ -323,7 +323,7 @@ impl VersionStore for S3VersionStore {
             .key(key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("S3 get_object failed: {e}")))?;
 
         let adapter = ByteStreamAdapter { inner: resp.body };
         Ok(Box::new(adapter) as Box<_>)
@@ -348,12 +348,12 @@ impl VersionStore for S3VersionStore {
 
             Err(SdkError::ServiceError(err)) => match err.err() {
                 HeadObjectError::NotFound(_) => Ok(false),
-                err => Err(OxenError::basic_str(format!(
+                err => Err(OxenError::basic_str(&format!(
                     "derived_exists failed with S3 head_object error: {err:?}"
                 ))),
             },
 
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "derived_exists failed with S3 head_object error: {err:?}"
             ))),
         }
@@ -364,10 +364,10 @@ impl VersionStore for S3VersionStore {
         let data = self.get_version(hash).await?;
         let mut tmp = TempFile::new()
             .await
-            .map_err(|e| OxenError::basic_str(format!("Failed to create temp file: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("Failed to create temp file: {e}")))?;
         tmp.write_all(&data)
             .await
-            .map_err(|e| OxenError::basic_str(format!("Failed to write temp file: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("Failed to write temp file: {e}")))?;
         Ok(LocalFilePath::Temp(tmp))
     }
 
@@ -377,11 +377,11 @@ impl VersionStore for S3VersionStore {
         if let Some(parent) = dest_path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
-                .map_err(|e| OxenError::basic_str(format!("Failed to create parent dirs: {e}")))?;
+                .map_err(|e| OxenError::basic_str(&format!("Failed to create parent dirs: {e}")))?;
         }
         tokio::fs::write(dest_path, &data)
             .await
-            .map_err(|e| OxenError::basic_str(format!("Failed to write file: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("Failed to write file: {e}")))?;
         Ok(())
     }
 
@@ -442,12 +442,12 @@ impl VersionStore for S3VersionStore {
 
             Err(SdkError::ServiceError(err)) => match err.err() {
                 HeadObjectError::NotFound(_) => Ok(false),
-                err => Err(OxenError::basic_str(format!(
+                err => Err(OxenError::basic_str(&format!(
                     "version_exists failed with S3 head_object error: {err:?}"
                 ))),
             },
 
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "version_exists failed with S3 head_object error: {err:?}"
             ))),
         }

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -314,7 +314,7 @@ pub fn create_version_store(
                     .join(constants::FILES_DIR)
             };
 
-            let store = LocalVersionStore::new(versions_dir);
+            let store = LocalVersionStore::new(&versions_dir);
 
             Ok(Arc::new(store))
         }
@@ -329,7 +329,7 @@ pub fn create_version_store(
 
             Ok(Arc::new(store))
         }
-        _ => Err(OxenError::basic_str(format!(
+        _ => Err(OxenError::basic_str(&format!(
             "Unsupported async storage type: {}",
             storage_opts.type_
         ))),

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -298,7 +298,9 @@ pub fn create_version_store(
     match storage_opts.type_.as_str() {
         "local" => {
             let Some(ref local_storage_opts) = storage_opts.local_storage_opts else {
-                return Err(OxenError::basic_str("local storage opts not found"));
+                return Err(OxenError::basic_str(
+                    "local storage opts not found".to_string(),
+                ));
             };
 
             let versions_dir = if let Some(path) = &local_storage_opts.path {
@@ -320,7 +322,9 @@ pub fn create_version_store(
         }
         "s3" => {
             let Some(ref s3_opts) = storage_opts.s3_opts else {
-                return Err(OxenError::basic_str("s3 storage opts not found"));
+                return Err(OxenError::basic_str(
+                    "s3 storage opts not found".to_string(),
+                ));
             };
 
             let bucket = s3_opts.bucket.clone();
@@ -329,7 +333,7 @@ pub fn create_version_store(
 
             Ok(Arc::new(store))
         }
-        _ => Err(OxenError::basic_str(&format!(
+        _ => Err(OxenError::basic_str(format!(
             "Unsupported async storage type: {}",
             storage_opts.type_
         ))),

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -2190,9 +2190,7 @@ pub fn append_line_txt_file(path: &Path, line: &str) -> Result<PathBuf, OxenErro
     let mut file = OpenOptions::new().append(true).open(path)?;
 
     if let Err(e) = writeln!(file, "{line}") {
-        return Err(OxenError::basic_str(&format!(
-            "Couldn't write to file: {e}"
-        )));
+        return Err(OxenError::basic_str(format!("Couldn't write to file: {e}")));
     }
 
     Ok(path.to_path_buf())
@@ -2245,7 +2243,7 @@ pub fn add_img_file_to_dir(dir: &Path, file_path: &Path) -> Result<PathBuf, Oxen
         Ok(full_new_path)
     } else {
         let err = format!("Unknown extension file: {file_path:?}");
-        Err(OxenError::basic_str(&err))
+        Err(OxenError::basic_str(err))
     }
 }
 

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -95,31 +95,26 @@ pub fn init_test_env() {
     }
 }
 
-fn create_prefixed_dir(
-    base_dir: impl AsRef<Path>,
-    prefix: impl AsRef<Path>,
-) -> Result<PathBuf, OxenError> {
-    let base_dir = base_dir.as_ref();
-    let prefix = prefix.as_ref();
+fn create_prefixed_dir(base_dir: &Path, prefix: &Path) -> Result<PathBuf, OxenError> {
     let repo_name = format!("{}", uuid::Uuid::new_v4());
     let full_dir = Path::new(base_dir).join(prefix).join(repo_name);
     util::fs::create_dir_all(&full_dir)?;
     Ok(full_dir)
 }
 
-pub fn create_repo_dir(base_dir: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
-    create_prefixed_dir(base_dir, "repo")
+pub fn create_repo_dir(base_dir: &Path) -> Result<PathBuf, OxenError> {
+    create_prefixed_dir(base_dir, Path::new("repo"))
 }
 
-fn create_empty_dir(base_dir: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
-    create_prefixed_dir(base_dir, "dir")
+fn create_empty_dir(base_dir: &Path) -> Result<PathBuf, OxenError> {
+    create_prefixed_dir(base_dir, Path::new("dir"))
 }
 
 pub async fn create_remote_repo(repo: &LocalRepository) -> Result<RemoteRepository, OxenError> {
     let repo_new = RepoNew::from_namespace_name_host(
         constants::DEFAULT_NAMESPACE,
-        repo.dirname(),
-        test_host(),
+        &repo.dirname(),
+        &test_host(),
         None,
     );
     api::client::repositories::create_from_local(repo, repo_new).await
@@ -131,8 +126,8 @@ pub async fn create_or_clear_remote_repo(
 ) -> Result<RemoteRepository, OxenError> {
     let repo_new = RepoNew::from_namespace_name_host(
         constants::DEFAULT_NAMESPACE,
-        repo.dirname(),
-        test_host(),
+        &repo.dirname(),
+        &test_host(),
         None,
     );
 
@@ -161,7 +156,7 @@ pub async fn add_n_files_m_dirs(
     */
 
     let readme_file = repo.path.join("README.md");
-    util::fs::write_to_path(&readme_file, format!("Repo with {num_files} files"))?;
+    util::fs::write_to_path(&readme_file, &format!("Repo with {num_files} files"))?;
 
     repositories::add(repo, &readme_file).await?;
 
@@ -185,7 +180,7 @@ pub async fn add_n_files_m_dirs(
         util::fs::create_dir_all(&dir_path)?;
 
         let file_file = dir_path.join(format!("file{i}.txt"));
-        util::fs::write_to_path(&file_file, format!("File {i}"))?;
+        util::fs::write_to_path(&file_file, &format!("File {i}"))?;
     }
 
     repositories::add(repo, &files_csv).await?;
@@ -212,7 +207,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_dir_test start");
-    let repo_dir = create_empty_dir(test_run_dir())?;
+    let repo_dir = create_empty_dir(&test_run_dir())?;
 
     // Run test to see if it panic'd
     log::info!(">>>>> run_empty_dir_test running test");
@@ -239,7 +234,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_dir_test_async start");
-    let repo_dir = create_empty_dir(test_run_dir())?;
+    let repo_dir = create_empty_dir(&test_run_dir())?;
 
     // Run test to see if it panic'd
     log::info!(">>>>> run_empty_dir_test_async running test");
@@ -269,7 +264,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_local_repo_test start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     log::info!(">>>>> run_empty_local_repo_test running test");
@@ -297,7 +292,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_local_repo_test start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init::init_with_version(&repo_dir, version)?;
 
     log::info!(">>>>> run_empty_local_repo_test running test");
@@ -323,7 +318,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_local_repo_test_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     let version_store = repo.version_store()?;
@@ -352,7 +347,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_one_commit_local_repo_test start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     let txt = generate_random_string(20);
@@ -383,7 +378,7 @@ where
 {
     init_test_env();
     log::debug!("run_one_commit_local_repo_test_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     let txt = generate_random_string(20);
@@ -415,7 +410,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_one_commit_sync_repo_test start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
 
     let mut local_repo = repositories::init(&repo_dir)?;
 
@@ -462,7 +457,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_many_local_commits_empty_sync_remote_test start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
 
     let mut local_repo = repositories::init(&repo_dir)?;
     let remote_repo = create_remote_repo(&local_repo).await?;
@@ -509,7 +504,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_training_data_sync_test_no_commits start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let local_repo = repositories::init(&repo_dir)?;
 
     // Write all the training data files
@@ -538,16 +533,16 @@ where
 
 pub async fn make_many_commits(local_repo: &LocalRepository) -> Result<(), OxenError> {
     // Make a few commits before we sync
-    repositories::add(local_repo, local_repo.path.join("train")).await?;
+    repositories::add(local_repo, &local_repo.path.join("train")).await?;
     repositories::commit(local_repo, "Adding train/")?;
 
-    repositories::add(local_repo, local_repo.path.join("test")).await?;
+    repositories::add(local_repo, &local_repo.path.join("test")).await?;
     repositories::commit(local_repo, "Adding test/")?;
 
-    repositories::add(local_repo, local_repo.path.join("annotations")).await?;
+    repositories::add(local_repo, &local_repo.path.join("annotations")).await?;
     repositories::commit(local_repo, "Adding annotations/")?;
 
-    repositories::add(local_repo, local_repo.path.join("nlp")).await?;
+    repositories::add(local_repo, &local_repo.path.join("nlp")).await?;
     repositories::commit(local_repo, "Adding nlp/")?;
 
     // Remove the test dir to make a more complex history
@@ -574,7 +569,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_local_repo_training_data_committed_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Write all the training data files
@@ -606,7 +601,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_training_data_fully_sync_remote start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let mut local_repo = repositories::init(&repo_dir)?;
 
     // Write all the training data files
@@ -650,14 +645,14 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_select_data_sync_remote start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let mut local_repo = repositories::init(&repo_dir)?;
 
     // Write all the training data files
     populate_select_training_data(&repo_dir, data)?;
 
     // Make a few commits before we sync
-    repositories::add(&local_repo, local_repo.path.join(data)).await?;
+    repositories::add(&local_repo, &local_repo.path.join(data)).await?;
     repositories::commit(&local_repo, &format!("Adding {data}"))?;
 
     // Create remote
@@ -698,7 +693,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_subset_of_data_fully_sync_remote start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let mut local_repo = repositories::init(&repo_dir)?;
 
     // Write all the training data files
@@ -741,7 +736,7 @@ where
     log::info!("<<<<< run_no_commit_remote_repo_test start");
     let name = format!("repo_{}", uuid::Uuid::new_v4());
     let namespace = constants::DEFAULT_NAMESPACE;
-    let repo_new = RepoNew::from_namespace_name_host(namespace, name, test_host(), None);
+    let repo_new = RepoNew::from_namespace_name_host(namespace, &name, &test_host(), None);
     let repo = api::client::repositories::create_empty(repo_new).await?;
 
     // Run test to see if it panic'd
@@ -770,7 +765,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_remote_repo_test start");
-    let empty_dir = create_empty_dir(test_run_dir())?;
+    let empty_dir = create_empty_dir(&test_run_dir())?;
     let name = format!("repo_{}", uuid::Uuid::new_v4());
     let path = empty_dir.join(name);
     let local_repo = repositories::init(&path)?;
@@ -804,7 +799,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_remote_repo_test start");
-    let empty_dir = create_empty_dir(test_run_dir())?;
+    let empty_dir = create_empty_dir(&test_run_dir())?;
     let name = format!("repo_{}", uuid::Uuid::new_v4());
     let path = empty_dir.join(name);
     let mut local_repo = repositories::init(&path)?;
@@ -849,13 +844,13 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_remote_repo_test start");
-    let empty_dir = create_empty_dir(test_run_dir())?;
+    let empty_dir = create_empty_dir(&test_run_dir())?;
     let name = format!("repo_{}", uuid::Uuid::new_v4());
     let path = empty_dir.join(name);
     let mut local_repo = repositories::init(&path)?;
 
     // Add a README file
-    util::fs::write_to_path(local_repo.path.join("README.md"), "Hello World")?;
+    util::fs::write_to_path(&local_repo.path.join("README.md"), "Hello World")?;
     repositories::add(&local_repo, &local_repo.path).await?;
     repositories::commit(&local_repo, "Adding README")?;
 
@@ -945,7 +940,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_remote_repo_test_all_data_pushed start");
-    let empty_dir = create_empty_dir(test_run_dir())?;
+    let empty_dir = create_empty_dir(&test_run_dir())?;
     let name = format!("repo_{}", uuid::Uuid::new_v4());
     let path = empty_dir.join(name);
     let mut local_repo = repositories::init(&path)?;
@@ -994,7 +989,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_remote_repo_test_bounding_box_csv_pushed start");
-    let empty_dir = create_empty_dir(test_run_dir())?;
+    let empty_dir = create_empty_dir(&test_run_dir())?;
     let name = format!("repo_{}", uuid::Uuid::new_v4());
     let path = empty_dir.join(name);
     let mut local_repo = repositories::init(&path)?;
@@ -1045,7 +1040,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_remote_repo_test_embeddings_jsonl_pushed start");
-    let empty_dir = create_empty_dir(test_run_dir())?;
+    let empty_dir = create_empty_dir(&test_run_dir())?;
     let name = format!("repo_{}", uuid::Uuid::new_v4());
     let path = empty_dir.join(name);
     let mut local_repo = repositories::init(&path)?;
@@ -1096,7 +1091,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_training_data_repo_test_no_commits_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     let version_store = repo.version_store()?;
@@ -1133,7 +1128,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_training_data_repo_test_no_commits_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init::init_with_version(&repo_dir, version)?;
 
     // Write all the files
@@ -1167,7 +1162,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_select_data_repo_test_no_commits_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Write all the files
@@ -1201,7 +1196,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_select_data_repo_test_committed_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Write all the files
@@ -1239,7 +1234,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_empty_data_repo_test_no_commits_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Run test to see if it panic'd
@@ -1267,7 +1262,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_training_data_repo_test_no_commits start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Write all the files
@@ -1301,7 +1296,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_select_data_repo_test_no_commits start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Write the select files
@@ -1334,7 +1329,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_training_data_repo_test_fully_committed_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Write all the files
@@ -1373,7 +1368,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_training_data_repo_test_fully_committed_async_min_version start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init::init_with_version(&repo_dir, version)?;
 
     // Write all the files
@@ -1408,7 +1403,7 @@ fn create_bounding_box_csv(repo_path: &Path) -> Result<(), OxenError> {
 
     // Write all the files
     write_txt_file_to_path(
-        dir.join("bounding_box.csv"),
+        &dir.join("bounding_box.csv"),
         r"file,label,min_x,min_y,width,height
 train/dog_1.jpg,dog,101.5,32.0,385,330
 train/dog_1.jpg,dog,102.5,31.0,386,330
@@ -1434,7 +1429,7 @@ fn create_embeddings_jsonl(repo_path: &Path) -> Result<(), OxenError> {
     }
 
     // Write all the files
-    write_txt_file_to_path(dir.join("embeddings.jsonl"), embeddings.join("\n"))?;
+    write_txt_file_to_path(&dir.join("embeddings.jsonl"), &embeddings.join("\n"))?;
 
     Ok(())
 }
@@ -1448,7 +1443,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_bounding_box_csv_repo_test_fully_committed_async start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Write all the files
@@ -1482,7 +1477,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_bounding_box_csv_repo_test_fully_committed start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Add all the files
@@ -1514,13 +1509,13 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_compare_data_repo_test_fully_committed start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
     // Has 6 match observations in both keys, 5 diffs,
     // 2 key sets left only, 1 keyset right only.
     write_txt_file_to_path(
-        repo.path.join("compare_left.csv"),
+        &repo.path.join("compare_left.csv"),
         r"height,weight,gender,target,other_target
 57,150,M,1,yes
 57,160,M,0,yes
@@ -1538,7 +1533,7 @@ where
     )?;
 
     write_txt_file_to_path(
-        repo.path.join("compare_right.csv"),
+        &repo.path.join("compare_right.csv"),
         r"height,weight,gender,target,other_target
 57,150,M,1,yes
 57,160,M,0,yes
@@ -1582,7 +1577,7 @@ where
 {
     init_test_env();
     log::info!("<<<<< run_training_data_repo_test_fully_committed start");
-    let repo_dir = create_repo_dir(test_run_dir())?;
+    let repo_dir = create_repo_dir(&test_run_dir())?;
     let repo = repositories::init::init_with_version(&repo_dir, version)?;
     // Write all the files
     populate_dir_with_training_data(&repo_dir)?;
@@ -1616,13 +1611,13 @@ where
 }
 
 async fn add_all_data_to_repo(repo: &LocalRepository) -> Result<(), OxenError> {
-    repositories::add(repo, repo.path.join("train")).await?;
-    repositories::add(repo, repo.path.join("test")).await?;
-    repositories::add(repo, repo.path.join("annotations")).await?;
-    repositories::add(repo, repo.path.join("large_files")).await?;
-    repositories::add(repo, repo.path.join("nlp")).await?;
-    repositories::add(repo, repo.path.join("labels.txt")).await?;
-    repositories::add(repo, repo.path.join("README.md")).await?;
+    repositories::add(repo, &repo.path.join("train")).await?;
+    repositories::add(repo, &repo.path.join("test")).await?;
+    repositories::add(repo, &repo.path.join("annotations")).await?;
+    repositories::add(repo, &repo.path.join("large_files")).await?;
+    repositories::add(repo, &repo.path.join("nlp")).await?;
+    repositories::add(repo, &repo.path.join("labels.txt")).await?;
+    repositories::add(repo, &repo.path.join("README.md")).await?;
 
     Ok(())
 }
@@ -1844,7 +1839,7 @@ pub fn test_bounding_box_csv() -> PathBuf {
 
 pub fn populate_readme(repo_dir: &Path) -> Result<(), OxenError> {
     write_txt_file_to_path(
-        repo_dir.join("README.md"),
+        &repo_dir.join("README.md"),
         r"
         # Welcome to the party
 
@@ -1861,7 +1856,7 @@ pub fn populate_readme(repo_dir: &Path) -> Result<(), OxenError> {
 
 pub fn populate_license(repo_dir: &Path) -> Result<(), OxenError> {
     write_txt_file_to_path(
-        repo_dir.join("LICENSE"),
+        &repo_dir.join("LICENSE"),
         r"Oxen.ai License. The best version control system for data is Oxen.ai.",
     )?;
 
@@ -1870,7 +1865,7 @@ pub fn populate_license(repo_dir: &Path) -> Result<(), OxenError> {
 
 pub fn populate_labels(repo_dir: &Path) -> Result<(), OxenError> {
     write_txt_file_to_path(
-        repo_dir.join("labels.txt"),
+        &repo_dir.join("labels.txt"),
         r"
         dog
         cat
@@ -1882,7 +1877,7 @@ pub fn populate_labels(repo_dir: &Path) -> Result<(), OxenError> {
 
 pub fn populate_prompts(repo_dir: &Path) -> Result<(), OxenError> {
     write_txt_file_to_path(
-        repo_dir.join("prompts.jsonl"),
+        &repo_dir.join("prompts.jsonl"),
         "{\"prompt\": \"What is the meaning of life?\", \"label\": \"42\"}\n{\"prompt\": \"What is the best data version control system?\", \"label\": \"Oxen.ai\"}\n",
     )?;
 
@@ -1894,7 +1889,7 @@ pub fn populate_large_files(repo_dir: &Path) -> Result<(), OxenError> {
     util::fs::create_dir_all(&large_dir)?;
     let large_file_1 = large_dir.join("test.csv");
     let from_file = test_200k_csv();
-    util::fs::copy(from_file, large_file_1)?;
+    util::fs::copy(&from_file, &large_file_1)?;
 
     Ok(())
 }
@@ -1903,33 +1898,33 @@ pub fn populate_train_dir(repo_dir: &Path) -> Result<(), OxenError> {
     let train_dir = repo_dir.join("train");
     util::fs::create_dir_all(&train_dir)?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("dog_1.jpg"),
-        train_dir.join("dog_1.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("dog_1.jpg"),
+        &train_dir.join("dog_1.jpg"),
     )?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("dog_2.jpg"),
-        train_dir.join("dog_2.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("dog_2.jpg"),
+        &train_dir.join("dog_2.jpg"),
     )?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("dog_3.jpg"),
-        train_dir.join("dog_3.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("dog_3.jpg"),
+        &train_dir.join("dog_3.jpg"),
     )?;
     // Add file with same content and different names to test edge cases
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("dog_3.jpg"),
-        train_dir.join("dog_4.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("dog_3.jpg"),
+        &train_dir.join("dog_4.jpg"),
     )?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("cat_1.jpg"),
-        train_dir.join("cat_1.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("cat_1.jpg"),
+        &train_dir.join("cat_1.jpg"),
     )?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("cat_2.jpg"),
-        train_dir.join("cat_2.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("cat_2.jpg"),
+        &train_dir.join("cat_2.jpg"),
     )?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("cat_2.jpg"),
-        train_dir.join("cat_3.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("cat_2.jpg"),
+        &train_dir.join("cat_3.jpg"),
     )?;
 
     Ok(())
@@ -1939,20 +1934,20 @@ pub fn populate_test_dir(repo_dir: &Path) -> Result<(), OxenError> {
     let test_dir = repo_dir.join("test");
     util::fs::create_dir_all(&test_dir)?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("dog_4.jpg"),
-        test_dir.join("1.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("dog_4.jpg"),
+        &test_dir.join("1.jpg"),
     )?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("cat_3.jpg"),
-        test_dir.join("2.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("cat_3.jpg"),
+        &test_dir.join("2.jpg"),
     )?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("dog_4.jpg"),
-        test_dir.join("3.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("dog_4.jpg"),
+        &test_dir.join("3.jpg"),
     )?;
     util::fs::copy(
-        TEST_DATA_DIR.join("test").join("images").join("cat_3.jpg"),
-        test_dir.join("4.jpg"),
+        &TEST_DATA_DIR.join("test").join("images").join("cat_3.jpg"),
+        &test_dir.join("4.jpg"),
     )?;
 
     Ok(())
@@ -1963,7 +1958,7 @@ pub fn populate_annotations_dir(repo_dir: &Path) -> Result<(), OxenError> {
     util::fs::create_dir_all(&annotations_dir)?;
     let annotations_readme_file = annotations_dir.join("README.md");
     write_txt_file_to_path(
-        annotations_readme_file,
+        &annotations_readme_file,
         r"
         # Annotations
         Some info about our annotations structure....
@@ -1974,7 +1969,7 @@ pub fn populate_annotations_dir(repo_dir: &Path) -> Result<(), OxenError> {
     let train_annotations_dir = annotations_dir.join("train");
     util::fs::create_dir_all(&train_annotations_dir)?;
     write_txt_file_to_path(
-        train_annotations_dir.join("annotations.txt"),
+        &train_annotations_dir.join("annotations.txt"),
         r"
 train/dog_1.jpg 0
 train/dog_2.jpg 0
@@ -1987,14 +1982,14 @@ train/cat_2.jpg 1
     create_bounding_box_csv(repo_dir)?;
 
     write_txt_file_to_path(
-        train_annotations_dir.join("one_shot.csv"),
+        &train_annotations_dir.join("one_shot.csv"),
         r"file,label,min_x,min_y,width,height
 train/dog_1.jpg,dog,101.5,32.0,385,330
 ",
     )?;
 
     write_txt_file_to_path(
-        train_annotations_dir.join("two_shot.csv"),
+        &train_annotations_dir.join("two_shot.csv"),
         r"file,label,min_x,min_y,width,height
 train/dog_3.jpg,dog,19.0,63.5,376,421
 train/cat_1.jpg,cat,57.0,35.5,304,427
@@ -2005,7 +2000,7 @@ train/cat_1.jpg,cat,57.0,35.5,304,427
     let test_annotations_dir = annotations_dir.join("test");
     util::fs::create_dir_all(&test_annotations_dir)?;
     write_txt_file_to_path(
-        test_annotations_dir.join("annotations.csv"),
+        &test_annotations_dir.join("annotations.csv"),
         r"file,label,min_x,min_y,width,height
 test/dog_3.jpg,dog,19.0,63.5,376,421
 test/cat_1.jpg,cat,57.0,35.5,304,427
@@ -2038,7 +2033,7 @@ pub fn populate_nlp_dir(repo_dir: &Path) -> Result<(), OxenError> {
         "One more time\tpositive",
     ]
     .join("\n");
-    write_txt_file_to_path(nlp_annotations_dir.join("train.tsv"), &train_data)?;
+    write_txt_file_to_path(&nlp_annotations_dir.join("train.tsv"), &train_data)?;
 
     let test_data = [
         "text\tlabel",
@@ -2053,7 +2048,7 @@ pub fn populate_nlp_dir(repo_dir: &Path) -> Result<(), OxenError> {
         "I am a great testing example\tpositive",
     ]
     .join("\n");
-    write_txt_file_to_path(nlp_annotations_dir.join("test.tsv"), &test_data)?;
+    write_txt_file_to_path(&nlp_annotations_dir.join("test.tsv"), &test_data)?;
     Ok(())
 }
 
@@ -2185,32 +2180,25 @@ pub fn add_csv_file_to_dir(dir: &Path, contents: &str) -> Result<PathBuf, OxenEr
     add_file_to_dir(dir, contents, "csv")
 }
 
-pub fn write_txt_file_to_path(
-    path: impl AsRef<Path>,
-    contents: impl AsRef<str>,
-) -> Result<PathBuf, OxenError> {
-    let path = path.as_ref();
-    let contents = contents.as_ref();
+pub fn write_txt_file_to_path(path: &Path, contents: &str) -> Result<PathBuf, OxenError> {
     let mut file = File::create(path)?;
     file.write_all(contents.as_bytes())?;
     Ok(path.to_path_buf())
 }
 
-pub fn append_line_txt_file<P: AsRef<Path>>(path: P, line: &str) -> Result<PathBuf, OxenError> {
-    let path = path.as_ref();
-
+pub fn append_line_txt_file(path: &Path, line: &str) -> Result<PathBuf, OxenError> {
     let mut file = OpenOptions::new().append(true).open(path)?;
 
     if let Err(e) = writeln!(file, "{line}") {
-        return Err(OxenError::basic_str(format!("Couldn't write to file: {e}")));
+        return Err(OxenError::basic_str(&format!(
+            "Couldn't write to file: {e}"
+        )));
     }
 
     Ok(path.to_path_buf())
 }
 
-pub fn modify_txt_file<P: AsRef<Path>>(path: P, contents: &str) -> Result<PathBuf, OxenError> {
-    let path = path.as_ref();
-
+pub fn modify_txt_file(path: &Path, contents: &str) -> Result<PathBuf, OxenError> {
     // Overwrite
     if path.exists() {
         util::fs::remove_file(path)?;
@@ -2231,7 +2219,7 @@ pub fn schema_bounding_box() -> Schema {
     Schema::new(fields)
 }
 
-pub fn add_random_bbox_to_file<P: AsRef<Path>>(path: P) -> Result<PathBuf, OxenError> {
+pub fn add_random_bbox_to_file(path: &Path) -> Result<PathBuf, OxenError> {
     let mut rng = rand::thread_rng();
     let file_name = format!("random_img_{}.jpg", rng.gen_range(0..10));
     let x: f64 = rng.gen_range(0.0..1000.0);
@@ -2257,7 +2245,7 @@ pub fn add_img_file_to_dir(dir: &Path, file_path: &Path) -> Result<PathBuf, Oxen
         Ok(full_new_path)
     } else {
         let err = format!("Unknown extension file: {file_path:?}");
-        Err(OxenError::basic_str(err))
+        Err(OxenError::basic_str(&err))
     }
 }
 
@@ -2278,10 +2266,10 @@ mod tests {
             // Add a file that we are going to ignore
             let ignore_filename = "ignoreme.txt";
             let ignore_path = repo.path.join(ignore_filename);
-            write_txt_file_to_path(ignore_path, "I should be ignored")?;
+            write_txt_file_to_path(&ignore_path, "I should be ignored")?;
 
             let oxenignore_file = repo.path.join(".oxenignore");
-            write_txt_file_to_path(oxenignore_file, ignore_filename)?;
+            write_txt_file_to_path(&oxenignore_file, ignore_filename)?;
 
             let status = repositories::status(&repo)?;
             // Only untracked file should be .oxenignore
@@ -2303,11 +2291,11 @@ mod tests {
             let ignore_dir = "ignoreme/";
             let ignore_path = repo.path.join(ignore_dir);
             std::fs::create_dir(&ignore_path)?;
-            write_txt_file_to_path(ignore_path.join("0.txt"), "I should be ignored")?;
-            write_txt_file_to_path(ignore_path.join("1.txt"), "I should also be ignored")?;
+            write_txt_file_to_path(&ignore_path.join("0.txt"), "I should be ignored")?;
+            write_txt_file_to_path(&ignore_path.join("1.txt"), "I should also be ignored")?;
 
             let oxenignore_file = repo.path.join(".oxenignore");
-            write_txt_file_to_path(oxenignore_file, "ignoreme/")?;
+            write_txt_file_to_path(&oxenignore_file, "ignoreme/")?;
 
             let status = repositories::status(&repo)?;
             // Only untracked file should be .oxenignore

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -45,8 +45,8 @@ use image::{ImageFormat, ImageReader};
 use thumbnails::Thumbnailer;
 
 // Deprecated
-pub fn oxen_hidden_dir(repo_path: impl AsRef<Path>) -> PathBuf {
-    PathBuf::from(repo_path.as_ref()).join(Path::new(constants::OXEN_HIDDEN_DIR))
+pub fn oxen_hidden_dir(repo_path: &Path) -> PathBuf {
+    PathBuf::from(repo_path).join(Path::new(constants::OXEN_HIDDEN_DIR))
 }
 
 pub fn oxen_tmp_dir() -> Result<PathBuf, OxenError> {
@@ -142,11 +142,11 @@ pub fn video_thumbnail_filename(
     format!("thumbnail_{width_str}x{height_str}_{timestamp_str}.{extension}")
 }
 
-pub fn chunk_path(repo: &LocalRepository, hash: impl AsRef<str>) -> PathBuf {
+pub fn chunk_path(repo: &LocalRepository, hash: &str) -> PathBuf {
     oxen_hidden_dir(&repo.path)
         .join(TREE_DIR)
         .join(CHUNKS_DIR)
-        .join(hash.as_ref())
+        .join(hash)
         .join("data")
 }
 
@@ -158,20 +158,18 @@ pub fn extension_from_path(path: &Path) -> String {
     }
 }
 
-pub fn read_bytes_from_path(path: impl AsRef<Path>) -> Result<Vec<u8>, OxenError> {
-    let path = path.as_ref();
+pub fn read_bytes_from_path(path: &Path) -> Result<Vec<u8>, OxenError> {
     Ok(std::fs::read(path)?)
 }
 
-pub fn read_file(path: Option<impl AsRef<Path>>) -> Result<String, OxenError> {
+pub fn read_file(path: Option<&Path>) -> Result<String, OxenError> {
     match path {
         Some(path) => read_from_path(path),
         None => Ok(String::new()),
     }
 }
 
-pub fn read_from_path(path: impl AsRef<Path>) -> Result<String, OxenError> {
-    let path = path.as_ref();
+pub fn read_from_path(path: &Path) -> Result<String, OxenError> {
     match std::fs::read_to_string(path) {
         Ok(contents) => Ok(contents),
         Err(err) => {
@@ -181,10 +179,7 @@ pub fn read_from_path(path: impl AsRef<Path>) -> Result<String, OxenError> {
     }
 }
 
-pub fn write_to_path(path: impl AsRef<Path>, value: impl AsRef<str>) -> Result<(), OxenError> {
-    let path = path.as_ref();
-    let value = value.as_ref();
-
+pub fn write_to_path(path: &Path, value: &str) -> Result<(), OxenError> {
     // Make sure the parent directory exists
     if let Some(parent) = path.parent() {
         create_dir_all(parent)?;
@@ -193,11 +188,11 @@ pub fn write_to_path(path: impl AsRef<Path>, value: impl AsRef<str>) -> Result<(
     match File::create(path) {
         Ok(mut file) => match file.write(value.as_bytes()) {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "Could not write file {path:?}\n{err}"
             ))),
         },
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "Could not create file to write {path:?}\n{err}"
         ))),
     }
@@ -207,11 +202,11 @@ pub fn write_data(path: &Path, data: &[u8]) -> Result<(), OxenError> {
     match File::create(path) {
         Ok(mut file) => match file.write(data) {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "Could not write file {path:?}\n{err}"
             ))),
         },
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "Could not create file to write {path:?}\n{err}"
         ))),
     }
@@ -221,21 +216,17 @@ pub fn append_to_file(path: &Path, value: &str) -> Result<(), OxenError> {
     match OpenOptions::new().append(true).open(path) {
         Ok(mut file) => match file.write(value.as_bytes()) {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(format!(
+            Err(err) => Err(OxenError::basic_str(&format!(
                 "Could not append to file {path:?}\n{err}"
             ))),
         },
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "Could not open file to append {path:?}\n{err}"
         ))),
     }
 }
 
-pub fn count_lines(
-    path: impl AsRef<Path>,
-    opts: CountLinesOpts,
-) -> Result<(usize, Option<usize>), OxenError> {
-    let path = path.as_ref();
+pub fn count_lines(path: &Path, opts: CountLinesOpts) -> Result<(usize, Option<usize>), OxenError> {
     let file = File::open(path)?;
 
     let mut reader = BufReader::with_capacity(1024 * 32, file);
@@ -289,16 +280,16 @@ pub fn read_lines_file(file: &File) -> Vec<String> {
     lines
 }
 
-pub fn read_first_n_bytes(path: impl AsRef<Path>, n: usize) -> Result<Vec<u8>, OxenError> {
-    let mut file = File::open(path.as_ref())?;
+pub fn read_first_n_bytes(path: &Path, n: usize) -> Result<Vec<u8>, OxenError> {
+    let mut file = File::open(path)?;
     let mut buffer = vec![0; n];
     let bytes_read = file.read(&mut buffer)?;
     buffer.truncate(bytes_read);
     Ok(buffer)
 }
 
-pub fn read_first_line(path: impl AsRef<Path>) -> Result<String, OxenError> {
-    let file = File::open(path.as_ref())?;
+pub fn read_first_line(path: &Path) -> Result<String, OxenError> {
+    let file = File::open(path)?;
     read_first_line_from_file(&file)
 }
 
@@ -307,13 +298,13 @@ pub fn read_first_line_from_file(file: &File) -> Result<String, OxenError> {
     if let Some(Ok(line)) = reader.lines().next() {
         Ok(line)
     } else {
-        Err(OxenError::basic_str(format!(
+        Err(OxenError::basic_str(&format!(
             "Could not read line from file: {file:?}"
         )))
     }
 }
 
-pub fn read_first_byte_from_file(path: impl AsRef<Path>) -> Result<char, OxenError> {
+pub fn read_first_byte_from_file(path: &Path) -> Result<char, OxenError> {
     let mut file = File::open(path)?;
     let mut buffer = [0; 1]; // Single byte buffer
     file.read_exact(&mut buffer)?;
@@ -476,10 +467,8 @@ pub fn get_repo_root_from_current_dir() -> Option<PathBuf> {
     get_repo_root(&path)
 }
 
-pub fn copy_dir_all(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), OxenError> {
+pub fn copy_dir_all(from: &Path, to: &Path) -> Result<(), OxenError> {
     // There is not a recursive copy in the standard library, so we implement it here
-    let from = from.as_ref();
-    let to = to.as_ref();
     log::debug!("copy_dir_all Copy directory from: {from:?} -> to: {to:?}");
 
     let mut stack = Vec::new();
@@ -529,9 +518,7 @@ pub fn copy_dir_all(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), 
 }
 
 /// Wrapper around the std::fs::copy command to tell us which file failed to copy
-pub fn copy(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), OxenError> {
-    let src = src.as_ref();
-    let dst = dst.as_ref();
+pub fn copy(src: &Path, dst: &Path) -> Result<(), OxenError> {
     let max_retries = 3;
     let mut attempt = 0;
 
@@ -542,7 +529,7 @@ pub fn copy(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), OxenErro
                 if err.raw_os_error() == Some(32) {
                     attempt += 1;
                     if attempt == max_retries {
-                        return Err(OxenError::basic_str(format!(
+                        return Err(OxenError::basic_str(&format!(
                             "File is in use by another process after {max_retries} attempts: {src:?}"
                         )));
                     }
@@ -564,10 +551,7 @@ pub fn copy(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), OxenErro
 }
 
 /// Wrapper around the std::fs::rename command to tell us which file failed to copy
-pub fn rename(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), OxenError> {
-    let src = src.as_ref();
-    let dst = dst.as_ref();
-
+pub fn rename(src: &Path, dst: &Path) -> Result<(), OxenError> {
     // Platform-specific behavior
     // This function currently corresponds to the rename function on Unix and the MoveFileEx function with the MOVEFILE_REPLACE_EXISTING flag on Windows.
     if cfg!(windows) {
@@ -616,10 +600,10 @@ pub async fn copy_mkdir(src: &Path, dst: &Path) -> Result<(), OxenError> {
 }
 
 /// Recursively check if a file exists within a directory
-pub fn file_exists_in_directory(directory: impl AsRef<Path>, file: impl AsRef<Path>) -> bool {
-    let mut file = file.as_ref();
+pub fn file_exists_in_directory(directory: &Path, file: &Path) -> bool {
+    let mut file = file;
     while file.parent().is_some() {
-        if directory.as_ref() == file.parent().unwrap() {
+        if directory == file.parent().unwrap() {
             return true;
         }
         file = file.parent().unwrap();
@@ -629,12 +613,11 @@ pub fn file_exists_in_directory(directory: impl AsRef<Path>, file: impl AsRef<Pa
 
 /// Wrapper around the util::fs::create_dir_all command to tell us which file it failed on
 /// creates a directory if they don't exist
-pub fn create_dir_all(src: impl AsRef<Path>) -> Result<(), OxenError> {
-    if src.as_ref().exists() {
+pub fn create_dir_all(src: &Path) -> Result<(), OxenError> {
+    if src.exists() {
         return Ok(());
     }
 
-    let src = src.as_ref();
     match std::fs::create_dir_all(src) {
         Ok(_) => Ok(()),
         Err(err) => {
@@ -646,12 +629,11 @@ pub fn create_dir_all(src: impl AsRef<Path>) -> Result<(), OxenError> {
 
 /// Wrapper around the util::fs::create_dir command to tell us which file it failed on
 /// creates a directory if they don't exist
-pub fn create_dir(src: impl AsRef<Path>) -> Result<(), OxenError> {
-    if src.as_ref().exists() {
+pub fn create_dir(src: &Path) -> Result<(), OxenError> {
+    if src.exists() {
         return Ok(());
     }
 
-    let src = src.as_ref();
     match std::fs::create_dir(src) {
         Ok(_) => Ok(()),
         Err(err) => {
@@ -662,8 +644,7 @@ pub fn create_dir(src: impl AsRef<Path>) -> Result<(), OxenError> {
 }
 
 /// Wrapper around the util::fs::remove_dir_all command to tell us which file it failed on
-pub fn remove_dir_all(src: impl AsRef<Path>) -> Result<(), OxenError> {
-    let src = src.as_ref();
+pub fn remove_dir_all(src: &Path) -> Result<(), OxenError> {
     match std::fs::remove_dir_all(src) {
         Ok(_) => Ok(()),
         Err(err) => {
@@ -674,8 +655,7 @@ pub fn remove_dir_all(src: impl AsRef<Path>) -> Result<(), OxenError> {
 }
 
 /// Wrapper around the std::fs::write command to tell us which file it failed on
-pub fn write(src: impl AsRef<Path>, data: impl AsRef<[u8]>) -> Result<(), OxenError> {
-    let src = src.as_ref();
+pub fn write(src: &Path, data: &[u8]) -> Result<(), OxenError> {
     match std::fs::write(src, data) {
         Ok(_) => Ok(()),
         Err(err) => {
@@ -686,8 +666,7 @@ pub fn write(src: impl AsRef<Path>, data: impl AsRef<[u8]>) -> Result<(), OxenEr
 }
 
 /// Wrapper around the std::fs::remove_file command to tell us which file it failed on
-pub fn remove_file(src: impl AsRef<Path>) -> Result<(), OxenError> {
-    let src = src.as_ref();
+pub fn remove_file(src: &Path) -> Result<(), OxenError> {
     log::debug!("Removing file: {}", src.display());
     match std::fs::remove_file(src) {
         Ok(_) => Ok(()),
@@ -699,8 +678,7 @@ pub fn remove_file(src: impl AsRef<Path>) -> Result<(), OxenError> {
 }
 
 /// Wrapper around util::fs::metadata to give us a better error on failure
-pub fn metadata(path: impl AsRef<Path>) -> Result<std::fs::Metadata, OxenError> {
-    let path = path.as_ref();
+pub fn metadata(path: &Path) -> Result<std::fs::Metadata, OxenError> {
     match std::fs::metadata(path) {
         Ok(file) => Ok(file),
         Err(err) => {
@@ -711,8 +689,7 @@ pub fn metadata(path: impl AsRef<Path>) -> Result<std::fs::Metadata, OxenError> 
 }
 
 /// Wrapper around std::fs::File::create to give us a better error on failure
-pub fn file_create(path: impl AsRef<Path>) -> Result<std::fs::File, OxenError> {
-    let path = path.as_ref();
+pub fn file_create(path: &Path) -> Result<std::fs::File, OxenError> {
     match std::fs::File::create(path) {
         Ok(file) => Ok(file),
         Err(err) => {
@@ -723,9 +700,7 @@ pub fn file_create(path: impl AsRef<Path>) -> Result<std::fs::File, OxenError> {
 }
 
 /// Looks at both the extension and the first bytes of the file to determine if it is tabular
-pub fn is_tabular_from_extension(data_path: impl AsRef<Path>, file_path: impl AsRef<Path>) -> bool {
-    let data_path = data_path.as_ref();
-    let file_path = file_path.as_ref();
+pub fn is_tabular_from_extension(data_path: &Path, file_path: &Path) -> bool {
     if has_ext(file_path, "json")
         && let Ok(c) = read_first_byte_from_file(data_path)
         && "[" == c.to_string()
@@ -737,8 +712,7 @@ pub fn is_tabular_from_extension(data_path: impl AsRef<Path>, file_path: impl As
 }
 
 /// Looks at the extension of the file to determine if it is tabular
-pub fn has_tabular_extension(file_path: impl AsRef<Path>) -> bool {
-    let file_path = file_path.as_ref();
+pub fn has_tabular_extension(file_path: &Path) -> bool {
     let exts: HashSet<String> = vec!["csv", "tsv", "parquet", "arrow", "ndjson", "jsonl"]
         .into_iter()
         .map(String::from)
@@ -1099,8 +1073,7 @@ pub fn p_count_files_in_dir_w_progress(dir: &Path, pb: Option<ProgressBar>) -> u
     count
 }
 
-pub fn count_files_in_dir_with_progress(dir: impl AsRef<Path>) -> usize {
-    let dir = dir.as_ref();
+pub fn count_files_in_dir_with_progress(dir: &Path) -> usize {
     let pb = ProgressBar::new_spinner();
     pb.set_style(
         ProgressStyle::default_spinner()
@@ -1216,8 +1189,7 @@ pub fn is_in_oxen_hidden_dir(path: &Path) -> bool {
     false
 }
 
-pub fn is_canonical(path: impl AsRef<Path>) -> Result<bool, OxenError> {
-    let path = path.as_ref();
+pub fn is_canonical(path: &Path) -> Result<bool, OxenError> {
     let canon_path = canonicalize(path)?;
 
     if path == canon_path {
@@ -1230,39 +1202,29 @@ pub fn is_canonical(path: impl AsRef<Path>) -> Result<bool, OxenError> {
 }
 
 // Return canonicalized path if possible, otherwise return original
-pub fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
-    let path = path.as_ref();
+pub fn canonicalize(path: &Path) -> Result<PathBuf, OxenError> {
     //log::debug!("Path to canonicalize: {path:?}");
     match dunce::canonicalize(path) {
         Ok(canon_path) => Ok(canon_path),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "path {path:?} cannot be canonicalized due to err {err:?}"
         ))),
     }
 }
 
 // Get the full path of a non-canonical parent from a canonical child path
-pub fn full_path_from_child_path(
-    parent: impl AsRef<Path>,
-    child: impl AsRef<Path>,
-) -> Result<PathBuf, OxenError> {
-    let parent_path = parent.as_ref();
-    let child_path = child.as_ref();
-
-    let parent_stem = stem_from_canonical_child_path(parent_path, child_path)?;
-    Ok(parent_stem.join(parent_path))
+pub fn full_path_from_child_path(parent: &Path, child: &Path) -> Result<PathBuf, OxenError> {
+    let parent_stem = stem_from_canonical_child_path(parent, child)?;
+    Ok(parent_stem.join(parent))
 }
 
 // Find the stem that completes the absolute path of the parent from its child
 // This is useful to find the absolute path of a repo when directly canonicalizing its path isn't possible, and we're calling add with an absolute path
 // If the file is under the oxen control of the repo, then this will recover the necessary stem to get the correct canonical path to that repo
 fn stem_from_canonical_child_path(
-    parent_path: impl AsRef<Path>,
-    child_path: impl AsRef<Path>,
+    parent_path: &Path,
+    child_path: &Path,
 ) -> Result<PathBuf, OxenError> {
-    let parent_path = parent_path.as_ref();
-    let child_path = child_path.as_ref();
-
     let child_components: Vec<Component> = child_path.components().collect();
     let parent_components: Vec<Component> = parent_path.components().collect();
 
@@ -1270,7 +1232,7 @@ fn stem_from_canonical_child_path(
     let relative_components: Vec<Component> = relative_path.components().collect();
 
     if child_components.len() < parent_components.len() + relative_components.len() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Invalid path relationship: child path {child_path:?} is not under parent path {parent_path:?}"
         )));
     }
@@ -1281,13 +1243,7 @@ fn stem_from_canonical_child_path(
     Ok(result)
 }
 
-pub fn path_relative_to_dir(
-    path: impl AsRef<Path>,
-    dir: impl AsRef<Path>,
-) -> Result<PathBuf, OxenError> {
-    let path = path.as_ref();
-    let dir = dir.as_ref();
-
+pub fn path_relative_to_dir(path: &Path, dir: &Path) -> Result<PathBuf, OxenError> {
     // log::debug!("path_relative_to_dir starting path: {path:?}");
     // log::debug!("path_relative_to_dir staring dir: {dir:?}");
 
@@ -1393,10 +1349,7 @@ pub fn path_relative_to_dir(
 }
 
 // Check whether a path can be found relative to a dir
-pub fn is_relative_to_dir(path: impl AsRef<Path>, dir: impl AsRef<Path>) -> bool {
-    let path = path.as_ref();
-    let dir = dir.as_ref();
-
+pub fn is_relative_to_dir(path: &Path, dir: &Path) -> bool {
     let path_components: Vec<Component> = path.components().collect();
     let dir_components: Vec<Component> = dir.components().collect();
 
@@ -1538,13 +1491,12 @@ pub fn is_any_parent_in_set(file_path: &Path, path_set: &HashSet<PathBuf>) -> bo
     false
 }
 
-pub fn open_file(path: impl AsRef<Path>) -> Result<File, OxenError> {
-    match File::open(path.as_ref()) {
+pub fn open_file(path: &Path) -> Result<File, OxenError> {
+    match File::open(path) {
         Ok(file) => Ok(file),
-        Err(err) => Err(OxenError::basic_str(format!(
+        Err(err) => Err(OxenError::basic_str(&format!(
             "Failed to open file: {:?}\n{:?}",
-            path.as_ref(),
-            err
+            path, err
         ))),
     }
 }
@@ -1559,7 +1511,7 @@ async fn detect_image_format_from_version(
     while header.len() < 16 {
         if let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| {
-                OxenError::basic_str(format!("Failed to read version file {hash}: {e}"))
+                OxenError::basic_str(&format!("Failed to read version file {hash}: {e}"))
             })?;
             let to_take = 16 - header.len();
             header.extend_from_slice(&chunk[..to_take.min(chunk.len())]);
@@ -1569,13 +1521,13 @@ async fn detect_image_format_from_version(
     }
 
     if header.is_empty() {
-        return Err(OxenError::basic_str(format!(
+        return Err(OxenError::basic_str(&format!(
             "Version file {hash} is empty"
         )));
     }
 
     let format = image::guess_format(&header)
-        .map_err(|_| OxenError::basic_str(format!("Unknown image format for version: {hash}")))?;
+        .map_err(|_| OxenError::basic_str(&format!("Unknown image format for version: {hash}")))?;
 
     Ok(format)
 }
@@ -1705,12 +1657,12 @@ async fn generate_video_thumbnail_version_store(
         // Generate thumbnail from video file
         let thumb_image = thumbnailer
             .get(&version_path)
-            .map_err(|e| OxenError::basic_str(format!("Failed to generate thumbnail: {e}.")))?;
+            .map_err(|e| OxenError::basic_str(&format!("Failed to generate thumbnail: {e}.")))?;
 
         let mut buf = Vec::new();
         thumb_image
             .write_to(&mut Cursor::new(&mut buf), image::ImageFormat::Jpeg)
-            .map_err(|e| OxenError::basic_str(format!("Failed to encode thumbnail: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("Failed to encode thumbnail: {e}")))?;
         Ok(buf)
     })
     .await??;
@@ -1766,18 +1718,15 @@ pub async fn handle_video_thumbnail(
     }
 }
 
-pub fn to_unix_str(path: impl AsRef<Path>) -> String {
-    path.as_ref()
-        .to_str()
-        .unwrap_or_default()
-        .replace('\\', "/")
+pub fn to_unix_str(path: &Path) -> String {
+    path.to_str().unwrap_or_default().replace('\\', "/")
 }
 
-pub fn is_glob_path(path: impl AsRef<Path>) -> bool {
+pub fn is_glob_path(path: &Path) -> bool {
     let glob_chars = ['*', '?', '[', ']'];
     glob_chars
         .iter()
-        .any(|c| path.as_ref().to_str().unwrap_or_default().contains(*c))
+        .any(|c| path.to_str().unwrap_or_default().contains(*c))
 }
 
 pub fn remove_paths(src: &Path) -> Result<(), OxenError> {
@@ -1902,9 +1851,7 @@ pub fn last_modified_time(last_modified_seconds: i64, last_modified_nanoseconds:
 /// - Cannot contain parent directory references (..)
 /// - Cannot contain empty segments
 /// - Current directory references (.) are skipped
-pub fn validate_and_normalize_path(path: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
-    let path = path.as_ref();
-
+pub fn validate_and_normalize_path(path: &Path) -> Result<PathBuf, OxenError> {
     let mut normalized = PathBuf::new();
     for component in path.components() {
         match component {
@@ -1957,7 +1904,7 @@ mod tests {
             .join("file.txt");
         let dir = Path::new("data").join("test");
 
-        let relative = util::fs::path_relative_to_dir(file, dir)?;
+        let relative = util::fs::path_relative_to_dir(&file, &dir)?;
         assert_eq!(relative, Path::new("other").join("file.txt"));
 
         Ok(())
@@ -1971,7 +1918,7 @@ mod tests {
             .join("file.txt");
         let dir = Path::new("data").join("test").join("other");
 
-        let relative = util::fs::path_relative_to_dir(file, dir)?;
+        let relative = util::fs::path_relative_to_dir(&file, &dir)?;
         assert_eq!(relative, Path::new("file.txt"));
 
         Ok(())
@@ -1986,7 +1933,7 @@ mod tests {
             .join("file.txt");
         let dir = Path::new("data").join("test").join("runs").join("54321");
 
-        let relative = util::fs::path_relative_to_dir(file, dir)?;
+        let relative = util::fs::path_relative_to_dir(&file, &dir)?;
         assert_eq!(relative, Path::new("file.txt"));
 
         Ok(())
@@ -2000,7 +1947,7 @@ mod tests {
             .join("file.txt");
         let dir = Path::new("data").join("test").join("other");
 
-        let relative = util::fs::path_relative_to_dir(file, dir)?;
+        let relative = util::fs::path_relative_to_dir(&file, &dir)?;
         assert_eq!(relative, Path::new("file.txt"));
 
         Ok(())
@@ -2011,7 +1958,7 @@ mod tests {
         let file = Path::new("data").join("test").join("other");
         let dir = Path::new("data").join("test");
 
-        let relative = util::fs::path_relative_to_dir(file, dir)?;
+        let relative = util::fs::path_relative_to_dir(&file, &dir)?;
         assert_eq!(relative, Path::new("other"));
 
         Ok(())
@@ -2022,7 +1969,7 @@ mod tests {
         let file = Path::new("data").join("test").join("other").join("dir");
         let dir = Path::new("data").join("test");
 
-        let relative = util::fs::path_relative_to_dir(file, dir)?;
+        let relative = util::fs::path_relative_to_dir(&file, &dir)?;
         assert_eq!(relative, Path::new("other").join("dir"));
 
         Ok(())
@@ -2033,7 +1980,7 @@ mod tests {
         let file = Path::new("data").join("test").join("other").join("dir");
         let dir = Path::new("some").join("repo");
 
-        let relative = util::fs::path_relative_to_dir(file, dir)?;
+        let relative = util::fs::path_relative_to_dir(&file, &dir)?;
         assert_eq!(
             relative,
             Path::new("data").join("test").join("other").join("dir")
@@ -2049,7 +1996,7 @@ mod tests {
             let python_with_interpreter_file = "add_2.py";
 
             test::write_txt_file_to_path(
-                repo.path.join(python_file),
+                &repo.path.join(python_file),
                 r"import os
 
 
@@ -2058,7 +2005,7 @@ def add(a, b):
             )?;
 
             test::write_txt_file_to_path(
-                repo.path.join(python_with_interpreter_file),
+                &repo.path.join(python_with_interpreter_file),
                 r"#!/usr/bin/env python3
 import os
 
@@ -2101,7 +2048,7 @@ def add(a, b):
             let test_id_file = repo.path.join("test_id.txt");
             let test_id_file_no_ext = repo.path.join("test_id");
             util::fs::copy(
-                test::REPO_ROOT
+                &test::REPO_ROOT
                     .join("data")
                     .join("test")
                     .join("text")
@@ -2109,7 +2056,7 @@ def add(a, b):
                 &test_id_file,
             )?;
             util::fs::copy(
-                test::REPO_ROOT
+                &test::REPO_ROOT
                     .join("data")
                     .join("test")
                     .join("text")

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -188,11 +188,11 @@ pub fn write_to_path(path: &Path, value: &str) -> Result<(), OxenError> {
     match File::create(path) {
         Ok(mut file) => match file.write(value.as_bytes()) {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "Could not write file {path:?}\n{err}"
             ))),
         },
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "Could not create file to write {path:?}\n{err}"
         ))),
     }
@@ -202,11 +202,11 @@ pub fn write_data(path: &Path, data: &[u8]) -> Result<(), OxenError> {
     match File::create(path) {
         Ok(mut file) => match file.write(data) {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "Could not write file {path:?}\n{err}"
             ))),
         },
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "Could not create file to write {path:?}\n{err}"
         ))),
     }
@@ -216,11 +216,11 @@ pub fn append_to_file(path: &Path, value: &str) -> Result<(), OxenError> {
     match OpenOptions::new().append(true).open(path) {
         Ok(mut file) => match file.write(value.as_bytes()) {
             Ok(_) => Ok(()),
-            Err(err) => Err(OxenError::basic_str(&format!(
+            Err(err) => Err(OxenError::basic_str(format!(
                 "Could not append to file {path:?}\n{err}"
             ))),
         },
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "Could not open file to append {path:?}\n{err}"
         ))),
     }
@@ -298,7 +298,7 @@ pub fn read_first_line_from_file(file: &File) -> Result<String, OxenError> {
     if let Some(Ok(line)) = reader.lines().next() {
         Ok(line)
     } else {
-        Err(OxenError::basic_str(&format!(
+        Err(OxenError::basic_str(format!(
             "Could not read line from file: {file:?}"
         )))
     }
@@ -529,7 +529,7 @@ pub fn copy(src: &Path, dst: &Path) -> Result<(), OxenError> {
                 if err.raw_os_error() == Some(32) {
                     attempt += 1;
                     if attempt == max_retries {
-                        return Err(OxenError::basic_str(&format!(
+                        return Err(OxenError::basic_str(format!(
                             "File is in use by another process after {max_retries} attempts: {src:?}"
                         )));
                     }
@@ -1206,7 +1206,7 @@ pub fn canonicalize(path: &Path) -> Result<PathBuf, OxenError> {
     //log::debug!("Path to canonicalize: {path:?}");
     match dunce::canonicalize(path) {
         Ok(canon_path) => Ok(canon_path),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "path {path:?} cannot be canonicalized due to err {err:?}"
         ))),
     }
@@ -1232,7 +1232,7 @@ fn stem_from_canonical_child_path(
     let relative_components: Vec<Component> = relative_path.components().collect();
 
     if child_components.len() < parent_components.len() + relative_components.len() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Invalid path relationship: child path {child_path:?} is not under parent path {parent_path:?}"
         )));
     }
@@ -1443,7 +1443,7 @@ pub fn disk_usage_for_path(path: &Path) -> Result<DiskUsage, OxenError> {
     let disks = sysinfo::Disks::new_with_refreshed_list();
 
     if disks.is_empty() {
-        return Err(OxenError::basic_str("No disks found"));
+        return Err(OxenError::basic_str("No disks found".to_string()));
     }
 
     // try to choose the disk that the path is on
@@ -1494,7 +1494,7 @@ pub fn is_any_parent_in_set(file_path: &Path, path_set: &HashSet<PathBuf>) -> bo
 pub fn open_file(path: &Path) -> Result<File, OxenError> {
     match File::open(path) {
         Ok(file) => Ok(file),
-        Err(err) => Err(OxenError::basic_str(&format!(
+        Err(err) => Err(OxenError::basic_str(format!(
             "Failed to open file: {:?}\n{:?}",
             path, err
         ))),
@@ -1511,7 +1511,7 @@ async fn detect_image_format_from_version(
     while header.len() < 16 {
         if let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| {
-                OxenError::basic_str(&format!("Failed to read version file {hash}: {e}"))
+                OxenError::basic_str(format!("Failed to read version file {hash}: {e}"))
             })?;
             let to_take = 16 - header.len();
             header.extend_from_slice(&chunk[..to_take.min(chunk.len())]);
@@ -1521,13 +1521,13 @@ async fn detect_image_format_from_version(
     }
 
     if header.is_empty() {
-        return Err(OxenError::basic_str(&format!(
+        return Err(OxenError::basic_str(format!(
             "Version file {hash} is empty"
         )));
     }
 
     let format = image::guess_format(&header)
-        .map_err(|_| OxenError::basic_str(&format!("Unknown image format for version: {hash}")))?;
+        .map_err(|_| OxenError::basic_str(format!("Unknown image format for version: {hash}")))?;
 
     Ok(format)
 }
@@ -1657,12 +1657,12 @@ async fn generate_video_thumbnail_version_store(
         // Generate thumbnail from video file
         let thumb_image = thumbnailer
             .get(&version_path)
-            .map_err(|e| OxenError::basic_str(&format!("Failed to generate thumbnail: {e}.")))?;
+            .map_err(|e| OxenError::basic_str(format!("Failed to generate thumbnail: {e}.")))?;
 
         let mut buf = Vec::new();
         thumb_image
             .write_to(&mut Cursor::new(&mut buf), image::ImageFormat::Jpeg)
-            .map_err(|e| OxenError::basic_str(&format!("Failed to encode thumbnail: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("Failed to encode thumbnail: {e}")))?;
         Ok(buf)
     })
     .await??;
@@ -1859,17 +1859,21 @@ pub fn validate_and_normalize_path(path: &Path) -> Result<PathBuf, OxenError> {
                 let segment_str = segment.to_string_lossy();
                 // Reject empty segments (e.g., from "foo//bar")
                 if segment_str.is_empty() {
-                    return Err(OxenError::basic_str("path contains empty segments"));
+                    return Err(OxenError::basic_str(
+                        "path contains empty segments".to_string(),
+                    ));
                 }
                 normalized.push(segment);
             }
             Component::ParentDir => {
                 return Err(OxenError::basic_str(
-                    "path cannot contain parent directory references (..)",
+                    "path cannot contain parent directory references (..)".to_string(),
                 ));
             }
             Component::RootDir | Component::Prefix(_) => {
-                return Err(OxenError::basic_str("path must be relative, not absolute"));
+                return Err(OxenError::basic_str(
+                    "path must be relative, not absolute".to_string(),
+                ));
             }
             Component::CurDir => {
                 // Skip "." components (current directory)
@@ -1880,7 +1884,7 @@ pub fn validate_and_normalize_path(path: &Path) -> Result<PathBuf, OxenError> {
     // Ensure we have a valid path after normalization
     if normalized.as_os_str().is_empty() {
         return Err(OxenError::basic_str(
-            "path resolves to empty after normalization",
+            "path resolves to empty after normalization".to_string(),
         ));
     }
 

--- a/crates/lib/src/util/glob.rs
+++ b/crates/lib/src/util/glob.rs
@@ -69,7 +69,7 @@ pub fn parse_glob_paths(
                 // If staged flag set, only match against the staged db
                 let Some(repo) = repo else {
                     return Err(OxenError::basic_str(
-                        "Cannot parse staged_db for paths without a repo",
+                        "Cannot parse staged_db for paths without a repo".to_string(),
                     ));
                 };
 
@@ -82,7 +82,8 @@ pub fn parse_glob_paths(
                     search_merkle_tree(&mut expanded_paths, repo, &glob_path)?;
                 } else {
                     return Err(OxenError::basic_str(
-                        "Error: Cannot parse paths from merkle tree without local repository",
+                        "Error: Cannot parse paths from merkle tree without local repository"
+                            .to_string(),
                     ));
                 }
             }
@@ -132,7 +133,7 @@ fn search_staged_db(path: &Path, repo: &LocalRepository) -> Result<HashSet<PathB
     let mut paths = HashSet::new();
     let path_str = path
         .to_str()
-        .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in search path"))?;
+        .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in search path".to_string()))?;
     let glob_pattern = Pattern::new(path_str)?;
     let staged_data = repositories::status::status(repo)?;
 
@@ -140,7 +141,7 @@ fn search_staged_db(path: &Path, repo: &LocalRepository) -> Result<HashSet<PathB
         let entry_path_str = entry
             .0
             .to_str()
-            .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in entry path"))?;
+            .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in entry path".to_string()))?;
         if glob_pattern.matches(entry_path_str) {
             let entry_path = entry.0.to_owned();
             paths.insert(entry_path);
@@ -271,7 +272,7 @@ fn expand_glob_pattern(
                     }
                 }
                 _ => {
-                    return Err(OxenError::basic_str("Unexpected node type"));
+                    return Err(OxenError::basic_str("Unexpected node type".to_string()));
                 }
             }
         }
@@ -289,7 +290,7 @@ fn search_working_dir(
     let full_path = repo_path.join(glob_path);
     let path_str = full_path
         .to_str()
-        .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in search path"))?;
+        .ok_or_else(|| OxenError::basic_str("Invalid UTF-8 in search path".to_string()))?;
 
     if let Some(oxenignore) = oxenignore {
         let oxenignore = Some(oxenignore);

--- a/crates/lib/src/util/glob.rs
+++ b/crates/lib/src/util/glob.rs
@@ -316,7 +316,7 @@ fn search_working_dir(
 // Walk through dirs,
 fn walk_working_dir(
     paths: &mut HashSet<PathBuf>,
-    repo_path: &PathBuf,
+    repo_path: &Path,
     glob_path: &PathBuf,
     oxenignore: Option<Gitignore>,
 ) -> Result<(), OxenError> {
@@ -410,7 +410,7 @@ pub fn collect_removed_paths(
 
 pub fn r_collect_removed_paths(
     repo: &LocalRepository,
-    dir_path: &PathBuf,
+    dir_path: &Path,
     removed_paths: &mut HashSet<PathBuf>,
 ) -> Result<(), OxenError> {
     let repo_path = repo.path.clone();
@@ -442,6 +442,7 @@ mod tests {
     use crate::{repositories, test};
 
     use std::collections::HashSet;
+    use std::path::Path;
     use std::path::PathBuf;
 
     #[tokio::test]
@@ -563,9 +564,9 @@ mod tests {
     async fn test_glob_parse_staged_db() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|repo| async move {
             // Stage some specific files and a directory
-            repositories::add(&repo, "train/dog_1.jpg").await?;
-            repositories::add(&repo, "annotations/train/*").await?;
-            repositories::add(&repo, "README.md").await?;
+            repositories::add(&repo, Path::new("train/dog_1.jpg")).await?;
+            repositories::add(&repo, Path::new("annotations/train/*")).await?;
+            repositories::add(&repo, Path::new("README.md")).await?;
 
             // Test glob in sub-directory
             let opts = GlobOpts {

--- a/crates/lib/src/util/hasher.rs
+++ b/crates/lib/src/util/hasher.rs
@@ -170,14 +170,16 @@ fn hash_small_file_contents(path: &Path) -> Result<u128, OxenError> {
                 }
                 Err(_) => {
                     eprintln!("Could not read file for hashing {path:?}");
-                    Err(OxenError::basic_str("Could not read file for hashing"))
+                    Err(OxenError::basic_str(
+                        "Could not read file for hashing".to_string(),
+                    ))
                 }
             }
         }
         Err(err) => {
             let err =
                 format!("util::hasher::hash_file_contents Could not open file {path:?} {err:?}");
-            Err(OxenError::basic_str(&err))
+            Err(OxenError::basic_str(err))
         }
     }
 }
@@ -185,7 +187,7 @@ fn hash_small_file_contents(path: &Path) -> Result<u128, OxenError> {
 fn hash_large_file_contents(path: &Path) -> Result<u128, OxenError> {
     let file = File::open(path).map_err(|err| {
         eprintln!("Could not open file {path:?} due to {err:?}");
-        OxenError::basic_str(&format!("Could not open file {path:?} due to {err:?}"))
+        OxenError::basic_str(format!("Could not open file {path:?} due to {err:?}"))
     })?;
 
     let mut reader = BufReader::new(file);
@@ -195,7 +197,7 @@ fn hash_large_file_contents(path: &Path) -> Result<u128, OxenError> {
     loop {
         let count = reader.read(&mut buffer).map_err(|_| {
             eprintln!("Could not read file for hashing {path:?}");
-            OxenError::basic_str("Could not read file for hashing")
+            OxenError::basic_str("Could not read file for hashing".to_string())
         })?;
 
         if count == 0 {

--- a/crates/lib/src/util/hasher.rs
+++ b/crates/lib/src/util/hasher.rs
@@ -14,14 +14,14 @@ pub fn hash_buffer(buffer: &[u8]) -> String {
     format!("{val:x}")
 }
 
-pub fn hash_str<S: AsRef<str>>(buffer: S) -> String {
-    let buffer = buffer.as_ref().as_bytes();
+pub fn hash_str(buffer: &str) -> String {
+    let buffer = buffer.as_bytes();
     hash_buffer(buffer)
 }
 
-pub fn hash_str_sha256<S: AsRef<str>>(str: S) -> String {
+pub fn hash_str_sha256(str: &str) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(str.as_ref().as_bytes());
+    hasher.update(str.as_bytes());
     let result = hasher.finalize();
     format!("{result:x}")
 }
@@ -177,7 +177,7 @@ fn hash_small_file_contents(path: &Path) -> Result<u128, OxenError> {
         Err(err) => {
             let err =
                 format!("util::hasher::hash_file_contents Could not open file {path:?} {err:?}");
-            Err(OxenError::basic_str(err))
+            Err(OxenError::basic_str(&err))
         }
     }
 }
@@ -185,7 +185,7 @@ fn hash_small_file_contents(path: &Path) -> Result<u128, OxenError> {
 fn hash_large_file_contents(path: &Path) -> Result<u128, OxenError> {
     let file = File::open(path).map_err(|err| {
         eprintln!("Could not open file {path:?} due to {err:?}");
-        OxenError::basic_str(format!("Could not open file {path:?} due to {err:?}"))
+        OxenError::basic_str(&format!("Could not open file {path:?} due to {err:?}"))
     })?;
 
     let mut reader = BufReader::new(file);
@@ -208,6 +208,6 @@ fn hash_large_file_contents(path: &Path) -> Result<u128, OxenError> {
     Ok(hasher.digest128())
 }
 
-pub fn hash_path_name(path: impl AsRef<Path>) -> String {
-    hash_str(path.as_ref().to_str().unwrap())
+pub fn hash_path_name(path: &Path) -> String {
+    hash_str(path.to_str().unwrap())
 }

--- a/crates/lib/src/util/image.rs
+++ b/crates/lib/src/util/image.rs
@@ -2,15 +2,11 @@ use crate::error::OxenError;
 use image::imageops;
 use std::path::Path;
 
-pub fn resize_and_save(
-    src: impl AsRef<Path>,
-    dst: impl AsRef<Path>,
-    dims: u32,
-) -> Result<(), OxenError> {
-    let src_path = src.as_ref();
+pub fn resize_and_save(src: &Path, dst: &Path, dims: u32) -> Result<(), OxenError> {
+    let src_path = src;
     let img = match image::open(src_path) {
         Ok(img) => img,
-        Err(e) => return Err(OxenError::basic_str(e.to_string())),
+        Err(e) => return Err(OxenError::basic_str(&e.to_string())),
     };
 
     // If the path ends in .jpg or .jpeg, convert to RGB

--- a/crates/lib/src/util/image.rs
+++ b/crates/lib/src/util/image.rs
@@ -6,7 +6,7 @@ pub fn resize_and_save(src: &Path, dst: &Path, dims: u32) -> Result<(), OxenErro
     let src_path = src;
     let img = match image::open(src_path) {
         Ok(img) => img,
-        Err(e) => return Err(OxenError::basic_str(&e.to_string())),
+        Err(e) => return Err(OxenError::basic_str(e.to_string())),
     };
 
     // If the path ends in .jpg or .jpeg, convert to RGB

--- a/crates/lib/src/util/oxen_version.rs
+++ b/crates/lib/src/util/oxen_version.rs
@@ -13,7 +13,9 @@ impl FromStr for OxenVersion {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts: Vec<&str> = s.split(['.', '-']).collect();
         if parts.len() < 3 || parts.len() > 4 {
-            return Err(OxenError::basic_str(format!("Invalid version string: {s}")));
+            return Err(OxenError::basic_str(&format!(
+                "Invalid version string: {s}"
+            )));
         }
         let major = parts[0].parse::<u32>()?;
         let minor = parts[1].parse::<u32>()?;

--- a/crates/lib/src/util/oxen_version.rs
+++ b/crates/lib/src/util/oxen_version.rs
@@ -13,9 +13,7 @@ impl FromStr for OxenVersion {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts: Vec<&str> = s.split(['.', '-']).collect();
         if parts.len() < 3 || parts.len() > 4 {
-            return Err(OxenError::basic_str(&format!(
-                "Invalid version string: {s}"
-            )));
+            return Err(OxenError::basic_str(format!("Invalid version string: {s}")));
         }
         let major = parts[0].parse::<u32>()?;
         let minor = parts[1].parse::<u32>()?;

--- a/crates/lib/src/util/progress_bar.rs
+++ b/crates/lib/src/util/progress_bar.rs
@@ -9,9 +9,9 @@ pub enum ProgressBarType {
     None,
 }
 
-pub fn spinner_with_msg(msg: impl AsRef<str>) -> ProgressBar {
+pub fn spinner_with_msg(msg: &str) -> ProgressBar {
     let spinner = ProgressBar::new_spinner();
-    spinner.set_message(msg.as_ref().to_owned());
+    spinner.set_message(msg.to_owned());
     spinner.set_style(ProgressStyle::default_spinner());
     spinner.enable_steady_tick(Duration::from_millis(100));
     spinner
@@ -42,9 +42,9 @@ pub fn oxen_progress_bar_indeterminate(
     bar
 }
 
-pub fn oxen_progress_bar_with_msg(size: u64, msg: impl AsRef<str>) -> Arc<ProgressBar> {
+pub fn oxen_progress_bar_with_msg(size: u64, msg: &str) -> Arc<ProgressBar> {
     let bar = Arc::new(ProgressBar::new(size));
-    bar.set_message(msg.as_ref().to_owned());
+    bar.set_message(msg.to_owned());
     bar.set_style(
         ProgressStyle::default_bar()
             .template(progress_type_to_template(ProgressBarType::Counter).as_str())

--- a/crates/lib/src/view/compare.rs
+++ b/crates/lib/src/view/compare.rs
@@ -270,7 +270,7 @@ impl TabularCompareTargetBody {
             .clone()
             .or_else(|| self.right.clone())
             .ok_or(OxenError::basic_str(
-                "Both 'left' and 'right' fields are None",
+                "Both 'left' and 'right' fields are None".to_string(),
             ))
     }
 }

--- a/crates/lib/src/view/sql_parse_error.rs
+++ b/crates/lib/src/view/sql_parse_error.rs
@@ -12,7 +12,7 @@ pub struct SQLParseError {
 impl SQLParseError {
     pub fn new(sql: String) -> Self {
         Self {
-            status: StatusMessage::error(format!("Error running SQL query '{sql}'")),
+            status: StatusMessage::error(&format!("Error running SQL query '{sql}'")),
             sql,
         }
     }

--- a/crates/lib/src/view/status_message.rs
+++ b/crates/lib/src/view/status_message.rs
@@ -20,26 +20,25 @@ pub struct StatusMessageDescription {
 }
 
 impl StatusMessageDescription {
-    pub fn not_found(description: impl AsRef<str>) -> StatusMessageDescription {
+    pub fn not_found(description: &str) -> StatusMessageDescription {
         StatusMessageDescription {
             status: String::from(view::http::STATUS_ERROR),
             status_message: String::from(view::http::MSG_RESOURCE_NOT_FOUND),
             oxen_version: Some(OXEN_VERSION.to_string()),
-            status_description: String::from(description.as_ref()),
+            status_description: String::from(description),
         }
     }
 
-    pub fn workspace_not_found(workspace_id: impl AsRef<str>) -> StatusMessageDescription {
-        let workspace_id = workspace_id.as_ref();
-        StatusMessageDescription::not_found(format!("Workspace not found: {workspace_id}"))
+    pub fn workspace_not_found(workspace_id: &str) -> StatusMessageDescription {
+        StatusMessageDescription::not_found(&format!("Workspace not found: {workspace_id}"))
     }
 
-    pub fn bad_request(description: impl AsRef<str>) -> StatusMessageDescription {
+    pub fn bad_request(description: &str) -> StatusMessageDescription {
         StatusMessageDescription {
             status: String::from(view::http::STATUS_ERROR),
             status_message: String::from(view::http::MSG_BAD_REQUEST),
             oxen_version: Some(OXEN_VERSION.to_string()),
-            status_description: String::from(description.as_ref()),
+            status_description: String::from(description),
         }
     }
 }
@@ -53,10 +52,10 @@ impl StatusMessage {
         }
     }
 
-    pub fn error(msg: impl AsRef<str>) -> StatusMessage {
+    pub fn error(msg: &str) -> StatusMessage {
         StatusMessage {
             status: String::from(view::http::STATUS_ERROR),
-            status_message: String::from(msg.as_ref()),
+            status_message: String::from(msg),
             oxen_version: Some(OXEN_VERSION.to_string()),
         }
     }

--- a/crates/oxen-py/src/auth.rs
+++ b/crates/oxen-py/src/auth.rs
@@ -20,7 +20,7 @@ pub fn config_auth(host: String, token: String, path: String) -> Result<(), PyOx
     }
 
     let mut config = AuthConfig::get_or_create()?;
-    config.add_host_auth_token(host, token);
+    config.add_host_auth_token(&host, &token);
     config.save(final_path)?;
     Ok(())
 }

--- a/crates/oxen-py/src/df_utils.rs
+++ b/crates/oxen-py/src/df_utils.rs
@@ -9,13 +9,13 @@ use pyo3_polars::PyDataFrame;
 pub fn load(path: PathBuf) -> Result<PyDataFrame, PyOxenError> {
     let opts = DFOpts::empty();
     let df = pyo3_async_runtimes::tokio::get_runtime()
-        .block_on(async { tabular::read_df(path, opts).await })?;
+        .block_on(async { tabular::read_df(&path, opts).await })?;
     Ok(PyDataFrame(df))
 }
 
 #[pyfunction]
 pub fn save(df: PyDataFrame, path: PathBuf) -> Result<(), PyOxenError> {
     let mut df = df.as_ref().clone();
-    tabular::write_df(&mut df, path)?;
+    tabular::write_df(&mut df, &path)?;
     Ok(())
 }

--- a/crates/oxen-py/src/py_dataset.rs
+++ b/crates/oxen-py/src/py_dataset.rs
@@ -19,7 +19,7 @@ impl PyDataset {
     fn df(path: PathBuf) -> Result<PyDataFrame, PyOxenError> {
         let opts = DFOpts::empty();
         let df = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { liboxen::core::df::tabular::read_df(path, opts).await })?;
+            .block_on(async { liboxen::core::df::tabular::read_df(&path, opts).await })?;
         Ok(PyDataFrame(df))
     }
 }

--- a/crates/oxen-py/src/py_diff.rs
+++ b/crates/oxen-py/src/py_diff.rs
@@ -34,7 +34,7 @@ impl PyDiff {
         //TODO: This should be more correct instead of picking the first
         match &self.diff.first() {
             Some(DiffResult::Tabular(diff)) => Ok(PyTabularDiff::from(diff)),
-            _ => Err(OxenError::basic_str("Diff is not tabular").into()),
+            _ => Err(OxenError::basic_str("Diff is not tabular".to_string()).into()),
         }
     }
 
@@ -43,7 +43,7 @@ impl PyDiff {
         //TODO: This should be more correct instead of picking the first
         match &self.diff.first() {
             Some(DiffResult::Text(diff)) => Ok(PyTextDiff::from(diff)),
-            _ => Err(OxenError::basic_str("Diff is not text").into()),
+            _ => Err(OxenError::basic_str("Diff is not text".to_string()).into()),
         }
     }
 }
@@ -73,7 +73,7 @@ impl PyDiffEntry {
     fn text(&self) -> Result<PyTextDiff, PyOxenError> {
         match &self._diff.diff {
             Some(GenericDiff::TextDiff(diff)) => Ok(PyTextDiff::from(diff)),
-            _ => Err(OxenError::basic_str("Diff is not text").into()),
+            _ => Err(OxenError::basic_str("Diff is not text".to_string()).into()),
         }
     }
 }

--- a/crates/oxen-py/src/py_remote_data_frame.rs
+++ b/crates/oxen-py/src/py_remote_data_frame.rs
@@ -63,7 +63,7 @@ impl PyRemoteDataFrame {
             // convert view to json string
             match serde_json::to_string(&response.data_frame.view.data) {
                 Ok(json) => Ok(json),
-                Err(e) => Err(OxenError::basic_str(&format!(
+                Err(e) => Err(OxenError::basic_str(format!(
                     "Could not convert view to json: {e}",
                 ))),
             }
@@ -97,7 +97,7 @@ impl PyRemoteDataFrame {
             // convert view to json string
             match serde_json::to_string(&response.data_frame.view.data) {
                 Ok(json) => Ok(json),
-                Err(e) => Err(OxenError::basic_str(&format!(
+                Err(e) => Err(OxenError::basic_str(format!(
                     "Could not convert view to json: {e}",
                 ))),
             }

--- a/crates/oxen-py/src/py_remote_data_frame.rs
+++ b/crates/oxen-py/src/py_remote_data_frame.rs
@@ -63,7 +63,7 @@ impl PyRemoteDataFrame {
             // convert view to json string
             match serde_json::to_string(&response.data_frame.view.data) {
                 Ok(json) => Ok(json),
-                Err(e) => Err(OxenError::basic_str(format!(
+                Err(e) => Err(OxenError::basic_str(&format!(
                     "Could not convert view to json: {e}",
                 ))),
             }
@@ -97,7 +97,7 @@ impl PyRemoteDataFrame {
             // convert view to json string
             match serde_json::to_string(&response.data_frame.view.data) {
                 Ok(json) => Ok(json),
-                Err(e) => Err(OxenError::basic_str(format!(
+                Err(e) => Err(OxenError::basic_str(&format!(
                     "Could not convert view to json: {e}",
                 ))),
             }

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -51,7 +51,7 @@ impl PyRemoteRepo {
         let (namespace, repo_name) = match repo.split_once('/') {
             Some((namespace, repo_name)) => (namespace.to_string(), repo_name.to_string()),
             None => {
-                return Err(OxenError::basic_str(&format!(
+                return Err(OxenError::basic_str(format!(
                     "Invalid repo name, must be in format namespace/repo_name. Got {repo}"
                 ))
                 .into());
@@ -144,7 +144,8 @@ impl PyRemoteRepo {
             // parse storage backend options
             if storage_backend.is_none() && (storage_backend_path.is_some() || storage_backend_bucket.is_some()) {
                 return Err(OxenError::basic_str(
-                    "storage_backend must be specified when storage_backend_path or storage_backend_bucket is provided"
+                    "storage_backend must be specified when storage_backend_path or storage_backend_bucket is provided".to_string()
+
                 ));
             }
 
@@ -219,7 +220,7 @@ impl PyRemoteRepo {
                 repositories::download(&self.repo, &remote_path, &local_path, revision).await
             } else {
                 Err(OxenError::basic_str(
-                    "Invalid Revision: Cannot download without a version.",
+                    "Invalid Revision: Cannot download without a version.".to_string(),
                 ))
             }
         })?;
@@ -252,7 +253,7 @@ impl PyRemoteRepo {
                 .await
             } else {
                 Err(OxenError::basic_str(
-                    "Invalid Revision: Cannot download zip file without a revision.",
+                    "Invalid Revision: Cannot download zip file without a revision.".to_string(),
                 ))
             }
         })?;

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -11,7 +11,7 @@ use liboxen::opts::StorageOpts;
 use liboxen::{api, repositories};
 
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::PyOxenError;
 use crate::py_branch::PyBranch;
@@ -51,7 +51,7 @@ impl PyRemoteRepo {
         let (namespace, repo_name) = match repo.split_once('/') {
             Some((namespace, repo_name)) => (namespace.to_string(), repo_name.to_string()),
             None => {
-                return Err(OxenError::basic_str(format!(
+                return Err(OxenError::basic_str(&format!(
                     "Invalid repo name, must be in format namespace/repo_name. Got {repo}"
                 ))
                 .into());
@@ -156,9 +156,9 @@ impl PyRemoteRepo {
 
             if empty {
                 let mut repo = RepoNew::from_namespace_name_host(
-                    self.repo.namespace.clone(),
-                    self.repo.name.clone(),
-                    self.host.clone(),
+                    &self.repo.namespace,
+                    &self.repo.name,
+                    &self.host,
                     storage_opts,
                 );
                 repo.is_public = Some(is_public);
@@ -216,7 +216,7 @@ impl PyRemoteRepo {
             if !revision.is_empty() {
                 repositories::download(&self.repo, &remote_path, &local_path, revision).await
             } else if let Some(revision) = &self.revision {
-                repositories::download(&self.repo, &remote_path, &local_path, &revision).await
+                repositories::download(&self.repo, &remote_path, &local_path, revision).await
             } else {
                 Err(OxenError::basic_str(
                     "Invalid Revision: Cannot download without a version.",
@@ -263,7 +263,7 @@ impl PyRemoteRepo {
 
     fn get_file(&self, remote_path: PathBuf, revision: &str) -> Result<Cow<'_, [u8]>, PyOxenError> {
         let bytes = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::file::get_file(&self.repo, &revision, &remote_path).await
+            api::client::file::get_file(&self.repo, revision, &remote_path).await
         })?;
 
         Ok(bytes.to_vec().into())
@@ -286,8 +286,8 @@ impl PyRemoteRepo {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::file::put_file(
                 &self.repo,
-                &branch,
-                &directory,
+                branch,
+                directory,
                 &local_path,
                 Some(file_name),
                 Some(commit_body),
@@ -312,7 +312,7 @@ impl PyRemoteRepo {
         });
 
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::file::delete_file(&self.repo, &branch, &file_path, commit_body).await
+            api::client::file::delete_file(&self.repo, branch, &file_path, commit_body).await
         })?;
 
         Ok(())
@@ -333,8 +333,13 @@ impl PyRemoteRepo {
 
         let paginated_commits = if let Some(path) = path {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-                api::client::commits::list_commits_for_path(&self.repo, revision, path, &page_opts)
-                    .await
+                api::client::commits::list_commits_for_path(
+                    &self.repo,
+                    revision,
+                    Path::new(path),
+                    &page_opts,
+                )
+                .await
             })?
         } else {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
@@ -368,7 +373,7 @@ impl PyRemoteRepo {
         };
 
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::dir::list(&self.repo, &revision, &path, page_num, page_size).await
+            api::client::dir::list(&self.repo, revision, &path, page_num, page_size).await
         })?;
 
         // Convert remote status to a PyStagedData using the from method
@@ -377,7 +382,7 @@ impl PyRemoteRepo {
 
     fn file_exists(&self, path: PathBuf, revision: &str) -> Result<bool, PyOxenError> {
         let exists = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            match api::client::metadata::get_file(&self.repo, &revision, &path).await {
+            match api::client::metadata::get_file(&self.repo, revision, &path).await {
                 Ok(Some(_)) => Ok(true),
                 Ok(None) => Ok(false),
                 Err(e) => Err(e),
@@ -394,7 +399,7 @@ impl PyRemoteRepo {
         revision: &str,
     ) -> PyResult<bool> {
         match pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::metadata::get_file(&self.repo, &revision, &remote_path).await
+            api::client::metadata::get_file(&self.repo, revision, &remote_path).await
         }) {
             Ok(Some(remote_metadata)) => {
                 let remote_hash = remote_metadata.entry.hash();
@@ -418,7 +423,7 @@ impl PyRemoteRepo {
         };
 
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::metadata::get_file(&self.repo, &revision, &path).await
+            api::client::metadata::get_file(&self.repo, revision, &path).await
         })?;
 
         Ok(result.map(|e| PyEntry::from(e.entry)))
@@ -466,7 +471,7 @@ impl PyRemoteRepo {
         };
 
         let branch = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::branches::create_from_commit_id(&self.repo, &new_name, &commit_id).await
+            api::client::branches::create_from_commit_id(&self.repo, &new_name, commit_id).await
         });
 
         match branch {
@@ -534,9 +539,9 @@ impl PyRemoteRepo {
         }
     }
 
-    fn diff_file(&self, base: &str, head: &str, path: &str) -> Result<PyDiffEntry, PyOxenError> {
+    fn diff_file(&self, base: &str, head: &str, path: PathBuf) -> Result<PyDiffEntry, PyOxenError> {
         let diff = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::diff::diff_entries(&self.repo, &base, &head, path).await
+            api::client::diff::diff_entries(&self.repo, base, head, &path).await
         })?;
 
         Ok(diff.into())

--- a/crates/oxen-py/src/py_repo.rs
+++ b/crates/oxen-py/src/py_repo.rs
@@ -97,7 +97,7 @@ impl PyRepo {
 
         // make sure metadata is valid json, return oxen error if not
         let metadata: serde_json::Value = serde_json::from_str(metadata).map_err(|e| {
-            OxenError::basic_str(&format!(
+            OxenError::basic_str(format!(
                 "Metadata must be valid JSON: ''\n{e}",
                 // metadata.as_ref(),
             ))

--- a/crates/oxen-py/src/py_repo.rs
+++ b/crates/oxen-py/src/py_repo.rs
@@ -83,13 +83,13 @@ impl PyRepo {
     pub fn add(&self, path: PathBuf) -> Result<(), PyOxenError> {
         let repo = LocalRepository::from_dir(&self.path)?;
         pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { repositories::add(&repo, path).await.unwrap() });
+            .block_on(async { repositories::add(&repo, &path).await.unwrap() });
         Ok(())
     }
 
     pub fn add_schema_metadata(
         &self,
-        path: &str,
+        path: PathBuf,
         column: &str,
         metadata: &str,
     ) -> Result<(), PyOxenError> {
@@ -97,15 +97,15 @@ impl PyRepo {
 
         // make sure metadata is valid json, return oxen error if not
         let metadata: serde_json::Value = serde_json::from_str(metadata).map_err(|e| {
-            OxenError::basic_str(format!(
+            OxenError::basic_str(&format!(
                 "Metadata must be valid JSON: ''\n{e}",
                 // metadata.as_ref(),
             ))
         })?;
 
-        for (path, schema) in
-            repositories::data_frames::schemas::add_column_metadata(&repo, path, column, &metadata)?
-        {
+        for (path, schema) in repositories::data_frames::schemas::add_column_metadata(
+            &repo, &path, column, &metadata,
+        )? {
             println!("{:?}\n{}", path, schema.verbose_str());
         }
 

--- a/crates/oxen-py/src/py_workspace.rs
+++ b/crates/oxen-py/src/py_workspace.rs
@@ -133,7 +133,7 @@ impl PyWorkspace {
         Ok(PyStagedData::from(remote_status))
     }
 
-    fn add_bytes(&self, src: PathBuf, buf: Vec<u8>, dst: String) -> Result<(), PyOxenError> {
+    fn add_bytes(&self, src: PathBuf, buf: Vec<u8>, dst: PathBuf) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::files::add_bytes(
                 &self.repo.repo,
@@ -147,7 +147,7 @@ impl PyWorkspace {
         Ok(())
     }
 
-    fn add(&self, src: Vec<PathBuf>, dst: String) -> Result<Vec<PyErrorFileInfo>, PyOxenError> {
+    fn add(&self, src: Vec<PathBuf>, dst: PathBuf) -> Result<Vec<PyErrorFileInfo>, PyOxenError> {
         let errors = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::files::add(
                 &self.repo.repo,
@@ -170,7 +170,7 @@ impl PyWorkspace {
             api::client::workspaces::files::add_files(
                 &self.repo.repo,
                 &self.get_identifier(),
-                base_dir,
+                &base_dir,
                 src,
             )
             .await
@@ -180,7 +180,7 @@ impl PyWorkspace {
 
     fn rm(&self, path: PathBuf) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::workspaces::files::rm(&self.repo.repo, &self.id, path).await
+            api::client::workspaces::files::rm(&self.repo.repo, &self.id, &path).await
         })?;
         Ok(())
     }

--- a/crates/oxen-py/src/py_workspace_data_frame.rs
+++ b/crates/oxen-py/src/py_workspace_data_frame.rs
@@ -40,19 +40,18 @@ pub fn index(
 
 fn _get(
     repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
+    workspace_id: &str,
+    path: &Path,
 ) -> Result<JsonDataFrameViews, PyOxenError> {
-    let path = path.as_ref();
     let opts = DFOpts::empty();
 
     let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-        api::client::workspaces::data_frames::get(repo, &workspace_id, path, &opts).await
+        api::client::workspaces::data_frames::get(repo, workspace_id, path, &opts).await
     })?;
 
     let Some(data_frame) = data.data_frame else {
         return Err(
-            OxenError::basic_str(format!("Failed to get data frame for path: {path:?}")).into(),
+            OxenError::basic_str(&format!("Failed to get data frame for path: {path:?}")).into(),
         );
     };
 
@@ -205,7 +204,7 @@ impl PyWorkspaceDataFrame {
                 let result: String = serde_json::to_string(&view).unwrap();
                 Ok(result)
             }
-            Err(e) => Err(OxenError::basic_str(format!("Failed to query data frame: {e}")).into()),
+            Err(e) => Err(OxenError::basic_str(&format!("Failed to query data frame: {e}")).into()),
         }
     }
 
@@ -319,7 +318,7 @@ impl PyWorkspaceDataFrame {
             // convert view to json string
             match serde_json::to_string(&response.data_frame.unwrap().view.data) {
                 Ok(json) => Ok(json),
-                Err(e) => Err(OxenError::basic_str(format!(
+                Err(e) => Err(OxenError::basic_str(&format!(
                     "Could not convert view to json: {e}"
                 ))),
             }
@@ -346,7 +345,7 @@ impl PyWorkspaceDataFrame {
 
     fn insert_row(&self, data: String) -> Result<String, PyOxenError> {
         let Ok(_) = serde_json::from_str::<serde_json::Value>(&data) else {
-            return Err(OxenError::basic_str(format!("Failed to parse json data: {data}")).into());
+            return Err(OxenError::basic_str(&format!("Failed to parse json data: {data}")).into());
         };
 
         let workspace_id = self.workspace.get_identifier();
@@ -369,7 +368,7 @@ impl PyWorkspaceDataFrame {
 
     fn update_row(&self, id: String, data: String) -> Result<String, PyOxenError> {
         let Ok(_) = serde_json::from_str::<serde_json::Value>(&data) else {
-            return Err(OxenError::basic_str(format!("Failed to parse json data: {data}")).into());
+            return Err(OxenError::basic_str(&format!("Failed to parse json data: {data}")).into());
         };
 
         let view = pyo3_async_runtimes::tokio::get_runtime().block_on(async {

--- a/crates/oxen-py/src/py_workspace_data_frame.rs
+++ b/crates/oxen-py/src/py_workspace_data_frame.rs
@@ -51,7 +51,7 @@ fn _get(
 
     let Some(data_frame) = data.data_frame else {
         return Err(
-            OxenError::basic_str(&format!("Failed to get data frame for path: {path:?}")).into(),
+            OxenError::basic_str(format!("Failed to get data frame for path: {path:?}")).into(),
         );
     };
 
@@ -204,7 +204,7 @@ impl PyWorkspaceDataFrame {
                 let result: String = serde_json::to_string(&view).unwrap();
                 Ok(result)
             }
-            Err(e) => Err(OxenError::basic_str(&format!("Failed to query data frame: {e}")).into()),
+            Err(e) => Err(OxenError::basic_str(format!("Failed to query data frame: {e}")).into()),
         }
     }
 
@@ -318,7 +318,7 @@ impl PyWorkspaceDataFrame {
             // convert view to json string
             match serde_json::to_string(&response.data_frame.unwrap().view.data) {
                 Ok(json) => Ok(json),
-                Err(e) => Err(OxenError::basic_str(&format!(
+                Err(e) => Err(OxenError::basic_str(format!(
                     "Could not convert view to json: {e}"
                 ))),
             }
@@ -345,7 +345,7 @@ impl PyWorkspaceDataFrame {
 
     fn insert_row(&self, data: String) -> Result<String, PyOxenError> {
         let Ok(_) = serde_json::from_str::<serde_json::Value>(&data) else {
-            return Err(OxenError::basic_str(&format!("Failed to parse json data: {data}")).into());
+            return Err(OxenError::basic_str(format!("Failed to parse json data: {data}")).into());
         };
 
         let workspace_id = self.workspace.get_identifier();
@@ -360,7 +360,7 @@ impl PyWorkspaceDataFrame {
             .await
         })?
         else {
-            return Err(OxenError::basic_str("Failed to insert data").into());
+            return Err(OxenError::basic_str("Failed to insert data".to_string()).into());
         };
 
         Ok(row_id)
@@ -368,7 +368,7 @@ impl PyWorkspaceDataFrame {
 
     fn update_row(&self, id: String, data: String) -> Result<String, PyOxenError> {
         let Ok(_) = serde_json::from_str::<serde_json::Value>(&data) else {
-            return Err(OxenError::basic_str(&format!("Failed to parse json data: {data}")).into());
+            return Err(OxenError::basic_str(format!("Failed to parse json data: {data}")).into());
         };
 
         let view = pyo3_async_runtimes::tokio::get_runtime().block_on(async {

--- a/crates/oxen-py/src/remote.rs
+++ b/crates/oxen-py/src/remote.rs
@@ -63,7 +63,7 @@ pub fn create_repo(
 ) -> Result<PyRemoteRepo, PyOxenError> {
     // Check that name is valid ex: :namespace/:repo_name
     if !name.contains("/") {
-        return Err(OxenError::basic_str(&format!("Invalid repository name: {name}")).into());
+        return Err(OxenError::basic_str(format!("Invalid repository name: {name}")).into());
     }
 
     let namespace = name.split("/").collect::<Vec<&str>>()[0].to_string();

--- a/crates/oxen-py/src/remote.rs
+++ b/crates/oxen-py/src/remote.rs
@@ -18,7 +18,7 @@ pub fn get_repo(
     scheme: &str,
 ) -> Result<Option<PyRemoteRepo>, PyOxenError> {
     let remote_repo = match pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-        liboxen::api::client::repositories::get_by_name_host_and_scheme(name, &host, &scheme).await
+        liboxen::api::client::repositories::get_by_name_host_and_scheme(&name, &host, scheme).await
     }) {
         Ok(repo) => repo,
         Err(liboxen::error::OxenError::RemoteRepoNotFound(_)) => return Ok(None),
@@ -63,7 +63,7 @@ pub fn create_repo(
 ) -> Result<PyRemoteRepo, PyOxenError> {
     // Check that name is valid ex: :namespace/:repo_name
     if !name.contains("/") {
-        return Err(OxenError::basic_str(format!("Invalid repository name: {name}")).into());
+        return Err(OxenError::basic_str(&format!("Invalid repository name: {name}")).into());
     }
 
     let namespace = name.split("/").collect::<Vec<&str>>()[0].to_string();
@@ -79,7 +79,7 @@ pub fn create_repo(
         )?;
         if files.is_empty() {
             let mut repo =
-                RepoNew::from_namespace_name_host(namespace, repo_name, host.clone(), storage_opts);
+                RepoNew::from_namespace_name_host(&namespace, &repo_name, &host, storage_opts);
             if !description.is_empty() {
                 repo.description = Some(description);
             }
@@ -112,7 +112,7 @@ pub fn create_repo(
             repo.scheme = Some(scheme.clone());
 
             let repo = liboxen::api::client::repositories::create(repo).await?;
-            let branch = liboxen::api::client::branches::get_by_name(&repo, &DEFAULT_BRANCH_NAME)
+            let branch = liboxen::api::client::branches::get_by_name(&repo, DEFAULT_BRANCH_NAME)
                 .await?
                 .unwrap();
 

--- a/crates/oxen-py/src/util.rs
+++ b/crates/oxen-py/src/util.rs
@@ -28,6 +28,6 @@ pub fn is_tabular(path: PathBuf) -> PyResult<bool> {
 pub fn read_df(path: PathBuf) -> Result<PyDataFrame, PyOxenError> {
     let opts = DFOpts::empty();
     let df = pyo3_async_runtimes::tokio::get_runtime()
-        .block_on(async { liboxen::core::df::tabular::read_df(path, opts).await })?;
+        .block_on(async { liboxen::core::df::tabular::read_df(&path, opts).await })?;
     Ok(PyDataFrame(df))
 }

--- a/crates/server/src/auth/access_keys.rs
+++ b/crates/server/src/auth/access_keys.rs
@@ -101,7 +101,7 @@ impl AccessKeyManager {
             }
             Err(_) => {
                 let err = format!("Could not create access key for: {user_claims:?}");
-                Err(OxenError::basic_str(err))
+                Err(OxenError::basic_str(&err))
             }
         }
     }
@@ -117,7 +117,7 @@ impl AccessKeyManager {
             Ok(None) => Ok(None),
             Err(err) => {
                 let err = format!("Err could not red from commit db: {err}");
-                Err(OxenError::basic_str(err))
+                Err(OxenError::basic_str(&err))
             }
         }
     }
@@ -154,7 +154,7 @@ impl AccessKeyManager {
 
     fn read_secret_key(&self) -> Result<String, OxenError> {
         let path = AccessKeyManager::secret_key_path(&self.sync_dir);
-        util::fs::read_from_path(path)
+        util::fs::read_from_path(&path)
     }
 }
 

--- a/crates/server/src/auth/access_keys.rs
+++ b/crates/server/src/auth/access_keys.rs
@@ -101,7 +101,7 @@ impl AccessKeyManager {
             }
             Err(_) => {
                 let err = format!("Could not create access key for: {user_claims:?}");
-                Err(OxenError::basic_str(&err))
+                Err(OxenError::basic_str(err))
             }
         }
     }
@@ -117,7 +117,7 @@ impl AccessKeyManager {
             Ok(None) => Ok(None),
             Err(err) => {
                 let err = format!("Err could not red from commit db: {err}");
-                Err(OxenError::basic_str(&err))
+                Err(OxenError::basic_str(err))
             }
         }
     }

--- a/crates/server/src/controllers/branches.rs
+++ b/crates/server/src/controllers/branches.rs
@@ -69,7 +69,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(&app_data.path, &namespace, &name)?;
 
     let branches = repositories::branches::list(&repo)?;
 
@@ -101,7 +101,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
     let branch_name = path_param(&req, "branch_name")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     log::debug!("show branch {branch_name:?}");
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?
@@ -145,7 +145,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     log::debug!("Create branch: {body}");
 
@@ -183,7 +183,7 @@ fn create_from_branch(
     let from_branch = repositories::branches::get_by_name(repo, &data.from_name)?
         .ok_or(OxenHttpError::NotFound)?;
 
-    let new_branch = repositories::branches::create(repo, &data.new_name, from_branch.commit_id)?;
+    let new_branch = repositories::branches::create(repo, &data.new_name, &from_branch.commit_id)?;
 
     Ok(HttpResponse::Ok().json(BranchResponse {
         status: StatusMessage::resource_created(),
@@ -224,7 +224,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
     let branch_name = path_param(&req, "branch_name")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?
         .ok_or(OxenError::remote_branch_not_found(&branch_name))?;
@@ -268,12 +268,12 @@ pub async fn update(
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
     let branch_name = path_param(&req, "branch_name")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     let data: Result<BranchUpdate, serde_json::Error> = serde_json::from_str(&body);
     let data = data.map_err(|err| OxenHttpError::BadRequest(format!("{err:?}").into()))?;
 
-    let branch = repositories::branches::update(&repository, branch_name, data.commit_id)?;
+    let branch = repositories::branches::update(&repository, &branch_name, &data.commit_id)?;
 
     Ok(HttpResponse::Ok().json(BranchResponse {
         status: StatusMessage::resource_updated(),
@@ -313,7 +313,7 @@ pub async fn maybe_create_merge(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
     let branch_name = path_param(&req, "branch_name")?;
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?
         .ok_or(OxenError::remote_branch_not_found(&branch_name))?;
@@ -385,12 +385,12 @@ pub async fn list_entry_versions(
     let branch_name = path_param(&req, "branch_name")?;
 
     // Get branch
-    let repo = get_repo(&app_data.path, namespace.clone(), &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let branch = repositories::branches::get_by_name(&repo, &branch_name)?
         .ok_or(OxenError::remote_branch_not_found(&branch_name))?;
 
     let path = PathBuf::from(path_param(&req, "path")?);
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);

--- a/crates/server/src/controllers/branches.rs
+++ b/crates/server/src/controllers/branches.rs
@@ -322,11 +322,11 @@ pub async fn maybe_create_merge(
     let data = data.map_err(|err| OxenHttpError::BadRequest(format!("{err:?}").into()))?;
     let incoming_commit_id = data.client_commit_id;
     let incoming_commit = repositories::commits::get_by_id(&repository, &incoming_commit_id)?
-        .ok_or(OxenError::resource_not_found(&incoming_commit_id))?;
+        .ok_or(OxenError::resource_not_found(incoming_commit_id.clone()))?;
 
     let current_commit_id = data.server_commit_id;
     let current_commit = repositories::commits::get_by_id(&repository, &current_commit_id)?
-        .ok_or(OxenError::resource_not_found(&current_commit_id))?;
+        .ok_or(OxenError::resource_not_found(current_commit_id.clone()))?;
 
     log::debug!("maybe_create_merge got client head commit {incoming_commit_id:?}");
 

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -89,7 +89,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let commits = repositories::commits::list(&repo).unwrap_or_default();
     Ok(HttpResponse::Ok().json(ListCommitResponse::success(commits)))
@@ -122,7 +122,7 @@ pub async fn history(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let resource_param = path_param(&req, "resource")?;
 
     let pagination = PaginateOpts {
@@ -208,7 +208,7 @@ pub async fn list_all(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let pagination = PaginateOpts {
         page_num: query.page.unwrap_or(constants::DEFAULT_PAGE_NUM),
@@ -249,7 +249,7 @@ pub async fn list_missing(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     // Parse commit ids from a body and return the missing ids
     let data: Result<MerkleHashes, serde_json::Error> = serde_json::from_str(&body);
@@ -298,7 +298,7 @@ pub async fn list_missing_files(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let base_commit = match &query.base {
         Some(base) => repositories::commits::get_by_id(&repo, base)?,
@@ -351,7 +351,7 @@ pub async fn mark_commits_as_synced(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -397,7 +397,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let commit_id = path_param(&req, "commit_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let commit = repositories::commits::get_by_id(&repo, &commit_id)?
         .ok_or(OxenError::revision_not_found(commit_id.into()))?;
 
@@ -428,7 +428,7 @@ pub async fn parents(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHt
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
     let commit_or_branch = path_param(&req, "commit_or_branch")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
     let commit = repositories::revisions::get(&repository, &commit_or_branch)?
         .ok_or(OxenError::revision_not_found(commit_or_branch.into()))?;
     let parents = repositories::commits::list_from(&repository, &commit.id)?;
@@ -459,7 +459,7 @@ pub async fn download_commits_db(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     let buffer = compress_commits_db(&repository)?;
     Ok(HttpResponse::Ok().body(buffer))
@@ -512,7 +512,7 @@ pub async fn download_dir_hashes_db(
     let name = path_param(&req, "repo_name")?;
     // base_head is the base and head commit id separated by ..
     let base_head = path_param(&req, "base_head")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     // Let user pass in base..head to download a range of commits
     // or we just get all the commits from the base commit to the first commit
@@ -560,7 +560,7 @@ pub async fn download_commit_entries_db(
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
     let commit_or_branch = path_param(&req, "commit_or_branch")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     let commit = repositories::revisions::get(&repository, &commit_or_branch)?
         .ok_or(OxenError::revision_not_found(commit_or_branch.into()))?;
@@ -684,7 +684,7 @@ pub async fn create(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let new_commit: Commit = match serde_json::from_str(&body) {
         Ok(commit) => commit,
@@ -705,7 +705,7 @@ pub async fn create(
         };
 
     // Create Commit from uri params
-    match repositories::commits::create_empty_commit(&repository, bn.branch_name, &new_commit) {
+    match repositories::commits::create_empty_commit(&repository, &bn.branch_name, &new_commit) {
         Ok(commit) => Ok(HttpResponse::Ok().json(CommitResponse {
             status: StatusMessage::resource_created(),
             commit: commit.to_owned(),
@@ -750,7 +750,7 @@ pub async fn upload_chunk(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(&app_data.path, &namespace, &name)?;
 
     let hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
     let id = query.hash.clone();
@@ -1141,7 +1141,7 @@ pub async fn upload_tree(
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
     let client_head_id = path_param(&req, "commit_id")?;
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(&app_data.path, &namespace, &name)?;
     // Get head commit on sever repo
     let server_head_commit = repositories::commits::head_commit(&repo)?;
 
@@ -1190,7 +1190,7 @@ pub async fn root_commit(req: HttpRequest) -> Result<HttpResponse, OxenHttpError
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(&app_data.path, &namespace, &name)?;
 
     let root = repositories::commits::root_commit_maybe(&repo)?;
 
@@ -1266,7 +1266,7 @@ async fn unpack_entry_tarball_async(
         let mut file = entry?;
         let path = file
             .path()
-            .map_err(|e| OxenError::basic_str(format!("Invalid path in archive: {e}")))?;
+            .map_err(|e| OxenError::basic_str(&format!("Invalid path in archive: {e}")))?;
 
         if path.starts_with("versions") && path.to_string_lossy().contains("files") {
             // Handle version files with streaming
@@ -1283,7 +1283,7 @@ async fn unpack_entry_tarball_async(
             // For non-version files, unpack to hidden dir
             file.unpack_in(&hidden_dir)
                 .await
-                .map_err(|e| OxenError::basic_str(format!("Failed to unpack file: {e}")))?;
+                .map_err(|e| OxenError::basic_str(&format!("Failed to unpack file: {e}")))?;
         }
     }
 
@@ -1313,7 +1313,7 @@ fn extract_hash_from_path(path: &Path) -> Result<String, OxenError> {
         }
     }
 
-    Err(OxenError::basic_str(format!(
+    Err(OxenError::basic_str(&format!(
         "Could not get hash for file: {path:?}"
     )))
 }

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -1211,7 +1211,9 @@ async fn unpack_tree_tarball(tmp_dir: &Path, data: &[u8]) -> Result<(), OxenErro
         Err(e) => {
             log::error!("Could not unpack tree database from archive...");
             log::error!("Err: {e:?}");
-            return Err(OxenError::basic_str("Failed to get archive entries"));
+            return Err(OxenError::basic_str(
+                "Failed to get archive entries".to_string(),
+            ));
         }
     };
 
@@ -1224,7 +1226,9 @@ async fn unpack_tree_tarball(tmp_dir: &Path, data: &[u8]) -> Result<(), OxenErro
                     Ok(stripped) => stripped,
                     Err(err) => {
                         log::error!("Could not strip prefix from path {err:?}");
-                        return Err(OxenError::basic_str("Failed to strip path prefix"));
+                        return Err(OxenError::basic_str(
+                            "Failed to strip path prefix".to_string(),
+                        ));
                     }
                 }
             } else {
@@ -1266,7 +1270,7 @@ async fn unpack_entry_tarball_async(
         let mut file = entry?;
         let path = file
             .path()
-            .map_err(|e| OxenError::basic_str(&format!("Invalid path in archive: {e}")))?;
+            .map_err(|e| OxenError::basic_str(format!("Invalid path in archive: {e}")))?;
 
         if path.starts_with("versions") && path.to_string_lossy().contains("files") {
             // Handle version files with streaming
@@ -1283,7 +1287,7 @@ async fn unpack_entry_tarball_async(
             // For non-version files, unpack to hidden dir
             file.unpack_in(&hidden_dir)
                 .await
-                .map_err(|e| OxenError::basic_str(&format!("Failed to unpack file: {e}")))?;
+                .map_err(|e| OxenError::basic_str(format!("Failed to unpack file: {e}")))?;
         }
     }
 
@@ -1313,7 +1317,7 @@ fn extract_hash_from_path(path: &Path) -> Result<String, OxenError> {
         }
     }
 
-    Err(OxenError::basic_str(&format!(
+    Err(OxenError::basic_str(format!(
         "Could not get hash for file: {path:?}"
     )))
 }

--- a/crates/server/src/controllers/data_frames.rs
+++ b/crates/server/src/controllers/data_frames.rs
@@ -45,7 +45,7 @@ pub async fn get(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
 
     let commit = match &resource.workspace {
@@ -143,7 +143,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
 
@@ -164,7 +164,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
         log::debug!("data frame is not indexed");
         // If not, proceed to create a new workspace and index the data frame.
         let workspace_id = Uuid::new_v4().to_string();
-        let workspace = match repositories::workspaces::create(&repo, &commit, workspace_id, false)
+        let workspace = match repositories::workspaces::create(&repo, &commit, &workspace_id, false)
         {
             Ok(workspace) => workspace,
             Err(_e) => repositories::workspaces::get_non_editable_by_commit_id(&repo, &commit.id)?,
@@ -211,7 +211,7 @@ pub async fn from_directory(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
     let branch = resource.clone().branch.ok_or(OxenHttpError::NotFound)?;
@@ -221,7 +221,7 @@ pub async fn from_directory(
         Ok(data) => data,
         Err(err) => {
             log::error!("Unable to parse body. Err: {err}\n{body}");
-            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
+            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(&err.to_string())));
         }
     };
 
@@ -241,7 +241,7 @@ pub async fn from_directory(
         &repo,
         &temp_workspace,
         &path,
-        &output_path,
+        std::path::Path::new(&output_path),
         &extra_columns,
         recursive,
         &new_commit,

--- a/crates/server/src/controllers/diff.rs
+++ b/crates/server/src/controllers/diff.rs
@@ -63,7 +63,7 @@ pub async fn commits(
     let base_head = path_param(&req, "base_head")?;
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     // Page size and number
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
@@ -122,7 +122,7 @@ pub async fn entries(
     let base_head = path_param(&req, "base_head")?;
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     // Page size and number
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
@@ -201,7 +201,7 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
     let base_head = path_param(&req, "base_head")?;
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
@@ -254,7 +254,7 @@ pub async fn dir_entries(
     let dir = path_param(&req, "dir")?;
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     // Page size and number
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
@@ -338,7 +338,7 @@ pub async fn file(
     let base_head = path_param(&req, "base_head")?;
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     // Parse the base and head from the base..head/resource string
     // For Example)
@@ -363,7 +363,7 @@ pub async fn file(
 
     let diff = repositories::diffs::diff_entries(
         &repository,
-        resource,
+        &resource,
         base_entry,
         &base_commit,
         head_entry,
@@ -408,14 +408,14 @@ pub async fn create_df_diff(
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
 
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     let data: Result<TabularCompareBody, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
         Ok(data) => data,
         Err(err) => {
             log::error!("unable to parse tabular comparison data. Err: {err}\n{body}");
-            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
+            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(&err.to_string())));
         }
     };
 
@@ -515,14 +515,14 @@ pub async fn update_df_diff(
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
     let compare_id = path_param(&req, "compare_id")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     let data: Result<TabularCompareBody, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
         Ok(data) => data,
         Err(err) => {
             log::error!("unable to parse tabular comparison data. Err: {err}\n{body}");
-            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
+            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(&err.to_string())));
         }
     };
 
@@ -624,7 +624,7 @@ pub async fn get_df_diff(
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
     let compare_id = path_param(&req, "compare_id")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
     let base_head = path_param(&req, "base_head")?;
 
     let data: TabularCompareBody = serde_json::from_str(&body)?;
@@ -705,7 +705,7 @@ pub async fn delete_df_diff(req: HttpRequest) -> Result<HttpResponse, OxenHttpEr
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let compare_id = path_param(&req, "compare_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     repositories::diffs::delete_df_diff(&repo, &compare_id)?;
 
@@ -737,7 +737,7 @@ pub async fn get_derived_df(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let compare_id = path_param(&req, "compare_id")?;
     // let base_head = path_param(&req, "base_head")?;
 
@@ -748,7 +748,7 @@ pub async fn get_derived_df(
     // TODO: If this structure holds for diff + query, there is some amt of reusability with
     // controllers::df::get logic
 
-    let df = tabular::read_df(derived_df_path, DFOpts::empty()).await?;
+    let df = tabular::read_df(&derived_df_path, DFOpts::empty()).await?;
 
     let og_schema = Schema::from_polars(df.schema());
 
@@ -1007,8 +1007,8 @@ mod tests {
         let path1 = repo.path.join("file1.csv");
         let path2 = repo.path.join("file2.csv");
 
-        liboxen::test::write_txt_file_to_path(path1, csv1)?;
-        liboxen::test::write_txt_file_to_path(path2, csv2)?;
+        liboxen::test::write_txt_file_to_path(&path1, csv1)?;
+        liboxen::test::write_txt_file_to_path(&path2, csv2)?;
 
         repositories::add(&repo, &repo.path).await?;
 

--- a/crates/server/src/controllers/diff.rs
+++ b/crates/server/src/controllers/diff.rs
@@ -866,10 +866,10 @@ fn parse_base_head_resource(
     let mut split = base_head.split("..");
     let base = split
         .next()
-        .ok_or(OxenError::resource_not_found(base_head))?;
+        .ok_or(OxenError::resource_not_found(base_head.to_string()))?;
     let head = split
         .next()
-        .ok_or(OxenError::resource_not_found(base_head))?;
+        .ok_or(OxenError::resource_not_found(base_head.to_string()))?;
 
     let base_commit = repositories::revisions::get(repo, base)?
         .ok_or(OxenError::revision_not_found(base.into()))?;

--- a/crates/server/src/controllers/dir.rs
+++ b/crates/server/src/controllers/dir.rs
@@ -66,7 +66,7 @@ pub async fn get(
     let paginated_entries = repositories::entries::list_directory_w_workspace_depth(
         &repo,
         &resource.path,
-        revision,
+        &revision,
         resource.workspace.clone(),
         &PaginateOpts {
             page_num: page,

--- a/crates/server/src/controllers/entries.rs
+++ b/crates/server/src/controllers/entries.rs
@@ -85,7 +85,7 @@ pub async fn download_data_from_version_paths(
             tar.append_path_with_name(path_to_read, content_file)?;
         } else {
             log::error!("Could not find content: {content_file:?} -> {path_to_read:?}");
-            return Err(OxenError::path_does_not_exist(&path_to_read).into());
+            return Err(OxenError::path_does_not_exist(path_to_read).into());
         }
     }
 

--- a/crates/server/src/controllers/entries.rs
+++ b/crates/server/src/controllers/entries.rs
@@ -33,7 +33,7 @@ pub async fn download_data_from_version_paths(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -85,7 +85,7 @@ pub async fn download_data_from_version_paths(
             tar.append_path_with_name(path_to_read, content_file)?;
         } else {
             log::error!("Could not find content: {content_file:?} -> {path_to_read:?}");
-            return Err(OxenError::path_does_not_exist(path_to_read).into());
+            return Err(OxenError::path_does_not_exist(&path_to_read).into());
         }
     }
 
@@ -102,7 +102,7 @@ pub async fn download_chunk(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
     let path = resource.path.clone();
@@ -140,7 +140,7 @@ pub async fn list_tabular(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let commit_or_branch = path_param(&req, "commit_or_branch")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let commit = repositories::revisions::get(&repo, &commit_or_branch)?
         .ok_or_else(|| OxenError::revision_not_found(commit_or_branch.into()))?;
 

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -164,13 +164,13 @@ pub async fn get(
                 // Fall back to commit tree using workspace's commit
                 let commit = &ws.commit;
                 repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                    .ok_or(OxenError::path_does_not_exist(path.clone()))?
+                    .ok_or(OxenError::path_does_not_exist(&path))?
             }
         }
         None => {
             let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
             repositories::tree::get_file_by_path(base_repo, &commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(path.clone()))?
+                .ok_or(OxenError::path_does_not_exist(&path))?
         }
     };
 
@@ -279,7 +279,7 @@ pub async fn put(
         .branch
         .clone()
         .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
+            &resource.version.to_string_lossy(),
         ))?;
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
     let node = repositories::tree::get_node_by_path(&repo, &commit, &resource.path)?;
@@ -335,7 +335,7 @@ pub async fn put(
         }),
     };
 
-    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, &branch.name).await?;
 
     log::debug!("file::put workspace commit ✅ success! commit {commit:?}");
 
@@ -384,7 +384,7 @@ pub async fn delete(
         .branch
         .clone()
         .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
+            &resource.version.to_string_lossy(),
         ))?;
     let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
     let path = resource.path;
@@ -409,7 +409,7 @@ pub async fn delete(
             .unwrap_or(format!("Remove {}", &path.to_string_lossy())),
     };
 
-    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, &branch.name).await?;
 
     log::debug!("file::delete workspace commit ✅ success! commit {commit:?}");
 
@@ -477,7 +477,7 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
         .branch
         .clone()
         .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
+            &resource.version.to_string_lossy(),
         ))?;
     let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
     let source_path = resource.path;
@@ -491,7 +491,7 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
     }
 
     // Validate and normalize new_path
-    let new_path = util::fs::validate_and_normalize_path(&body.new_path)?;
+    let new_path = util::fs::validate_and_normalize_path(Path::new(&body.new_path))?;
 
     // Verify source file exists
     if repositories::entries::get_file(&repo, &commit, &source_path)?.is_none() {
@@ -525,7 +525,7 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
         }),
     };
 
-    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, &branch.name).await?;
 
     log::debug!("file::mv workspace commit ✅ success! commit {commit:?}");
 
@@ -806,7 +806,7 @@ mod tests {
         let namespace = "Testing-Namespace";
         let repo_name = "Testing-Name";
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
-        util::fs::create_dir_all(repo.path.join("data"))?;
+        util::fs::create_dir_all(&repo.path.join("data"))?;
         let hello_file = repo.path.join("data/hello.txt");
         util::fs::write_to_path(&hello_file, "Hello")?;
         repositories::add(&repo, &hello_file).await?;
@@ -851,9 +851,12 @@ mod tests {
         assert_eq!(resp.status.status, "success");
 
         // Check that the file was updated
-        let entry =
-            repositories::entries::get_file(&repo, &resp.commit, PathBuf::from("data/hello.txt"))?
-                .unwrap();
+        let entry = repositories::entries::get_file(
+            &repo,
+            &resp.commit,
+            &PathBuf::from("data").join("hello.txt"),
+        )?
+        .unwrap();
         let version_store = repo.version_store()?;
         let uploaded_content = version_store.get_version(&entry.hash().to_string()).await?;
         assert_eq!(
@@ -875,7 +878,7 @@ mod tests {
         let repo_name = "Testing-Get-Headers";
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
 
-        util::fs::create_dir_all(repo.path.join("data"))?;
+        util::fs::create_dir_all(&repo.path.join("data"))?;
         let hello_file = repo.path.join("data/hello.txt");
         let file_content = "Hello";
         util::fs::write_to_path(&hello_file, file_content)?;

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -157,20 +157,20 @@ pub async fn get(
                 match staged_node.node.node {
                     EMerkleTreeNode::File(f) => Ok(f),
                     _ => Err(OxenError::basic_str(
-                        "Only single file download is supported",
+                        "Only single file download is supported".to_string(),
                     )),
                 }?
             } else {
                 // Fall back to commit tree using workspace's commit
                 let commit = &ws.commit;
                 repositories::tree::get_file_by_path(base_repo, commit, &path)?
-                    .ok_or(OxenError::path_does_not_exist(&path))?
+                    .ok_or(OxenError::path_does_not_exist(path.clone()))?
             }
         }
         None => {
             let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
             repositories::tree::get_file_by_path(base_repo, &commit, &path)?
-                .ok_or(OxenError::path_does_not_exist(&path))?
+                .ok_or(OxenError::path_does_not_exist(path.clone()))?
         }
     };
 

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -100,7 +100,7 @@ pub async fn import(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
 
     // Resource must specify branch for committing the workspace
@@ -108,7 +108,7 @@ pub async fn import(
         .branch
         .clone()
         .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
+            &resource.version.to_string_lossy(),
         ))?;
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
     let directory = resource.path.clone();
@@ -192,7 +192,7 @@ pub async fn import(
             .unwrap_or_else(|| format!("Import files to {}", &resource.path.to_string_lossy())),
     };
 
-    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, &branch.name).await?;
     log::debug!("workspace::commit ✅ success! commit {commit:?}");
 
     Ok(HttpResponse::Ok().json(CommitResponse {
@@ -248,7 +248,7 @@ pub async fn upload_zip(
         .branch
         .clone()
         .ok_or(OxenError::local_branch_not_found(
-            resource.version.to_string_lossy(),
+            &resource.version.to_string_lossy(),
         ))?;
     let directory = resource.path.clone();
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
@@ -318,7 +318,8 @@ async fn handle_initial_upload_zip_empty_repo(
 
     for temp_file in temp_files {
         let files = decompress_zip(&temp_file.temp_file_path)?;
-        repositories::add::add_all(repo, &files).await?;
+        let file_paths: Vec<&std::path::Path> = files.iter().map(|p| p.as_path()).collect();
+        repositories::add::add_all(repo, file_paths).await?;
     }
 
     // Commit the files
@@ -467,7 +468,7 @@ mod tests {
     use liboxen::error::OxenError;
 
     use actix_web::{App, web};
-    use std::path::PathBuf;
+    use std::path::Path;
 
     #[actix_web::test]
     async fn test_controllers_file_import_tabular_file() -> Result<(), OxenError> {
@@ -483,7 +484,7 @@ mod tests {
         let author = "test_user";
         let email = "ox@oxen.ai";
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
-        util::fs::create_dir_all(repo.path.join("data"))?;
+        util::fs::create_dir_all(&repo.path.join("data"))?;
         let hello_file = repo.path.join("data/hello.txt");
         util::fs::write_to_path(&hello_file, "Hello")?;
         repositories::add(&repo, &hello_file).await?;
@@ -522,8 +523,12 @@ mod tests {
         let resp: CommitResponse = serde_json::from_str(body)?;
         assert_eq!(resp.status.status, "success");
 
-        let entry =
-            repositories::entries::get_file(&repo, &resp.commit, "data/cats_vs_dogs.tsv")?.unwrap();
+        let entry = repositories::entries::get_file(
+            &repo,
+            &resp.commit,
+            Path::new("data/cats_vs_dogs.tsv"),
+        )?
+        .unwrap();
         let version_store = repo.version_store()?;
         assert!(
             version_store
@@ -546,7 +551,7 @@ mod tests {
         let author = "test_user";
         let email = "ox@oxen.ai";
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
-        util::fs::create_dir_all(repo.path.join("data"))?;
+        util::fs::create_dir_all(&repo.path.join("data"))?;
         let hello_file = repo.path.join("data/hello.txt");
         util::fs::write_to_path(&hello_file, "Hello")?;
         repositories::add(&repo, &hello_file).await?;
@@ -585,12 +590,9 @@ mod tests {
         let resp: CommitResponse = serde_json::from_str(body)?;
         assert_eq!(resp.status.status, "success");
 
-        let entry = repositories::entries::get_file(
-            &repo,
-            &resp.commit,
-            PathBuf::from("notebooks/chat.py"),
-        )?
-        .unwrap();
+        let entry =
+            repositories::entries::get_file(&repo, &resp.commit, Path::new("notebooks/chat.py"))?
+                .unwrap();
         let version_store = repo.version_store()?;
         assert!(
             version_store

--- a/crates/server/src/controllers/merger.rs
+++ b/crates/server/src/controllers/merger.rs
@@ -34,7 +34,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let base_head = path_param(&req, "base_head")?;
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
@@ -93,7 +93,7 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let base_head = path_param(&req, "base_head")?;
 
     // Get the repository or return error
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(&app_data.path, &namespace, &name)?;
 
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
@@ -126,7 +126,7 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
         }
         Ok(None) => {
             log::debug!("Merge has conflicts");
-            Err(OxenError::merge_conflict(format!(
+            Err(OxenError::merge_conflict(&format!(
                 "Unable to merge {head} into {base} due to conflicts"
             )))?
         }

--- a/crates/server/src/controllers/merger.rs
+++ b/crates/server/src/controllers/merger.rs
@@ -126,7 +126,7 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
         }
         Ok(None) => {
             log::debug!("Merge has conflicts");
-            Err(OxenError::merge_conflict(&format!(
+            Err(OxenError::merge_conflict(format!(
                 "Unable to merge {head} into {base} due to conflicts"
             )))?
         }

--- a/crates/server/src/controllers/metadata.rs
+++ b/crates/server/src/controllers/metadata.rs
@@ -33,7 +33,7 @@ pub async fn file(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let workspace_ref = resource.workspace.as_ref();
 

--- a/crates/server/src/controllers/repositories.rs
+++ b/crates/server/src/controllers/repositories.rs
@@ -90,7 +90,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     // If we have a commit on the main branch, we can get the size and data types from the commit
     if let Ok(Some(commit)) = repositories::revisions::get(&repository, DEFAULT_BRANCH_NAME)
         && let Some(dir_node) =
-            repositories::entries::get_directory(&repository, &commit, PathBuf::from(""))?
+            repositories::entries::get_directory(&repository, &commit, &PathBuf::from(""))?
     {
         size = dir_node.num_bytes();
         data_types = dir_node
@@ -333,7 +333,7 @@ async fn handle_json_creation(
         }
         Err(OxenError::InvalidRepoName(name)) => {
             log::debug!("Invalid repo name: {name}");
-            Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!(
+            Ok(HttpResponse::BadRequest().json(StatusMessage::error(&format!(
                 "Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"
             ))))
         }
@@ -478,7 +478,7 @@ async fn handle_multipart_creation(
         }
         Err(OxenError::InvalidRepoName(name)) => {
             log::debug!("Invalid repo name: {name}");
-            Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!(
+            Ok(HttpResponse::BadRequest().json(StatusMessage::error(&format!(
                 "Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"
             ))))
         }

--- a/crates/server/src/controllers/revisions.rs
+++ b/crates/server/src/controllers/revisions.rs
@@ -30,7 +30,7 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let resource = parse_resource(&req, &repository)?;
     let response = ParseResourceResponse {
@@ -64,7 +64,7 @@ mod tests {
 
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
         let path = liboxen::test::add_txt_file_to_dir(&repo.path, resource_str)?;
-        repositories::add(&repo, path).await?;
+        repositories::add(&repo, &path).await?;
         repositories::commit(&repo, "first commit")?;
 
         let uri = format!(

--- a/crates/server/src/controllers/schemas.rs
+++ b/crates/server/src/controllers/schemas.rs
@@ -17,7 +17,7 @@ pub async fn list_or_get(req: HttpRequest) -> actix_web::Result<HttpResponse, Ox
 
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     // Try to see if they are asking for a specific file
     if let Ok(resource) = parse_resource(&req, &repo)

--- a/crates/server/src/controllers/tree.rs
+++ b/crates/server/src/controllers/tree.rs
@@ -283,7 +283,7 @@ fn get_commit_list(
     // The first pull doesn't have a head commit, but subsequent pulls do
     let mut commits = if let Some(head_commit_id) = maybe_head_commit_id {
         let head_commit = repositories::commits::get_by_id(repository, head_commit_id)?
-            .ok_or(OxenError::resource_not_found(head_commit_id))?;
+            .ok_or(OxenError::resource_not_found(head_commit_id.to_string()))?;
         repositories::commits::list_between(repository, base_commit, &head_commit)?
     } else {
         // If the subtree is specified, we only want to get the latest commit
@@ -343,7 +343,7 @@ fn maybe_parse_base_head(base_head: &str) -> Result<(String, Option<String>), Ox
             Ok((base.to_string(), Some(head.to_string())))
         } else {
             Err(OxenError::basic_str(
-                "Could not parse commits. Format should be base..head",
+                "Could not parse commits. Format should be base..head".to_string(),
             ))
         }
     } else {

--- a/crates/server/src/controllers/tree.rs
+++ b/crates/server/src/controllers/tree.rs
@@ -28,7 +28,7 @@ pub async fn get_node_by_id(req: HttpRequest) -> actix_web::Result<HttpResponse,
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
     let hash_str = path_param(&req, "hash")?;
 
     let node = repositories::tree::get_node_by_id(&repository, &hash_str.parse()?)?
@@ -44,7 +44,7 @@ pub async fn list_missing_node_hashes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -75,7 +75,7 @@ pub async fn list_missing_file_hashes_from_commits(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -111,7 +111,7 @@ pub async fn list_missing_file_hashes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
     let hash_str = path_param(&req, "hash")?;
     let hash = hash_str.parse()?;
 
@@ -134,7 +134,7 @@ pub async fn mark_nodes_as_synced(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -163,7 +163,7 @@ pub async fn create_nodes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -184,7 +184,7 @@ pub async fn download_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, 
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     // Download the entire tree
     let buffer = repositories::tree::compress_tree(&repository)?;
@@ -198,7 +198,7 @@ pub async fn get_node_hash_by_path(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repository)?;
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
 
@@ -218,7 +218,7 @@ pub async fn download_tree_nodes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
     let base_head_str = path_param(&req, "base_head")?;
     let is_download = query.is_download.unwrap_or(false);
 
@@ -229,7 +229,7 @@ pub async fn download_tree_nodes(
         query.depth
     );
 
-    let (base_commit_id, maybe_head_commit_id) = maybe_parse_base_head(base_head_str)?;
+    let (base_commit_id, maybe_head_commit_id) = maybe_parse_base_head(&base_head_str)?;
     let base_commit = repositories::commits::get_by_id(&repository, &base_commit_id)?
         .ok_or(OxenError::revision_not_found(base_commit_id.into()))?;
 
@@ -305,7 +305,7 @@ pub async fn download_node(req: HttpRequest) -> actix_web::Result<HttpResponse, 
     let name = path_param(&req, "repo_name")?;
     let hash_str = path_param(&req, "hash")?;
     let hash = hash_str.parse()?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(&app_data.path, &namespace, &name)?;
 
     let buffer = repositories::tree::compress_node(&repository, &hash)?;
 
@@ -336,12 +336,9 @@ fn node_to_json(node: MerkleTreeNode) -> actix_web::Result<HttpResponse, OxenHtt
 
 /// Parses a base..head string into a base and head string
 /// If the base..head string does not contain a .., then it returns the base as the base and head as None
-fn maybe_parse_base_head(
-    base_head: impl AsRef<str>,
-) -> Result<(String, Option<String>), OxenError> {
-    let base_head_str = base_head.as_ref();
-    if base_head_str.contains("..") {
-        let mut split = base_head_str.split("..");
+fn maybe_parse_base_head(base_head: &str) -> Result<(String, Option<String>), OxenError> {
+    if base_head.contains("..") {
+        let mut split = base_head.split("..");
         if let (Some(base), Some(head)) = (split.next(), split.next()) {
             Ok((base.to_string(), Some(head.to_string())))
         } else {
@@ -350,7 +347,7 @@ fn maybe_parse_base_head(
             ))
         }
     } else {
-        Ok((base_head_str.to_string(), None))
+        Ok((base_head.to_string(), None))
     }
 }
 

--- a/crates/server/src/controllers/versions.rs
+++ b/crates/server/src/controllers/versions.rs
@@ -55,7 +55,7 @@ pub async fn metadata(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?;
     let version_id = path_param(&req, "version_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let exists = repo.version_store()?.version_exists(&version_id).await?;
     if !exists {
@@ -77,7 +77,7 @@ pub async fn clean(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let version_store = repo.version_store()?;
     let result = version_store.clean_corrupted_versions(false).await?;
 
@@ -126,7 +126,7 @@ pub async fn download(
     log::debug!("Download resource {namespace}/{repo_name}/{resource} version file");
 
     let entry = repositories::entries::get_file(&repo, &commit, &path)?
-        .ok_or(OxenError::path_does_not_exist(path.clone()))?;
+        .ok_or(OxenError::path_does_not_exist(&path.clone()))?;
     let file_hash = entry.hash();
     let hash_str = file_hash.to_string();
     let mime_type = entry.mime_type();
@@ -183,7 +183,7 @@ pub async fn batch_download(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -251,7 +251,7 @@ pub async fn stream_versions_tar_gz(
                     if let Err(e) = header.set_path(file_hash) {
                         log::error!("Failed to set path for {file_hash}: {e}");
                         error_tx
-                            .send(OxenError::basic_str(format!(
+                            .send(OxenError::basic_str(&format!(
                                 "Failed to set path for {file_hash}: {e}"
                             )))
                             .ok();
@@ -351,7 +351,7 @@ pub async fn stream_versions_zip(
                 Some(path) => path,
                 None => {
                     let err = "Invalid UTF-8 in path".to_string();
-                    error_tx.send(OxenError::basic_str(err)).ok();
+                    error_tx.send(OxenError::basic_str(&err)).ok();
                     had_error = true;
                     break;
                 }
@@ -485,7 +485,7 @@ pub async fn batch_upload(
 
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let err_files = save_multiparts(payload, &repo).await?;
     log::debug!("batch upload complete with err_files: {}", err_files.len());
 
@@ -616,7 +616,7 @@ mod tests {
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
 
         // create test file and commit
-        util::fs::create_dir_all(repo.path.join("data"))?;
+        util::fs::create_dir_all(&repo.path.join("data"))?;
         let relative_path = "data/hello.txt";
         let hello_file = repo.path.join(relative_path);
         let file_content = "Hello";
@@ -670,7 +670,7 @@ mod tests {
         let repo_name = "Testing-Resize-Content-Length";
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
 
-        util::fs::create_dir_all(repo.path.join("data"))?;
+        util::fs::create_dir_all(&repo.path.join("data"))?;
         let relative_path = "data/pixel.png";
         let image_file = repo.path.join(relative_path);
         let png_bytes = [
@@ -733,7 +733,7 @@ mod tests {
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
 
         // create test file and commit so we have a valid repo
-        util::fs::create_dir_all(repo.path.join("data"))?;
+        util::fs::create_dir_all(&repo.path.join("data"))?;
         let relative_path = "data/hello.txt";
         let hello_file = repo.path.join(relative_path);
         util::fs::write_to_path(&hello_file, "Hello")?;
@@ -775,7 +775,7 @@ mod tests {
         let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
 
         let path = liboxen::test::add_txt_file_to_dir(&repo.path, "hello")?;
-        repositories::add(&repo, path).await?;
+        repositories::add(&repo, &path).await?;
         repositories::commit(&repo, "first commit")?;
 
         let file_content = "Test Content";

--- a/crates/server/src/controllers/versions.rs
+++ b/crates/server/src/controllers/versions.rs
@@ -126,7 +126,7 @@ pub async fn download(
     log::debug!("Download resource {namespace}/{repo_name}/{resource} version file");
 
     let entry = repositories::entries::get_file(&repo, &commit, &path)?
-        .ok_or(OxenError::path_does_not_exist(&path.clone()))?;
+        .ok_or(OxenError::path_does_not_exist(path.clone()))?;
     let file_hash = entry.hash();
     let hash_str = file_hash.to_string();
     let mime_type = entry.mime_type();
@@ -251,7 +251,7 @@ pub async fn stream_versions_tar_gz(
                     if let Err(e) = header.set_path(file_hash) {
                         log::error!("Failed to set path for {file_hash}: {e}");
                         error_tx
-                            .send(OxenError::basic_str(&format!(
+                            .send(OxenError::basic_str(format!(
                                 "Failed to set path for {file_hash}: {e}"
                             )))
                             .ok();
@@ -351,7 +351,7 @@ pub async fn stream_versions_zip(
                 Some(path) => path,
                 None => {
                     let err = "Invalid UTF-8 in path".to_string();
-                    error_tx.send(OxenError::basic_str(&err)).ok();
+                    error_tx.send(OxenError::basic_str(err)).ok();
                     had_error = true;
                     break;
                 }

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -32,7 +32,7 @@ pub async fn upload(
 
     let offset = query.offset.unwrap_or(0);
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     log::debug!(
         "/upload version {} chunk offset{} to repo: {:?}",
@@ -69,7 +69,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let version_id = path_param(&req, "version_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     log::debug!("/complete version chunk upload to repo: {:?}", repo.path);
 
@@ -102,7 +102,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
 
         if chunks.len() != num_chunks {
             return Ok(
-                HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                HttpResponse::BadRequest().json(StatusMessage::error(&format!(
                     "Number of chunks does not match expected number of chunks: {} != {}",
                     chunks.len(),
                     num_chunks
@@ -118,7 +118,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
         // If the workspace id is provided, stage the file
         if let Some(workspace_id) = request.workspace_id {
             let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
-                return Ok(HttpResponse::NotFound().json(StatusMessage::error(format!(
+                return Ok(HttpResponse::NotFound().json(StatusMessage::error(&format!(
                     "Workspace not found: {workspace_id}"
                 ))));
             };
@@ -154,7 +154,7 @@ pub async fn download(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let version_id = path_param(&req, "version_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let offset = query.offset.unwrap_or(0);
     let size = query.size.unwrap_or(AVG_CHUNK_SIZE);

--- a/crates/server/src/controllers/workspaces.rs
+++ b/crates/server/src/controllers/workspaces.rs
@@ -94,8 +94,9 @@ pub async fn get_or_create(
             )?;
 
             // Now get the newly created branch
-            repositories::branches::get_by_name(&repo, &data.branch_name)?
-                .ok_or_else(|| OxenError::basic_str("Failed to create initial branch"))?
+            repositories::branches::get_by_name(&repo, &data.branch_name)?.ok_or_else(|| {
+                OxenError::basic_str("Failed to create initial branch".to_string())
+            })?
         }
     };
 

--- a/crates/server/src/controllers/workspaces.rs
+++ b/crates/server/src/controllers/workspaces.rs
@@ -51,14 +51,14 @@ pub async fn get_or_create(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let data: Result<NewWorkspace, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
         Ok(data) => data,
         Err(err) => {
             log::error!("Unable to parse body. Err: {err}\n{body}");
-            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
+            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(&err.to_string())));
         }
     };
 
@@ -70,7 +70,7 @@ pub async fn get_or_create(
             if repositories::commits::head_commit_maybe(&repo)?.is_some() {
                 // Repo has commits but branch doesn't exist - this is an error
                 return Ok(
-                    HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                    HttpResponse::BadRequest().json(StatusMessage::error(&format!(
                         "Branch not found: {}. For non-empty repositories, create the branch first.",
                         data.branch_name
                     ))),
@@ -163,10 +163,10 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     Ok(HttpResponse::Ok().json(WorkspaceResponseView {
@@ -216,7 +216,7 @@ pub async fn list(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     log::debug!("workspaces::list got repo: {:?}", repo.path);
     let workspaces = repositories::workspaces::list(&repo)?;
     let workspace_views = workspaces
@@ -262,7 +262,7 @@ pub async fn clear(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     repositories::workspaces::clear(&repo)?;
     Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))
 }
@@ -289,10 +289,10 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     repositories::workspaces::delete(&workspace)?;
@@ -334,7 +334,7 @@ pub async fn mergeability(req: HttpRequest) -> Result<HttpResponse, OxenHttpErro
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let mergeable = repositories::workspaces::mergeability(&workspace, &branch_name)?;
 
@@ -392,17 +392,17 @@ pub async fn commit(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
         Ok(data) => data,
         Err(err) => {
             log::error!("unable to parse commit data. Err: {err}\n{body}");
-            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
+            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(&err.to_string())));
         }
     };
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let Some(branch) = repositories::branches::get_by_name(&repo, &branch_name)? else {
-        return Ok(HttpResponse::NotFound().json(StatusMessageDescription::not_found(branch_name)));
+        return Ok(HttpResponse::NotFound().json(StatusMessageDescription::not_found(&branch_name)));
     };
 
     match repositories::workspaces::commit(&workspace, &data, &branch_name).await {
@@ -421,7 +421,7 @@ pub async fn commit(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
         }
         Err(err) => {
             log::error!("unable to commit branch {branch_name:?}. Err: {err}");
-            Ok(HttpResponse::UnprocessableEntity().json(StatusMessage::error(format!("{err:?}"))))
+            Ok(HttpResponse::UnprocessableEntity().json(StatusMessage::error(&format!("{err:?}"))))
         }
     }
 }

--- a/crates/server/src/controllers/workspaces/changes.rs
+++ b/crates/server/src/controllers/workspaces/changes.rs
@@ -12,6 +12,7 @@ use liboxen::view::remote_staged_status::RemoteStagedStatus;
 use liboxen::view::{
     FilePathsResponse, RemoteStagedStatusResponse, StatusMessage, StatusMessageDescription,
 };
+use std::path::Path;
 
 use actix_web::{HttpRequest, HttpResponse, web};
 
@@ -27,7 +28,7 @@ pub async fn list_root(
     let workspace_id = path_param(&req, "workspace_id")?;
     log::debug!("/changes looking up repo: {namespace}/{repo_name}");
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let page_num = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
 
@@ -35,7 +36,7 @@ pub async fn list_root(
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         log::debug!("/changes could not find workspace_id: {workspace_id}");
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let path = PathBuf::from(".");
     let staged = repositories::workspaces::status::status_from_dir(&workspace, &path)?;
@@ -64,7 +65,7 @@ pub async fn list(
     let workspace_id = path_param(&req, "workspace_id")?;
     log::debug!("/changes looking up repo: {namespace}/{repo_name}");
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
     let page_num = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
@@ -73,7 +74,7 @@ pub async fn list(
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         log::debug!("/changes could not find workspace_id: {workspace_id}");
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let staged = repositories::workspaces::status::status_from_dir(&workspace, &path)?;
 
@@ -113,12 +114,12 @@ pub async fn unstage(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     unstage_from_workspace(&repo, &workspace, &path).await
@@ -154,12 +155,12 @@ pub async fn unstage_many(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     log::debug!("unstage_many found repo {repo_name}, workspace_id {workspace_id}");
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let paths_to_remove: Vec<PathBuf> = payload.into_inner();
@@ -201,7 +202,7 @@ pub async fn unstage_many(
 async fn unstage_from_workspace(
     repo: &LocalRepository,
     workspace: &Workspace,
-    path: &PathBuf,
+    path: &Path,
 ) -> Result<HttpResponse, OxenHttpError> {
     // This may not be in the commit if it's added, so have to parse tabular-ness from the path.
     if util::fs::is_tabular(path) {

--- a/crates/server/src/controllers/workspaces/data_frames.rs
+++ b/crates/server/src/controllers/workspaces/data_frames.rs
@@ -96,10 +96,10 @@ pub async fn get(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
@@ -176,9 +176,11 @@ pub async fn get(
         version: workspace.commit.id.to_string(),
     };
 
-    let og_schema = if let Some(schema) =
-        repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, &resource.path)?
-    {
+    let og_schema = if let Some(schema) = repositories::data_frames::schemas::get_by_path(
+        &repo,
+        &workspace.commit,
+        std::path::Path::new(&resource.path),
+    )? {
         schema
     } else {
         Schema::from_polars(df.schema())
@@ -222,10 +224,10 @@ pub async fn get_schema(req: HttpRequest) -> Result<HttpResponse, OxenHttpError>
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
@@ -277,10 +279,10 @@ pub async fn download(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(filename) = file_path.file_name().and_then(|n| n.to_str()) else {
@@ -324,7 +326,7 @@ pub async fn download(
         Err(e) => {
             let error_str = format!("{e:?}");
             log::error!("Error exporting data frame {file_path:?}: {error_str}");
-            let response = StatusMessageDescription::bad_request(error_str);
+            let response = StatusMessageDescription::bad_request(&error_str);
             return Ok(HttpResponse::BadRequest().json(response));
         }
     };
@@ -367,7 +369,7 @@ fn df_opts_from_query(query: &web::Query<DFOptsQuery>, file_path: PathBuf) -> DF
 /// If not, then it should be a genuine 404.
 fn file_exists_in_workspace_or_commit(
     workspace: &Workspace,
-    file_path: impl AsRef<Path>,
+    file_path: &Path,
 ) -> Result<bool, OxenHttpError> {
     let file_exists = {
         (
@@ -375,12 +377,12 @@ fn file_exists_in_workspace_or_commit(
             repositories::tree::get_file_by_path(
                 &workspace.base_repo,
                 &workspace.commit,
-                &file_path,
+                file_path,
             )?
             .is_some()
         ) || (
             // if not, does it exist in the workspace
-            repositories::workspaces::files::exists(workspace, &file_path)?
+            repositories::workspaces::files::exists(workspace, file_path)?
         )
     };
     Ok(file_exists)
@@ -406,10 +408,10 @@ pub async fn download_streaming(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(filename) = file_path.file_name().and_then(|n| n.to_str()) else {
@@ -451,7 +453,7 @@ pub async fn download_streaming(
         Err(e) => {
             log::error!("Error exporting data frame {file_path:?}: {e:?}");
             let error_str = format!("{e:?}");
-            let response = StatusMessageDescription::bad_request(error_str);
+            let response = StatusMessageDescription::bad_request(&error_str);
             return Ok(HttpResponse::BadRequest().json(response));
         }
     };
@@ -477,11 +479,11 @@ pub async fn get_by_branch(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let branch_name: &str = req.match_info().query("branch");
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
@@ -525,12 +527,12 @@ pub async fn diff(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let workspace_id = path_param(&req, "workspace_id")?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let mut opts = DFOpts::empty();
@@ -549,9 +551,11 @@ pub async fn diff(
         version: workspace.commit.id.to_string(),
     };
 
-    let og_schema = if let Some(schema) =
-        repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, resource.path)?
-    {
+    let og_schema = if let Some(schema) = repositories::data_frames::schemas::get_by_path(
+        &repo,
+        &workspace.commit,
+        std::path::Path::new(&resource.path),
+    )? {
         schema
     } else {
         Schema::from_polars(df.schema())
@@ -590,13 +594,13 @@ pub async fn put(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHtt
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     log::debug!("workspace {workspace_id} data frame put {file_path:?}");
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let data: DataFramePayload = serde_json::from_str(&body)?;
     log::debug!("workspace {workspace_id} data frame put {data:?}");
@@ -619,14 +623,14 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
-    repositories::workspaces::data_frames::restore(&repo, &workspace, file_path).await?;
+    repositories::workspaces::data_frames::restore(&repo, &workspace, &file_path).await?;
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_deleted()))
 }
@@ -636,7 +640,7 @@ pub async fn rename(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
     // Attempt to parse the body
     let body: RenameRequest = serde_json::from_str(&body)?; // Use the Json wrapper to get the inner value
@@ -650,7 +654,7 @@ pub async fn rename(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     if repositories::entries::get_file(&repo, &workspace.commit, &new_path)?.is_some() {

--- a/crates/server/src/controllers/workspaces/data_frames.rs
+++ b/crates/server/src/controllers/workspaces/data_frames.rs
@@ -494,7 +494,7 @@ pub async fn get_by_branch(
         .ok_or(OxenError::remote_branch_not_found(branch_name))?;
 
     let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?
-        .ok_or(OxenError::resource_not_found(&branch.commit_id))?;
+        .ok_or(OxenError::resource_not_found(branch.commit_id.clone()))?;
 
     let entries = repositories::entries::list_tabular_files_in_repo(&repo, &commit)?;
     log::debug!("got {} tabular entries", entries.len());

--- a/crates/server/src/controllers/workspaces/data_frames/columns.rs
+++ b/crates/server/src/controllers/workspaces/data_frames/columns.rs
@@ -25,7 +25,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace.clone(), repo_name.clone())?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     let mut body_json: Value = serde_json::from_str(&body).map_err(|_err| {
@@ -53,7 +53,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     // Get the workspace
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     // Make sure the data frame is indexed
@@ -106,7 +106,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace.clone(), repo_name.clone())?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let column_name = path_param(&req, "column_name")
         .map_err(|_| OxenHttpError::BadRequest("Column name missing in path parameters".into()))?;
@@ -121,7 +121,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     // Get the workspace
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     // Make sure the data frame is indexed
@@ -181,7 +181,7 @@ pub async fn update(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace.clone(), repo_name.clone())?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let column_name = path_param(&req, "column_name")
         .map_err(|_| OxenHttpError::BadRequest("Column name missing in path parameters".into()))?;
@@ -225,7 +225,7 @@ pub async fn update(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     // Get the workspace
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     // Make sure the data frame is indexed
@@ -303,11 +303,11 @@ pub async fn add_column_metadata(
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
     let path = path_param(&req, "path")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let parsed_json: serde_json::Value = serde_json::from_str(&body)?;
@@ -342,11 +342,11 @@ pub async fn restore(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
 
     let column_to_restore: ColumnToRestore = ColumnToRestore { name: column_name };
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let is_editable = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;

--- a/crates/server/src/controllers/workspaces/data_frames/embeddings.rs
+++ b/crates/server/src/controllers/workspaces/data_frames/embeddings.rs
@@ -21,12 +21,13 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
-    let file_path = path_param(&req, "path")?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let file_path_str = path_param(&req, "path")?;
+    let file_path = std::path::Path::new(&file_path_str);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let response = EmbeddingColumnsResponse {
@@ -46,15 +47,16 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
-    let file_path = path_param(&req, "path")?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let file_path_str = path_param(&req, "path")?;
+    let file_path = std::path::Path::new(&file_path_str);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
-    let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;
+    let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, file_path)?;
     log::debug!("neighbors is_indexed: {is_indexed}");
     if !is_indexed {
         let response = WorkspaceJsonDataFrameViewResponse {
@@ -71,7 +73,7 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
 
     log::debug!("neighbors: Embedding query: {body:?}");
     let request: EmbeddingQuery = serde_json::from_str(&body)?;
-    let count = repositories::workspaces::data_frames::count(&workspace, &file_path)?;
+    let count = repositories::workspaces::data_frames::count(&workspace, file_path)?;
 
     let mut opts = DFOpts::empty();
     opts.page = Some(request.page_num);
@@ -79,7 +81,7 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
 
     let df = repositories::workspaces::data_frames::embeddings::nearest_neighbors(
         &workspace,
-        &file_path,
+        file_path,
         &request.column,
         request.embedding,
         &PaginateOpts {
@@ -90,20 +92,22 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
     )?;
 
     let Some(mut df_schema) =
-        repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, &file_path)?
+        repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, file_path)?
     else {
         log::error!("Failed to get schema for data frame {file_path:?}");
         return Err(OxenHttpError::NotFound);
     };
 
     let resource = ResourceVersion {
-        path: file_path.clone(),
+        path: file_path_str.clone(),
         version: workspace.commit.id.to_string(),
     };
 
-    let og_schema = if let Some(schema) =
-        repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, &resource.path)?
-    {
+    let og_schema = if let Some(schema) = repositories::data_frames::schemas::get_by_path(
+        &repo,
+        &workspace.commit,
+        std::path::Path::new(&resource.path),
+    )? {
         schema
     } else {
         Schema::from_polars(df.schema())
@@ -116,13 +120,13 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
 
     repositories::workspaces::data_frames::columns::decorate_fields_with_column_diffs(
         &workspace,
-        &file_path,
+        file_path,
         &mut df_views,
     )?;
 
     let new_schema = repositories::data_frames::schemas::get_staged_schema_with_staged_db_manager(
         &workspace.workspace_repo,
-        &file_path,
+        file_path,
     )?;
     repositories::workspaces::data_frames::columns::update_column_schemas(
         new_schema,
@@ -149,12 +153,13 @@ pub async fn post(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, OxenHt
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
-    let file_path = path_param(&req, "path")?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let file_path_str = path_param(&req, "path")?;
+    let file_path = std::path::Path::new(&file_path_str);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let Ok(data) = String::from_utf8(bytes.to_vec()) else {
         return Err(OxenHttpError::BadRequest(
@@ -168,7 +173,7 @@ pub async fn post(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, OxenHt
 
     repositories::workspaces::data_frames::embeddings::index(
         &workspace,
-        &file_path,
+        file_path,
         &column,
         use_background_thread,
     )?;

--- a/crates/server/src/controllers/workspaces/data_frames/rows.rs
+++ b/crates/server/src/controllers/workspaces/data_frames/rows.rs
@@ -23,7 +23,7 @@ pub async fn create(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace.clone(), repo_name.clone())?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     let data = String::from_utf8(bytes.to_vec()).expect("Could not parse bytes as utf8");
@@ -45,7 +45,7 @@ pub async fn create(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     // Get the workspace
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     // Make sure the data frame is indexed
@@ -92,16 +92,19 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let file_path = path_param(&req, "path")?;
     let row_id = path_param(&req, "row_id")?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
-    let row_df =
-        repositories::workspaces::data_frames::rows::get_by_id(&workspace, file_path, row_id)?;
+    let row_df = repositories::workspaces::data_frames::rows::get_by_id(
+        &workspace,
+        std::path::Path::new(&file_path),
+        &row_id,
+    )?;
 
     let row_id = repositories::workspaces::data_frames::rows::get_row_id(&row_df)?;
     let row_index = repositories::workspaces::data_frames::rows::get_row_idx(&row_df)?;
@@ -157,7 +160,7 @@ pub async fn update(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     // Assumes the workspace is already created
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     log::debug!(
         "update row repo {namespace}/{repo_name} -> {workspace_id}/{file_path:?} with json data {data:?}"
@@ -197,12 +200,12 @@ pub async fn delete(req: HttpRequest, _bytes: Bytes) -> Result<HttpResponse, Oxe
     let workspace_id = path_param(&req, "workspace_id")?;
     let row_id = path_param(&req, "row_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let df = repositories::workspaces::data_frames::rows::delete(
@@ -234,12 +237,12 @@ pub async fn restore(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let workspace_id = path_param(&req, "workspace_id")?;
     let row_id = path_param(&req, "row_id")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let restored_row = repositories::workspaces::data_frames::rows::restore(
@@ -294,7 +297,7 @@ pub async fn batch_update(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     log::debug!("update row repo {namespace}/{repo_name} -> {workspace_id}/{file_path:?}");
 

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -97,7 +97,7 @@ pub async fn get(
         Some(staged_node) => match staged_node.node.node {
             EMerkleTreeNode::File(f) => Ok(f),
             _ => Err(OxenError::basic_str(
-                "Only single file download is supported",
+                "Only single file download is supported".to_string(),
             )),
         }?,
         None => {
@@ -108,7 +108,7 @@ pub async fn get(
                 file_node
             } else {
                 return Err(OxenHttpError::InternalOxenError(
-                    OxenError::resource_not_found(&path.to_string_lossy()),
+                    OxenError::resource_not_found(path.to_string_lossy().to_string()),
                 ));
             }
         }
@@ -517,7 +517,7 @@ pub async fn save_parts(
                         let mut decoder = GzDecoder::new(&field_bytes[..]);
                         let mut decompressed_bytes: Vec<u8> = Vec::new();
                         decoder.read_to_end(&mut decompressed_bytes).map_err(|e| {
-                            OxenError::basic_str(&format!("Failed to decompress gzipped data: {e}"))
+                            OxenError::basic_str(format!("Failed to decompress gzipped data: {e}"))
                         })?;
 
                         // Hash file contents

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -80,19 +80,20 @@ pub async fn get(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let version_store = repo.version_store()?;
     let workspace_id = path_param(&req, "workspace_id")?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Err(OxenHttpError::NotFound);
     };
 
-    let path = path_param(&req, "path")?;
-    log::debug!("got workspace file path {:?}", &path);
+    let path_str = path_param(&req, "path")?;
+    let path = std::path::Path::new(&path_str);
+    log::debug!("got workspace file path {:?}", path);
 
     // First, look for the file in the workspace staged_db
     let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
-    let file_node = match staged_db_manager.read_from_staged_db(&path)? {
+    let file_node = match staged_db_manager.read_from_staged_db(path)? {
         Some(staged_node) => match staged_node.node.node {
             EMerkleTreeNode::File(f) => Ok(f),
             _ => Err(OxenError::basic_str(
@@ -101,15 +102,13 @@ pub async fn get(
         }?,
         None => {
             // If the file isn't in the workspace staged_db, look for it in the base repo
-            if let Some(file_node) = repositories::tree::get_file_by_path(
-                &workspace.base_repo,
-                &workspace.commit,
-                &path,
-            )? {
+            if let Some(file_node) =
+                repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
+            {
                 file_node
             } else {
                 return Err(OxenHttpError::InternalOxenError(
-                    OxenError::resource_not_found(&path),
+                    OxenError::resource_not_found(&path.to_string_lossy()),
                 ));
             }
         }
@@ -199,12 +198,12 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let directory = path_param(&req, "path")?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let version_store = repo.version_store()?;
@@ -283,10 +282,10 @@ pub async fn add_version_files(
     let workspace_id = path_param(&req, "workspace_id")?;
     let directory = path_param(&req, "directory")?;
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
     let files_with_hash: Vec<FileWithHash> = payload.into_inner();
     log::debug!(
@@ -340,11 +339,11 @@ pub async fn rm_files(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     let paths_to_remove: Vec<PathBuf> = payload.into_inner();
@@ -353,7 +352,7 @@ pub async fn rm_files(
     let mut err_files = vec![];
 
     for path in &paths_to_remove {
-        err_files.extend(repositories::workspaces::files::rm(&workspace, &path).await?);
+        err_files.extend(repositories::workspaces::files::rm(&workspace, path).await?);
         log::debug!("rm ✅ success! staged file {path:?} as removed");
         ret_files.push(path);
     }
@@ -384,11 +383,11 @@ pub async fn validate(req: HttpRequest, _body: String) -> Result<HttpResponse, O
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
     let Some(_workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_found()))
@@ -422,7 +421,7 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
 
     // Parse request body
@@ -434,11 +433,11 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     }
 
     // Validate and normalize new_path
-    let new_path = util::fs::validate_and_normalize_path(&body.new_path)?;
+    let new_path = util::fs::validate_and_normalize_path(std::path::Path::new(&body.new_path))?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+            .json(StatusMessageDescription::workspace_not_found(&workspace_id)));
     };
 
     // Check if new_path already exists in the workspace or base repo
@@ -518,7 +517,7 @@ pub async fn save_parts(
                         let mut decoder = GzDecoder::new(&field_bytes[..]);
                         let mut decompressed_bytes: Vec<u8> = Vec::new();
                         decoder.read_to_end(&mut decompressed_bytes).map_err(|e| {
-                            OxenError::basic_str(format!("Failed to decompress gzipped data: {e}"))
+                            OxenError::basic_str(&format!("Failed to decompress gzipped data: {e}"))
                         })?;
 
                         // Hash file contents

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -242,9 +242,9 @@ impl error::ResponseError for OxenHttpError {
                     OxenError::RepoNotFound(repo) => {
                         log::debug!("Repo not found: {repo}");
 
-                        HttpResponse::NotFound().json(StatusMessageDescription::not_found(format!(
-                            "Repository '{repo}' not found"
-                        )))
+                        HttpResponse::NotFound().json(StatusMessageDescription::not_found(
+                            &format!("Repository '{repo}' not found"),
+                        ))
                     }
                     OxenError::ResourceNotFound(resource) => {
                         log::debug!("Resource not found: {resource}");
@@ -335,9 +335,9 @@ impl error::ResponseError for OxenHttpError {
                     OxenError::RemoteRepoNotFound(remote) => {
                         log::debug!("Remote repo not found: {remote}");
 
-                        HttpResponse::NotFound().json(StatusMessageDescription::not_found(format!(
-                            "Remote repository not found: {remote}"
-                        )))
+                        HttpResponse::NotFound().json(StatusMessageDescription::not_found(
+                            &format!("Remote repository not found: {remote}"),
+                        ))
                     }
                     OxenError::CommitEntryNotFound(msg) => {
                         log::error!("{msg}");
@@ -373,20 +373,20 @@ impl error::ResponseError for OxenHttpError {
                         log::error!("Invalid schema: {schema}");
 
                         HttpResponse::BadRequest().json(StatusMessageDescription::bad_request(
-                            format!("Schema is invalid: '{schema}'"),
+                            &format!("Schema is invalid: '{schema}'"),
                         ))
                     }
                     OxenError::RemoteAheadOfLocal(desc) => {
                         log::error!("Remote ahead of local: {desc}");
 
                         HttpResponse::BadRequest()
-                            .json(StatusMessageDescription::bad_request(format!("{desc}")))
+                            .json(StatusMessageDescription::bad_request(&format!("{desc}")))
                     }
                     OxenError::IncompleteLocalHistory(desc) => {
                         log::error!("Cannot push repo with incomplete local history: {desc}");
 
                         HttpResponse::BadRequest()
-                            .json(StatusMessageDescription::bad_request(format!("{desc}")))
+                            .json(StatusMessageDescription::bad_request(&format!("{desc}")))
                     }
                     OxenError::IncompatibleSchemas(schema) => {
                         log::error!("Incompatible schemas: {schema}");

--- a/crates/server/src/helpers.rs
+++ b/crates/server/src/helpers.rs
@@ -11,15 +11,14 @@ use crate::errors::OxenHttpError;
 
 pub fn get_repo(
     path: &Path,
-    namespace: impl AsRef<str>,
-    name: impl AsRef<str>,
+    namespace: &str,
+    name: &str,
 ) -> Result<LocalRepository, OxenHttpError> {
-    let repo = repositories::get_by_namespace_and_name(path, &namespace, &name)?;
+    let repo = repositories::get_by_namespace_and_name(path, namespace, name)?;
     let Some(repo) = repo else {
-        return Err(OxenError::repo_not_found(RepoNew::from_namespace_name(
-            &namespace, &name, None,
-        ))
-        .into());
+        return Err(
+            OxenError::repo_not_found(RepoNew::from_namespace_name(namespace, name, None)).into(),
+        );
     };
 
     Ok(repo)

--- a/crates/server/src/params.rs
+++ b/crates/server/src/params.rs
@@ -110,12 +110,12 @@ pub fn parse_resource(
         "parse_resource_from_path looking for resource: {resource:?} decoded_resource: {decoded_resource:?}"
     );
     parse_resource_from_path(repo, &decoded_resource)?
-        .ok_or(OxenError::path_does_not_exist(resource).into())
+        .ok_or(OxenError::path_does_not_exist(&resource).into())
 }
 
 /// Split the base..head string into base and head strings
-pub fn parse_base_head(base_head: impl AsRef<str>) -> Result<(String, String), OxenError> {
-    let mut split = base_head.as_ref().split("..");
+pub fn parse_base_head(base_head: &str) -> Result<(String, String), OxenError> {
+    let mut split = base_head.split("..");
     if let (Some(base), Some(head)) = (split.next(), split.next()) {
         Ok((base.to_string(), head.to_string()))
     } else {

--- a/crates/server/src/params.rs
+++ b/crates/server/src/params.rs
@@ -110,7 +110,7 @@ pub fn parse_resource(
         "parse_resource_from_path looking for resource: {resource:?} decoded_resource: {decoded_resource:?}"
     );
     parse_resource_from_path(repo, &decoded_resource)?
-        .ok_or(OxenError::path_does_not_exist(&resource).into())
+        .ok_or(OxenError::path_does_not_exist(resource).into())
 }
 
 /// Split the base..head string into base and head strings
@@ -120,7 +120,7 @@ pub fn parse_base_head(base_head: &str) -> Result<(String, String), OxenError> {
         Ok((base.to_string(), head.to_string()))
     } else {
         Err(OxenError::basic_str(
-            "Could not parse commits. Format should be base..head",
+            "Could not parse commits. Format should be base..head".to_string(),
         ))
     }
 }

--- a/log_compile_times
+++ b/log_compile_times
@@ -1,0 +1,49 @@
+## Fresh Build
+
+No `target/` directory present before running commands.
+
+### Workspace
+Before any changes:
+```
+cargo build --workspace  1336.46s user 137.43s system 668% cpu 3:40.40 total
+```
+
+After changes:
+```
+...
+```
+
+### Tests
+Before any changes:
+```
+cargo build --workspace --tests  314.31s user 29.90s system 435% cpu 1:19.10 total
+```
+
+After changes:
+```
+```
+
+## Oxen-Only Changes
+
+Changes only made to the local crates. A full `target/` directory from a previous build.
+
+### Workspace
+Before any changes:
+```
+cargo build --workspace  16.03s user 5.48s system 191% cpu 11.225 total
+```
+
+After changes:
+```
+```
+
+### Tests
+Before any changes:
+```
+cargo build --workspace --tests  33.13s user 8.02s system 291% cpu 14.100 total
+```
+
+After changes:
+```
+```
+

--- a/log_compile_times
+++ b/log_compile_times
@@ -10,7 +10,7 @@ cargo build --workspace  1336.46s user 137.43s system 668% cpu 3:40.40 total
 
 After changes:
 ```
-...
+cargo build --workspace  1325.70s user 144.97s system 646% cpu 3:47.33 total
 ```
 
 ### Tests
@@ -21,6 +21,7 @@ cargo build --workspace --tests  314.31s user 29.90s system 435% cpu 1:19.10 tot
 
 After changes:
 ```
+cargo build --workspace --tests  1453.71s user 162.21s system 654% cpu 4:06.72 total
 ```
 
 ## Oxen-Only Changes
@@ -35,6 +36,7 @@ cargo build --workspace  16.03s user 5.48s system 191% cpu 11.225 total
 
 After changes:
 ```
+cargo build --workspace  6.13s user 1.82s system 186% cpu 4.270 total
 ```
 
 ### Tests
@@ -45,5 +47,10 @@ cargo build --workspace --tests  33.13s user 8.02s system 291% cpu 14.100 total
 
 After changes:
 ```
+# Changing src/lib/io.rs
+cargo build --workspace --tests  25.83s user 7.67s system 289% cpu 11.559 total
+
+# Changing fetch.rs test
+cargo build --workspace --tests  32.84s user 11.86s system 284% cpu 15.735 total
 ```
 


### PR DESCRIPTION
Replaces all generic `AsRef<X>` uses with `&X` direct references.

Includes all instances of a generic parameter of the form `Y: AsRef<X>` and
`impl AsRef<X>`. Notably, this included many `AsRef<str>` and `AsRef<Path>`,
which are now replaced with `&str` and `&Path`, respectively.

This cuts down on compilation time and binary size considerably. Since
Rust monomorphizes generics: it must compile new variants of each function
for every different concrete type use. Unlike other traits, the codebase's
use of `AsRef` doesn't provide much utility as we nearly never swap-out
different things that could be turned into the reference type. The code is
not only smaller and faster to compile, it is clearer in what, exactly,
it requires and what it exactly operates on.

