### PR TITLE
Josh/fast workspace lookup

### DIFF
--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use liboxen::command::migrate::AddChildCountsToNodesMigration;
+use liboxen::command::migrate::AddWorkspaceNameIndexMigration;
 
 pub fn get_scheme_and_host_or_default() -> Result<(String, String), OxenError> {
     let config = AuthConfig::get_or_create()?;
@@ -88,6 +89,10 @@ pub fn migrations() -> HashMap<String, Box<dyn Migrate>> {
     map.insert(
         AddChildCountsToNodesMigration.name().to_string(),
         Box::new(AddChildCountsToNodesMigration),
+    );
+    map.insert(
+        AddWorkspaceNameIndexMigration.name().to_string(),
+        Box::new(AddWorkspaceNameIndexMigration),
     );
     map
 }

--- a/crates/lib/src/command/migrate.rs
+++ b/crates/lib/src/command/migrate.rs
@@ -5,6 +5,9 @@ use crate::{error::OxenError, model::LocalRepository};
 pub mod m20250111083535_add_child_counts_to_nodes;
 pub use m20250111083535_add_child_counts_to_nodes::AddChildCountsToNodesMigration;
 
+pub mod m20260408_add_workspace_name_index;
+pub use m20260408_add_workspace_name_index::AddWorkspaceNameIndexMigration;
+
 pub trait Migrate {
     fn up(&self, path: &Path, all: bool) -> Result<(), OxenError>;
     fn down(&self, path: &Path, all: bool) -> Result<(), OxenError>;

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -1,0 +1,122 @@
+use std::path::Path;
+
+use super::Migrate;
+
+use crate::core::workspaces::workspace_name_index;
+use crate::error::OxenError;
+use crate::model::LocalRepository;
+use crate::model::Workspace;
+use crate::repositories;
+use crate::util;
+use crate::util::progress_bar::{ProgressBarType, oxen_progress_bar};
+
+pub struct AddWorkspaceNameIndexMigration;
+
+impl Migrate for AddWorkspaceNameIndexMigration {
+    fn name(&self) -> &'static str {
+        "add_workspace_name_index"
+    }
+
+    fn description(&self) -> &'static str {
+        "Creates a RocksDB index mapping workspace names to IDs for O(1) lookup"
+    }
+
+    fn up(&self, path: &Path, all: bool) -> Result<(), OxenError> {
+        if all {
+            run_on_all_repos(path)?;
+        } else {
+            let repo = LocalRepository::from_dir(path)?;
+            run_on_one_repo(&repo)?;
+        }
+        Ok(())
+    }
+
+    fn down(&self, path: &Path, all: bool) -> Result<(), OxenError> {
+        if all {
+            revert_all_repos(path)?;
+        } else {
+            let repo = LocalRepository::from_dir(path)?;
+            revert_one_repo(&repo)?;
+        }
+        Ok(())
+    }
+
+    fn is_needed(&self, repo: &LocalRepository) -> Result<bool, OxenError> {
+        // Needed if workspace directory exists but index does not
+        let workspaces_dir = Workspace::workspaces_dir(repo);
+        Ok(workspaces_dir.exists() && !workspace_name_index::index_exists(repo))
+    }
+}
+
+fn run_on_all_repos(path: &Path) -> Result<(), OxenError> {
+    println!("🐂 Collecting namespaces to migrate...");
+    let namespaces = repositories::list_namespaces(path)?;
+    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
+    println!("🐂 Migrating {} namespaces", namespaces.len());
+    for namespace in namespaces {
+        let namespace_path = path.join(namespace);
+        let repos = repositories::list_repos_in_namespace(&namespace_path);
+        for repo in repos {
+            match run_on_one_repo(&repo) {
+                Ok(_) => {}
+                Err(err) => {
+                    log::error!(
+                        "Could not create workspace name index for repo {:?}\nErr: {}",
+                        repo.path.canonicalize(),
+                        err
+                    );
+                }
+            }
+        }
+        bar.inc(1);
+    }
+    Ok(())
+}
+
+fn run_on_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
+    let workspaces_dir = Workspace::workspaces_dir(repo);
+    if !workspaces_dir.exists() {
+        return Ok(());
+    }
+
+    log::info!("Creating workspace name index for repo: {:?}", repo.path);
+
+    workspace_name_index::with_index(repo, |idx| idx.rebuild_from_disk(repo))
+}
+
+fn revert_all_repos(path: &Path) -> Result<(), OxenError> {
+    println!("🐂 Collecting namespaces to revert...");
+    let namespaces = repositories::list_namespaces(path)?;
+    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
+    println!("🐂 Reverting {} namespaces", namespaces.len());
+    for namespace in namespaces {
+        let namespace_path = path.join(namespace);
+        let repos = repositories::list_repos_in_namespace(&namespace_path);
+        for repo in repos {
+            match revert_one_repo(&repo) {
+                Ok(_) => {}
+                Err(err) => {
+                    log::error!(
+                        "Could not revert workspace name index for repo {:?}\nErr: {}",
+                        repo.path.canonicalize(),
+                        err
+                    );
+                }
+            }
+        }
+        bar.inc(1);
+    }
+    Ok(())
+}
+
+fn revert_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
+    workspace_name_index::remove_from_cache(&repo.path)?;
+    let index_dir = repo
+        .path
+        .join(crate::constants::OXEN_HIDDEN_DIR)
+        .join(crate::constants::WORKSPACE_NAME_INDEX_DIR);
+    if index_dir.exists() {
+        util::fs::remove_dir_all(&index_dir)?;
+    }
+    Ok(())
+}

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -62,7 +62,7 @@ fn run_on_all_repos(path: &Path) -> Result<(), OxenError> {
                 Err(err) => {
                     log::error!(
                         "Could not create workspace name index for repo {:?}\nErr: {}",
-                        repo.path.canonicalize(),
+                        util::fs::canonicalize(repo.path),
                         err
                     );
                 }

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -81,7 +81,8 @@ fn run_on_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
 
     log::info!("Creating workspace name index for repo: {:?}", repo.path);
 
-    workspace_name_index::with_index(repo, |idx| idx.rebuild_from_disk(repo))
+    let idx = workspace_name_index::get_index(repo)?;
+    idx.rebuild_from_disk(repo)
 }
 
 fn revert_all_repos(path: &Path) -> Result<(), OxenError> {

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -115,6 +115,7 @@ fn revert_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
     let index_dir = repo
         .path
         .join(crate::constants::OXEN_HIDDEN_DIR)
+        .join(crate::constants::WORKSPACES_DIR)
         .join(crate::constants::WORKSPACE_NAME_INDEX_DIR);
     if index_dir.exists() {
         util::fs::remove_dir_all(&index_dir)?;

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -111,14 +111,10 @@ fn revert_all_repos(path: &Path) -> Result<(), OxenError> {
 }
 
 fn revert_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
+    let index_dir = workspace_name_index::index_dir(repo);
     workspace_name_index::remove_from_cache(&repo.path)?;
-    let index_dir = repo
-        .path
-        .join(crate::constants::OXEN_HIDDEN_DIR)
-        .join(crate::constants::WORKSPACES_DIR)
-        .join(crate::constants::WORKSPACE_NAME_INDEX_DIR);
     if index_dir.exists() {
-        util::fs::remove_dir_all(&index_dir)?;
+        util::fs::remove_dir_all(index_dir)?;
     }
     Ok(())
 }

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -82,7 +82,8 @@ fn run_on_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
     log::info!("Creating workspace name index for repo: {:?}", repo.path);
 
     let idx = workspace_name_index::get_index(repo)?;
-    idx.rebuild_from_disk(repo)
+    idx.rebuild_from_disk(repo)?;
+    Ok(())
 }
 
 fn revert_all_repos(path: &Path) -> Result<(), OxenError> {
@@ -111,7 +112,7 @@ fn revert_all_repos(path: &Path) -> Result<(), OxenError> {
 }
 
 fn revert_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
-    workspace_name_index::remove_from_cache(&repo.path)?;
+    workspace_name_index::remove_from_cache(repo);
     let index_dir = repo
         .path
         .join(crate::constants::OXEN_HIDDEN_DIR)

--- a/crates/lib/src/constants.rs
+++ b/crates/lib/src/constants.rs
@@ -114,6 +114,8 @@ pub const MODS_DIR: &str = "mods";
 pub const WORKSPACES_DIR: &str = "workspaces";
 /// workspace commit id
 pub const WORKSPACE_CONFIG: &str = "WORKSPACE_CONFIG";
+/// workspace_name_index/ is a RocksDB mapping workspace names to workspace IDs for O(1) lookup
+pub const WORKSPACE_NAME_INDEX_DIR: &str = "workspace_name_index";
 
 /// if we have merge conflicts we write to MERGE_HEAD and ORIG_HEAD to keep track of the parents
 pub const MERGE_HEAD_FILE: &str = "MERGE_HEAD";

--- a/crates/lib/src/core.rs
+++ b/crates/lib/src/core.rs
@@ -13,3 +13,4 @@ pub mod staged;
 pub mod v_latest;
 pub mod v_old;
 pub mod versions;
+pub mod workspaces;

--- a/crates/lib/src/core/workspaces.rs
+++ b/crates/lib/src/core/workspaces.rs
@@ -1,4 +1,4 @@
 pub mod workspace_name_index;
 
+pub use workspace_name_index::get_index;
 pub use workspace_name_index::remove_from_cache;
-pub use workspace_name_index::with_index;

--- a/crates/lib/src/core/workspaces.rs
+++ b/crates/lib/src/core/workspaces.rs
@@ -1,0 +1,4 @@
+pub mod workspace_name_index;
+
+pub use workspace_name_index::remove_from_cache;
+pub use workspace_name_index::with_index;

--- a/crates/lib/src/core/workspaces/workspace_name_index.rs
+++ b/crates/lib/src/core/workspaces/workspace_name_index.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
-use std::str;
+use std::str::{self, Utf8Error};
 use std::sync::{Arc, LazyLock};
 
 use lru::LruCache;
@@ -20,6 +20,33 @@ const DB_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
 static DB_INSTANCES: LazyLock<Mutex<LruCache<PathBuf, Arc<DB>>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(DB_CACHE_SIZE)));
 
