### PR TITLE
Add webhook notification system

### DIFF
--- a/crates/lib/src/core.rs
+++ b/crates/lib/src/core.rs
@@ -13,3 +13,4 @@ pub mod staged;
 pub mod v_latest;
 pub mod v_old;
 pub mod versions;
+pub mod webhooks;

--- a/crates/lib/src/core/db.rs
+++ b/crates/lib/src/core/db.rs
@@ -5,3 +5,4 @@ pub mod data_frames;
 pub mod dir_hashes;
 pub mod key_val;
 pub mod merkle_node;
+pub mod webhooks;

--- a/crates/lib/src/core/db/webhooks.rs
+++ b/crates/lib/src/core/db/webhooks.rs
@@ -1,0 +1,286 @@
+use crate::error::OxenError;
+use crate::model::webhook::{Webhook, WebhookAddRequest, WebhookConfig};
+use std::path::{Path, PathBuf};
+
+pub struct WebhookDB {
+    webhooks_path: PathBuf,
+    config_path: PathBuf,
+}
+
+impl WebhookDB {
+    pub fn new(repo_dot_oxen_path: &Path) -> Result<Self, OxenError> {
+        let dir = repo_dot_oxen_path.join("webhooks");
+        std::fs::create_dir_all(&dir)?;
+        Ok(WebhookDB {
+            webhooks_path: dir.join("webhooks.json"),
+            config_path: dir.join("config.json"),
+        })
+    }
+
+    pub fn add_webhook(&self, req: WebhookAddRequest) -> Result<Webhook, OxenError> {
+        let mut webhooks = self.list_all_webhooks()?;
+        let webhook = Webhook {
+            id: uuid::Uuid::new_v4().to_string(),
+            path: req.path,
+            webhook_url: req.webhook_url,
+            webhook_secret: uuid::Uuid::new_v4().to_string(),
+            purpose: req.purpose,
+            contact: req.contact,
+            consecutive_failures: 0,
+        };
+        webhooks.push(webhook.clone());
+        self.save_webhooks(&webhooks)?;
+        Ok(webhook)
+    }
+
+    pub fn list_all_webhooks(&self) -> Result<Vec<Webhook>, OxenError> {
+        if !self.webhooks_path.exists() {
+            return Ok(vec![]);
+        }
+        let content = std::fs::read_to_string(&self.webhooks_path)?;
+        if content.trim().is_empty() {
+            return Ok(vec![]);
+        }
+        let webhooks: Vec<Webhook> = serde_json::from_str(&content)?;
+        Ok(webhooks)
+    }
+
+    pub fn remove_webhook(&self, id: &str) -> Result<(), OxenError> {
+        let mut webhooks = self.list_all_webhooks()?;
+        webhooks.retain(|w| w.id != id);
+        self.save_webhooks(&webhooks)?;
+        Ok(())
+    }
+
+    /// Find all webhooks whose path prefix matches the given changed file path.
+    /// A webhook registered at `/data` will match changes to `/data/file.txt`,
+    /// `/data/subdir/file.txt`, etc. A root webhook (`/` or empty) matches everything.
+    pub fn list_webhooks_for_path(&self, changed_path: &str) -> Result<Vec<Webhook>, OxenError> {
+        let webhooks = self.list_all_webhooks()?;
+        let normalized_changed = normalize_webhook_path(changed_path);
+        Ok(webhooks
+            .into_iter()
+            .filter(|w| {
+                let normalized_webhook = normalize_webhook_path(&w.path);
+                if normalized_webhook.is_empty() {
+                    return true; // Root webhook matches everything
+                }
+                normalized_changed.starts_with(&normalized_webhook)
+                    && (normalized_changed.len() == normalized_webhook.len()
+                        || normalized_changed.as_bytes().get(normalized_webhook.len())
+                            == Some(&b'/'))
+            })
+            .collect())
+    }
+
+    pub fn increment_failure(&self, id: &str) -> Result<u32, OxenError> {
+        let mut webhooks = self.list_all_webhooks()?;
+        let mut count = 0;
+        for w in &mut webhooks {
+            if w.id == id {
+                w.consecutive_failures += 1;
+                count = w.consecutive_failures;
+            }
+        }
+        self.save_webhooks(&webhooks)?;
+        Ok(count)
+    }
+
+    pub fn reset_failure(&self, id: &str) -> Result<(), OxenError> {
+        let mut webhooks = self.list_all_webhooks()?;
+        for w in &mut webhooks {
+            if w.id == id {
+                w.consecutive_failures = 0;
+            }
+        }
+        self.save_webhooks(&webhooks)?;
+        Ok(())
+    }
+
+    pub fn get_config(&self) -> Result<WebhookConfig, OxenError> {
+        if !self.config_path.exists() {
+            return Ok(WebhookConfig::default());
+        }
+        let content = std::fs::read_to_string(&self.config_path)?;
+        let config: WebhookConfig = serde_json::from_str(&content)?;
+        Ok(config)
+    }
+
+    pub fn set_config(&self, config: &WebhookConfig) -> Result<(), OxenError> {
+        let content = serde_json::to_string_pretty(config)?;
+        std::fs::write(&self.config_path, content)?;
+        Ok(())
+    }
+
+    pub fn stats(&self) -> Result<serde_json::Value, OxenError> {
+        let webhooks = self.list_all_webhooks()?;
+        Ok(serde_json::json!({
+            "total_webhooks": webhooks.len(),
+        }))
+    }
+
+    fn save_webhooks(&self, webhooks: &[Webhook]) -> Result<(), OxenError> {
+        let content = serde_json::to_string_pretty(webhooks)?;
+        std::fs::write(&self.webhooks_path, content)?;
+        Ok(())
+    }
+}
+
+fn normalize_webhook_path(path: &str) -> String {
+    path.trim_start_matches('/')
+        .trim_end_matches('/')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::webhook::WebhookMode;
+    use tempfile::TempDir;
+
+    fn create_test_db() -> (TempDir, WebhookDB) {
+        let dir = TempDir::new().expect("Failed to create temp dir");
+        let db = WebhookDB::new(dir.path()).expect("Failed to create WebhookDB");
+        (dir, db)
+    }
+
+    fn add_test_webhook(db: &WebhookDB, path: &str, url: &str) -> Webhook {
+        db.add_webhook(WebhookAddRequest {
+            path: path.to_string(),
+            webhook_url: url.to_string(),
+            current_oxen_revision: None,
+            purpose: "test".to_string(),
+            contact: "test@example.com".to_string(),
+        })
+        .expect("Failed to add webhook")
+    }
+
+    #[test]
+    fn test_webhook_db_add_and_list() {
+        let (_dir, db) = create_test_db();
+        let webhook = add_test_webhook(&db, "/data", "http://example.com/hook");
+
+        let webhooks = db.list_all_webhooks().expect("Failed to list");
+        assert_eq!(webhooks.len(), 1);
+        assert_eq!(webhooks[0].id, webhook.id);
+        assert_eq!(webhooks[0].path, "/data");
+    }
+
+    #[test]
+    fn test_webhook_db_remove() {
+        let (_dir, db) = create_test_db();
+        let webhook = add_test_webhook(&db, "/data", "http://example.com/hook");
+
+        db.remove_webhook(&webhook.id).expect("Failed to remove");
+        let webhooks = db.list_all_webhooks().expect("Failed to list");
+        assert!(webhooks.is_empty());
+    }
+
+    #[test]
+    fn test_webhook_db_hierarchical_matching() {
+        let (_dir, db) = create_test_db();
+        add_test_webhook(&db, "/", "http://example.com/root");
+        add_test_webhook(&db, "/a", "http://example.com/a");
+        add_test_webhook(&db, "/a/b", "http://example.com/ab");
+        add_test_webhook(&db, "/a/b/c", "http://example.com/abc");
+
+        let matches = db
+            .list_webhooks_for_path("/a/b/c/d.txt")
+            .expect("Failed to match");
+        assert_eq!(matches.len(), 4, "All parent webhooks should match");
+    }
+
+    #[test]
+    fn test_webhook_db_sibling_isolation() {
+        let (_dir, db) = create_test_db();
+        add_test_webhook(&db, "/data", "http://example.com/data");
+        add_test_webhook(&db, "/logs", "http://example.com/logs");
+        add_test_webhook(&db, "/config", "http://example.com/config");
+
+        let matches = db
+            .list_webhooks_for_path("/data/new_file.txt")
+            .expect("Failed to match");
+        assert_eq!(matches.len(), 1, "Only /data webhook should match");
+        assert_eq!(matches[0].path, "/data");
+    }
+
+    #[test]
+    fn test_webhook_db_path_normalization() {
+        let (_dir, db) = create_test_db();
+
+        // Test various path formats
+        let test_cases = vec![
+            ("data/", true),
+            ("data", true),
+            ("/data/", true),
+            ("/data", true),
+            ("other", false),
+        ];
+
+        for (webhook_path, should_match) in test_cases {
+            // Clear existing webhooks
+            for w in db.list_all_webhooks().expect("list") {
+                db.remove_webhook(&w.id).expect("remove");
+            }
+            add_test_webhook(&db, webhook_path, "http://example.com/hook");
+
+            let matches = db
+                .list_webhooks_for_path("/data/subdir/file.txt")
+                .expect("match");
+            assert_eq!(
+                !matches.is_empty(),
+                should_match,
+                "webhook_path='{}' should {}match '/data/subdir/file.txt'",
+                webhook_path,
+                if should_match { "" } else { "NOT " }
+            );
+        }
+    }
+
+    #[test]
+    fn test_webhook_db_root_webhook() {
+        let (_dir, db) = create_test_db();
+        add_test_webhook(&db, "/", "http://example.com/root");
+
+        let test_paths = vec!["/file.txt", "/data/file.txt", "/deep/nested/path/file.txt"];
+
+        for path in test_paths {
+            let matches = db.list_webhooks_for_path(path).expect("match");
+            assert_eq!(matches.len(), 1, "Root webhook should match '{}'", path);
+        }
+    }
+
+    #[test]
+    fn test_webhook_db_increment_failure() {
+        let (_dir, db) = create_test_db();
+        let webhook = add_test_webhook(&db, "/data", "http://example.com/hook");
+
+        for i in 1..=5 {
+            let count = db.increment_failure(&webhook.id).expect("increment");
+            assert_eq!(count, i);
+        }
+
+        let webhooks = db.list_all_webhooks().expect("list");
+        assert_eq!(webhooks[0].consecutive_failures, 5);
+    }
+
+    #[test]
+    fn test_webhook_db_config() {
+        let (_dir, db) = create_test_db();
+
+        let default_config = db.get_config().expect("get config");
+        assert_eq!(default_config.mode, WebhookMode::Inline);
+        assert!(default_config.enabled);
+
+        let new_config = WebhookConfig {
+            mode: WebhookMode::Queue,
+            enabled: true,
+            queue_path: Some("/tmp/webhook_events".to_string()),
+        };
+        db.set_config(&new_config).expect("set config");
+
+        let loaded = db.get_config().expect("get config");
+        assert_eq!(loaded.mode, WebhookMode::Queue);
+        assert_eq!(loaded.queue_path, Some("/tmp/webhook_events".to_string()));
+    }
+}

