### PR TITLE
Make metrics opt-in and gated by new feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,9 @@ tail -f ~/.oxen/logs/oxen-server.2026-04-06 | jq 'select(.level == "ERROR")'
 
 ## Prometheus Metrics
 
-`oxen-server` exposes a Prometheus-compatible metrics endpoint.
-See [Prometheus Metrics](crates/server/README.md#prometheus-metrics) for details.
+`oxen-server` can expose a Prometheus-compatible metrics endpoint. Requires
+the `metrics` compile-time feature (included in `production`) and `OXEN_METRICS_PORT`
+at runtime. See [Prometheus Metrics](crates/server/README.md#prometheus-metrics) for details.
 
 ## OpenTelemetry Tracing
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,8 +21,9 @@ path = "src/main.rs"
 
 [features]
 default = []
+metrics = ["liboxen/metrics"]
 otel = ["liboxen/otel"]
-production = ["otel", "default"]
+production = ["metrics", "otel", "default"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/lib.rs"
 default = ["duckdb/bundled"]
 docs = ["duckdb"]
 ffmpeg = ["thumbnails"]
+metrics = ["dep:metrics"]
 otel = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
@@ -34,7 +35,7 @@ otel = [
     "dep:tracing-opentelemetry",
 ]
 perf-logging = []
-production = ["otel", "ffmpeg", "perf-logging", "default"]
+production = ["metrics", "otel", "ffmpeg", "perf-logging", "default"]
 
 [dependencies]
 approx = { workspace = true }
@@ -83,7 +84,7 @@ libduckdb-sys = { workspace = true, optional = true }
 lofty = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
-metrics = { workspace = true }
+metrics = { workspace = true, optional = true }
 minus = { workspace = true }
 mp4 = { workspace = true }
 num_cpus = { workspace = true }

--- a/crates/lib/src/repositories/fetch.rs
+++ b/crates/lib/src/repositories/fetch.rs
@@ -18,6 +18,7 @@ pub async fn fetch_all(
     repo: &LocalRepository,
     fetch_opts: &FetchOpts,
 ) -> Result<Vec<Branch>, OxenError> {
+    #[cfg(feature = "metrics")]
     metrics::counter!("oxen_fetch_total").increment(1);
     let remote = repo
         .get_remote(&fetch_opts.remote)
@@ -88,6 +89,7 @@ pub async fn fetch_branch(
     repo: &LocalRepository,
     fetch_opts: &FetchOpts,
 ) -> Result<Branch, OxenError> {
+    #[cfg(feature = "metrics")]
     metrics::counter!("oxen_fetch_total").increment(1);
     let remote = repo
         .get_remote(&fetch_opts.remote)

--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -14,18 +14,28 @@ use crate::opts::fetch_opts::FetchOpts;
 /// `constants::DEFAULT_REMOTE_NAME` and `constants::DEFAULT_BRANCH_NAME`
 #[tracing::instrument(skip(repo), fields(repo_path = %repo.path.display()))]
 pub async fn pull(repo: &LocalRepository) -> Result<(), OxenError> {
+    #[cfg(feature = "metrics")]
     metrics::counter!("oxen_pull_total").increment(1);
+    #[cfg(feature = "metrics")]
     let timer = std::time::Instant::now();
+
     let result = match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::pull::pull(repo).await,
     };
-    metrics::histogram!("oxen_pull_duration_ms").record(timer.elapsed().as_millis() as f64);
+
+    #[cfg(feature = "metrics")]
+    {
+        let end = timer.elapsed();
+        metrics::histogram!("oxen_pull_duration_ms").record(end.as_millis() as f64);
+    }
+
     result
 }
 
 #[tracing::instrument(skip(repo), fields(repo_path = %repo.path.display()))]
 pub async fn pull_all(repo: &LocalRepository) -> Result<(), OxenError> {
+    #[cfg(feature = "metrics")]
     metrics::counter!("oxen_pull_total").increment(1);
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),

--- a/crates/lib/src/util/telemetry.rs
+++ b/crates/lib/src/util/telemetry.rs
@@ -19,8 +19,10 @@ pub enum TelemetryError {
     CreateLogDir(PathBuf, std::io::Error),
     #[error("Failed to initialize tracing: {0}")]
     InitFail(#[from] TryInitError),
+    #[cfg(feature = "otel")]
     #[error("Unknown OXEN_OTEL_PROTOCOL value: {0}")]
     UnknownProtocol(String),
+    #[cfg(feature = "otel")]
     #[error("OXEN_OTEL_ENDPOINT must start with http:// (got: {0})")]
     InvalidEndpoint(String),
 }

--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -16,8 +16,9 @@ crate-type = ["cdylib"] # PyO3 needs this crate to be a cdylib so it can link ag
 
 [features]
 default = []
+metrics = ["liboxen/metrics"]
 otel = ["liboxen/otel"]
-production = ["otel", "default"]
+production = ["metrics", "otel", "default"]
 
 [dependencies]
 liboxen = { path = "../lib" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,8 +19,9 @@ path = "src/main.rs"
 
 [features]
 default = []
+metrics = ["liboxen/metrics", "dep:metrics", "dep:metrics-exporter-prometheus"]
 otel = ["liboxen/otel", "dep:tracing-opentelemetry"]
-production = ["otel", "liboxen/production", "default"]
+production = ["metrics", "otel", "liboxen/production", "default"]
 
 [dependencies]
 actix-http = { workspace = true }
@@ -42,8 +43,8 @@ jsonwebtoken = { workspace = true }
 liboxen = { path = "../lib" }
 log = { workspace = true }
 lru = { workspace = true }
-metrics = { workspace = true }
-metrics-exporter-prometheus = { workspace = true }
+metrics = { workspace = true, optional = true }
+metrics-exporter-prometheus = { workspace = true, optional = true }
 mime = { workspace = true }
 os_path = { workspace = true }
 percent-encoding = { workspace = true }

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -96,31 +96,67 @@ metrics endpoint. This allows you to monitor server health, track request
 counts, error rates, and other operational metrics using standard Prometheus
 tooling.
 
+### Compile-time feature flag
+
+Metrics collection requires the `metrics` Cargo feature. Without it, all
+metric collections (`counter!`, `histogram!`, etc.) compile to no-ops —
+no counters are recorded and no `/metrics` endpoint is served,
+regardless of environment variables.
+
+The `metrics` feature is included in `production`, so a production build
+already has it:
+
+```bash
+cargo build --workspace --features production
+```
+
+To enable metrics alone (without OpenTelemetry tracing or other production
+features):
+
+```bash
+# just metrics, for any crate
+cargo build --workspace --features metrics
+
+# or per-crate
+cargo build -p oxen-server --features metrics
+cargo build -p oxen        --features metrics
+cargo build -p liboxen     --features metrics
+```
+
+If `OXEN_METRICS_PORT` is set at runtime (to a value other than `off`)
+but the binary was compiled **without** the `metrics` feature, the server
+logs an error at startup explaining the mismatch.
+
 ### How it works
 
-On startup, `oxen-server` launches a lightweight HTTP server (separate from
-the main API) that serves metrics in the Prometheus exposition format. Any
-counters, gauges, or histograms recorded via the [`metrics`](https://docs.rs/metrics)
-crate are automatically exposed.
+On startup (when compiled with `metrics`), `oxen-server` launches a
+lightweight HTTP server (separate from the main API) that serves metrics
+in the Prometheus exposition format. Any counters, gauges, or histograms
+recorded via the [`metrics`](https://docs.rs/metrics) crate are
+automatically exposed.
 
 ### Configuration
 
-The metrics endpoint is **enabled by default** on port **9090**.
+The metrics endpoint is **opt-in**. Set `OXEN_METRICS_PORT` to a port number
+to enable it.
 
 | Variable | Description | Default |
 |---|---|---|
-| `OXEN_METRICS_PORT` | Port for the metrics HTTP server | `9090` |
-| `OXEN_METRICS_PORT=off` | Disable the metrics endpoint entirely | -- |
+| `OXEN_METRICS_PORT` | Port for the metrics HTTP server (opt-in) | *(none — disabled)* |
+| `OXEN_METRICS_PORT=off` | Explicitly disable the metrics endpoint | -- |
 
 ```bash
-# Use the default port (9090)
-cargo run -p oxen-server start
+# No metrics server (default)
+cargo run -p oxen-server --features metrics start
 
-# Use a custom port
-OXEN_METRICS_PORT=9100 cargo run -p oxen-server start
+# Enable metrics on port 9090
+OXEN_METRICS_PORT=9090 cargo run -p oxen-server --features metrics start
 
-# Disable metrics entirely
-OXEN_METRICS_PORT=off cargo run -p oxen-server start
+# Enable metrics on a custom port
+OXEN_METRICS_PORT=9100 cargo run -p oxen-server --features metrics start
+
+# Explicitly disable metrics
+OXEN_METRICS_PORT=off cargo run -p oxen-server --features metrics start
 ```
 
 ### Verifying with `curl`

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -21,15 +21,15 @@ pub mod services;
 #[cfg(test)]
 pub(crate) mod test;
 
-pub(crate) mod telemetry;
+pub(crate) mod metrics;
 
+extern crate liboxen;
 extern crate log;
 extern crate lru;
 
 use actix_web::middleware::{Condition, DefaultHeaders, Logger};
 use actix_web::{App, HttpServer, web};
 use actix_web_httpauth::middleware::HttpAuthentication;
-use metrics_exporter_prometheus::BuildError;
 use thiserror::Error;
 
 use middleware::{MetricsMiddleware, RequestIdMiddleware};
@@ -77,11 +77,9 @@ use utoipa_swagger_ui::SwaggerUi;
 use clap::{Parser, Subcommand};
 
 use std::env;
-use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
 
-use crate::telemetry::MetricsGuard;
-use crate::telemetry::init_metrics_prometheus;
+use crate::metrics::MetricsGuard;
 
 const VERSION: &str = liboxen::constants::OXEN_VERSION;
 
@@ -375,10 +373,12 @@ enum ServerError {
     Io(#[from] std::io::Error),
     #[error("{0}")]
     Oxen(#[from] OxenError),
+    #[cfg(feature = "metrics")]
     #[error("Invalid OXEN_METRICS_PORT value: {0} (parsing error: {1})")]
-    InvalidPort(String, ParseIntError),
+    InvalidPort(String, std::num::ParseIntError),
+    #[cfg(feature = "metrics")]
     #[error("Failed to start Prometheus metrics server: {0}")]
-    Metrics(#[from] BuildError),
+    Metrics(#[from] metrics_exporter_prometheus::BuildError),
 }
 
 /// The actual main oxen-server loop.
@@ -435,8 +435,9 @@ async fn server() -> Result<(), ServerError> {
     }
 }
 
-/// Initialize the Prometheus metrics server on `OXEN_METRICS_PORT`, defaulting to port 9090.
-/// Returns `Ok(None)` if `OXEN_METRICS_PORT='off'`.
+/// Initialize the Prometheus metrics server on the port specified by `OXEN_METRICS_PORT`.
+/// Metrics are **opt-in**: if the variable is not set, no metrics server is started.
+/// Returns `Ok(None)` if `OXEN_METRICS_PORT` is unset or `'off'`.
 ///
 /// # Errors
 ///   - `OXEN_METRICS_PORT` is set to a value that cannot be parsed as a `u16`
@@ -444,10 +445,11 @@ async fn server() -> Result<(), ServerError> {
 ///   - The Prometheus exporter fails to start
 ///
 /// Callers should propagate or handle the returned error.
+#[cfg(feature = "metrics")]
 fn init_metrics() -> Result<Option<MetricsGuard>, ServerError> {
     let enable_metrics = match env::var("OXEN_METRICS_PORT").as_deref() {
         Ok(val) if val.to_lowercase() == "off" => {
-            log::info!("Prometheus metrics disabled.");
+            log::info!("Prometheus metrics explicitly disabled (OXEN_METRICS_PORT=off).");
             None
         }
         Ok(val) => {
@@ -456,11 +458,12 @@ fn init_metrics() -> Result<Option<MetricsGuard>, ServerError> {
                 .map_err(|e| ServerError::InvalidPort(val.to_string(), e))?;
             Some(port)
         }
-        Err(_) => Some(9090),
+        // Not set: opt-in only, no metrics server
+        Err(_) => None,
     };
 
     if let Some(port) = enable_metrics {
-        let guard = init_metrics_prometheus(port)?;
+        let guard = crate::metrics::init_metrics_prometheus(port)?;
         log::info!(
             "Prometheus metrics at http://0.0.0.0:{port}/metrics \
              (set OXEN_METRICS_PORT to change, OXEN_METRICS_PORT='off' to disable)"
@@ -469,6 +472,21 @@ fn init_metrics() -> Result<Option<MetricsGuard>, ServerError> {
     } else {
         Ok(None)
     }
+}
+
+/// Returns `Ok(None)` when the "metrics" feature is not enabled.
+#[cfg(not(feature = "metrics"))]
+fn init_metrics() -> Result<Option<MetricsGuard>, ServerError> {
+    if let Ok(val) = env::var("OXEN_METRICS_PORT")
+        && !val.eq_ignore_ascii_case("off")
+    {
+        log::error!(
+            "OXEN_METRICS_PORT is set but the 'metrics' feature is not enabled. \
+                 Re-compile with `--features metrics` to enable metrics collection and the \
+                 Prometheus-compatible /metrics endpoint. (Ignoring.)"
+        );
+    }
+    Ok(None)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/server/src/metrics.rs
+++ b/crates/server/src/metrics.rs
@@ -1,19 +1,26 @@
+#[cfg(feature = "metrics")]
 use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
 
 /// Guard for the Prometheus metrics exporter. Dropping this aborts the
 /// background HTTP server that serves the `/metrics` endpoint.
 ///
 /// Use `init_metrics_prometheus` to create an instance.
+#[cfg(feature = "metrics")]
 pub(crate) struct MetricsGuard {
     handle: tokio::task::JoinHandle<Result<(), String>>,
 }
 
+#[cfg(feature = "metrics")]
 impl Drop for MetricsGuard {
     /// Aborts the background HTTP server that serves the `/metrics` endpoint.
     fn drop(&mut self) {
         self.handle.abort();
     }
 }
+
+/// An empty struct used as a placeholder when the `metrics` feature is disabled.
+#[cfg(not(feature = "metrics"))]
+pub(crate) struct MetricsGuard {}
 
 /// Install the Prometheus metrics exporter, listening on the given port.
 ///
@@ -27,6 +34,7 @@ impl Drop for MetricsGuard {
 ///
 /// Returns an error if the port is already in use or if the Prometheus recorder
 /// or exporter cannot be initialized.
+#[cfg(feature = "metrics")]
 pub(crate) fn init_metrics_prometheus(port: u16) -> Result<MetricsGuard, BuildError> {
     // Verify the port is free before committing to the recorder and spawning
     // the background task. The listener is dropped immediately so the exporter

--- a/crates/server/src/middleware.rs
+++ b/crates/server/src/middleware.rs
@@ -5,7 +5,7 @@ use actix_web::{
 use futures_util::future::LocalBoxFuture;
 use liboxen::request_context::REQUEST_ID;
 use std::future::{Ready, ready};
-use std::time::Instant;
+
 // Oxen request Id
 pub const OXEN_REQUEST_ID: &str = "x-oxen-request-id";
 
@@ -96,12 +96,20 @@ where
 /// `/api/repos/{namespace}/{repo_name}/branches`) to keep cardinality low.
 pub struct MetricsMiddleware;
 
+// These constants are consumed by the `counter!`/`histogram!` macros from `metrics`.
+// When the `metrics` feature is disabled, the macros expand to no-ops and the constants
+// appear unused to the compiler — but they are still required for compilation with metrics.
+#[cfg(feature = "metrics")]
 const HTTP_REQUESTS_TOTAL: &str = "http_requests_total";
+#[cfg(feature = "metrics")]
 const HTTP_ERRORS_TOTAL: &str = "http_errors_total";
+#[cfg(feature = "metrics")]
 const HTTP_REQUEST_DURATION_MS: &str = "http_request_duration_ms";
-
+#[cfg(feature = "metrics")]
 const METHOD: &str = "method";
+#[cfg(feature = "metrics")]
 const PATH: &str = "path";
+#[cfg(feature = "metrics")]
 const STATUS: &str = "status";
 
 impl<S, B> Transform<S, ServiceRequest> for MetricsMiddleware
@@ -137,49 +145,58 @@ where
 
     forward_ready!(service);
 
+    #[inline]
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        let start = Instant::now();
+        #[cfg(feature = "metrics")]
+        let start = std::time::Instant::now();
+        #[cfg(feature = "metrics")]
         let method = req.method().to_string();
 
         let fut = self.service.call(req);
 
-        Box::pin(async move {
-            match fut.await {
-                Ok(res) => {
-                    let status = res.status().as_u16().to_string();
-                    let path = res
-                        .request()
-                        .match_pattern()
-                        .unwrap_or_else(|| "unmatched".to_string());
-                    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+        #[cfg(feature = "metrics")]
+        {
+            Box::pin(async move {
+                match fut.await {
+                    Ok(res) => {
+                        let status = res.status().as_u16().to_string();
+                        let path = res
+                            .request()
+                            .match_pattern()
+                            .unwrap_or_else(|| "unmatched".to_string());
+                        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
 
-                    metrics::counter!(HTTP_REQUESTS_TOTAL, METHOD => method.clone(), PATH => path.clone(), STATUS => status.clone())
-                        .increment(1);
-                    if res.status().is_client_error() || res.status().is_server_error() {
-                        metrics::counter!(HTTP_ERRORS_TOTAL, METHOD => method.clone(), PATH => path.clone(), STATUS => status)
-                            .increment(1);
+                        metrics::counter!(HTTP_REQUESTS_TOTAL, METHOD => method.clone(), PATH => path.clone(), STATUS => status.clone()).increment(1);
+                        if res.status().is_client_error() || res.status().is_server_error() {
+                            metrics::counter!(HTTP_ERRORS_TOTAL, METHOD => method.clone(), PATH => path.clone(), STATUS => status)
+                                .increment(1);
+                        }
+                        metrics::histogram!(HTTP_REQUEST_DURATION_MS, METHOD => method, PATH => path)
+                            .record(elapsed_ms);
+
+                        Ok(res)
                     }
-                    metrics::histogram!(HTTP_REQUEST_DURATION_MS, METHOD => method, PATH => path)
-                        .record(elapsed_ms);
+                    Err(err) => {
+                        let status = "500";
+                        let path = "unmatched";
+                        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
 
-                    Ok(res)
+                        metrics::counter!(HTTP_REQUESTS_TOTAL, METHOD => method.clone(), PATH => path, STATUS => status).increment(1);
+                        metrics::counter!(HTTP_ERRORS_TOTAL, METHOD => method.clone(), PATH => path, STATUS => status)
+                                                .increment(1);
+                        metrics::histogram!(HTTP_REQUEST_DURATION_MS, METHOD => method, PATH => path)
+                            .record(elapsed_ms);
+
+                        Err(err)
+                    }
                 }
-                Err(err) => {
-                    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-                    let status = "500";
-                    let path = "unmatched";
+            })
+        }
 
-                    metrics::counter!(HTTP_REQUESTS_TOTAL, METHOD => method.clone(), PATH => path, STATUS => status)
-                        .increment(1);
-                    metrics::counter!(HTTP_ERRORS_TOTAL, METHOD => method.clone(), PATH => path, STATUS => status)
-                        .increment(1);
-                    metrics::histogram!(HTTP_REQUEST_DURATION_MS, METHOD => method, PATH => path)
-                        .record(elapsed_ms);
-
-                    Err(err)
-                }
-            }
-        })
+        #[cfg(not(feature = "metrics"))]
+        {
+            Box::pin(fut)
+        }
     }
 }
 


### PR DESCRIPTION
**Make Metrics Opt-In**
Makes starting the `/metrics` endpoint an explicit opt-in. Users must explicitly
set `OXEN_METRICS_PORT` for `oxen-server`'s `/metrics` to function.
`OXEN_METRICS_PORT=off` still disabled metrics, which is the default behavior now.

**`metrics` compilation feature**
All `metrics`-crate using features of all oxen crates are now gated behind a new
compilation feature flag called `"metrics"`. Collection in `liboxen`, `oxen`, and
`oxen-py` and serving in `oxen-server` is disabled in the default build.

The `production` flag includes `metrics`.

For `oxen-server`: if a user supplies `OXEN_METRICS_PORT` when `metrics` is not
enabled, then a warning is logged telling the user to recompile with `metrics` enabled.