### PR TITLE
S3: Implement `combine_version_chunks` (step 10)

### DIFF
--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -426,7 +426,7 @@ pub async fn pull_large_entry(
     }
 
     // Once all downloaded, recombine file and delete temp dir
-    version_store.combine_version_chunks(&hash, true).await?;
+    version_store.combine_version_chunks(&hash).await?;
 
     Ok(())
 }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -358,6 +358,9 @@ pub enum OxenError {
     // TODO: remove all uses of `Basic` and replace with specific errors.
     #[error("{0}")]
     Basic(StringError),
+
+    #[error("{0}")]
+    InternalError(StringError),
 }
 
 impl OxenError {
@@ -555,6 +558,11 @@ impl OxenError {
     /// Make a new OxenError::Basic error.
     pub fn basic_str(s: impl AsRef<str>) -> Self {
         OxenError::Basic(StringError::from(s.as_ref()))
+    }
+
+    /// Make a new OxenError::InternalError error.
+    pub fn internal_error(s: impl AsRef<str>) -> Self {
+        OxenError::InternalError(StringError::from(s.as_ref()))
     }
 
     //

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -310,21 +310,16 @@ impl VersionStore for LocalVersionStore {
                 chunks.push(chunk_offset);
             }
         }
+        chunks.sort();
         Ok(chunks)
     }
 
