### PR TITLE
Allow skipping dependencies

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -116,6 +116,7 @@ oxen push origin main               # Push to remote
 - When calling `get_staged_db_manager`, follow the doc comment on that function: drop the returned `StagedDBManager` as soon as possible (via a block scope or explicit `drop()`) to avoid holding the shared database handle longer than necessary.
 - When altering the `OxenError` enum, consider whether a hint needs to be added or updated in the `hint` method.
 - Instead of using `cargo test` to test Rust code, use the `bin/test-rust` script. The script usage is documented in a comment at the top of its file.
+- When running the `bin/test-rust` script use the `--skip-deps` flag. If any dependencies turn out to be missing, prompt the user to run `bin/install-prereqs`.
 - Prefer using inline code over creating a new function when the function would only be called once and the function body would be less than 15 lines.
 - Preserve comments whenever possible. Comments that were written by someone other than Claude should always be preserved or updated if possible.
 - The Python project calls into the Rust project. Whenever changing the Rust code, check to see if the Python code needs to be updated.

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -2,11 +2,12 @@
 #
 # Build, configure, and run the Oxen test suite.
 #
-# Usage: test-rust [--ffmpeg] [--keep] [-p|--python] [extra args...]
+# Usage: test-rust [--ffmpeg] [--keep] [--skip-deps] [-p|--python] [extra args...]
 #
 #   --ffmpeg      Enable the "ffmpeg" cargo feature for build and test commands.
 #   --keep        Do not remove test data (in data/ox and data/test/runs) on cleanup — useful for
 #                 debugging failed tests.
+#   --skip-deps   Skip checking/installing prerequisites (install-prereqs).
 #   -p|--python   Run the oxen-python test suite (via pytest) instead of the Rust test suite.
 #                 Builds the native extension with maturin.
 #   All remaining arguments are forwarded to `cargo nextest run` or `pytest` (with -p).
@@ -20,11 +21,13 @@
 # Check for flags
 FEATURE_ARGS=""
 KEEP_DATA=false
+SKIP_DEPS=false
 RUN_PYTHON=false
 while true; do
     case "${1:-}" in
         --ffmpeg)        FEATURE_ARGS="-F ffmpeg"; shift ;;
         --keep)          KEEP_DATA=true; shift ;;
+        --skip-deps)     SKIP_DEPS=true; shift ;;
         -p|--python)     RUN_PYTHON=true; shift ;;
         *) break ;;
     esac
@@ -77,7 +80,11 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Ensure all prerequisites are installed
-"$SCRIPT_DIR/install-prereqs"
+if [ "$SKIP_DEPS" = false ]; then
+    "$SCRIPT_DIR/install-prereqs"
+else
+    echo "==> Skipping dependency check (--skip-deps)"
+fi
 
 # Build
 echo "==> Building oxen (cargo build $FEATURE_ARGS)..."


### PR DESCRIPTION
Claude's sandbox restrictions don't play nicely with installing prerequisites. Luckily, we only need to install them once locally, so let's give Claude a way to skip them.