### PR TITLE
Use structured CannotPushShallowClone error variant instead of basic_str

### DIFF
--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -250,12 +250,11 @@ async fn list_and_push_missing_files(
     if let Some(entry) = missing_files.first() {
         let version_store = repo.version_store()?;
         if !version_store.version_exists(&entry.hash()).await? {
-            return Err(OxenError::basic_str(format!(
-                "Cannot push missing files for commit '{}' (\"{}\"): file data is not available locally.\n\
-                 This usually means the repository was cloned without full history.\n\
-                 To repair the remote, re-run this command from a clone that has the full history.",
-                head_commit.id, head_commit.message
-            )));
+            return Err(OxenError::CannotPushShallowClone {
+                commit_id: head_commit.id.clone(),
+                commit_message: head_commit.message.clone(),
+                help: "To repair the remote, re-run this command from a clone that has the full history.".to_string(),
+            });
         }
     }
 
@@ -434,12 +433,11 @@ async fn push_commits(
         if let Some(entry) = info.unique_file_hashes.first()
             && !version_store.version_exists(&entry.hash()).await?
         {
-            return Err(OxenError::basic_str(format!(
-                "Cannot push commit '{}' (\"{}\"): file data is not available locally.\n\
-                 This usually means the repository was cloned without full history.\n\
-                 Run `oxen pull --all` to fetch all data, then try again.",
-                commit.id, commit.message
-            )));
+            return Err(OxenError::CannotPushShallowClone {
+                commit_id: commit.id.clone(),
+                commit_message: commit.message.clone(),
+                help: "Run `oxen pull --all` to fetch all data, then try again.".to_string(),
+            });
         }
     }
 

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -336,6 +336,15 @@ pub enum OxenError {
     #[error("{0}")]
     JoinError(#[from] JoinError),
 
+    #[error(
+        "Cannot push commit '{commit_id}' (\"{commit_message}\"): file data is not available locally.\nThis usually means the repository was cloned without full history.\n{help}"
+    )]
+    CannotPushShallowClone {
+        commit_id: String,
+        commit_message: String,
+        help: String,
+    },
+
     // Fallback
     // TODO: remove all uses of `Basic` and replace with specific errors.
     #[error("{0}")]


### PR DESCRIPTION
Replace the two OxenError::basic_str calls for shallow clone push errors with a new CannotPushShallowClone variant. The variant carries commit_id, commit_message, and a context-specific help string so the error is self-describing and matchable.