### PR TITLE
S3: Remove `get_version_chunk_writer` from `VersionStore`

### DIFF
--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use tokio::fs::{self, File, metadata};
 use tokio::io::AsyncReadExt;
-use tokio::io::{BufReader, BufWriter};
+use tokio::io::BufReader;
 use tokio::sync::Semaphore;
 use tokio_stream::Stream;
 use tokio_util::io::ReaderStream;
@@ -262,21 +262,6 @@ impl VersionStore for LocalVersionStore {
         }
 
         Ok(())
-    }
-
-    async fn get_version_chunk_writer(
-        &self,
-        hash: &str,
-        offset: u64,
-    ) -> Result<Box<dyn tokio::io::AsyncWrite + Send + Unpin>, OxenError> {
-        let chunk_dir = self.version_chunk_dir(hash, offset);
-        fs::create_dir_all(&chunk_dir).await?;
-
-        let chunk_path = self.version_chunk_file(hash, offset);
-        let file = File::create(&chunk_path).await?;
-        let writer = BufWriter::new(file);
-
-        Ok(Box::new(writer))
     }
 
     async fn get_version_chunk(

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -607,17 +607,6 @@ impl VersionStore for S3VersionStore {
         Ok(())
     }
 
-    async fn get_version_chunk_writer(
-        &self,
-        _hash: &str,
-        _offset: u64,
-    ) -> Result<Box<dyn tokio::io::AsyncWrite + Send + Unpin>, OxenError> {
-        // TODO: Implement S3 version chunk stream storage
-        Err(OxenError::basic_str(
-            "S3VersionStore get_version_chunk_writer not yet implemented",
-        ))
-    }
-
     async fn get_version_chunk(
         &self,
         _hash: &str,

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::AsyncRead;
 use tokio_stream::Stream;
 
 use crate::constants;
@@ -136,17 +136,6 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         derived_filename: &str,
         derived_data: &[u8],
     ) -> Result<(), OxenError>;
-
-    /// Get a writer for a chunk of a version file
-    ///
-    /// # Arguments
-    /// * `hash` - The content hash that identifies this version
-    /// * `offset` - The starting byte position of the chunk
-    async fn get_version_chunk_writer(
-        &self,
-        hash: &str,
-        offset: u64,
-    ) -> Result<Box<dyn AsyncWrite + Send + Unpin>, OxenError>;
 
     /// Retrieve a chunk of a version file
     ///

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -12,7 +12,6 @@ use liboxen::repositories;
 use liboxen::view::StatusMessage;
 use liboxen::view::versions::CompleteVersionUploadRequest;
 use serde::Deserialize;
-use tokio::io::AsyncWriteExt;
 
 #[derive(Deserialize, Debug)]
 pub struct ChunkQuery {
@@ -43,23 +42,16 @@ pub async fn upload(
 
     let version_store = repo.version_store()?;
 
-    let mut writer = version_store
-        .get_version_chunk_writer(&version_id, offset)
-        .await?;
-
-    // Write chunks in stream
-    while let Some(chunk_result) = body.next().await {
-        let chunk = chunk_result.map_err(|e| OxenHttpError::BadRequest(e.to_string().into()))?;
-        writer
-            .write_all(&chunk)
-            .await
-            .map_err(|e| OxenHttpError::BasicError(e.to_string().into()))?;
+    // Read the chunk from the payload. Chunks are <= 10MB (AVG_CHUNK_SIZE)
+    let mut chunk = web::BytesMut::new();
+    while let Some(part_result) = body.next().await {
+        let part = part_result.map_err(|e| OxenHttpError::BadRequest(e.to_string().into()))?;
+        chunk.extend_from_slice(&part);
     }
 
-    writer
-        .flush()
-        .await
-        .map_err(|e| OxenHttpError::BasicError(e.to_string().into()))?;
+    version_store
+        .store_version_chunk(&version_id, offset, chunk.freeze())
+        .await?;
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))
 }


### PR DESCRIPTION
Step 8: Remove `get_version_chunk_writer` from the `VersionStore` trait

The `/upload` HTTP handler was the sole caller of `get_version_chunk_writer`, streaming the request body through an `AsyncWrite` handle. We can get rid of the `get_version_chunk_writer` trait method and implementations entirely by buffering the body (one 10MB `AVG_CHUNK_SIZE` chunk) and calling `store_version_chunk` directly instead.

- Removes the method from the `VersionStore` trait, `LocalVersionStore,` and `S3VersionStore`

Resolves ENG-865