### PR TITLE
Add raw PUT support and oxen-based-on optimistic concurrency

### DIFF
--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -76,8 +76,43 @@ curl -H "Authorization: Bearer $TOKEN" "http://0.0.0.0:3000/api/repos"
 
 #### Create Repository
 ```bash
-curl -H "Authorization: Bearer $TOKEN" -X POST -d '{"name": "MyRepo"}' "http://0.0.0.0:3000api/repos"
+curl -H "Authorization: Bearer $TOKEN" -X POST -d '{"name": "MyRepo"}' "http://0.0.0.0:3000/api/repos"
 ```
+
+#### Upload a File (Raw PUT)
+
+Upload a file directly using a raw HTTP body (no multipart form needed):
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: text/plain" \
+     -X PUT \
+     -d "Hello, World!" \
+     "http://0.0.0.0:3000/api/repos/my_namespace/MyRepo/file/main/hello.txt"
+```
+
+The existing multipart PUT is still supported. The server detects the format from the `Content-Type` header.
+
+#### Optimistic Concurrency (`oxen-based-on`)
+
+When downloading a file via GET, the response includes an `oxen-revision-id` header with the commit that last modified the file. To prevent overwriting concurrent changes, pass this value back on PUT or DELETE:
+
+```bash
+# Get the current revision
+REVISION=$(curl -sI -H "Authorization: Bearer $TOKEN" \
+  "http://0.0.0.0:3000/api/repos/my_namespace/MyRepo/file/main/hello.txt" \
+  | grep -i oxen-revision-id | awk '{print $2}' | tr -d '\r')
+
+# Update with concurrency check
+curl -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: text/plain" \
+     -H "oxen-based-on: $REVISION" \
+     -X PUT \
+     -d "Updated content" \
+     "http://0.0.0.0:3000/api/repos/my_namespace/MyRepo/file/main/hello.txt"
+```
+
+If the file has been modified since the claimed revision, the server returns `400 Bad Request`.
 
 
 ## Logging

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -86,12 +86,23 @@ Upload a file directly using a raw HTTP body (no multipart form needed):
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: text/plain" \
+     -H "oxen-commit-author: Ox" \
+     -H "oxen-commit-email: ox@oxen.ai" \
+     -H "oxen-commit-message: Add hello.txt" \
      -X PUT \
      -d "Hello, World!" \
      "http://0.0.0.0:3000/api/repos/my_namespace/MyRepo/file/main/hello.txt"
 ```
 
-The existing multipart PUT is still supported. The server detects the format from the `Content-Type` header.
+For raw PUTs, commit metadata is supplied via headers:
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `oxen-commit-author` | No | Commit author name (defaults to empty) |
+| `oxen-commit-email` | No | Commit author email (defaults to empty) |
+| `oxen-commit-message` | No | Commit message (defaults to "Auto-commit files to {path}") |
+
+The existing multipart PUT is still supported (where these fields are form parts instead). The server detects the format from the `Content-Type` header.
 
 #### Optimistic Concurrency (`oxen-based-on`)
 

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -5,7 +5,8 @@ use crate::params::{app_data, parse_resource, path_param, query_param};
 use actix_multipart::form::text::Text;
 use actix_multipart::form::{FieldReader, Limits, MultipartForm};
 use actix_multipart::{Field, MultipartError};
-use actix_web::{HttpRequest, HttpResponse, web};
+use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, web};
+use futures_util::StreamExt as _;
 use futures_util::TryStreamExt as _;
 use futures_util::future::LocalBoxFuture;
 use liboxen::core::staged::get_staged_db_manager;