--- a/crates/lib/src/core/webhooks.rs
+++ b/crates/lib/src/core/webhooks.rs
@@ -44,6 +44,7 @@ impl WebhookNotifier {
 
     /// Notify all webhooks that match the given changed path.
     /// Returns the number of webhooks that were notified (not rate-limited).
+    /// Respects the repo's webhook config: skips delivery if disabled.
     pub async fn notify_path_changed(
         &self,
         repo_path: &Path,
@@ -51,13 +52,18 @@ impl WebhookNotifier {
     ) -> Result<usize, OxenError> {
         let oxen_dir = repo_path.join(".oxen");
         let db = WebhookDB::new(&oxen_dir)?;
+
+        let config = db.get_config()?;
+        if !config.enabled {
+            return Ok(0);
+        }
+
         let webhooks = db.list_webhooks_for_path(changed_path)?;
 
         let mut notified_count = 0;
 
         for webhook in &webhooks {
-            // Check rate limiting
-            if self.is_rate_limited(&webhook.id) {
+            if !self.try_acquire_rate_limit(&webhook.id) {
                 continue;
             }
 
@@ -75,7 +81,6 @@ impl WebhookNotifier {
             match result {
                 Ok(resp) if resp.status().is_success() => {
                     db.reset_failure(&webhook.id)?;
-                    self.update_rate_limit(&webhook.id);
                     notified_count += 1;
                 }
                 _ => {
@@ -88,7 +93,6 @@ impl WebhookNotifier {
                         );
                         db.remove_webhook(&webhook.id)?;
                     }
-                    self.update_rate_limit(&webhook.id);
                     notified_count += 1;
                 }
             }
@@ -97,20 +101,19 @@ impl WebhookNotifier {
         Ok(notified_count)
     }
 
-    fn is_rate_limited(&self, webhook_id: &str) -> bool {
+    /// Atomically check rate limit and reserve the slot if not limited.
+    /// Returns true if the notification should proceed.
+    fn try_acquire_rate_limit(&self, webhook_id: &str) -> bool {
         if self.rate_limit_duration.is_zero() {
+            return true;
+        }
+        let mut rate_limits = self.rate_limits.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(last_notified) = rate_limits.get(webhook_id)
+            && last_notified.elapsed() < self.rate_limit_duration
+        {
             return false;
         }
-        let rate_limits = self.rate_limits.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(last_notified) = rate_limits.get(webhook_id) {
-            last_notified.elapsed() < self.rate_limit_duration
-        } else {
-            false
-        }
-    }
-
-    fn update_rate_limit(&self, webhook_id: &str) {
-        let mut rate_limits = self.rate_limits.lock().unwrap_or_else(|e| e.into_inner());
         rate_limits.insert(webhook_id.to_string(), Instant::now());
+        true
     }
 }

--- a/crates/lib/src/core/webhooks.rs
+++ b/crates/lib/src/core/webhooks.rs
@@ -1,0 +1,116 @@
+use crate::core::db::webhooks::WebhookDB;
+use crate::error::OxenError;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+const MAX_CONSECUTIVE_FAILURES: u32 = 5;
+
+pub struct WebhookNotifier {
+    rate_limits: Mutex<HashMap<String, Instant>>,
+    rate_limit_duration: Duration,
+    client: reqwest::Client,
+}
+
+impl Default for WebhookNotifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WebhookNotifier {
+    pub fn new() -> Self {
+        WebhookNotifier {
+            rate_limits: Mutex::new(HashMap::new()),
+            rate_limit_duration: Duration::from_secs(1),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap_or_default(),
+        }
+    }
+
+    pub fn new_with_rate_limit(rate_limit_secs: u64) -> Self {
+        WebhookNotifier {
+            rate_limits: Mutex::new(HashMap::new()),
+            rate_limit_duration: Duration::from_secs(rate_limit_secs),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Notify all webhooks that match the given changed path.
+    /// Returns the number of webhooks that were notified (not rate-limited).
+    pub async fn notify_path_changed(
+        &self,
+        repo_path: &Path,
+        changed_path: &str,
+    ) -> Result<usize, OxenError> {
+        let oxen_dir = repo_path.join(".oxen");
+        let db = WebhookDB::new(&oxen_dir)?;
+        let webhooks = db.list_webhooks_for_path(changed_path)?;
+
+        let mut notified_count = 0;
+
+        for webhook in &webhooks {
+            // Check rate limiting
+            if self.is_rate_limited(&webhook.id) {
+                continue;
+            }
+
+            let payload = serde_json::json!({
+                "path": changed_path,
+            });
+
+            let result = self
+                .client
+                .post(&webhook.webhook_url)
+                .json(&payload)
+                .send()
+                .await;
+
+            match result {
+                Ok(resp) if resp.status().is_success() => {
+                    db.reset_failure(&webhook.id)?;
+                    self.update_rate_limit(&webhook.id);
+                    notified_count += 1;
+                }
+                _ => {
+                    let count = db.increment_failure(&webhook.id)?;
+                    if count >= MAX_CONSECUTIVE_FAILURES {
+                        log::warn!(
+                            "Webhook {} exceeded {} consecutive failures, removing",
+                            webhook.id,
+                            MAX_CONSECUTIVE_FAILURES
+                        );
+                        db.remove_webhook(&webhook.id)?;
+                    }
+                    self.update_rate_limit(&webhook.id);
+                    notified_count += 1;
+                }
+            }
+        }
+
+        Ok(notified_count)
+    }
+
+    fn is_rate_limited(&self, webhook_id: &str) -> bool {
+        if self.rate_limit_duration.is_zero() {
+            return false;
+        }
+        let rate_limits = self.rate_limits.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(last_notified) = rate_limits.get(webhook_id) {
+            last_notified.elapsed() < self.rate_limit_duration
+        } else {
+            false
+        }
+    }
+
+    fn update_rate_limit(&self, webhook_id: &str) {
+        let mut rate_limits = self.rate_limits.lock().unwrap_or_else(|e| e.into_inner());
+        rate_limits.insert(webhook_id.to_string(), Instant::now());
+    }
+}

--- a/crates/lib/src/model.rs
+++ b/crates/lib/src/model.rs
@@ -24,6 +24,7 @@ pub mod staged_dir_stats;
 pub mod staged_row_status;
 pub mod summarized_staged_dir_stats;
 pub mod user;
+pub mod webhook;
 pub mod workspace;
 
 // Namespace
@@ -76,6 +77,9 @@ pub use crate::model::diff::data_frame_diff::DataFrameDiff;
 
 pub use crate::model::data_frame::schema::Schema;
 pub use crate::model::data_frame::schema::staged_schema::StagedSchema;
+
+// Webhook
+pub use crate::model::webhook::{Webhook, WebhookAddRequest, WebhookConfig, WebhookMode};
 
 // Workspace
 pub use crate::model::workspace::Workspace;

--- a/crates/lib/src/model/webhook.rs
+++ b/crates/lib/src/model/webhook.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Webhook {
+    pub id: String,
+    pub path: String,
+    pub webhook_url: String,
+    pub webhook_secret: String,
+    pub purpose: String,
+    pub contact: String,
+    pub consecutive_failures: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WebhookAddRequest {
+    pub path: String,
+    pub webhook_url: String,
+    #[serde(alias = "currentOxenRevision")]
+    pub current_oxen_revision: Option<String>,
+    pub purpose: String,
+    pub contact: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookConfig {
+    pub mode: WebhookMode,
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queue_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum WebhookMode {
+    Inline,
+    Queue,
+}
+
+impl Default for WebhookConfig {
+    fn default() -> Self {
+        WebhookConfig {
+            mode: WebhookMode::Inline,
+            enabled: true,
+            queue_path: None,
+        }
+    }
+}

--- a/crates/lib/src/model/webhook.rs
+++ b/crates/lib/src/model/webhook.rs
@@ -11,6 +11,30 @@ pub struct Webhook {
     pub consecutive_failures: u32,
 }
 
+/// Response type that omits the webhook_secret for list/get endpoints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookResponse {
+    pub id: String,
+    pub path: String,
+    pub webhook_url: String,
+    pub purpose: String,
+    pub contact: String,
+    pub consecutive_failures: u32,
+}
+
+impl From<Webhook> for WebhookResponse {
+    fn from(w: Webhook) -> Self {
+        WebhookResponse {
+            id: w.id,
+            path: w.path,
+            webhook_url: w.webhook_url,
+            purpose: w.purpose,
+            contact: w.contact,
+            consecutive_failures: w.consecutive_failures,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct WebhookAddRequest {
     pub path: String,

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -76,8 +76,41 @@ curl -H "Authorization: Bearer $TOKEN" "http://0.0.0.0:3000/api/repos"
 
 #### Create Repository
 ```bash
-curl -H "Authorization: Bearer $TOKEN" -X POST -d '{"name": "MyRepo"}' "http://0.0.0.0:3000api/repos"
+curl -H "Authorization: Bearer $TOKEN" -X POST -d '{"name": "MyRepo"}' "http://0.0.0.0:3000/api/repos"
 ```
+
+#### Webhooks
+
+Register a webhook to be notified when files change under a path:
+
+```bash
+# Register a webhook for changes under /data
+curl -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d '{"path": "/data", "webhook_url": "https://example.com/hook", "purpose": "CI trigger", "contact": "admin@example.com"}' \
+     "http://0.0.0.0:3000/api/repos/my_namespace/MyRepo/webhooks/add"
+```
+
+Webhooks use hierarchical path matching -- a webhook on `/data` fires for changes to any file under `/data/...`. A webhook on `/` catches all changes.
+
+Other webhook endpoints:
+
+```bash
+# List webhooks
+curl -H "Authorization: Bearer $TOKEN" \
+     "http://0.0.0.0:3000/api/repos/my_namespace/MyRepo/webhooks"
+
+# Delete a webhook
+curl -H "Authorization: Bearer $TOKEN" -X DELETE \
+     "http://0.0.0.0:3000/api/repos/my_namespace/MyRepo/webhooks/{webhook_id}"
+
+# View/update webhook config
+curl -H "Authorization: Bearer $TOKEN" \
+     "http://0.0.0.0:3000/api/repos/my_namespace/MyRepo/webhooks/config"
+```
+
+Webhooks that fail 5 times consecutively are automatically removed.
 
 
 ## Logging

--- a/crates/server/src/controllers.rs
+++ b/crates/server/src/controllers.rs
@@ -22,4 +22,5 @@ pub mod revisions;
 pub mod schemas;
 pub mod tree;
 pub mod versions;
+pub mod webhooks;
 pub mod workspaces;

--- a/crates/server/src/controllers/webhooks.rs
+++ b/crates/server/src/controllers/webhooks.rs
@@ -1,0 +1,104 @@
+use actix_web::{HttpRequest, HttpResponse};
+use serde_json::Value;
+
+use crate::errors::OxenHttpError;
+use crate::helpers::get_repo;
+use crate::params::{app_data, path_param};
+
+use liboxen::core::db::webhooks::WebhookDB;
+use liboxen::model::webhook::WebhookAddRequest;
+use liboxen::repositories;
+
+pub async fn create(
+    req: HttpRequest,
+    body: actix_web::web::Json<Value>,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+
+    let webhook_req: WebhookAddRequest = serde_json::from_value(body.into_inner())?;
+
+    // Validate current_oxen_revision if provided
+    if let Some(ref claimed_revision) = webhook_req.current_oxen_revision {
+        let head_commit = repositories::commits::head_commit_maybe(&repo)?;
+        let matches = head_commit
+            .as_ref()
+            .map(|c| c.id == *claimed_revision)
+            .unwrap_or(false);
+        if !matches {
+            return Ok(HttpResponse::BadRequest().json(serde_json::json!({"error": "no"})));
+        }
+    }
+
+    let db = WebhookDB::new(&repo.path.join(".oxen"))?;
+    let webhook = db.add_webhook(webhook_req)?;
+
+    Ok(HttpResponse::Ok().json(webhook))
+}
+
+pub async fn list(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+
+    let db = WebhookDB::new(&repo.path.join(".oxen"))?;
+    let webhooks = db.list_all_webhooks()?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({"webhooks": webhooks})))
+}
+
+pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let webhook_id = path_param(&req, "webhook_id")?;
+
+    let db = WebhookDB::new(&repo.path.join(".oxen"))?;
+    db.remove_webhook(webhook_id)?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({"status": "deleted"})))
+}
+
+pub async fn stats(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+
+    let db = WebhookDB::new(&repo.path.join(".oxen"))?;
+    let stats = db.stats()?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({"stats": stats})))
+}
+
+pub async fn get_config(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+
+    let db = WebhookDB::new(&repo.path.join(".oxen"))?;
+    let config = db.get_config()?;
+
+    Ok(HttpResponse::Ok().json(config))
+}
+
+pub async fn update_config(
+    req: HttpRequest,
+    body: actix_web::web::Json<Value>,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+
+    let config: liboxen::model::webhook::WebhookConfig = serde_json::from_value(body.into_inner())?;
+    let db = WebhookDB::new(&repo.path.join(".oxen"))?;
+    db.set_config(&config)?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({"status": "updated"})))
+}

--- a/crates/server/src/controllers/webhooks.rs
+++ b/crates/server/src/controllers/webhooks.rs
@@ -6,7 +6,7 @@ use crate::helpers::get_repo;
 use crate::params::{app_data, path_param};
 
 use liboxen::core::db::webhooks::WebhookDB;
-use liboxen::model::webhook::WebhookAddRequest;
+use liboxen::model::webhook::{WebhookAddRequest, WebhookResponse};
 use liboxen::repositories;
 
 pub async fn create(
@@ -20,6 +20,16 @@ pub async fn create(
 
     let webhook_req: WebhookAddRequest = serde_json::from_value(body.into_inner())?;
 
+    // Validate webhook URL scheme
+    let url_parsed = url::Url::parse(&webhook_req.webhook_url)
+        .map_err(|_| OxenHttpError::BadRequest("Invalid webhook URL".into()))?;
+    let scheme = url_parsed.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(OxenHttpError::BadRequest(
+            "Only http and https webhook URLs are allowed".into(),
+        ));
+    }
+
     // Validate current_oxen_revision if provided
     if let Some(ref claimed_revision) = webhook_req.current_oxen_revision {
         let head_commit = repositories::commits::head_commit_maybe(&repo)?;
@@ -28,7 +38,13 @@ pub async fn create(
             .map(|c| c.id == *claimed_revision)
             .unwrap_or(false);
         if !matches {
-            return Ok(HttpResponse::BadRequest().json(serde_json::json!({"error": "no"})));
+            let actual = head_commit.map(|c| c.id).unwrap_or("none".to_string());
+            return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+                "error": "revision_mismatch",
+                "field": "current_oxen_revision",
+                "claimed": claimed_revision,
+                "actual": actual,
+            })));
         }
     }
 
@@ -45,7 +61,11 @@ pub async fn list(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
 
     let db = WebhookDB::new(&repo.path.join(".oxen"))?;
-    let webhooks = db.list_all_webhooks()?;
+    let webhooks: Vec<WebhookResponse> = db
+        .list_all_webhooks()?
+        .into_iter()
+        .map(WebhookResponse::from)
+        .collect();
 
     Ok(HttpResponse::Ok().json(serde_json::json!({"webhooks": webhooks})))
 }

--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -46,6 +46,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
                 .service(services::transfer())
                 .service(services::tree())
                 .service(services::versions())
+                .service(services::webhooks())
                 .service(services::workspace()),
         );
 }