-    async fn combine_version_chunks(
-        &self,
-        hash: &str,
-        cleanup: bool,
-    ) -> Result<PathBuf, OxenError> {
+    async fn combine_version_chunks(&self, hash: &str) -> Result<(), OxenError> {
         let version_path = self.version_path(hash);
         let mut output_file = File::create(&version_path).await?;
 
-        // Get list of chunks and sort them to ensure correct order
-        let mut chunks = self.list_version_chunks(hash).await?;
+        let chunks = self.list_version_chunks(hash).await?;
         log::debug!("combine_version_chunks found {:?} chunks", chunks.len());
-        chunks.sort();
 
         // Process each chunk
         for chunk_offset in chunks {
@@ -333,15 +328,13 @@ impl VersionStore for LocalVersionStore {
             tokio::io::copy(&mut chunk_file, &mut output_file).await?;
         }
 
-        // Cleanup the chunks directory if requested
-        if cleanup {
-            let chunks_dir = self.version_chunks_dir(hash);
-            if chunks_dir.exists() {
-                fs::remove_dir_all(&chunks_dir).await?;
-            }
+        // Clean up chunks
+        let chunks_dir = self.version_chunks_dir(hash);
+        if chunks_dir.exists() {
+            fs::remove_dir_all(&chunks_dir).await?;
         }
 
-        Ok(version_path)
+        Ok(())
     }
 
     // It's left here for a quick fix. TODO: Move the business logic to versions controller.

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -748,7 +748,7 @@ impl VersionStore for S3VersionStore {
                     .collect()
                     .await
                     .map_err(|e| {
-                        OxenError::basic_str(format!(
+                        OxenError::internal_error(format!(
                             "Failed to read chunk body at offset {offset}: {e}"
                         ))
                     })?

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -708,7 +708,6 @@ impl VersionStore for S3VersionStore {
     }
 
     async fn combine_version_chunks(&self, hash: &str) -> Result<(), OxenError> {
-        // 1. List chunk offsets (already sorted by list_version_chunks)
         let offsets = self.list_version_chunks(hash).await?;
         if offsets.is_empty() {
             return Ok(());
@@ -718,7 +717,6 @@ impl VersionStore for S3VersionStore {
         let client = self.client().await?;
         let key = self.generate_key(hash);
 
-        // 2. Create multipart upload
         let upload = client
             .create_multipart_upload()
             .bucket(&self.bucket)
@@ -730,7 +728,6 @@ impl VersionStore for S3VersionStore {
             .ok_or_else(|| OxenError::upload("S3 multipart upload missing upload_id"))?
             .to_string();
 
-        // 3. Stream chunks and upload as multipart parts
         const MIN_PART_SIZE: usize = 5 * 1024 * 1024; // 5 MB, S3 minimum
         let mut part_buf: Vec<u8> = Vec::new();
         let mut part_num: i32 = 1;
@@ -740,7 +737,6 @@ impl VersionStore for S3VersionStore {
             for (i, offset) in offsets.iter().enumerate() {
                 let is_last_chunk = i == offsets.len() - 1;
 
-                // Download chunk from S3
                 let resp = client
                     .get_object()
                     .bucket(&self.bucket)
@@ -758,7 +754,6 @@ impl VersionStore for S3VersionStore {
                     })?
                     .into_bytes();
 
-                // Append to part buffer
                 part_buf.extend_from_slice(&chunk_bytes);
 
                 // Upload part when buffer is large enough (or on last chunk)
@@ -795,7 +790,6 @@ impl VersionStore for S3VersionStore {
         }
         .await;
 
-        // On failure, abort the multipart upload
         if let Err(e) = result {
             let _ = client
                 .abort_multipart_upload()
@@ -807,7 +801,6 @@ impl VersionStore for S3VersionStore {
             return Err(e);
         }
 
-        // 4. Complete multipart upload
         let completed = CompletedMultipartUpload::builder()
             .set_parts(Some(completed_parts))
             .build();

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use log;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use tokio::fs::{File, create_dir_all};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -663,6 +663,7 @@ impl VersionStore for S3VersionStore {
                 offsets.push(offset);
             }
         }
+        offsets.sort();
 
         Ok(offsets)
     }
@@ -706,15 +707,128 @@ impl VersionStore for S3VersionStore {
         ))
     }
 
-    async fn combine_version_chunks(
-        &self,
-        _hash: &str,
-        _cleanup: bool,
-    ) -> Result<PathBuf, OxenError> {
-        // TODO: Implement S3 version chunk combination
-        Err(OxenError::basic_str(
-            "S3VersionStore combine_version_chunks not yet implemented",
-        ))
+    async fn combine_version_chunks(&self, hash: &str) -> Result<(), OxenError> {
+        // 1. List chunk offsets (already sorted by list_version_chunks)
+        let offsets = self.list_version_chunks(hash).await?;
+        if offsets.is_empty() {
+            return Ok(());
+        }
+        log::debug!("combine_version_chunks found {} chunks", offsets.len());
+
+        let client = self.client().await?;
+        let key = self.generate_key(hash);
+
+        // 2. Create multipart upload
+        let upload = client
+            .create_multipart_upload()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await?;
+        let upload_id = upload
+            .upload_id()
+            .ok_or_else(|| OxenError::upload("S3 multipart upload missing upload_id"))?
+            .to_string();
+
+        // 3. Stream chunks and upload as multipart parts
+        const MIN_PART_SIZE: usize = 5 * 1024 * 1024; // 5 MB, S3 minimum
+        let mut part_buf: Vec<u8> = Vec::new();
+        let mut part_num: i32 = 1;
+        let mut completed_parts: Vec<CompletedPart> = Vec::new();
+
+        let result: Result<(), OxenError> = async {
+            for (i, offset) in offsets.iter().enumerate() {
+                let is_last_chunk = i == offsets.len() - 1;
+
+                // Download chunk from S3
+                let resp = client
+                    .get_object()
+                    .bucket(&self.bucket)
+                    .key(self.chunk_key(hash, *offset))
+                    .send()
+                    .await?;
+                let chunk_bytes = resp
+                    .body
+                    .collect()
+                    .await
+                    .map_err(|e| {
+                        OxenError::basic_str(format!(
+                            "Failed to read chunk body at offset {offset}: {e}"
+                        ))
+                    })?
+                    .into_bytes();
+
+                // Append to part buffer
+                part_buf.extend_from_slice(&chunk_bytes);
+
+                // Upload part when buffer is large enough (or on last chunk)
+                while part_buf.len() >= MIN_PART_SIZE || (is_last_chunk && !part_buf.is_empty()) {
+                    let drain_len = if part_buf.len() >= MIN_PART_SIZE && !is_last_chunk {
+                        MIN_PART_SIZE
+                    } else if is_last_chunk && part_buf.len() <= MIN_PART_SIZE {
+                        // Last flush — drain everything
+                        part_buf.len()
+                    } else {
+                        MIN_PART_SIZE
+                    };
+
+                    let part_data: Vec<u8> = part_buf.drain(..drain_len).collect();
+                    let part = upload_part(
+                        client.clone(),
+                        self.bucket.clone(),
+                        key.clone(),
+                        upload_id.clone(),
+                        part_num,
+                        part_data,
+                    )
+                    .await?;
+                    completed_parts.push(part);
+                    part_num += 1;
+
+                    // If this is the last chunk and buffer is empty, stop
+                    if is_last_chunk && part_buf.is_empty() {
+                        break;
+                    }
+                }
+            }
+            Ok(())
+        }
+        .await;
+
+        // On failure, abort the multipart upload
+        if let Err(e) = result {
+            let _ = client
+                .abort_multipart_upload()
+                .bucket(&self.bucket)
+                .key(&key)
+                .upload_id(&upload_id)
+                .send()
+                .await;
+            return Err(e);
+        }
+
+        // 4. Complete multipart upload
+        let completed = CompletedMultipartUpload::builder()
+            .set_parts(Some(completed_parts))
+            .build();
+        client
+            .complete_multipart_upload()
+            .bucket(&self.bucket)
+            .key(&key)
+            .upload_id(&upload_id)
+            .multipart_upload(completed)
+            .send()
+            .await?;
+
+        // 5. Delete chunk objects
+        let chunk_keys = self
+            .list_objects_with_prefix(&self.chunks_prefix(hash))
+            .await?;
+        if !chunk_keys.is_empty() {
+            self.delete_objects(chunk_keys).await?;
+        }
+
+        Ok(())
     }
 
     async fn clean_corrupted_versions(
@@ -1107,8 +1221,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut offsets = store.list_version_chunks(hash).await.unwrap();
-        offsets.sort();
+        let offsets = store.list_version_chunks(hash).await.unwrap();
         assert_eq!(offsets, vec![0, 10240, 20480]);
     }
 
@@ -1143,8 +1256,7 @@ mod tests {
         let offsets_a = store.list_version_chunks(hash_a).await.unwrap();
         assert_eq!(offsets_a, vec![0]);
 
-        let mut offsets_b = store.list_version_chunks(hash_b).await.unwrap();
-        offsets_b.sort();
+        let offsets_b = store.list_version_chunks(hash_b).await.unwrap();
         assert_eq!(offsets_b, vec![0, 512]);
     }
 
@@ -1204,6 +1316,59 @@ mod tests {
         assert!(
             result.is_err(),
             "expected error for offset past EOF, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_combine_version_chunks() {
+        use crate::util::hasher;
+
+        let (store, _tmp, _server) = setup().await;
+
+        // Pre-compute the hash of the combined data
+        let combined = b"chunk-0chunk-10240chunk-20480";
+        let hash = hasher::hash_buffer(combined);
+
+        // Store three chunks
+        store
+            .store_version_chunk(&hash, 0, Bytes::from_static(b"chunk-0"))
+            .await
+            .expect("store chunk 0");
+        store
+            .store_version_chunk(&hash, 10240, Bytes::from_static(b"chunk-10240"))
+            .await
+            .expect("store chunk 10240");
+        store
+            .store_version_chunk(&hash, 20480, Bytes::from_static(b"chunk-20480"))
+            .await
+            .expect("store chunk 20480");
+
+        // Combine
+        store
+            .combine_version_chunks(&hash)
+            .await
+            .expect("combine_version_chunks should succeed");
+
+        // Verify VERSION object has the correct content
+        let client = store.client().await.expect("client");
+        let resp = client
+            .get_object()
+            .bucket(&store.bucket)
+            .key(store.generate_key(&hash))
+            .send()
+            .await
+            .expect("VERSION object should exist");
+        let body = resp.body.collect().await.expect("body").into_bytes();
+        assert_eq!(&body[..], combined);
+
+        // Verify chunk objects were deleted
+        let chunk_keys = store
+            .list_objects_with_prefix(&store.chunks_prefix(&hash))
+            .await
+            .expect("list chunks");
+        assert!(
+            chunk_keys.is_empty(),
+            "chunks should be deleted after combine, found: {chunk_keys:?}"
         );
     }
 }

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -150,24 +150,21 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         size: u64,
     ) -> Result<Vec<u8>, OxenError>;
 
-    /// List all chunks for a version file
+    /// List all chunks for a version file.
     ///
-    /// Returns the byte offsets of each chunk within the original file. When sorted,
-    /// these offsets define the order in which chunks must be concatenated to
-    /// reconstruct the complete file.
+    /// Returns the byte offsets of each chunk within the original file, sorted in
+    /// ascending order. Concatenating chunks in this order reconstructs the
+    /// complete file.
     ///
     /// # Arguments
     /// * `hash` - The content hash that identifies this version
     async fn list_version_chunks(&self, hash: &str) -> Result<Vec<u64>, OxenError>;
 
-    /// Combine all the chunks for a version file into a single file
+    /// Combine all the chunks for a version file into a single file, then delete the chunks.
     ///
     /// # Arguments
     /// * `hash` - The content hash that identifies this version
-    /// * `cleanup` - Whether to delete the chunks after combining. If false, the chunks will be left in place.
-    ///   May be helpful for debugging or chunk-level deduplication.
-    async fn combine_version_chunks(&self, hash: &str, cleanup: bool)
-    -> Result<PathBuf, OxenError>;
+    async fn combine_version_chunks(&self, hash: &str) -> Result<(), OxenError>;
 
     /// Get metadata of a version file
     ///

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -103,9 +103,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
         }
 
         // Combine all the chunks for a version file into a single file
-        let version_path = version_store
-            .combine_version_chunks(&version_id, true)
-            .await?;
+        version_store.combine_version_chunks(&version_id).await?;
 
         // If the workspace id is provided, stage the file
         if let Some(workspace_id) = request.workspace_id {
@@ -114,8 +112,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                     "Workspace not found: {workspace_id}"
                 ))));
             };
-            // TODO: Can we just replace workspaces::files::add with this?
-            // repositories::workspaces::files::add(&workspace, &version_path)?;
+            let version_path = version_store.get_version_path(&version_id).await?;
             let dst_path = if let Some(dst_dir) = &file.dst_dir {
                 dst_dir.join(file.file_name.clone())
             } else {
@@ -124,7 +121,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
 
             core::v_latest::workspaces::files::add_version_file(
                 &workspace,
-                &version_path,
+                &*version_path,
                 &dst_path,
                 &version_id,
                 request.update_timestamp,

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -498,7 +498,7 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::InternalServerError().json(error_json)
                     }
-                    OxenError::Basic(error) => {
+                    OxenError::Basic(error) | OxenError::InternalError(error) => {
                         let error_json = json!({
                             "error": {
                                 "type": MSG_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
This is step 10 of the S3 project.

- Implement `S3VersionStore::combine_version_chunks`
- Simplify the trait signature: remove the unused `cleanup` parameter (always clean up) 
- Change the return type from `PathBuf` to `()` since the return value was unused.
- Guarantee sorted order from `list_version_chunks` so callers don't need to sort.
- Add tests

SIDENOTE: Much (or all?) of the optimizations from the parallel upload between client and server are lost since we've got to store the chunks in S3, then retrieve the chunks from S3, then combine and (re)store them back into S3. That's a lot of manual complexity for no benefit, here. One of my later steps is to look into removing the manual chunking/combining entirely in favor of the single, streaming upload from client to server to S3.