@@ -253,9 +254,102 @@ pub async fn get(
 )]
 pub async fn put(
     req: HttpRequest,
-    MultipartForm(form): MultipartForm<FileUploadBody>,
+    mut payload: web::Payload,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
     log::debug!("file::put path {:?}", req.path());
+
+    if req.content_type().starts_with("multipart/form-data") {
+        let mut pl = payload.into_inner();
+        let form = MultipartForm::<FileUploadBody>::from_request(&req, &mut pl)
+            .await
+            .map_err(|e| OxenHttpError::BadRequest(format!("Multipart parse error: {e}").into()))?;
+        put_multipart(req, form.into_inner()).await
+    } else {
+        // Raw body PUT
+        let mut bytes = web::BytesMut::new();
+        while let Some(item) = payload.next().await {
+            bytes.extend_from_slice(&item.map_err(|_| OxenHttpError::FailedToReadRequestPayload)?);
+        }
+        put_raw(req, bytes.freeze()).await
+    }
+}
+
+async fn put_raw(
+    req: HttpRequest,
+    body: web::Bytes,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    log::debug!("file::put_raw path {:?}", req.path());
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?.to_string();
+    let repo_name = path_param(&req, "repo_name")?.to_string();
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+
+    let resource = parse_resource(&req, &repo)?;
+
+    // Resource must specify branch because we need to commit the workspace back to a branch
+    let branch = resource
+        .branch
+        .clone()
+        .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
+    let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
+
+    check_oxen_based_on(&req, &repo, &commit, &resource.path)?;
+
+    ensure_no_file_ancestors_in_tree(&repo, &commit, &resource.path, &resource.path)?;
+
+    // Extract commit metadata from headers
+    let name = req
+        .headers()
+        .get("oxen-commit-author")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let email = req
+        .headers()
+        .get("oxen-commit-email")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let message = req
+        .headers()
+        .get("oxen-commit-message")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    let user = create_user_from_options(name.clone(), email.clone())?;
+
+    let file = FileNew {
+        path: resource.path.clone(),
+        contents: FileContents::Binary(body.to_vec()),
+        user,
+    };
+
+    let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+
+    process_and_add_files(&repo, Some(&workspace), &[file]).await?;
+
+    // Commit workspace
+    let commit_body = NewCommitBody {
+        author: name.unwrap_or_default(),
+        email: email.unwrap_or_default(),
+        message: message.unwrap_or_else(|| {
+            format!("Auto-commit files to {}", &resource.path.to_string_lossy())
+        }),
+    };
+
+    let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
+
+    log::debug!("file::put_raw workspace commit ✅ success! commit {commit:?}");
+
+    Ok(HttpResponse::Ok().json(CommitResponse {
+        status: StatusMessage::resource_created(),
+        commit,
+    }))
+}
+
+async fn put_multipart(
+    req: HttpRequest,
+    form: FileUploadBody,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    log::debug!("file::put_multipart path {:?}", req.path());
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
@@ -280,6 +374,9 @@ pub async fn put(
         .clone()
         .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
+
+    check_oxen_based_on(&req, &repo, &commit, &resource.path)?;
+
     let node = repositories::tree::get_node_by_path(&repo, &commit, &resource.path)?;
     let upload_mode = resolve_upload_mode(
         file_parts,
@@ -335,7 +432,7 @@ pub async fn put(
 
     let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
 
-    log::debug!("file::put workspace commit ✅ success! commit {commit:?}");
+    log::debug!("file::put_multipart workspace commit ✅ success! commit {commit:?}");
 
     Ok(HttpResponse::Ok().json(CommitResponse {
         status: StatusMessage::resource_created(),
@@ -384,6 +481,8 @@ pub async fn delete(
         .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
     let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
     let path = resource.path;
+
+    check_oxen_based_on(&req, &repo, &commit, &path)?;
 
     let name = form.name();
     let email = form.email();
@@ -527,6 +626,40 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
         status: StatusMessage::resource_updated(),
         commit,
     }))
+}
+
+fn check_oxen_based_on(
+    req: &HttpRequest,
+    repo: &liboxen::model::LocalRepository,
+    commit: &Commit,
+    path: &Path,
+) -> Result<(), OxenHttpError> {
+    let claimed = match req
+        .headers()
+        .get("oxen-based-on")
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(v) => v,
+        None => return Ok(()), // No concurrency check requested
+    };
+
+    let node = repositories::tree::get_node_by_path(repo, commit, path)?;
+    let node = match node {
+        Some(n) if n.is_file() => n,
+        _ => return Ok(()), // File doesn't exist, treat as new file creation
+    };
+
+    let current_id = node.latest_commit_id()?.to_string();
+    if current_id == claimed {
+        Ok(())
+    } else {
+        Err(OxenHttpError::BadRequest(
+            format!(
+                "File has been modified since claimed revision. Current: {current_id}, Claimed: {claimed}. Your changes would overwrite another change without that being from a merge"
+            )
+            .into(),
+        ))
+    }
 }
 
 // Helper: when the repository has no commits yet, accept the upload as the first commit
@@ -1347,6 +1480,320 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(err, OxenHttpError::BadRequest(_)));
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    async fn do_raw_put(
+        sync_dir: &std::path::Path,
+        namespace: &'static str,
+        repo_name: &'static str,
+        resource: &'static str,
+        content_type: &str,
+        body: Vec<u8>,
+        oxen_based_on: Option<&str>,
+    ) -> actix_web::dev::ServiceResponse {
+        let uri: String = format!("/oxen/{namespace}/{repo_name}/file/{resource}");
+        let mut req = actix_web::test::TestRequest::put()
+            .uri(&uri)
+            .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+            .param("namespace", namespace)
+            .param("resource", resource)
+            .param("repo_name", repo_name)
+            .insert_header(("Content-Type", content_type.to_string()))
+            .insert_header(("oxen-commit-author", "test_user"))
+            .insert_header(("oxen-commit-email", "test@oxen.ai"));
+
+        if let Some(based_on) = oxen_based_on {
+            req = req.insert_header(("oxen-based-on", based_on.to_string()));
+        }
+
+        let req = req.set_payload(body).to_request();
+
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+                .route(
+                    "/oxen/{namespace}/{repo_name}/file/{resource:.*}",
+                    web::put().to(controllers::file::put),
+                ),
+        )
+        .await;
+
+        actix_web::test::call_service(&app, req).await
+    }
+
+    async fn do_delete_with_header(
+        sync_dir: &std::path::Path,
+        namespace: &'static str,
+        repo_name: &'static str,
+        resource: &'static str,
+        oxen_based_on: Option<&str>,
+    ) -> actix_web::dev::ServiceResponse {
+        let uri: String = format!("/oxen/{namespace}/{repo_name}/file/{resource}");
+
+        let mut multipart_form_data_builder = MultiPartFormDataBuilder::new();
+        multipart_form_data_builder.with_text("name", "test_user");
+        multipart_form_data_builder.with_text("email", "test@oxen.ai");
+        multipart_form_data_builder.with_text("message", "delete file");
+        let (header, body) = multipart_form_data_builder.build();
+
+        let mut req = actix_web::test::TestRequest::delete()
+            .uri(&uri)
+            .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+            .param("namespace", namespace)
+            .param("resource", resource)
+            .param("repo_name", repo_name)
+            .insert_header(header);
+
+        if let Some(based_on) = oxen_based_on {
+            req = req.insert_header(("oxen-based-on", based_on.to_string()));
+        }
+
+        let req = req.set_payload(body).to_request();
+
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+                .route(
+                    "/oxen/{namespace}/{repo_name}/file/{resource:.*}",
+                    web::delete().to(controllers::file::delete),
+                ),
+        )
+        .await;
+
+        actix_web::test::call_service(&app, req).await
+    }
+
+    #[actix_web::test]
+    async fn test_put_raw_text_creates_file() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Raw-Put";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let readme_file = repo.path.join("README.md");
+        util::fs::write_to_path(&readme_file, "Initial commit")?;
+        repositories::add(&repo, &readme_file).await?;
+        let _commit = repositories::commit(&repo, "First commit")?;
+
+        let resp = do_raw_put(
+            &sync_dir,
+            namespace,
+            repo_name,
+            "main/data/new.txt",
+            "text/plain",
+            b"Hello raw world".to_vec(),
+            None,
+        )
+        .await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let body_str = std::str::from_utf8(&bytes).unwrap();
+        let resp: CommitResponse = serde_json::from_str(body_str)?;
+        assert_eq!(resp.status.status, "success");
+
+        // Read back the content via version store
+        let entry =
+            repositories::entries::get_file(&repo, &resp.commit, PathBuf::from("data/new.txt"))?
+                .unwrap();
+        let version_store = repo.version_store()?;
+        let uploaded_content = version_store.get_version(&entry.hash().to_string()).await?;
+        assert_eq!(
+            String::from_utf8(uploaded_content).unwrap(),
+            "Hello raw world"
+        );
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_put_without_oxen_based_on_succeeds() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-No-BasedOn";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let hello_file = repo.path.join("data/hello.txt");
+        util::fs::create_dir_all(hello_file.parent().unwrap())?;
+        util::fs::write_to_path(&hello_file, "Hello")?;
+        repositories::add(&repo, &hello_file).await?;
+        let _commit = repositories::commit(&repo, "First commit")?;
+
+        let resp = do_raw_put(
+            &sync_dir,
+            namespace,
+            repo_name,
+            "main/data/hello.txt",
+            "text/plain",
+            b"Updated without header".to_vec(),
+            None,
+        )
+        .await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let body_str = std::str::from_utf8(&bytes).unwrap();
+        let resp: CommitResponse = serde_json::from_str(body_str)?;
+        assert_eq!(resp.status.status, "success");
+
+        // Read back the content
+        let entry =
+            repositories::entries::get_file(&repo, &resp.commit, PathBuf::from("data/hello.txt"))?
+                .unwrap();
+        let version_store = repo.version_store()?;
+        let uploaded_content = version_store.get_version(&entry.hash().to_string()).await?;
+        assert_eq!(
+            String::from_utf8(uploaded_content).unwrap(),
+            "Updated without header"
+        );
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_put_with_matching_oxen_based_on_succeeds() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Match-BasedOn";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let hello_file = repo.path.join("data/hello.txt");
+        util::fs::create_dir_all(hello_file.parent().unwrap())?;
+        util::fs::write_to_path(&hello_file, "Hello")?;
+        repositories::add(&repo, &hello_file).await?;
+        let commit = repositories::commit(&repo, "First commit")?;
+
+        // Get the latest_commit_id for the file
+        let node =
+            repositories::tree::get_node_by_path(&repo, &commit, Path::new("data/hello.txt"))?
+                .unwrap();
+        let latest_commit_id = node.latest_commit_id()?.to_string();
+
+        let resp = do_raw_put(
+            &sync_dir,
+            namespace,
+            repo_name,
+            "main/data/hello.txt",
+            "text/plain",
+            b"Updated with matching header".to_vec(),
+            Some(&latest_commit_id),
+        )
+        .await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let body_str = std::str::from_utf8(&bytes).unwrap();
+        let resp: CommitResponse = serde_json::from_str(body_str)?;
+        assert_eq!(resp.status.status, "success");
+
+        // Read back the content
+        let entry =
+            repositories::entries::get_file(&repo, &resp.commit, PathBuf::from("data/hello.txt"))?
+                .unwrap();
+        let version_store = repo.version_store()?;
+        let uploaded_content = version_store.get_version(&entry.hash().to_string()).await?;
+        assert_eq!(
+            String::from_utf8(uploaded_content).unwrap(),
+            "Updated with matching header"
+        );
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_put_with_mismatched_oxen_based_on_fails() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Mismatch-BasedOn";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let hello_file = repo.path.join("data/hello.txt");
+        util::fs::create_dir_all(hello_file.parent().unwrap())?;
+        util::fs::write_to_path(&hello_file, "Hello")?;
+        repositories::add(&repo, &hello_file).await?;
+        let _commit = repositories::commit(&repo, "First commit")?;
+
+        let resp = do_raw_put(
+            &sync_dir,
+            namespace,
+            repo_name,
+            "main/data/hello.txt",
+            "text/plain",
+            b"Should fail".to_vec(),
+            Some("fake_hash"),
+        )
+        .await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_put_new_file_ignores_oxen_based_on() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-NewFile-BasedOn";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let readme_file = repo.path.join("README.md");
+        util::fs::write_to_path(&readme_file, "Initial commit")?;
+        repositories::add(&repo, &readme_file).await?;
+        let _commit = repositories::commit(&repo, "First commit")?;
+
+        let resp = do_raw_put(
+            &sync_dir,
+            namespace,
+            repo_name,
+            "main/data/brand_new.txt",
+            "text/plain",
+            b"New file content".to_vec(),
+            Some("random"),
+        )
+        .await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_delete_with_mismatched_oxen_based_on_fails() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Delete-BasedOn";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let hello_file = repo.path.join("data/hello.txt");
+        util::fs::create_dir_all(hello_file.parent().unwrap())?;
+        util::fs::write_to_path(&hello_file, "Hello")?;
+        repositories::add(&repo, &hello_file).await?;
+        let _commit = repositories::commit(&repo, "First commit")?;
+
+        let resp = do_delete_with_header(
+            &sync_dir,
+            namespace,
+            repo_name,
+            "main/data/hello.txt",
+            Some("wrong_id"),
+        )
+        .await;
+
+        assert!(resp.status().is_client_error());
 
         test::cleanup_sync_dir(&sync_dir)?;
         Ok(())

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -307,12 +307,7 @@ async fn put_raw(
     }
 
     let resource = parse_resource(&req, &repo)?;
