### PR TITLE
S3: Implement `delete_version`

### DIFF
--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -3,6 +3,7 @@
 //! Enumeration for all errors that can occur in the oxen library
 //!
 
+use aws_sdk_s3::error::BuildError;
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use aws_smithy_runtime_api::client::result::SdkError;
 use duckdb::arrow::error::ArrowError;
@@ -221,9 +222,9 @@ pub enum OxenError {
     // Wrappers
     //
     //
-    /// An error encountered dealing with AWS S3
-    #[error("AWS S3 error: {0}")]
-    AwsS3Error(Box<SdkError<Box<dyn std::error::Error + Send + Sync>, HttpResponse>>),
+    /// An error encountered dealing with AWS
+    #[error("AWS error: {0}")]
+    AwsError(Box<dyn std::error::Error + Send + Sync>),
 
     /// Wraps the error from std::path::strip_prefix.
     #[error("Error stripping prefix: {0}")]
@@ -468,15 +469,6 @@ impl OxenError {
     /// Make a new OxenError::FileImportError error.
     pub fn file_import_error(s: impl AsRef<str>) -> Self {
         OxenError::ImportFileError(StringError::from(s.as_ref()))
-    }
-
-    /// Make a new OxenError::AwsS3Error error.
-    pub fn aws_s3_error<E: std::error::Error + Send + Sync + 'static>(
-        e: SdkError<E, HttpResponse>,
-    ) -> Self {
-        OxenError::AwsS3Error(Box::new(e.map_service_error(|e| {
-            Box::new(e) as Box<dyn std::error::Error + Send + Sync>
-        })))
     }
 
     /// Makes a new OxenError::ResourceNotFound error.
@@ -801,5 +793,22 @@ impl OxenError {
 impl From<String> for OxenError {
     fn from(error: String) -> Self {
         OxenError::Basic(StringError::from(error))
+    }
+}
+
+/// AWS SDK Error
+impl<E> From<SdkError<E, HttpResponse>> for OxenError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn from(e: SdkError<E, HttpResponse>) -> Self {
+        OxenError::AwsError(Box::new(e))
+    }
+}
+
+/// AWS Build Error
+impl From<BuildError> for OxenError {
+    fn from(e: BuildError) -> Self {
+        OxenError::AwsError(Box::new(e))
     }
 }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -148,6 +148,10 @@ pub enum OxenError {
     #[error("{0}")]
     Upload(StringError),
 
+    /// An error deleting keys
+    #[error("delete_objects: some keys failed to delete: {0:?}")]
+    DeleteFailure(Vec<(String, String)>),
+
     // Entry
     /// A commit entry is not present in the repository.
     #[error("{0}")]

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -165,20 +165,16 @@ impl S3VersionStore {
             if let Some(errors) = resp.errors
                 && !errors.is_empty()
             {
-                let msg = errors
+                let key_failures = errors
                     .iter()
                     .map(|e| {
-                        format!(
-                            "{}: {}",
+                       (
                             e.key.as_deref().unwrap_or("?"),
                             e.message.as_deref().unwrap_or("?")
                         )
                     })
-                    .collect::<Vec<_>>()
-                    .join("; ");
-                return Err(OxenError::basic_str(format!(
-                    "delete_objects: some keys failed to delete: {msg}"
-                )));
+                    .collect::<Vec<_>>();
+                return Err(OxenError::DeleteFailure{key_failures});
             }
         }
 

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -168,13 +168,13 @@ impl S3VersionStore {
                 let key_failures = errors
                     .iter()
                     .map(|e| {
-                       (
-                            e.key.as_deref().unwrap_or("?"),
-                            e.message.as_deref().unwrap_or("?")
+                        (
+                            e.key.as_deref().unwrap_or("?").into(),
+                            e.message.as_deref().unwrap_or("?").into(),
                         )
                     })
                     .collect::<Vec<_>>();
-                return Err(OxenError::DeleteFailure{key_failures});
+                return Err(OxenError::DeleteFailure(key_failures));
             }
         }
 

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
-use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier};
 use aws_sdk_s3::{Client, config::Region, primitives::ByteStream};
 use bytes::Bytes;
 use futures::StreamExt;
@@ -110,6 +110,80 @@ impl S3VersionStore {
     fn chunk_key(&self, hash: &str, offset: u64) -> String {
         format!("{}/chunks/{}", self.version_dir(hash), offset)
     }
+
+    /// List all S3 object keys under a given prefix, following continuation tokens.
+    async fn list_objects_with_prefix(&self, prefix: &str) -> Result<Vec<String>, OxenError> {
+        let client = self.client().await?;
+        let mut keys = Vec::new();
+        let mut continuation_token: Option<String> = None;
+
+        loop {
+            let mut req = client.list_objects_v2().bucket(&self.bucket).prefix(prefix);
+            if let Some(token) = &continuation_token {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req.send().await?;
+
+            if let Some(contents) = resp.contents {
+                for obj in contents {
+                    if let Some(key) = obj.key {
+                        keys.push(key);
+                    }
+                }
+            }
+
+            if resp.is_truncated.unwrap_or(false) {
+                continuation_token = resp.next_continuation_token;
+            } else {
+                break;
+            }
+        }
+
+        Ok(keys)
+    }
+
+    /// Delete a set of S3 objects, batching into groups of 1000 (the S3 DeleteObjects limit).
+    async fn delete_objects(&self, keys: Vec<String>) -> Result<(), OxenError> {
+        let client = self.client().await?;
+
+        for batch in keys.chunks(1000) {
+            let objects: Vec<ObjectIdentifier> = batch
+                .iter()
+                .map(|k| ObjectIdentifier::builder().key(k).build())
+                .collect::<Result<_, _>>()?;
+
+            let delete = Delete::builder().set_objects(Some(objects)).build()?;
+
+            let resp = client
+                .delete_objects()
+                .bucket(&self.bucket)
+                .delete(delete)
+                .send()
+                .await?;
+
+            if let Some(errors) = resp.errors
+                && !errors.is_empty()
+            {
+                let msg = errors
+                    .iter()
+                    .map(|e| {
+                        format!(
+                            "{}: {}",
+                            e.key.as_deref().unwrap_or("?"),
+                            e.message.as_deref().unwrap_or("?")
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                return Err(OxenError::basic_str(format!(
+                    "delete_objects: some keys failed to delete: {msg}"
+                )));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -194,8 +268,7 @@ impl VersionStore for S3VersionStore {
                 .key(&key)
                 .body(ByteStream::from(buf))
                 .send()
-                .await
-                .map_err(OxenError::aws_s3_error)?;
+                .await?;
             return Ok(());
         }
 
@@ -208,8 +281,7 @@ impl VersionStore for S3VersionStore {
             .bucket(&self.bucket)
             .key(&key)
             .send()
-            .await
-            .map_err(OxenError::aws_s3_error)?;
+            .await?;
 
         let upload_id = upload
             .upload_id()
@@ -282,8 +354,7 @@ impl VersionStore for S3VersionStore {
                     .upload_id(&upload_id)
                     .multipart_upload(completed)
                     .send()
-                    .await
-                    .map_err(OxenError::aws_s3_error)?;
+                    .await?;
                 Ok(())
             }
             // Upload failed
@@ -535,8 +606,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .body(ByteStream::from(data))
             .send()
-            .await
-            .map_err(OxenError::aws_s3_error)?;
+            .await?;
 
         Ok(())
     }
@@ -597,11 +667,10 @@ impl VersionStore for S3VersionStore {
         }
     }
 
-    async fn delete_version(&self, _hash: &str) -> Result<(), OxenError> {
-        // TODO: Implement S3 version deletion
-        Err(OxenError::basic_str(
-            "S3VersionStore delete_version not yet implemented",
-        ))
+    async fn delete_version(&self, hash: &str) -> Result<(), OxenError> {
+        let prefix = format!("{}/", self.version_dir(hash));
+        let keys = self.list_objects_with_prefix(&prefix).await?;
+        self.delete_objects(keys).await
     }
 
     async fn list_versions(&self) -> Result<Vec<String>, OxenError> {
@@ -661,8 +730,7 @@ async fn upload_part(
         .part_number(part_num)
         .body(ByteStream::from(data))
         .send()
-        .await
-        .map_err(OxenError::aws_s3_error)?;
+        .await?;
 
     let etag = resp
         .e_tag()
@@ -945,5 +1013,68 @@ mod tests {
             .expect("body should collect")
             .into_bytes();
         assert_eq!(&body1024[..], b"chunk-1024");
+    }
+
+    #[tokio::test]
+    async fn test_delete_version_removes_data_and_chunks() {
+        let (store, _tmp, _server) = setup().await;
+        let hash = "abcdef1234567890abcdef1234567890";
+
+        // Store main data + two chunks
+        store.store_version(hash, b"main data").await.unwrap();
+        store
+            .store_version_chunk(hash, 0, Bytes::from_static(b"chunk-0"))
+            .await
+            .unwrap();
+        store
+            .store_version_chunk(hash, 1024, Bytes::from_static(b"chunk-1024"))
+            .await
+            .unwrap();
+
+        assert!(store.version_exists(hash).await.unwrap());
+
+        // Delete
+        store
+            .delete_version(hash)
+            .await
+            .expect("delete_version should succeed");
+
+        // Verify nothing remains under the version prefix
+        assert!(!store.version_exists(hash).await.unwrap());
+
+        let prefix = format!("{}/", store.version_dir(hash));
+        let remaining = store.list_objects_with_prefix(&prefix).await.unwrap();
+        assert!(
+            remaining.is_empty(),
+            "expected no objects, found: {:?}",
+            remaining
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_version_missing_is_noop() {
+        let (store, _tmp, _server) = setup().await;
+        let hash = "deadbeefdeadbeefdeadbeefdeadbeef";
+
+        // No objects exist; should not error
+        store
+            .delete_version(hash)
+            .await
+            .expect("delete of missing version should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_delete_version_isolates_by_hash() {
+        let (store, _tmp, _server) = setup().await;
+        let hash_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let hash_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        store.store_version(hash_a, b"a data").await.unwrap();
+        store.store_version(hash_b, b"b data").await.unwrap();
+
+        store.delete_version(hash_a).await.unwrap();
+
+        assert!(!store.version_exists(hash_a).await.unwrap());
+        assert!(store.version_exists(hash_b).await.unwrap());
     }
 }


### PR DESCRIPTION
Step 6 of the S3 Project: Implement `S3VersionStore::delete_version`

- List objects under `{prefix}/{hash}/` and batch-delete via `DeleteObjects`
- Add `list_objects_with_prefix()` helper method to list files in s3, handling pagination
- Add `delete_objects()` helper method to delete files in s3.
- For `OxenError`: rename the variant `AwsS3Error` → `AwsError` and replace the `aws_s3_error` method with `From` impls for `SdkError` and `BuildError,` so `?` propagates directly
- Implement `S3VersionStore::delete_version`
- Add tests for `S3VersionStore::delete_version`