+#[derive(Debug, thiserror::Error)]
+pub enum WsError {
+    #[error("Error looking up workspace name '{0}': {1}")]
+    LookupErr(String, rocksdb::Error),
+
+    #[error("Key {0} mapped to non-UTF-8 value. Error: {1}")]
+    NonUtf8Key(String, Utf8Error),
+
+    #[error("Failed to create workspace name index directory: {0}")]
+    CreateDirErr(Box<OxenError>),
+
+    #[error("Failed to open workspace name index database: {0}")]
+    OpenError(rocksdb::Error),
+
+    #[error("Failed to put key {0} in workspace name index. Error: {1}")]
+    PutError(String, rocksdb::Error),
+
+    #[error("Failed to delete key {0} from workspace name index. Error: {1}")]
+    DeleteError(String, rocksdb::Error),
+
+    #[error("Error iterating workspace name index: {0}")]
+    IterationError(rocksdb::Error),
+
+    #[error("Error listing workspace directories: {0}")]
+    ListWsErr(Box<OxenError>),
+}
+
 fn index_dir(repo: &LocalRepository) -> PathBuf {
     repo.path
         .join(OXEN_HIDDEN_DIR)
@@ -33,28 +60,29 @@ pub fn index_exists(repo: &LocalRepository) -> bool {
 }
 
 /// Removes this repository's workspace name index DB from the cache.
-pub fn remove_from_cache(repository_path: impl AsRef<Path>) -> Result<(), OxenError> {
-    let dir = util::fs::oxen_hidden_dir(&repository_path)
-        .join(WORKSPACES_DIR)
-        .join(WORKSPACE_NAME_INDEX_DIR);
+pub fn remove_from_cache(repo: &LocalRepository) {
+    let dir = index_dir(repo);
     let mut instances = DB_INSTANCES.lock();
     let _ = instances.pop(&dir); // drop immediately
-    Ok(())
 }
 
 /// Removes from cache including children paths (useful for test cleanup).
-pub fn remove_from_cache_with_children(repository_path: impl AsRef<Path>) -> Result<(), OxenError> {
-    let mut dbs_to_remove: Vec<PathBuf> = vec![];
+pub fn remove_from_cache_with_children(repository_path: &Path) {
     let mut instances = DB_INSTANCES.lock();
-    for (key, _) in instances.iter() {
-        if key.starts_with(&repository_path) {
-            dbs_to_remove.push(key.clone());
-        }
-    }
+
+    let dbs_to_remove = instances
+        .iter()
+        .filter_map(|(key, _)| {
+            if key.starts_with(repository_path) {
+                Some(key.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
     for db_path in dbs_to_remove {
         let _ = instances.pop(&db_path); // drop immediately
     }
-    Ok(())
 }
 
 pub struct WorkspaceNameIndex {
@@ -65,7 +93,7 @@ pub struct WorkspaceNameIndex {
 ///
 /// The handle holds a reference-counted DB instance cached in a global LRU cache.
 /// Drop it when you're done to avoid holding the DB open longer than necessary.
-pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, OxenError> {
+pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, WsError> {
     let dir = index_dir(repo);
 
     let mut instances = DB_INSTANCES.lock();
@@ -74,17 +102,11 @@ pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, OxenError
     }
 
     if !dir.exists() {
-        util::fs::create_dir_all(&dir).map_err(|e| {
-            OxenError::basic_str(format!(
-                "Failed to create workspace name index directory: {e}"
-            ))
-        })?;
+        util::fs::create_dir_all(&dir).map_err(|e| WsError::CreateDirErr(Box::new(e)))?;
     }
 
     let opts = db::key_val::opts::default();
-    let db = DB::open(&opts, dunce::simplified(&dir)).map_err(|e| {
-        OxenError::basic_str(format!("Failed to open workspace name index database: {e}"))
-    })?;
+    let db = DB::open(&opts, dunce::simplified(&dir)).map_err(WsError::OpenError)?;
     let arc_db = Arc::new(db);
     instances.put(dir, arc_db.clone());
     Ok(WorkspaceNameIndex { db: arc_db })
@@ -92,13 +114,13 @@ pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, OxenError
 
 impl WorkspaceNameIndex {
     /// Get workspace ID by name. O(1).
-    pub fn get_id_by_name(&self, name: &str) -> Result<Option<String>, OxenError> {
+    pub fn get_id_by_name(&self, name: &str) -> Result<Option<String>, WsError> {
         match self.db.get(name.as_bytes()) {
-            Ok(Some(value)) => Ok(Some(String::from(str::from_utf8(&value)?))),
-            Ok(None) => Ok(None),
-            Err(err) => Err(OxenError::basic_str(format!(
-                "Error looking up workspace name '{name}': {err}"
+            Ok(Some(value)) => Ok(Some(String::from(
+                str::from_utf8(&value).map_err(|e| WsError::NonUtf8Key(name.to_string(), e))?,
             ))),
+            Ok(None) => Ok(None),
+            Err(err) => Err(WsError::LookupErr(name.to_string(), err)),
         }
     }
 
@@ -115,29 +137,33 @@ impl WorkspaceNameIndex {
     }
 
     /// Insert a name -> workspace_id mapping.
-    pub fn put(&self, name: &str, workspace_id: &str) -> Result<(), OxenError> {
-        self.db.put(name.as_bytes(), workspace_id.as_bytes())?;
+    pub fn put(&self, name: &str, workspace_id: &str) -> Result<(), WsError> {
+        self.db
+            .put(name.as_bytes(), workspace_id.as_bytes())
+            .map_err(|e| WsError::PutError(name.to_string(), e))?;
         Ok(())
     }
 
     /// Remove a name from the index.
-    pub fn delete(&self, name: &str) -> Result<(), OxenError> {
-        self.db.delete(name.as_bytes())?;
+    pub fn delete(&self, name: &str) -> Result<(), WsError> {
+        self.db
+            .delete(name.as_bytes())
+            .map_err(|e| WsError::DeleteError(name.to_string(), e))?;
         Ok(())
     }
 
     /// Remove all entries from the index.
-    pub fn clear(&self) -> Result<(), OxenError> {
+    pub fn clear(&self) -> Result<(), WsError> {
         let iter = self.db.iterator(IteratorMode::Start);
         for item in iter {
             match item {
                 Ok((key, _)) => {
-                    self.db.delete(key)?;
+                    self.db.delete(&key).map_err(|e| {
+                        WsError::PutError(String::from_utf8_lossy(&key).to_string(), e)
+                    })?;
                 }
                 Err(err) => {
-                    return Err(OxenError::basic_str(format!(
-                        "Error iterating workspace name index: {err}"
-                    )));
+                    return Err(WsError::IterationError(err));
                 }
             }
         }
@@ -145,7 +171,7 @@ impl WorkspaceNameIndex {
     }
 
     /// List all (name, workspace_id) entries. Primarily for debugging/testing.
-    pub fn list(&self) -> Result<Vec<(String, String)>, OxenError> {
+    pub fn list(&self) -> Result<Vec<(String, String)>, WsError> {
         let iter = self.db.iterator(IteratorMode::Start);
         let mut results = Vec::new();
         for item in iter {
@@ -155,13 +181,13 @@ impl WorkspaceNameIndex {
                         results.push((name.to_string(), id.to_string()));
                     }
                     _ => {
-                        log::error!("Could not decode workspace name index entry");
+                        log::error!(
+                            "Could not decode workspace name index entry into valid UTF-8 strings."
+                        );
                     }
                 },
                 Err(err) => {
-                    return Err(OxenError::basic_str(format!(
-                        "Error iterating workspace name index: {err}"
-                    )));
+                    return Err(WsError::IterationError(err));
                 }
             }
         }
@@ -170,7 +196,7 @@ impl WorkspaceNameIndex {
 
     /// Rebuild the index from existing workspace configs on disk.
     /// Clears all existing entries first, then scans `.oxen/workspaces/` directories.
-    pub fn rebuild_from_disk(&self, repo: &LocalRepository) -> Result<(), OxenError> {
+    pub fn rebuild_from_disk(&self, repo: &LocalRepository) -> Result<(), WsError> {
         self.clear()?;
 
         let workspaces_dir = repo.path.join(OXEN_HIDDEN_DIR).join(WORKSPACES_DIR);
@@ -178,9 +204,8 @@ impl WorkspaceNameIndex {
             return Ok(());
         }
 
-        let workspace_dirs = util::fs::list_dirs_in_dir(&workspaces_dir).map_err(|e| {
-            OxenError::basic_str(format!("Error listing workspace directories: {e}"))
-        })?;
+        let workspace_dirs = util::fs::list_dirs_in_dir(&workspaces_dir)
+            .map_err(|e| WsError::ListWsErr(Box::new(e)))?;
 
         for workspace_dir in workspace_dirs {
             let config_path = workspace_dir
@@ -193,7 +218,9 @@ impl WorkspaceNameIndex {
             let config_contents = match util::fs::read_from_path(&config_path) {
                 Ok(contents) => contents,
                 Err(e) => {
-                    log::warn!("Could not read workspace config at {config_path:?}: {e}");
+                    log::warn!(
+                        "[Skip workspace in index] Could not read workspace config at {config_path:?}: {e}"
+                    );
                     continue;
                 }
             };
@@ -201,7 +228,9 @@ impl WorkspaceNameIndex {
             let config: WorkspaceConfig = match toml::from_str(&config_contents) {
                 Ok(config) => config,
                 Err(e) => {
-                    log::warn!("Could not parse workspace config at {config_path:?}: {e}");
+                    log::warn!(
+                        "[Skip workspace in index] Could not parse workspace config at {config_path:?}: {e}"
+                    );
                     continue;
                 }
             };

--- a/crates/lib/src/core/workspaces/workspace_name_index.rs
+++ b/crates/lib/src/core/workspaces/workspace_name_index.rs
@@ -23,6 +23,7 @@ static DB_INSTANCES: LazyLock<Mutex<LruCache<PathBuf, Arc<DB>>>> =
 fn index_dir(repo: &LocalRepository) -> PathBuf {
     repo.path
         .join(OXEN_HIDDEN_DIR)
+        .join(WORKSPACES_DIR)
         .join(WORKSPACE_NAME_INDEX_DIR)
 }
 
@@ -33,7 +34,9 @@ pub fn index_exists(repo: &LocalRepository) -> bool {
 
 /// Removes this repository's workspace name index DB from the cache.
 pub fn remove_from_cache(repository_path: impl AsRef<Path>) -> Result<(), OxenError> {
-    let dir = util::fs::oxen_hidden_dir(&repository_path).join(WORKSPACE_NAME_INDEX_DIR);
+    let dir = util::fs::oxen_hidden_dir(&repository_path)
+        .join(WORKSPACES_DIR)
+        .join(WORKSPACE_NAME_INDEX_DIR);
     let mut instances = DB_INSTANCES.lock();
     let _ = instances.pop(&dir); // drop immediately
     Ok(())

--- a/crates/lib/src/core/workspaces/workspace_name_index.rs
+++ b/crates/lib/src/core/workspaces/workspace_name_index.rs
@@ -58,39 +58,33 @@ pub struct WorkspaceNameIndex {
     db: Arc<DB>,
 }
 
-/// Execute an operation with access to the workspace name index DB.
-/// Creates the DB directory if it doesn't exist.
-pub fn with_index<F, T>(repo: &LocalRepository, operation: F) -> Result<T, OxenError>
-where
-    F: FnOnce(&WorkspaceNameIndex) -> Result<T, OxenError>,
-{
-    let db = {
-        let dir = index_dir(repo);
+/// Returns a [`WorkspaceNameIndex`] handle for the given repository.
+///
+/// The handle holds a reference-counted DB instance cached in a global LRU cache.
+/// Drop it when you're done to avoid holding the DB open longer than necessary.
+pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, OxenError> {
+    let dir = index_dir(repo);
 
-        let mut instances = DB_INSTANCES.lock();
-        if let Some(db) = instances.get(&dir) {
-            Ok::<Arc<DB>, OxenError>(db.clone())
-        } else {
-            if !dir.exists() {
-                util::fs::create_dir_all(&dir).map_err(|e| {
-                    OxenError::basic_str(format!(
-                        "Failed to create workspace name index directory: {e}"
-                    ))
-                })?;
-            }
+    let mut instances = DB_INSTANCES.lock();
+    if let Some(db) = instances.get(&dir) {
+        return Ok(WorkspaceNameIndex { db: db.clone() });
+    }
 
-            let opts = db::key_val::opts::default();
-            let db = DB::open(&opts, dunce::simplified(&dir)).map_err(|e| {
-                OxenError::basic_str(format!("Failed to open workspace name index database: {e}"))
-            })?;
-            let arc_db = Arc::new(db);
-            instances.put(dir, arc_db.clone());
-            Ok(arc_db)
-        }
-    }?;
+    if !dir.exists() {
+        util::fs::create_dir_all(&dir).map_err(|e| {
+            OxenError::basic_str(format!(
+                "Failed to create workspace name index directory: {e}"
+            ))
+        })?;
+    }
 
-    let index = WorkspaceNameIndex { db };
-    operation(&index)
+    let opts = db::key_val::opts::default();
+    let db = DB::open(&opts, dunce::simplified(&dir)).map_err(|e| {
+        OxenError::basic_str(format!("Failed to open workspace name index database: {e}"))
+    })?;
+    let arc_db = Arc::new(db);
+    instances.put(dir, arc_db.clone());
+    Ok(WorkspaceNameIndex { db: arc_db })
 }
 
 impl WorkspaceNameIndex {
@@ -228,15 +222,14 @@ mod tests {
     #[tokio::test]
     async fn test_workspace_name_index_put_and_get() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
-            with_index(&repo, |idx| {
-                idx.put("my-workspace", "abc-123")?;
-                let result = idx.get_id_by_name("my-workspace")?;
-                assert_eq!(result, Some("abc-123".to_string()));
+            let idx = get_index(&repo)?;
+            idx.put("my-workspace", "abc-123")?;
+            let result = idx.get_id_by_name("my-workspace")?;
+            assert_eq!(result, Some("abc-123".to_string()));
 
-                let missing = idx.get_id_by_name("nonexistent")?;
-                assert_eq!(missing, None);
-                Ok(())
-            })
+            let missing = idx.get_id_by_name("nonexistent")?;
+            assert_eq!(missing, None);
+            Ok(())
         })
         .await
     }
@@ -244,12 +237,11 @@ mod tests {
     #[tokio::test]
     async fn test_workspace_name_index_has_name() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
-            with_index(&repo, |idx| {
-                idx.put("exists", "id-1")?;
-                assert!(idx.has_name("exists"));
-                assert!(!idx.has_name("does-not-exist"));
-                Ok(())
-            })
+            let idx = get_index(&repo)?;
+            idx.put("exists", "id-1")?;
+            assert!(idx.has_name("exists"));
+            assert!(!idx.has_name("does-not-exist"));
+            Ok(())
         })
         .await
     }
@@ -257,14 +249,13 @@ mod tests {
     #[tokio::test]
     async fn test_workspace_name_index_delete() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
-            with_index(&repo, |idx| {
-                idx.put("to-delete", "id-1")?;
-                assert!(idx.has_name("to-delete"));
+            let idx = get_index(&repo)?;
+            idx.put("to-delete", "id-1")?;
+            assert!(idx.has_name("to-delete"));
 
-                idx.delete("to-delete")?;
-                assert!(!idx.has_name("to-delete"));
-                Ok(())
-            })
+            idx.delete("to-delete")?;
+            assert!(!idx.has_name("to-delete"));
+            Ok(())
         })
         .await
     }
@@ -272,15 +263,14 @@ mod tests {
     #[tokio::test]
     async fn test_workspace_name_index_clear() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
-            with_index(&repo, |idx| {
-                idx.put("ws-1", "id-1")?;
-                idx.put("ws-2", "id-2")?;
-                assert_eq!(idx.list()?.len(), 2);
+            let idx = get_index(&repo)?;
+            idx.put("ws-1", "id-1")?;
+            idx.put("ws-2", "id-2")?;
+            assert_eq!(idx.list()?.len(), 2);
 
-                idx.clear()?;
-                assert_eq!(idx.list()?.len(), 0);
-                Ok(())
-            })
+            idx.clear()?;
+            assert_eq!(idx.list()?.len(), 0);
+            Ok(())
         })
         .await
     }
@@ -288,16 +278,15 @@ mod tests {
     #[tokio::test]
     async fn test_workspace_name_index_list() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {
-            with_index(&repo, |idx| {
-                idx.put("alpha", "id-a")?;
-                idx.put("beta", "id-b")?;
+            let idx = get_index(&repo)?;
+            idx.put("alpha", "id-a")?;
+            idx.put("beta", "id-b")?;
 
-                let entries = idx.list()?;
-                assert_eq!(entries.len(), 2);
-                assert!(entries.contains(&("alpha".to_string(), "id-a".to_string())));
-                assert!(entries.contains(&("beta".to_string(), "id-b".to_string())));
-                Ok(())
-            })
+            let entries = idx.list()?;
+            assert_eq!(entries.len(), 2);
+            assert!(entries.contains(&("alpha".to_string(), "id-a".to_string())));
+            assert!(entries.contains(&("beta".to_string(), "id-b".to_string())));
+            Ok(())
         })
         .await
     }
@@ -318,20 +307,20 @@ mod tests {
                 "ws-id-1",
                 Some("named-ws".to_string()),
                 true,
-            )?;
+            )
+            .await?;
             repositories::workspaces::create(&repo, &commit, "ws-id-2", true)?;
 
             // Now rebuild the index from disk in a fresh index
-            with_index(&repo, |idx| {
-                idx.rebuild_from_disk(&repo)?;
+            let idx = get_index(&repo)?;
+            idx.rebuild_from_disk(&repo)?;
 
-                // Only the named workspace should be in the index
-                let entries = idx.list()?;
-                assert_eq!(entries.len(), 1);
-                assert_eq!(idx.get_id_by_name("named-ws")?, Some("ws-id-1".to_string()));
-                assert_eq!(idx.get_id_by_name("ws-id-2")?, None);
-                Ok(())
-            })
+            // Only the named workspace should be in the index
+            let entries = idx.list()?;
+            assert_eq!(entries.len(), 1);
+            assert_eq!(idx.get_id_by_name("named-ws")?, Some("ws-id-1".to_string()));
+            assert_eq!(idx.get_id_by_name("ws-id-2")?, None);
+            Ok(())
         })
         .await
     }

--- a/crates/lib/src/core/workspaces/workspace_name_index.rs
+++ b/crates/lib/src/core/workspaces/workspace_name_index.rs
@@ -1,0 +1,338 @@
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::str;
+use std::sync::{Arc, LazyLock};
+
+use lru::LruCache;
+use parking_lot::Mutex;
+use rocksdb::{DB, IteratorMode};
+
+use crate::constants::{OXEN_HIDDEN_DIR, WORKSPACE_NAME_INDEX_DIR, WORKSPACES_DIR};
+use crate::core::db;
+use crate::error::OxenError;
+use crate::model::LocalRepository;
+use crate::model::workspace::WorkspaceConfig;
+use crate::util;
+
+const DB_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
+
+// Static cache of DB instances with LRU eviction
+static DB_INSTANCES: LazyLock<Mutex<LruCache<PathBuf, Arc<DB>>>> =
+    LazyLock::new(|| Mutex::new(LruCache::new(DB_CACHE_SIZE)));
+
+fn index_dir(repo: &LocalRepository) -> PathBuf {
+    repo.path
+        .join(OXEN_HIDDEN_DIR)
+        .join(WORKSPACE_NAME_INDEX_DIR)
+}
+
+/// Check if the workspace name index DB exists for this repo.
+pub fn index_exists(repo: &LocalRepository) -> bool {
+    index_dir(repo).exists()
+}
+
+/// Removes this repository's workspace name index DB from the cache.
+pub fn remove_from_cache(repository_path: impl AsRef<Path>) -> Result<(), OxenError> {
+    let dir = util::fs::oxen_hidden_dir(&repository_path).join(WORKSPACE_NAME_INDEX_DIR);
+    let mut instances = DB_INSTANCES.lock();
+    let _ = instances.pop(&dir); // drop immediately
+    Ok(())
+}
+
+/// Removes from cache including children paths (useful for test cleanup).
+pub fn remove_from_cache_with_children(repository_path: impl AsRef<Path>) -> Result<(), OxenError> {
+    let mut dbs_to_remove: Vec<PathBuf> = vec![];
+    let mut instances = DB_INSTANCES.lock();
+    for (key, _) in instances.iter() {
+        if key.starts_with(&repository_path) {
+            dbs_to_remove.push(key.clone());
+        }
+    }
+    for db_path in dbs_to_remove {
+        let _ = instances.pop(&db_path); // drop immediately
+    }
+    Ok(())
+}
+
+pub struct WorkspaceNameIndex {
+    db: Arc<DB>,
+}
+
+/// Execute an operation with access to the workspace name index DB.
+/// Creates the DB directory if it doesn't exist.
+pub fn with_index<F, T>(repo: &LocalRepository, operation: F) -> Result<T, OxenError>
+where
+    F: FnOnce(&WorkspaceNameIndex) -> Result<T, OxenError>,
+{
+    let db = {
+        let dir = index_dir(repo);
+
+        let mut instances = DB_INSTANCES.lock();
+        if let Some(db) = instances.get(&dir) {
+            Ok::<Arc<DB>, OxenError>(db.clone())
+        } else {
+            if !dir.exists() {
+                util::fs::create_dir_all(&dir).map_err(|e| {
+                    OxenError::basic_str(format!(
+                        "Failed to create workspace name index directory: {e}"
+                    ))
+                })?;
+            }
+
+            let opts = db::key_val::opts::default();
+            let db = DB::open(&opts, dunce::simplified(&dir)).map_err(|e| {
+                OxenError::basic_str(format!("Failed to open workspace name index database: {e}"))
+            })?;
+            let arc_db = Arc::new(db);
+            instances.put(dir, arc_db.clone());
+            Ok(arc_db)
+        }
+    }?;
+
+    let index = WorkspaceNameIndex { db };
+    operation(&index)
+}
+
+impl WorkspaceNameIndex {
+    /// Get workspace ID by name. O(1).
+    pub fn get_id_by_name(&self, name: &str) -> Result<Option<String>, OxenError> {
+        match self.db.get(name.as_bytes()) {
+            Ok(Some(value)) => Ok(Some(String::from(str::from_utf8(&value)?))),
+            Ok(None) => Ok(None),
+            Err(err) => Err(OxenError::basic_str(format!(
+                "Error looking up workspace name '{name}': {err}"
+            ))),
+        }
+    }
+
+    /// Check if a name exists in the index. O(1).
+    pub fn has_name(&self, name: &str) -> bool {
+        match self.db.get_pinned(name.as_bytes()) {
+            Ok(Some(_)) => true,
+            Ok(None) => false,
+            Err(err) => {
+                log::error!("Error checking workspace name index for '{name}': {err}");
+                false
+            }
+        }
+    }
+
+    /// Insert a name -> workspace_id mapping.
+    pub fn put(&self, name: &str, workspace_id: &str) -> Result<(), OxenError> {
+        self.db.put(name.as_bytes(), workspace_id.as_bytes())?;
+        Ok(())
+    }
+
+    /// Remove a name from the index.
+    pub fn delete(&self, name: &str) -> Result<(), OxenError> {
+        self.db.delete(name.as_bytes())?;
+        Ok(())
+    }
+
+    /// Remove all entries from the index.
+    pub fn clear(&self) -> Result<(), OxenError> {
+        let iter = self.db.iterator(IteratorMode::Start);
+        for item in iter {
+            match item {
+                Ok((key, _)) => {
+                    self.db.delete(key)?;
+                }
+                Err(err) => {
+                    return Err(OxenError::basic_str(format!(
+                        "Error iterating workspace name index: {err}"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// List all (name, workspace_id) entries. Primarily for debugging/testing.
+    pub fn list(&self) -> Result<Vec<(String, String)>, OxenError> {
+        let iter = self.db.iterator(IteratorMode::Start);
+        let mut results = Vec::new();
+        for item in iter {
+            match item {
+                Ok((key, value)) => match (str::from_utf8(&key), str::from_utf8(&value)) {
+                    (Ok(name), Ok(id)) => {
+                        results.push((name.to_string(), id.to_string()));
+                    }
+                    _ => {
+                        log::error!("Could not decode workspace name index entry");
+                    }
+                },
+                Err(err) => {
+                    return Err(OxenError::basic_str(format!(
+                        "Error iterating workspace name index: {err}"
+                    )));
+                }
+            }
+        }
+        Ok(results)
+    }
+
+    /// Rebuild the index from existing workspace configs on disk.
+    /// Clears all existing entries first, then scans `.oxen/workspaces/` directories.
+    pub fn rebuild_from_disk(&self, repo: &LocalRepository) -> Result<(), OxenError> {
+        self.clear()?;
+
+        let workspaces_dir = repo.path.join(OXEN_HIDDEN_DIR).join(WORKSPACES_DIR);
+        if !workspaces_dir.exists() {
+            return Ok(());
+        }
+
+        let workspace_dirs = util::fs::list_dirs_in_dir(&workspaces_dir).map_err(|e| {
+            OxenError::basic_str(format!("Error listing workspace directories: {e}"))
+        })?;
+
+        for workspace_dir in workspace_dirs {
+            let config_path = workspace_dir
+                .join(OXEN_HIDDEN_DIR)
+                .join(crate::constants::WORKSPACE_CONFIG);
+            if !config_path.exists() {
+                continue;
+            }
+
+            let config_contents = match util::fs::read_from_path(&config_path) {
+                Ok(contents) => contents,
+                Err(e) => {
+                    log::warn!("Could not read workspace config at {config_path:?}: {e}");
+                    continue;
+                }
+            };
+
+            let config: WorkspaceConfig = match toml::from_str(&config_contents) {
+                Ok(config) => config,
+                Err(e) => {
+                    log::warn!("Could not parse workspace config at {config_path:?}: {e}");
+                    continue;
+                }
+            };
+
+            if let (Some(name), Some(id)) = (&config.workspace_name, &config.workspace_id) {
+                self.put(name, id)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::OxenError;
+    use crate::repositories;
+    use crate::test;
+
+    #[tokio::test]
+    async fn test_workspace_name_index_put_and_get() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            with_index(&repo, |idx| {
+                idx.put("my-workspace", "abc-123")?;
+                let result = idx.get_id_by_name("my-workspace")?;
+                assert_eq!(result, Some("abc-123".to_string()));
+
+                let missing = idx.get_id_by_name("nonexistent")?;
+                assert_eq!(missing, None);
+                Ok(())
+            })
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_workspace_name_index_has_name() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            with_index(&repo, |idx| {
+                idx.put("exists", "id-1")?;
+                assert!(idx.has_name("exists"));
+                assert!(!idx.has_name("does-not-exist"));
+                Ok(())
+            })
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_workspace_name_index_delete() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            with_index(&repo, |idx| {
+                idx.put("to-delete", "id-1")?;
+                assert!(idx.has_name("to-delete"));
+
+                idx.delete("to-delete")?;
+                assert!(!idx.has_name("to-delete"));
+                Ok(())
+            })
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_workspace_name_index_clear() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            with_index(&repo, |idx| {
+                idx.put("ws-1", "id-1")?;
+                idx.put("ws-2", "id-2")?;
+                assert_eq!(idx.list()?.len(), 2);
+
+                idx.clear()?;
+                assert_eq!(idx.list()?.len(), 0);
+                Ok(())
+            })
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_workspace_name_index_list() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            with_index(&repo, |idx| {
+                idx.put("alpha", "id-a")?;
+                idx.put("beta", "id-b")?;
+
+                let entries = idx.list()?;
+                assert_eq!(entries.len(), 2);
+                assert!(entries.contains(&("alpha".to_string(), "id-a".to_string())));
+                assert!(entries.contains(&("beta".to_string(), "id-b".to_string())));
+                Ok(())
+            })
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_workspace_name_index_rebuild_from_disk() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Create a file and commit so we have a valid commit to use
+            let test_file = repo.path.join("test.txt");
+            util::fs::write_to_path(&test_file, "hello")?;
+            repositories::add(&repo, &test_file).await?;
+            let commit = repositories::commit(&repo, "init")?;
+
+            // Create some workspaces (one named, one unnamed)
+            repositories::workspaces::create_with_name(
+                &repo,
+                &commit,
+                "ws-id-1",
+                Some("named-ws".to_string()),
+                true,
+            )?;
+            repositories::workspaces::create(&repo, &commit, "ws-id-2", true)?;
+
+            // Now rebuild the index from disk in a fresh index
+            with_index(&repo, |idx| {
+                idx.rebuild_from_disk(&repo)?;
+
+                // Only the named workspace should be in the index
+                let entries = idx.list()?;
+                assert_eq!(entries.len(), 1);
+                assert_eq!(idx.get_id_by_name("named-ws")?, Some("ws-id-1".to_string()));
+                assert_eq!(idx.get_id_by_name("ws-id-2")?, None);
+                Ok(())
+            })
+        })
+        .await
+    }
+}

--- a/crates/lib/src/core/workspaces/workspace_name_index.rs
+++ b/crates/lib/src/core/workspaces/workspace_name_index.rs
@@ -20,7 +20,7 @@ const DB_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
 static DB_INSTANCES: LazyLock<Mutex<LruCache<PathBuf, Arc<DB>>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(DB_CACHE_SIZE)));
 
-fn index_dir(repo: &LocalRepository) -> PathBuf {
+pub fn index_dir(repo: &LocalRepository) -> PathBuf {
     repo.path
         .join(OXEN_HIDDEN_DIR)
         .join(WORKSPACES_DIR)
@@ -103,14 +103,13 @@ impl WorkspaceNameIndex {
     }
 
     /// Check if a name exists in the index. O(1).
-    pub fn has_name(&self, name: &str) -> bool {
+    pub fn has_name(&self, name: &str) -> Result<bool, OxenError> {
         match self.db.get_pinned(name.as_bytes()) {
-            Ok(Some(_)) => true,
-            Ok(None) => false,
-            Err(err) => {
-                log::error!("Error checking workspace name index for '{name}': {err}");
-                false
-            }
+            Ok(Some(_)) => Ok(true),
+            Ok(None) => Ok(false),
+            Err(err) => Err(OxenError::basic_str(format!(
+                "Error checking workspace name index for '{name}': {err}"
+            ))),
         }
     }
 
@@ -144,7 +143,8 @@ impl WorkspaceNameIndex {
         Ok(())
     }
 
-    /// List all (name, workspace_id) entries. Primarily for debugging/testing.
+    /// List all (name, workspace_id) entries for debugging/testing.
+    #[cfg(test)]
     pub fn list(&self) -> Result<Vec<(String, String)>, OxenError> {
         let iter = self.db.iterator(IteratorMode::Start);
         let mut results = Vec::new();
@@ -242,8 +242,8 @@ mod tests {
         test::run_empty_local_repo_test_async(|repo| async move {
             let idx = get_index(&repo)?;
             idx.put("exists", "id-1")?;
-            assert!(idx.has_name("exists"));
-            assert!(!idx.has_name("does-not-exist"));
+            assert!(idx.has_name("exists")?);
+            assert!(!idx.has_name("does-not-exist")?);
             Ok(())
         })
         .await
@@ -254,10 +254,10 @@ mod tests {
         test::run_empty_local_repo_test_async(|repo| async move {
             let idx = get_index(&repo)?;
             idx.put("to-delete", "id-1")?;
-            assert!(idx.has_name("to-delete"));
+            assert!(idx.has_name("to-delete")?);
 
             idx.delete("to-delete")?;
-            assert!(!idx.has_name("to-delete"));
+            assert!(!idx.has_name("to-delete")?);
             Ok(())
         })
         .await

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -115,6 +115,9 @@ pub enum OxenError {
     #[error("Workspace is behind: {0}")]
     WorkspaceBehind(Box<Workspace>),
 
+    #[error("{0}")]
+    WorkspaceNameIndex(#[from] crate::core::workspaces::workspace_name_index::WsError),
+
     //
     // Resources (paths, uris, etc.)
     //

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -115,6 +115,10 @@ pub enum OxenError {
     #[error("Workspace is behind: {0}")]
     WorkspaceBehind(Box<Workspace>),
 
+    /// A workspace with this name already exists.
+    #[error("A workspace with the name '{0}' already exists")]
+    WorkspaceAlreadyExists(String),
+
     #[error("{0}")]
     WorkspaceNameIndex(#[from] crate::core::workspaces::workspace_name_index::WsError),
 

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -1,5 +1,5 @@
 use crate::config::RepositoryConfig;
-use crate::constants::{OXEN_HIDDEN_DIR, REPO_CONFIG_FILENAME, WORKSPACE_NAME_INDEX_DIR};
+use crate::constants::{OXEN_HIDDEN_DIR, REPO_CONFIG_FILENAME};
 use crate::core;
 use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::core::versions::MinOxenVersion;
@@ -54,11 +54,9 @@ pub fn get(
         return get_by_dir(repo, workspace_dir);
     }
 
-    // Second try: treat input as a workspace name
+    // Second try: treat input as a workspace name (already returns a loaded Workspace)
     if let Some(workspace) = get_by_name(repo, workspace_id)? {
-        let id_hash = util::hasher::hash_str_sha256(&workspace.id);
-        let workspace_dir = Workspace::workspace_dir(repo, &id_hash);
-        return get_by_dir(repo, workspace_dir);
+        return Ok(Some(workspace));
     }
 
     Ok(None)
@@ -445,15 +443,8 @@ pub fn clear(repo: &LocalRepository) -> Result<(), OxenError> {
         return Ok(());
     }
 
-    // Clean up the name index: evict from cache, then remove directory
+    // Evict the name index DB handle from cache before removing the directory
     workspace_name_index::remove_from_cache(&repo.path)?;
-    let index_dir = repo
-        .path
-        .join(OXEN_HIDDEN_DIR)
-        .join(WORKSPACE_NAME_INDEX_DIR);
-    if index_dir.exists() {
-        util::fs::remove_dir_all(&index_dir)?;
-    }
 
     util::fs::remove_dir_all(&workspaces_dir)?;
     Ok(())
@@ -710,7 +701,7 @@ fn build_file_status_maps_for_file(
 mod tests {
     use super::*;
     use crate::api;
-    use crate::constants::DEFAULT_BRANCH_NAME;
+    use crate::constants::{DEFAULT_BRANCH_NAME, WORKSPACE_NAME_INDEX_DIR};
     use crate::repositories;
     use crate::test;
     use crate::util;
@@ -919,16 +910,27 @@ mod tests {
                 assert_eq!(temp_workspace.commit.id, commit.id);
                 assert!(temp_workspace.is_editable);
 
-                let workspace_entries = std::fs::read_dir(&workspaces_dir)?;
-                assert_eq!(workspace_entries.count(), 1);
+                let workspace_count = std::fs::read_dir(&workspaces_dir)?
+                    .filter(|e| {
+                        e.as_ref()
+                            .map(|e| e.file_name() != WORKSPACE_NAME_INDEX_DIR)
+                            .unwrap_or(false)
+                    })
+                    .count();
+                assert_eq!(workspace_count, 1);
             } // temp_workspace goes out of scope here
 
-            // Verify workspace was cleaned up
-            let workspace_entries = std::fs::read_dir(&workspaces_dir)?;
+            // Verify workspace was cleaned up (only the name index dir should remain)
+            let workspace_count = std::fs::read_dir(&workspaces_dir)?
+                .filter(|e| {
+                    e.as_ref()
+                        .map(|e| e.file_name() != WORKSPACE_NAME_INDEX_DIR)
+                        .unwrap_or(false)
+                })
+                .count();
             assert_eq!(
-                workspace_entries.count(),
-                0,
-                "Workspace directory should be empty after cleanup"
+                workspace_count, 0,
+                "Workspace directory should have no workspace dirs after cleanup"
             );
 
             Ok(())

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -114,8 +114,8 @@ pub fn get_by_name(
 
     // Fast path: use the name index if it exists (O(1))
     if workspace_name_index::index_exists(repo) {
-        let maybe_id =
-            workspace_name_index::with_index(repo, |idx| idx.get_id_by_name(workspace_name))?;
+        let idx = workspace_name_index::get_index(repo)?;
+        let maybe_id = idx.get_id_by_name(workspace_name)?;
         if let Some(id) = maybe_id {
             let id_hash = util::hasher::hash_str_sha256(&id);
             let workspace_dir = Workspace::workspace_dir(repo, &id_hash);
@@ -127,7 +127,7 @@ pub fn get_by_name(
             log::warn!(
                 "workspace_name_index: stale entry for name '{workspace_name}' -> id '{id}', removing"
             );
-            workspace_name_index::with_index(repo, |idx| idx.delete(workspace_name))?;
+            idx.delete(workspace_name)?;
         }
         return Ok(None);
     }
@@ -150,10 +150,32 @@ pub fn create(
     workspace_id: impl AsRef<str>,
     is_editable: bool,
 ) -> Result<Workspace, OxenError> {
-    create_with_name(base_repo, commit, workspace_id, None, is_editable)
+    create_on_disk(base_repo, commit, workspace_id, None, is_editable)
 }
 
-pub fn create_with_name(
+pub async fn create_with_name(
+    base_repo: &LocalRepository,
+    commit: &Commit,
+    workspace_id: impl AsRef<str>,
+    workspace_name: Option<String>,
+    is_editable: bool,
+) -> Result<Workspace, OxenError> {
+    let workspace_id = workspace_id.as_ref();
+    let workspace = create_on_disk(base_repo, commit, workspace_id, workspace_name, is_editable)?;
+
+    // Update the name index (async: rebuild_from_disk may run on a blocking thread)
+    if let Some(ref name) = workspace.name {
+        ensure_name_index(base_repo).await?;
+        let idx = workspace_name_index::get_index(base_repo)?;
+        idx.put(name, workspace_id)?;
+    }
+
+    Ok(workspace)
+}
+
+/// Core sync workspace creation logic shared by `create` and `create_with_name`.
+/// Handles validation, directory setup, and TOML config writing — but NOT name indexing.
+fn create_on_disk(
     base_repo: &LocalRepository,
     commit: &Commit,
     workspace_id: impl AsRef<str>,
@@ -205,12 +227,6 @@ pub fn create_with_name(
     log::debug!("index::workspaces::create writing workspace config to: {workspace_config_path:?}");
     util::fs::write_to_path(&workspace_config_path, toml_string)?;
 
-    // Update the name index
-    if let Some(ref name) = workspace_name {
-        ensure_name_index(base_repo)?;
-        workspace_name_index::with_index(base_repo, |idx| idx.put(name, workspace_id))?;
-    }
-
     Ok(Workspace {
         id: workspace_id.to_owned(),
         name: workspace_name,
@@ -235,9 +251,8 @@ fn validate_create_constraints(
     if has_index && is_editable {
         if let Some(name) = workspace_name {
             // Check name doesn't collide with an existing workspace name
-            let name_taken =
-                workspace_name_index::with_index(base_repo, |idx| Ok(idx.has_name(name)))?;
-            if name_taken {
+            let idx = workspace_name_index::get_index(base_repo)?;
+            if idx.has_name(name) {
                 return Err(OxenError::basic_str(format!(
                     "A workspace with the name {name} already exists"
                 )));
@@ -268,10 +283,17 @@ fn validate_create_constraints(
 }
 
 /// Ensures the workspace name index exists, lazily creating it if needed.
-/// On first call for a repo, rebuilds the index from disk (one-time O(n)).
-fn ensure_name_index(repo: &LocalRepository) -> Result<(), OxenError> {
+/// On first call for a repo, rebuilds the index from disk (one-time O(n))
+/// on a blocking thread to avoid stalling the async runtime.
+async fn ensure_name_index(repo: &LocalRepository) -> Result<(), OxenError> {
     if !workspace_name_index::index_exists(repo) {
-        workspace_name_index::with_index(repo, |idx| idx.rebuild_from_disk(repo))?;
+        let repo = repo.clone();
+        tokio::task::spawn_blocking(move || {
+            let idx = workspace_name_index::get_index(&repo)?;
+            idx.rebuild_from_disk(&repo)
+        })
+        .await
+        .map_err(|e| OxenError::basic_str(format!("spawn_blocking join error: {e}")))??;
     }
     Ok(())
 }
@@ -305,13 +327,14 @@ impl Drop for TemporaryWorkspace {
 }
 
 /// Creates a new temporary workspace that will be deleted when the reference is dropped
-pub fn create_temporary(
+pub async fn create_temporary(
     base_repo: &LocalRepository,
     commit: &Commit,
 ) -> Result<TemporaryWorkspace, OxenError> {
     let workspace_id = Uuid::new_v4().to_string();
     let workspace_name = format!("temporary-{workspace_id}");
-    let workspace = create_with_name(base_repo, commit, workspace_id, Some(workspace_name), true)?;
+    let workspace =
+        create_with_name(base_repo, commit, workspace_id, Some(workspace_name), true).await?;
     Ok(TemporaryWorkspace { workspace })
 }
 
@@ -401,7 +424,8 @@ pub fn delete(workspace: &Workspace) -> Result<(), OxenError> {
     if let Some(ref name) = workspace.name
         && workspace_name_index::index_exists(&workspace.base_repo)
     {
-        workspace_name_index::with_index(&workspace.base_repo, |idx| idx.delete(name))?;
+        let idx = workspace_name_index::get_index(&workspace.base_repo)?;
+        idx.delete(name)?;
     }
 
     // Clean up caches before deleting the workspace
@@ -706,7 +730,7 @@ mod tests {
 
             {
                 // Create temporary workspace in new scope
-                let temp_workspace = create_temporary(&repo, &commit)?;
+                let temp_workspace = create_temporary(&repo, &commit).await?;
 
                 // Update the hello file in the temporary workspace
                 let workspace_hello_file = temp_workspace.dir().join("hello.txt");
@@ -727,7 +751,7 @@ mod tests {
 
             {
                 // Create a new temporary workspace off of the same original commit
-                let temp_workspace = create_temporary(&repo, &commit)?;
+                let temp_workspace = create_temporary(&repo, &commit).await?;
 
                 // Update the goodbye file in the temporary workspace
                 let workspace_goodbye_file = temp_workspace.dir().join("goodbye.txt");
@@ -764,7 +788,7 @@ mod tests {
 
             {
                 // Create temporary workspace in new scope
-                let temp_workspace = create_temporary(&repo, &commit)?;
+                let temp_workspace = create_temporary(&repo, &commit).await?;
 
                 // Update the hello file in the temporary workspace
                 let workspace_hello_file = temp_workspace.dir().join("greetings").join("hello.txt");
@@ -785,7 +809,7 @@ mod tests {
 
             {
                 // Create a new temporary workspace off of the same original commit
-                let temp_workspace = create_temporary(&repo, &commit)?;
+                let temp_workspace = create_temporary(&repo, &commit).await?;
 
                 // Update the hello file in the temporary workspace
                 let workspace_hello_file = temp_workspace.dir().join("greetings").join("hello.txt");
@@ -827,7 +851,7 @@ mod tests {
 
             {
                 // Create temporary workspace in new scope
-                let temp_workspace = create_temporary(&repo, &commit)?;
+                let temp_workspace = create_temporary(&repo, &commit).await?;
 
                 // Update the hello file in the temporary workspace
                 let workspace_hello_file = temp_workspace.dir().join("greetings").join("hello.txt");
@@ -848,7 +872,7 @@ mod tests {
 
             {
                 // Create a new temporary workspace off of the same original commit
-                let temp_workspace = create_temporary(&repo, &commit)?;
+                let temp_workspace = create_temporary(&repo, &commit).await?;
 
                 // Update the goodbye file in the temporary workspace
                 let workspace_goodbye_file =
@@ -886,7 +910,7 @@ mod tests {
 
             {
                 // Create temporary workspace in new scope
-                let temp_workspace = create_temporary(&repo, &commit)?;
+                let temp_workspace = create_temporary(&repo, &commit).await?;
 
                 // Verify workspace exists and contains our file
                 assert!(temp_workspace.dir().exists());

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -1,8 +1,9 @@
 use crate::config::RepositoryConfig;
-use crate::constants::{OXEN_HIDDEN_DIR, REPO_CONFIG_FILENAME};
+use crate::constants::{OXEN_HIDDEN_DIR, REPO_CONFIG_FILENAME, WORKSPACE_NAME_INDEX_DIR};
 use crate::core;
 use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::core::versions::MinOxenVersion;
+use crate::core::workspaces::workspace_name_index;
 use crate::error::OxenError;
 use crate::model::entry::metadata_entry::{WorkspaceChanges, WorkspaceMetadataEntry};
 use crate::model::{MetadataEntry, ParsedResource, StagedData, StagedEntryStatus, merkle_tree};
@@ -32,7 +33,10 @@ use uuid::Uuid;
 
 /// Loads a workspace from the filesystem. Must call create() first to create the workspace.
 ///
-/// Returns an None if the workspace does not exist
+/// Accepts either a workspace ID or a workspace name. Tries ID-based lookup first (O(1)),
+/// then falls back to name lookup (O(1) with index, O(n) without).
+///
+/// Returns None if the workspace does not exist.
 pub fn get(
     repo: &LocalRepository,
     workspace_id: impl AsRef<str>,
@@ -41,19 +45,23 @@ pub fn get(
     let workspace_id_hash = util::hasher::hash_str_sha256(workspace_id);
     log::debug!("workspace::get workspace_id: {workspace_id:?} hash: {workspace_id_hash:?}");
 
+    // First try: treat input as a workspace ID (O(1) directory lookup)
     let workspace_dir = Workspace::workspace_dir(repo, &workspace_id_hash);
     let config_path = Workspace::config_path_from_dir(&workspace_dir);
 
     log::debug!("workspace::get directory: {workspace_dir:?}");
     if config_path.exists() {
-        get_by_dir(repo, workspace_dir)
-    } else if let Some(workspace) = get_by_name(repo, workspace_id)? {
-        let workspace_id = util::hasher::hash_str_sha256(&workspace.id);
-        let workspace_dir = Workspace::workspace_dir(repo, &workspace_id);
-        get_by_dir(repo, workspace_dir)
-    } else {
-        Ok(None)
+        return get_by_dir(repo, workspace_dir);
     }
+
+    // Second try: treat input as a workspace name
+    if let Some(workspace) = get_by_name(repo, workspace_id)? {
+        let id_hash = util::hasher::hash_str_sha256(&workspace.id);
+        let workspace_dir = Workspace::workspace_dir(repo, &id_hash);
+        return get_by_dir(repo, workspace_dir);
+    }
+
+    Ok(None)
 }
 
 pub fn get_by_dir(
@@ -103,6 +111,28 @@ pub fn get_by_name(
     workspace_name: impl AsRef<str>,
 ) -> Result<Option<Workspace>, OxenError> {
     let workspace_name = workspace_name.as_ref();
+
+    // Fast path: use the name index if it exists (O(1))
+    if workspace_name_index::index_exists(repo) {
+        let maybe_id =
+            workspace_name_index::with_index(repo, |idx| idx.get_id_by_name(workspace_name))?;
+        if let Some(id) = maybe_id {
+            let id_hash = util::hasher::hash_str_sha256(&id);
+            let workspace_dir = Workspace::workspace_dir(repo, &id_hash);
+            let result = get_by_dir(repo, &workspace_dir)?;
+            if result.is_some() {
+                return Ok(result);
+            }
+            // Stale index entry: workspace dir no longer exists. Clean it up.
+            log::warn!(
+                "workspace_name_index: stale entry for name '{workspace_name}' -> id '{id}', removing"
+            );
+            workspace_name_index::with_index(repo, |idx| idx.delete(workspace_name))?;
+        }
+        return Ok(None);
+    }
+
+    // Slow path: iterate all workspaces (O(n)), used when index hasn't been created yet
     for workspace in iter_workspaces(repo)? {
         if let Some(workspace) = workspace?
             && workspace.name.as_deref() == Some(workspace_name)
@@ -143,16 +173,10 @@ pub fn create_with_name(
             "Workspace {workspace_id} already exists"
         )));
     }
-    let workspaces = list(base_repo)?;
 
-    // Check for existing non-editable workspaces on the same commit
-    for workspace in workspaces {
-        if !is_editable {
-            check_non_editable_workspace(&workspace, commit)?;
-        }
-        if let Some(workspace_name) = workspace_name.clone() {
-            check_existing_workspace_name(&workspace, &workspace_name)?;
-        }
+    // Validate name uniqueness and non-editable constraints
+    if workspace_name.is_some() || !is_editable {
+        validate_create_constraints(base_repo, commit, &workspace_name, is_editable)?;
     }
 
     log::debug!("index::workspaces::create Initializing oxen repo! 🐂");
@@ -181,6 +205,12 @@ pub fn create_with_name(
     log::debug!("index::workspaces::create writing workspace config to: {workspace_config_path:?}");
     util::fs::write_to_path(&workspace_config_path, toml_string)?;
 
+    // Update the name index
+    if let Some(ref name) = workspace_name {
+        ensure_name_index(base_repo)?;
+        workspace_name_index::with_index(base_repo, |idx| idx.put(name, workspace_id))?;
+    }
+
     Ok(Workspace {
         id: workspace_id.to_owned(),
         name: workspace_name,
@@ -189,6 +219,61 @@ pub fn create_with_name(
         commit: commit.clone(),
         is_editable,
     })
+}
+
+/// Validates name uniqueness and non-editable constraints before workspace creation.
+/// Uses the name index for O(1) checks when available, falls back to list() iteration.
+fn validate_create_constraints(
+    base_repo: &LocalRepository,
+    commit: &Commit,
+    workspace_name: &Option<String>,
+    is_editable: bool,
+) -> Result<(), OxenError> {
+    let has_index = workspace_name_index::index_exists(base_repo);
+
+    // Fast path: use the index for name checks when we don't need to iterate for non-editable
+    if has_index && is_editable {
+        if let Some(name) = workspace_name {
+            // Check name doesn't collide with an existing workspace name
+            let name_taken =
+                workspace_name_index::with_index(base_repo, |idx| Ok(idx.has_name(name)))?;
+            if name_taken {
+                return Err(OxenError::basic_str(format!(
+                    "A workspace with the name {name} already exists"
+                )));
+            }
+            // Check name doesn't collide with an existing workspace ID
+            let name_as_id_hash = util::hasher::hash_str_sha256(name);
+            let name_as_id_dir = Workspace::workspace_dir(base_repo, &name_as_id_hash);
+            if Workspace::config_path_from_dir(&name_as_id_dir).exists() {
+                return Err(OxenError::basic_str(format!(
+                    "A workspace with the name {name} already exists"
+                )));
+            }
+        }
+        return Ok(());
+    }
+
+    // Slow path: iterate all workspaces (needed when index doesn't exist or !is_editable)
+    let workspaces = list(base_repo)?;
+    for workspace in workspaces {
+        if !is_editable {
+            check_non_editable_workspace(&workspace, commit)?;
+        }
+        if let Some(name) = workspace_name {
+            check_existing_workspace_name(&workspace, name)?;
+        }
+    }
+    Ok(())
+}
+
+/// Ensures the workspace name index exists, lazily creating it if needed.
+/// On first call for a repo, rebuilds the index from disk (one-time O(n)).
+fn ensure_name_index(repo: &LocalRepository) -> Result<(), OxenError> {
+    if !workspace_name_index::index_exists(repo) {
+        workspace_name_index::with_index(repo, |idx| idx.rebuild_from_disk(repo))?;
+    }
+    Ok(())
 }
 
 /// A wrapper around Workspace that automatically deletes the workspace when dropped
@@ -312,6 +397,13 @@ pub fn delete(workspace: &Workspace) -> Result<(), OxenError> {
 
     log::debug!("workspace::delete cleaning up workspace dir: {workspace_dir:?}");
 
+    // Remove from name index before deleting the workspace directory
+    if let Some(ref name) = workspace.name
+        && workspace_name_index::index_exists(&workspace.base_repo)
+    {
+        workspace_name_index::with_index(&workspace.base_repo, |idx| idx.delete(name))?;
+    }
+
     // Clean up caches before deleting the workspace
     merkle_tree::merkle_tree_node_cache::remove_from_cache(&workspace.workspace_repo.path)?;
     core::staged::remove_from_cache(&workspace.workspace_repo.path)?;
@@ -327,6 +419,16 @@ pub fn clear(repo: &LocalRepository) -> Result<(), OxenError> {
     let workspaces_dir = Workspace::workspaces_dir(repo);
     if !workspaces_dir.exists() {
         return Ok(());
+    }
+
+    // Clean up the name index: evict from cache, then remove directory
+    workspace_name_index::remove_from_cache(&repo.path)?;
+    let index_dir = repo
+        .path
+        .join(OXEN_HIDDEN_DIR)
+        .join(WORKSPACE_NAME_INDEX_DIR);
+    if index_dir.exists() {
+        util::fs::remove_dir_all(&index_dir)?;
     }
 
     util::fs::remove_dir_all(&workspaces_dir)?;

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -251,17 +251,13 @@ fn validate_create_constraints(
             // Check name doesn't collide with an existing workspace name
             let idx = workspace_name_index::get_index(base_repo)?;
             if idx.has_name(name)? {
-                return Err(OxenError::basic_str(format!(
-                    "A workspace with the name {name} already exists"
-                )));
+                return Err(OxenError::WorkspaceAlreadyExists(name.to_string()));
             }
             // Check name doesn't collide with an existing workspace ID
             let name_as_id_hash = util::hasher::hash_str_sha256(name);
             let name_as_id_dir = Workspace::workspace_dir(base_repo, &name_as_id_hash);
             if Workspace::config_path_from_dir(&name_as_id_dir).exists() {
-                return Err(OxenError::basic_str(format!(
-                    "A workspace with the name {name} already exists"
-                )));
+                return Err(OxenError::WorkspaceAlreadyExists(name.to_string()));
             }
         }
         return Ok(());
@@ -351,9 +347,9 @@ fn check_existing_workspace_name(
     workspace_name: &str,
 ) -> Result<(), OxenError> {
     if workspace.name == Some(workspace_name.to_string()) || *workspace_name == workspace.id {
-        return Err(OxenError::basic_str(format!(
-            "A workspace with the name {workspace_name} already exists"
-        )));
+        return Err(OxenError::WorkspaceAlreadyExists(
+            workspace_name.to_string(),
+        ));
     }
     Ok(())
 }

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -444,7 +444,7 @@ pub fn clear(repo: &LocalRepository) -> Result<(), OxenError> {
     }
 
     // Evict the name index DB handle from cache before removing the directory
-    workspace_name_index::remove_from_cache(&repo.path)?;
+    workspace_name_index::remove_from_cache(repo);
 
     util::fs::remove_dir_all(&workspaces_dir)?;
     Ok(())

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -250,7 +250,7 @@ fn validate_create_constraints(
         if let Some(name) = workspace_name {
             // Check name doesn't collide with an existing workspace name
             let idx = workspace_name_index::get_index(base_repo)?;
-            if idx.has_name(name) {
+            if idx.has_name(name)? {
                 return Err(OxenError::basic_str(format!(
                     "A workspace with the name {name} already exists"
                 )));
@@ -422,8 +422,14 @@ pub fn delete(workspace: &Workspace) -> Result<(), OxenError> {
     if let Some(ref name) = workspace.name
         && workspace_name_index::index_exists(&workspace.base_repo)
     {
-        let idx = workspace_name_index::get_index(&workspace.base_repo)?;
-        idx.delete(name)?;
+        match workspace_name_index::get_index(&workspace.base_repo) {
+            Ok(idx) => {
+                if let Err(e) = idx.delete(name) {
+                    log::error!("workspace::delete error removing workspace index: {e:?}");
+                }
+            }
+            Err(e) => log::error!("workspace::delete error finding workspace index: {e:?}"),
+        }
     }
 
     // Clean up caches before deleting the workspace

--- a/crates/lib/src/repositories/workspaces/files.rs
+++ b/crates/lib/src/repositories/workspaces/files.rs
@@ -268,7 +268,7 @@ mod tests {
             repositories::add(&repo, &file).await?;
             let commit = repositories::commit(&repo, "Add hello.txt")?;
 
-            let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+            let workspace = repositories::workspaces::create_temporary(&repo, &commit).await?;
 
             let cases = [
                 ("http://127.0.0.1/secret", "loopback address"),

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -1662,6 +1662,7 @@ pub fn maybe_cleanup_repo(repo_dir: &Path) -> Result<(), OxenError> {
     core::refs::ref_manager::remove_from_cache_with_children(repo_dir)?;
     core::db::data_frames::df_db::remove_df_db_from_cache_with_children(repo_dir)?;
     core::db::dir_hashes::dir_hashes_db::remove_from_cache_with_children(repo_dir)?;
+    core::workspaces::workspace_name_index::remove_from_cache_with_children(repo_dir)?;
 
     if should_cleanup() {
         log::debug!("maybe_cleanup_repo: cleaning up repo: {repo_dir:?}");

--- a/crates/server/src/controllers/data_frames.rs
+++ b/crates/server/src/controllers/data_frames.rs
@@ -230,7 +230,7 @@ pub async fn from_directory(
     let commit_message = data.commit_message.unwrap_or("".to_string());
     let user_email = data.user_email.unwrap_or("".to_string());
     let recursive = data.recursive.unwrap_or(false);
-    let temp_workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+    let temp_workspace = repositories::workspaces::create_temporary(&repo, &commit).await?;
     let user_name = data.user_name.unwrap_or("".to_string());
     let new_commit = NewCommitBody {
         author: user_name,

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -316,7 +316,7 @@ pub async fn put(
         &files_array_parts,
         &user,
     )?;
-    let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+    let workspace = repositories::workspaces::create_temporary(&repo, &commit).await?;
 
     for file in &files {
         ensure_no_file_ancestors_in_tree(&repo, &commit, &file.path, &resource.path)?;
@@ -390,7 +390,7 @@ pub async fn delete(
     let message = form.message();
 
     log::debug!("file::delete creating workspace for commit: {commit}");
-    let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+    let workspace = repositories::workspaces::create_temporary(&repo, &commit).await?;
 
     // Stage the path as removed
     log::debug!("file::delete staging path {path:?}");
@@ -500,7 +500,7 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
     }
 
     log::debug!("file::mv creating workspace for commit: {commit}");
-    let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+    let workspace = repositories::workspaces::create_temporary(&repo, &commit).await?;
 
     // Stage the move
     log::debug!("file::mv moving {source_path:?} to {new_path:?}");

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -147,7 +147,7 @@ pub async fn import(
     }
 
     // Create temporary workspace
-    let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+    let workspace = repositories::workspaces::create_temporary(&repo, &commit).await?;
 
     log::debug!("workspace::files::import_file workspace created!");
 
@@ -265,7 +265,7 @@ pub async fn upload_zip(
     let directory = resource.path.clone();
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
 
-    let workspace = repositories::workspaces::create_temporary(&repo, &commit)?;
+    let workspace = repositories::workspaces::create_temporary(&repo, &commit).await?;
     let workspace_path = workspace.dir();
     let (commit_message, name, email, temp_files) =
         parse_multipart_fields_for_upload_zip(payload, &workspace_path, &directory).await?;

--- a/crates/server/src/controllers/workspaces.rs
+++ b/crates/server/src/controllers/workspaces.rs
@@ -218,24 +218,27 @@ pub async fn list(
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     log::debug!("workspaces::list got repo: {:?}", repo.path);
-    let workspaces = repositories::workspaces::list(&repo)?;
-    let workspace_views = workspaces
-        .iter()
-        .map(|workspace| WorkspaceResponse {
-            id: workspace.id.clone(),
-            name: workspace.name.clone(),
-            commit: workspace.commit.clone().into(),
-        })
-        .filter(|workspace| {
-            // TODO: Would be faster to have a map of names to namespaces, but this works for now
-            //       if getting a workspace is slow then we can optimize it
-            if let Some(name) = &params.name {
-                workspace.name == Some(name.to_string())
-            } else {
-                true
-            }
-        })
-        .collect();
+
+    // When filtering by name, use the indexed O(1) lookup instead of loading all workspaces
+    let workspace_views: Vec<WorkspaceResponse> = if let Some(name) = &params.name {
+        match repositories::workspaces::get_by_name(&repo, name)? {
+            Some(workspace) => vec![WorkspaceResponse {
+                id: workspace.id,
+                name: workspace.name,
+                commit: workspace.commit.into(),
+            }],
+            None => vec![],
+        }
+    } else {
+        repositories::workspaces::list(&repo)?
+            .into_iter()
+            .map(|workspace| WorkspaceResponse {
+                id: workspace.id,
+                name: workspace.name,
+                commit: workspace.commit.into(),
+            })
+            .collect()
+    };
 
     Ok(HttpResponse::Ok().json(ListWorkspaceResponseView {
         status: StatusMessage::resource_created(),

--- a/crates/server/src/controllers/workspaces.rs
+++ b/crates/server/src/controllers/workspaces.rs
@@ -129,7 +129,8 @@ pub async fn get_or_create(
         &workspace_id,
         data.name.clone(),
         true,
-    )?;
+    )
+    .await?;
 
     Ok(HttpResponse::Ok().json(WorkspaceResponseView {
         status: StatusMessage::resource_created(),

--- a/crates/server/src/test.rs
+++ b/crates/server/src/test.rs
@@ -2,6 +2,7 @@ use crate::app_data::OxenAppData;
 
 use liboxen::core::db::data_frames::df_db;
 use liboxen::core::db::dir_hashes::dir_hashes_db;
+use liboxen::core::workspaces::workspace_name_index;
 use liboxen::core::{refs, staged};
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
@@ -27,6 +28,7 @@ pub fn cleanup_sync_dir(sync_dir: &Path) -> Result<(), OxenError> {
     refs::ref_manager::remove_from_cache_with_children(sync_dir)?;
     df_db::remove_df_db_from_cache_with_children(sync_dir)?;
     dir_hashes_db::remove_from_cache_with_children(sync_dir)?;
+    workspace_name_index::remove_from_cache_with_children(sync_dir)?;
     std::fs::remove_dir_all(sync_dir)?;
     Ok(())
 }


### PR DESCRIPTION
Implement constant-time lookup for workspaces, instead of iterating over all the workspaces in the repository.

Creates a workspace index per-repo (RocksDB) that maps names to IDs.

Avg time on my machine with Greg's 9604 workspace repo goes from 1.35s to 10.5ms (~128x speedup) on the get workspace endpoint:
`curl localhost:3000/api/repos/<namespace>/<repo_name>/workspaces/<workspace-name>`

The first request to get a workspace will trigger building the index if it doesn't already exist. You can also migrate manually with `oxen migrate up add_workspace_name_index <path/to/repo>` (on your server-side repo).