-
-    if resource.path.as_os_str().is_empty() {
-        return Err(OxenHttpError::BadRequest(
-            "Invalid target path: expected a full file path for raw PUT uploads".into(),
-        ));
-    }
+    let path = normalize_relative_upload_path(&resource.path, false, "uploaded file")?;
 
     // Resource must specify branch because we need to commit the workspace back to a branch
     let branch = resource
@@ -321,14 +316,14 @@ async fn put_raw(
         .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
 
-    check_oxen_based_on(&req, &repo, &commit, &resource.path)?;
+    check_oxen_based_on(&req, &repo, &commit, &path)?;
 
-    ensure_no_file_ancestors_in_tree(&repo, &commit, &resource.path, &resource.path)?;
+    ensure_no_file_ancestors_in_tree(&repo, &commit, &path, &path)?;
 
     let user = create_user_from_options(name.clone(), email.clone())?;
 
     let file = FileNew {
-        path: resource.path.clone(),
+        path: path.clone(),
         contents: FileContents::Binary(body.to_vec()),
         user,
     };
@@ -341,9 +336,8 @@ async fn put_raw(
     let commit_body = NewCommitBody {
         author: name.unwrap_or_default(),
         email: email.unwrap_or_default(),
-        message: message.unwrap_or_else(|| {
-            format!("Auto-commit files to {}", &resource.path.to_string_lossy())
-        }),
+        message: message
+            .unwrap_or_else(|| format!("Auto-commit files to {}", &path.to_string_lossy())),
     };
 
     let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
@@ -373,12 +367,7 @@ async fn handle_initial_put_raw_empty_repo(
         .map(|c| c.as_os_str().to_string_lossy().into_owned())
         .unwrap_or("main".to_string());
     let path: PathBuf = resource.collect();
-
-    if path.as_os_str().is_empty() {
-        return Err(OxenHttpError::BadRequest(
-            "Invalid target path: expected a full file path for raw PUT uploads".into(),
-        ));
-    }
+    let path = normalize_relative_upload_path(&path, false, "uploaded file")?;
 
     let user = create_user_from_options(name.clone(), email.clone())?;
 

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -284,19 +284,6 @@ async fn put_raw(
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
-    let resource = parse_resource(&req, &repo)?;
-
-    // Resource must specify branch because we need to commit the workspace back to a branch
-    let branch = resource
-        .branch
-        .clone()
-        .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
-    let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
-
-    check_oxen_based_on(&req, &repo, &commit, &resource.path)?;
-
-    ensure_no_file_ancestors_in_tree(&repo, &commit, &resource.path, &resource.path)?;
-
     // Extract commit metadata from headers
     let name = req
         .headers()
@@ -313,6 +300,24 @@ async fn put_raw(
         .get("oxen-commit-message")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
+
+    // If there's no head commit, handle initial upload
+    if repositories::commits::head_commit_maybe(&repo)?.is_none() {
+        return handle_initial_put_raw_empty_repo(&req, body, &repo, name, email, message).await;
+    }
+
+    let resource = parse_resource(&req, &repo)?;
+
+    // Resource must specify branch because we need to commit the workspace back to a branch
+    let branch = resource
+        .branch
+        .clone()
+        .ok_or_else(|| OxenError::local_branch_not_found(resource.version.to_string_lossy()))?;
+    let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
+
+    check_oxen_based_on(&req, &repo, &commit, &resource.path)?;
+
+    ensure_no_file_ancestors_in_tree(&repo, &commit, &resource.path, &resource.path)?;
 
     let user = create_user_from_options(name.clone(), email.clone())?;
 
@@ -338,6 +343,44 @@ async fn put_raw(
     let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
 
     log::debug!("file::put_raw workspace commit ✅ success! commit {commit:?}");
+
+    Ok(HttpResponse::Ok().json(CommitResponse {
+        status: StatusMessage::resource_created(),
+        commit,
+    }))
+}
+
+// Helper: handle raw PUT to a repo with no commits yet
+async fn handle_initial_put_raw_empty_repo(
+    req: &HttpRequest,
+    body: web::Bytes,
+    repo: &liboxen::model::LocalRepository,
+    name: Option<String>,
+    email: Option<String>,
+    message: Option<String>,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let resource: PathBuf = PathBuf::from(query_param(req, "resource"));
+
+    let mut resource = resource.components();
+    let branch_name = resource
+        .next()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .unwrap_or("main".to_string());
+    let path: PathBuf = resource.collect();
+
+    let user = create_user_from_options(name.clone(), email.clone())?;
+
+    let file = FileNew {
+        path: path.clone(),
+        contents: FileContents::Binary(body.to_vec()),
+        user: user.clone(),
+    };
+
+    process_and_add_files(repo, None, &[file]).await?;
+
+    let commit_message = message.unwrap_or_else(|| "Initial commit".to_string());
+    let commit = commits::commit_with_user(repo, &commit_message, &user)?;
+    branches::create(repo, &branch_name, &commit.id)?;
 
     Ok(HttpResponse::Ok().json(CommitResponse {
         status: StatusMessage::resource_created(),

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -308,6 +308,12 @@ async fn put_raw(
 
     let resource = parse_resource(&req, &repo)?;
 
+    if resource.path.as_os_str().is_empty() {
+        return Err(OxenHttpError::BadRequest(
+            "Invalid target path: expected a full file path for raw PUT uploads".into(),
+        ));
+    }
+
     // Resource must specify branch because we need to commit the workspace back to a branch
     let branch = resource
         .branch
@@ -367,6 +373,12 @@ async fn handle_initial_put_raw_empty_repo(
         .map(|c| c.as_os_str().to_string_lossy().into_owned())
         .unwrap_or("main".to_string());
     let path: PathBuf = resource.collect();
+
+    if path.as_os_str().is_empty() {
+        return Err(OxenHttpError::BadRequest(
+            "Invalid target path: expected a full file path for raw PUT uploads".into(),
+        ));
+    }
 
     let user = create_user_from_options(name.clone(), email.clone())?;
 
@@ -1836,7 +1848,7 @@ mod tests {
         )
         .await;
 
-        assert!(resp.status().is_client_error());
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
 
         test::cleanup_sync_dir(&sync_dir)?;
         Ok(())


### PR DESCRIPTION
Two additions to the file endpoint:

**Raw PUT**: 
  
The PUT handler now accepts non-multipart requests where the HTTP body is the file content directly. Commit metadata comes from oxen-commit-author/email/message headers. The existing multipart PUT is unchanged.

**oxen-based-on header**: 

Optional optimistic concurrency for PUT and DELETE. Clients pass the oxen-revision-id (from GET) back as oxen-based-on. If the file has been modified since that revision, the server returns 400. If omitted, no check is performed.

 - 1 file changed, 6 new tests (all verify stored content round-trip)

This addresses item #4 on https://paulhammant.com/2020/01/19/vcs-nirvana/   That facillitates #10. 

As it happens. I have another PR that needs this one to be merged first.