--- a/crates/server/src/services.rs
+++ b/crates/server/src/services.rs
@@ -21,6 +21,7 @@ pub mod tabular;
 pub mod transfer;
 pub mod tree;
 pub mod versions;
+pub mod webhooks;
 pub mod workspaces;
 
 pub use action::action;
@@ -46,4 +47,5 @@ pub use tabular::tabular;
 pub use transfer::transfer;
 pub use tree::tree;
 pub use versions::versions;
+pub use webhooks::webhooks;
 pub use workspaces::workspace;

--- a/crates/server/src/services/webhooks.rs
+++ b/crates/server/src/services/webhooks.rs
@@ -1,0 +1,19 @@
+use actix_web::{Scope, web};
+
+use crate::controllers;
+
+pub fn webhooks() -> Scope {
+    web::scope("/webhooks")
+        .route("/add", web::post().to(controllers::webhooks::create))
+        .route("", web::get().to(controllers::webhooks::list))
+        .route("/stats", web::get().to(controllers::webhooks::stats))
+        .route("/config", web::get().to(controllers::webhooks::get_config))
+        .route(
+            "/config",
+            web::put().to(controllers::webhooks::update_config),
+        )
+        .route(
+            "/{webhook_id}",
+            web::delete().to(controllers::webhooks::delete),
+        )
+}


### PR DESCRIPTION
New webhook subsystem for notifying external services on file changes.

  - **Model**: Webhook, WebhookAddRequest, WebhookConfig types
  - **Storage**: JSON-file-backed per-repo at .oxen/webhooks/
  - **Path matching**: Hierarchical prefix matching (webhook on /data fires
    for /data/train/img.png; webhook on / catches everything)
  - **Notifier**: Async HTTP POST delivery with per-webhook rate limiting
    and auto-removal after 5 consecutive failures
  - **Endpoints**: POST /webhooks/add, GET /webhooks, DELETE /webhooks/{id},
    GET/PUT /webhooks/config, GET /webhooks/stats

5 new files, 6 modified files, 8 unit tests for the DB layer.

Connected apps including OxenSync would need this.