### PR TITLE
Make `list_files_in_dir` async

### DIFF
--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -95,6 +95,10 @@ pub enum OxenError {
     #[error("HEAD not found.")]
     HeadNotFound,
 
+    /// Missing a file name
+    #[error("{0}")]
+    MissingFileName(StringError),
+
     //
     // Workspaces
     //

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -807,7 +807,7 @@ mod tests {
                 assert!(test_dir_path.exists());
 
                 // list files in test_dir_path
-                let test_dir_files = util::fs::list_files_in_dir(&test_dir_path);
+                let test_dir_files = util::fs::list_files_in_dir(&test_dir_path).await?;
                 println!("test_dir_files: {:?}", test_dir_files.len());
                 for file in test_dir_files.iter() {
                     println!("file: {file:?}");

--- a/crates/lib/src/repositories/clone.rs
+++ b/crates/lib/src/repositories/clone.rs
@@ -380,7 +380,7 @@ mod tests {
                 assert!(test_dir_path.exists());
 
                 // list files in test_dir_path
-                let test_dir_files = util::fs::list_files_in_dir(&test_dir_path);
+                let test_dir_files = util::fs::list_files_in_dir(&test_dir_path).await?;
                 println!("test_dir_files: {:?}", test_dir_files.len());
                 for file in test_dir_files.iter() {
                     println!("file: {file:?}");

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -393,26 +393,16 @@ pub fn list_dirs_in_dir(dir: &Path) -> Result<Vec<PathBuf>, OxenError> {
     Ok(dirs)
 }
 
-pub fn list_files_in_dir(dir: &Path) -> Vec<PathBuf> {
+pub async fn list_files_in_dir(dir: &Path) -> Result<Vec<PathBuf>, OxenError> {
     let mut files: Vec<PathBuf> = Vec::new();
-    match std::fs::read_dir(dir) {
-        Ok(paths) => {
-            for path in paths.flatten() {
-                if path.path().is_file() {
-                    files.push(path.path());
-                }
-            }
-        }
-        Err(err) => {
-            eprintln!(
-                "util::fs::list_files_in_dir Could not find dir: {} err: {}",
-                dir.display(),
-                err
-            )
+    let mut entries = tokio::fs::read_dir(dir).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if entry.file_type().await?.is_file() {
+            files.push(path);
         }
     }
-
-    files
+    Ok(files)
 }
 
 pub fn rlist_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
@@ -2181,5 +2171,43 @@ def add(a, b):
             util::fs::to_unix_str(Path::new("data\\test\\file.txt")),
             "data/test/file.txt"
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_files_in_dir() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|dir| async move {
+            // Create a few files and a subdirectory
+            tokio::fs::write(dir.join("a.txt"), b"a").await?;
+            tokio::fs::write(dir.join("b.csv"), b"b").await?;
+            tokio::fs::create_dir(dir.join("subdir")).await?;
+            tokio::fs::write(dir.join("subdir").join("nested.txt"), b"n").await?;
+
+            let mut files = util::fs::list_files_in_dir(&dir).await?;
+            files.sort();
+
+            // Should only contain the two top-level files, not the subdir or its contents
+            assert_eq!(files.len(), 2);
+            assert!(files.contains(&dir.join("a.txt")));
+            assert!(files.contains(&dir.join("b.csv")));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_list_files_in_dir_empty() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|dir| async move {
+            let files = util::fs::list_files_in_dir(&dir).await?;
+            assert!(files.is_empty());
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_list_files_in_dir_nonexistent() {
+        let result = util::fs::list_files_in_dir(Path::new("/nonexistent/path")).await;
+        assert!(result.is_err());
     }
 }

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -7,7 +7,6 @@ use liboxen::constants::VERSION_FILE_NAME;
 
 use liboxen::core::commit_sync_status;
 use liboxen::error::OxenError;
-use liboxen::error::StringError;
 use liboxen::model::{Commit, LocalRepository};
 use liboxen::opts::PaginateOpts;
 use liboxen::perf_guard;
@@ -881,10 +880,10 @@ async fn check_if_upload_complete_and_unpack(
             unpack_compressed_data(&files, repo).await?;
         } else {
             let filename = filename.ok_or_else(|| {
-                OxenError::MissingFileName(StringError::new(
+                OxenError::MissingFileName(
                     "check_if_upload_complete_and_unpack must supply filename if !compressed"
                         .into(),
-                ))
+                )
             })?;
             unpack_to_file(&files, repo, &filename)?;
         }

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -797,7 +797,7 @@ pub async fn upload_chunk(
                     // but we should find a more elegant solution because we're
                     // doing a lot of extra work unpacking tarballs multiple
                     // times.
-                    check_if_upload_complete_and_unpack(
+                    if let Err(err) = check_if_upload_complete_and_unpack(
                         &repo,
                         tmp_dir,
                         total_chunks,
@@ -805,7 +805,12 @@ pub async fn upload_chunk(
                         query.is_compressed,
                         query.filename.to_owned(),
                     )
-                    .await;
+                    .await
+                    {
+                        log::error!("upload_chunk unpack failed: {err:?}");
+                        return Ok(HttpResponse::InternalServerError()
+                            .json(StatusMessage::internal_server_error()));
+                    }
 
                     Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))
                 }
@@ -834,8 +839,8 @@ async fn check_if_upload_complete_and_unpack(
     total_size: usize,
     is_compressed: bool,
     filename: Option<String>,
-) {
-    let mut files = util::fs::list_files_in_dir(&tmp_dir);
+) -> Result<(), OxenError> {
+    let mut files = util::fs::list_files_in_dir(&tmp_dir).await?;
 
     log::debug!(
         "check_if_upload_complete_and_unpack checking if complete... {} / {}",
@@ -844,20 +849,14 @@ async fn check_if_upload_complete_and_unpack(
     );
 
     if total_chunks < files.len() {
-        return;
+        return Ok(());
     }
     files.sort();
 
     let mut uploaded_size: u64 = 0;
     for file in files.iter() {
-        match util::fs::metadata(file) {
-            Ok(metadata) => {
-                uploaded_size += metadata.len();
-            }
-            Err(err) => {
-                log::warn!("Err getting metadata on {file:?}\n{err:?}");
-            }
-        }
+        let metadata = util::fs::metadata(file)?;
+        uploaded_size += metadata.len();
     }
 
     log::debug!(
@@ -868,7 +867,6 @@ async fn check_if_upload_complete_and_unpack(
     // But if we have all the chunks we should be good
 
     if (uploaded_size as usize) >= total_size {
-        // std::thread::spawn(move || {
         // Get tar.gz bytes for history/COMMIT_ID data
         log::debug!(
             "check_if_upload_complete_and_unpack decompressing {} bytes to {:?}",
@@ -879,55 +877,27 @@ async fn check_if_upload_complete_and_unpack(
         // TODO: Cleanup these if / else / match statements
         // Combine into actual file data
         if is_compressed {
-            match unpack_compressed_data(&files, repo).await {
-                Ok(_) => {
-                    log::debug!(
-                        "check_if_upload_complete_and_unpack unpacked {} files successfully",
-                        files.len()
-                    );
-                }
-                Err(err) => {
-                    log::error!(
-                        "check_if_upload_complete_and_unpack could not unpack compressed data {err:?}"
-                    );
-                }
-            }
+            unpack_compressed_data(&files, repo).await?;
         } else {
-            match filename {
-                Some(filename) => match unpack_to_file(&files, repo, &filename) {
-                    Ok(_) => {
-                        log::debug!(
-                            "check_if_upload_complete_and_unpack unpacked {} files successfully",
-                            files.len()
-                        );
-                    }
-                    Err(err) => {
-                        log::error!(
-                            "check_if_upload_complete_and_unpack could not unpack compressed data {err:?}"
-                        );
-                    }
-                },
-                None => {
-                    log::error!(
-                        "check_if_upload_complete_and_unpack must supply filename if !compressed"
-                    );
-                }
-            }
+            let filename = filename.ok_or_else(|| {
+                OxenError::basic_str(
+                    "check_if_upload_complete_and_unpack must supply filename if !compressed",
+                )
+            })?;
+            unpack_to_file(&files, repo, &filename)?;
         }
 
+        log::debug!(
+            "check_if_upload_complete_and_unpack unpacked {} files successfully",
+            files.len()
+        );
+
         // Cleanup tmp files
-        match util::fs::remove_dir_all(&tmp_dir) {
-            Ok(_) => {
-                log::debug!("check_if_upload_complete_and_unpack removed tmp dir {tmp_dir:?}");
-            }
-            Err(err) => {
-                log::error!(
-                    "check_if_upload_complete_and_unpack could not remove tmp dir {tmp_dir:?} {err:?}"
-                );
-            }
-        }
-        // });
+        util::fs::remove_dir_all(&tmp_dir)?;
+        log::debug!("check_if_upload_complete_and_unpack removed tmp dir {tmp_dir:?}");
     }
+
+    Ok(())
 }
 
 fn unpack_to_file(

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -848,7 +848,7 @@ async fn check_if_upload_complete_and_unpack(
         total_chunks
     );
 
-    if total_chunks < files.len() {
+    if files.len() < total_chunks {
         return Ok(());
     }
     files.sort();

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -7,6 +7,7 @@ use liboxen::constants::VERSION_FILE_NAME;
 
 use liboxen::core::commit_sync_status;
 use liboxen::error::OxenError;
+use liboxen::error::StringError;
 use liboxen::model::{Commit, LocalRepository};
 use liboxen::opts::PaginateOpts;
 use liboxen::perf_guard;
@@ -880,9 +881,10 @@ async fn check_if_upload_complete_and_unpack(
             unpack_compressed_data(&files, repo).await?;
         } else {
             let filename = filename.ok_or_else(|| {
-                OxenError::basic_str(
-                    "check_if_upload_complete_and_unpack must supply filename if !compressed",
-                )
+                OxenError::MissingFileName(StringError::new(
+                    "check_if_upload_complete_and_unpack must supply filename if !compressed"
+                        .into(),
+                ))
             })?;
             unpack_to_file(&files, repo, &filename)?;
         }

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -938,14 +938,8 @@ fn unpack_to_file(
 
         log::debug!("Read {} file bytes from file {:?}", buffer.len(), file);
 
-        match outf.write_all(&buffer) {
-            Ok(_) => {
-                log::debug!("Unpack successful! {full_path:?}");
-            }
-            Err(err) => {
-                log::error!("Could not write all data to disk {err:?}");
-            }
-        }
+        outf.write_all(&buffer)?;
+        log::debug!("Unpack successful! {full_path:?}");
     }
     Ok(())
 }

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -808,8 +808,7 @@ pub async fn upload_chunk(
                     .await
                     {
                         log::error!("upload_chunk unpack failed: {err:?}");
-                        return Ok(HttpResponse::InternalServerError()
-                            .json(StatusMessage::internal_server_error()));
+                        return Err(err.into());
                     }
 
                     Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))


### PR DESCRIPTION
Another step towards making all the things async.

- Convert `list_files_in_dir` to async
   -  Return `Result<Vec<PathBuf>, OxenError>` instead of silently ignoring errors
- Propagate the error through callers
  - Update `check_if_upload_complete_and_unpack` to also return `Result<(), OxenError>`
- Add unit tests for `list_files_in_dir`