### PR TITLE
add optional metadata to the workspace object

### DIFF
--- a/crates/cli/src/cmd/workspace/list.rs
+++ b/crates/cli/src/cmd/workspace/list.rs
@@ -2,6 +2,8 @@ use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 
 use liboxen::api;
+use liboxen::constants;
+use liboxen::opts::PaginateOpts;
 use liboxen::{error::OxenError, model::LocalRepository};
 
 use crate::cmd::RunCmd;
@@ -15,13 +17,29 @@ impl RunCmd for WorkspaceListCmd {
     }
 
     fn args(&self) -> Command {
-        Command::new(NAME).about("Lists all workspaces").arg(
-            clap::Arg::new("remote")
-                .short('r')
-                .long("remote")
-                .help("Remote repository name")
-                .required(false),
-        )
+        Command::new(NAME)
+            .about("Lists workspaces")
+            .arg(
+                clap::Arg::new("remote")
+                    .short('r')
+                    .long("remote")
+                    .help("Remote repository name")
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("page")
+                    .long("page")
+                    .help("Page number to fetch")
+                    .value_parser(clap::value_parser!(usize))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("page-size")
+                    .long("page-size")
+                    .help("Number of workspaces per page")
+                    .value_parser(clap::value_parser!(usize))
+                    .required(false),
+            )
     }
 
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
@@ -37,14 +55,25 @@ impl RunCmd for WorkspaceListCmd {
             None => api::client::repositories::get_default_remote(&repository).await?,
         };
 
-        let workspaces = api::client::workspaces::list(&remote_repo).await?;
-        if workspaces.is_empty() {
+        let page_opts = PaginateOpts {
+            page_num: args
+                .get_one::<usize>("page")
+                .copied()
+                .unwrap_or(constants::DEFAULT_PAGE_NUM),
+            page_size: args
+                .get_one::<usize>("page-size")
+                .copied()
+                .unwrap_or(constants::DEFAULT_PAGE_SIZE),
+        };
+
+        let paginated = api::client::workspaces::list(&remote_repo, &page_opts).await?;
+        if paginated.entries.is_empty() {
             println!("No workspaces found");
             return Ok(());
         }
 
         println!("id\tname\tcommit_id\tcommit_message");
-        for workspace in workspaces {
+        for workspace in paginated.entries {
             println!(
                 "{}\t{}\t{}\t{}",
                 workspace.id,
@@ -53,6 +82,12 @@ impl RunCmd for WorkspaceListCmd {
                 workspace.commit.message
             );
         }
+        println!(
+            "\nPage {} of {} ({} total)",
+            paginated.pagination.page_number,
+            paginated.pagination.total_pages,
+            paginated.pagination.total_entries,
+        );
         Ok(())
     }
 }

--- a/crates/lib/src/api/client/workspaces.rs
+++ b/crates/lib/src/api/client/workspaces.rs
@@ -11,23 +11,19 @@ use crate::api;
 use crate::api::client;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
-use crate::view::workspaces::{ListWorkspaceResponseView, WorkspaceResponseWithStatus};
+use crate::opts::PaginateOpts;
+use crate::view::workspaces::{
+    ListWorkspaceResponseView, PaginatedWorkspaces, UpdateWorkspaceMetadataRequest,
+    WorkspaceResponseWithStatus,
+};
 use crate::view::workspaces::{NewWorkspace, WorkspaceResponse};
 use crate::view::{StatusMessage, WorkspaceResponseView};
 
-pub async fn list(remote_repo: &RemoteRepository) -> Result<Vec<WorkspaceResponse>, OxenError> {
-    let url = api::endpoint::url_from_repo(remote_repo, "/workspaces")?;
-    let client = client::new_for_url(&url)?;
-    let res = client.get(&url).send().await?;
-    let body = client::parse_json_body(&url, res).await?;
-    let response: Result<ListWorkspaceResponseView, serde_json::Error> =
-        serde_json::from_str(&body);
-    match response {
-        Ok(val) => Ok(val.workspaces),
-        Err(err) => Err(OxenError::basic_str(format!(
-            "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
-        ))),
-    }
+pub async fn list(
+    remote_repo: &RemoteRepository,
+    page_opts: &PaginateOpts,
+) -> Result<PaginatedWorkspaces, OxenError> {
+    list_with_params(remote_repo, Some(page_opts), None).await
 }
 
 pub async fn get(
@@ -53,25 +49,44 @@ pub async fn get_by_name(
     name: impl AsRef<str>,
 ) -> Result<Option<WorkspaceResponse>, OxenError> {
     let name = name.as_ref();
-    let url = api::endpoint::url_from_repo(remote_repo, &format!("/workspaces?name={name}"))?;
+    let response = list_with_params(remote_repo, None, Some(name)).await?;
+    match response.entries.len() {
+        1 => Ok(Some(response.entries[0].clone())),
+        0 => Ok(None),
+        len => Err(OxenError::basic_str(format!(
+            "expected 1 workspace, got {len}"
+        ))),
+    }
+}
+
+async fn list_with_params(
+    remote_repo: &RemoteRepository,
+    page_opts: Option<&PaginateOpts>,
+    name: Option<&str>,
+) -> Result<PaginatedWorkspaces, OxenError> {
+    let mut query_params = Vec::new();
+    if let Some(page_opts) = page_opts {
+        query_params.push(format!("page={}", page_opts.page_num));
+        query_params.push(format!("page_size={}", page_opts.page_size));
+    }
+    if let Some(name) = name {
+        query_params.push(format!("name={name}"));
+    }
+
+    let mut uri = "/workspaces".to_string();
+    if !query_params.is_empty() {
+        uri.push('?');
+        uri.push_str(&query_params.join("&"));
+    }
+
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     let client = client::new_for_url(&url)?;
     let res = client.get(&url).send().await?;
     let body = client::parse_json_body(&url, res).await?;
     let response: Result<ListWorkspaceResponseView, serde_json::Error> =
         serde_json::from_str(&body);
     match response {
-        Ok(val) => {
-            if val.workspaces.len() == 1 {
-                Ok(Some(val.workspaces[0].clone()))
-            } else if val.workspaces.is_empty() {
-                Ok(None)
-            } else {
-                Err(OxenError::basic_str(format!(
-                    "expected 1 workspace, got {}",
-                    val.workspaces.len()
-                )))
-            }
-        }
+        Ok(val) => Ok(val.workspaces),
         Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
@@ -136,9 +151,32 @@ pub async fn create_with_path(
         Ok(val) => Ok(WorkspaceResponseWithStatus {
             id: val.workspace.id,
             name: val.workspace.name,
+            metadata: val.workspace.metadata,
             commit: val.workspace.commit,
             status: val.status.status_message,
         }),
+        Err(err) => Err(OxenError::basic_str(format!(
+            "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
+        ))),
+    }
+}
+
+pub async fn update_metadata(
+    remote_repo: &RemoteRepository,
+    workspace_id: impl AsRef<str>,
+    metadata: serde_json::Value,
+) -> Result<WorkspaceResponse, OxenError> {
+    let workspace_id = workspace_id.as_ref();
+    let url =
+        api::endpoint::url_from_repo(remote_repo, &format!("/workspaces/{workspace_id}/metadata"))?;
+    let client = client::new_for_url(&url)?;
+    let body = UpdateWorkspaceMetadataRequest { metadata };
+    let res = client.put(&url).json(&body).send().await?;
+
+    let body = client::parse_json_body(&url, res).await?;
+    let response: Result<WorkspaceResponseView, serde_json::Error> = serde_json::from_str(&body);
+    match response {
+        Ok(val) => Ok(val.workspace),
         Err(err) => Err(OxenError::basic_str(format!(
             "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
@@ -324,8 +362,15 @@ mod tests {
             clear(&remote_repo).await?;
 
             // Check they are gone
-            let workspaces = list(&remote_repo).await?;
-            assert_eq!(workspaces.len(), 0);
+            let workspaces = list(
+                &remote_repo,
+                &PaginateOpts {
+                    page_num: constants::DEFAULT_PAGE_NUM,
+                    page_size: constants::DEFAULT_PAGE_SIZE,
+                },
+            )
+            .await?;
+            assert_eq!(workspaces.entries.len(), 0);
 
             Ok(remote_repo)
         })
@@ -339,8 +384,44 @@ mod tests {
             create(&remote_repo, branch_name, "test_workspace_id").await?;
             create(&remote_repo, branch_name, "test_workspace_id2").await?;
 
-            let workspaces = list(&remote_repo).await?;
-            assert_eq!(workspaces.len(), 2);
+            let workspaces = list(
+                &remote_repo,
+                &PaginateOpts {
+                    page_num: constants::DEFAULT_PAGE_NUM,
+                    page_size: constants::DEFAULT_PAGE_SIZE,
+                },
+            )
+            .await?;
+            assert_eq!(workspaces.entries.len(), 2);
+            assert_eq!(workspaces.pagination.total_entries, 2);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_list_workspaces_paginated() -> Result<(), OxenError> {
+        test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
+            let branch_name = "main";
+            create(&remote_repo, branch_name, "test_workspace_id_1").await?;
+            create(&remote_repo, branch_name, "test_workspace_id_2").await?;
+            create(&remote_repo, branch_name, "test_workspace_id_3").await?;
+
+            let workspaces = list(
+                &remote_repo,
+                &PaginateOpts {
+                    page_num: 2,
+                    page_size: 2,
+                },
+            )
+            .await?;
+
+            assert_eq!(workspaces.entries.len(), 1);
+            assert_eq!(workspaces.pagination.page_number, 2);
+            assert_eq!(workspaces.pagination.page_size, 2);
+            assert_eq!(workspaces.pagination.total_entries, 3);
+            assert_eq!(workspaces.pagination.total_pages, 2);
 
             Ok(remote_repo)
         })
@@ -350,8 +431,71 @@ mod tests {
     #[tokio::test]
     async fn test_list_empty_workspaces() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|_local_repo, remote_repo| async move {
-            let workspaces = list(&remote_repo).await?;
-            assert_eq!(workspaces.len(), 0);
+            let workspaces = list(
+                &remote_repo,
+                &PaginateOpts {
+                    page_num: constants::DEFAULT_PAGE_NUM,
+                    page_size: constants::DEFAULT_PAGE_SIZE,
+                },
+            )
+            .await?;
+            assert_eq!(workspaces.entries.len(), 0);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_update_workspace_metadata() -> Result<(), OxenError> {
+        test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
+            let branch_name = "main";
+            let workspace_id = "test_workspace_id";
+            create(&remote_repo, branch_name, workspace_id).await?;
+
+            let metadata = serde_json::json!({
+                "label": "experiment-a",
+                "priority": 3,
+                "tags": ["one", "two"]
+            });
+
+            let workspace = update_metadata(&remote_repo, workspace_id, metadata.clone()).await?;
+            assert_eq!(workspace.metadata, Some(metadata.clone()));
+
+            let fetched = get(&remote_repo, workspace_id)
+                .await?
+                .expect("workspace should exist");
+            assert_eq!(fetched.metadata, Some(metadata));
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_clear_workspace_metadata() -> Result<(), OxenError> {
+        test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
+            let branch_name = "main";
+            let workspace_id = "test_workspace_id";
+            create(&remote_repo, branch_name, workspace_id).await?;
+
+            update_metadata(
+                &remote_repo,
+                workspace_id,
+                serde_json::json!({
+                    "label": "experiment-a"
+                }),
+            )
+            .await?;
+
+            let workspace =
+                update_metadata(&remote_repo, workspace_id, serde_json::Value::Null).await?;
+            assert_eq!(workspace.metadata, None);
+
+            let fetched = get(&remote_repo, workspace_id)
+                .await?
+                .expect("workspace should exist");
+            assert_eq!(fetched.metadata, None);
 
             Ok(remote_repo)
         })

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -107,6 +107,10 @@ pub enum OxenError {
     #[error("Workspace not found: {0}")]
     WorkspaceNotFound(StringError),
 
+    /// A workspace with the given id or name already exists.
+    #[error("A workspace with the identifier '{0}' already exists")]
+    WorkspaceAlreadyExists(StringError),
+
     /// No queryable workspace was found.
     #[error("No queryable workspace found")]
     QueryableWorkspaceNotFound,
@@ -114,10 +118,6 @@ pub enum OxenError {
     /// The workspace is behind the remote repository and cannot be automatically updated.
     #[error("Workspace is behind: {0}")]
     WorkspaceBehind(Box<Workspace>),
-
-    /// A workspace with this name already exists.
-    #[error("A workspace with the name '{0}' already exists")]
-    WorkspaceAlreadyExists(String),
 
     #[error("{0}")]
     WorkspaceNameIndex(#[from] crate::core::workspaces::workspace_name_index::WsError),
@@ -487,6 +487,11 @@ impl OxenError {
     /// Makes a new OxenError::ResourceNotFound error.
     pub fn resource_not_found(value: impl AsRef<str>) -> Self {
         OxenError::ResourceNotFound(StringError::from(value.as_ref()))
+    }
+
+    /// Makes a new OxenError::WorkspaceAlreadyExists error.
+    pub fn workspace_already_exists(identifier: impl AsRef<str>) -> Self {
+        OxenError::WorkspaceAlreadyExists(StringError::from(identifier.as_ref()))
     }
 
     /// Make a new OxenError::PathDoesNotExist error.

--- a/crates/lib/src/model/workspace.rs
+++ b/crates/lib/src/model/workspace.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::path::{Path, PathBuf};
 
 use crate::constants::{OXEN_HIDDEN_DIR, WORKSPACE_CONFIG, WORKSPACES_DIR};
@@ -14,12 +15,15 @@ pub struct WorkspaceConfig {
     pub is_editable: bool,
     pub workspace_name: Option<String>,
     pub workspace_id: Option<String>,
+    pub metadata: Option<Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Workspace {
     pub id: String,
     pub name: Option<String>,
+    #[schema(value_type = Object, nullable = true)]
+    pub metadata: Option<Value>,
     // Workspaces have a base repository that they are created in .oxen/
     pub base_repo: LocalRepository,
     // And a sub repository that is just to make changes in
@@ -72,6 +76,7 @@ impl From<Workspace> for WorkspaceView {
         Self {
             name: workspace.name,
             id: workspace.id,
+            metadata: workspace.metadata,
             commit: workspace.commit,
         }
     }
@@ -81,5 +86,7 @@ impl From<Workspace> for WorkspaceView {
 pub struct WorkspaceView {
     pub name: Option<String>,
     pub id: String,
+    #[schema(value_type = Object, nullable = true)]
+    pub metadata: Option<Value>,
     pub commit: Commit,
 }

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -178,9 +178,7 @@ fn create_on_disk(
 
     if oxen_dir.exists() {
         log::debug!("index::workspaces::create already have oxen repo directory {oxen_dir:?}");
-        return Err(OxenError::basic_str(format!(
-            "Workspace {workspace_id} already exists"
-        )));
+        return Err(OxenError::workspace_already_exists(workspace_id));
     }
 
     // Validate name uniqueness and non-editable constraints
@@ -242,13 +240,20 @@ fn validate_create_constraints(
             // Check name doesn't collide with an existing workspace name
             let idx = workspace_name_index::get_index(base_repo)?;
             if idx.has_name(name)? {
-                return Err(OxenError::WorkspaceAlreadyExists(name.to_string()));
+                return Err(OxenError::workspace_already_exists(name));
             }
             // Check name doesn't collide with an existing workspace ID
             let name_as_id_hash = util::hasher::hash_str_sha256(name);
             let name_as_id_dir = Workspace::workspace_dir(base_repo, &name_as_id_hash);
             if Workspace::config_path_from_dir(&name_as_id_dir).exists() {
-                return Err(OxenError::WorkspaceAlreadyExists(name.to_string()));
+                return Err(OxenError::workspace_already_exists(name));
+            }
+            // Defensive scan: if the index is incomplete (e.g. a stale entry was
+            // deleted but the workspace still exists on disk), fall back to a
+            // scan so duplicate-name detection remains correct. The scan also
+            // backfills the missing index entry.
+            if get_by_name_via_scan(base_repo, name)?.is_some() {
+                return Err(OxenError::workspace_already_exists(name));
             }
         }
         return Ok(());
@@ -338,9 +343,7 @@ fn check_existing_workspace_name(
     workspace_name: &str,
 ) -> Result<(), OxenError> {
     if workspace.name == Some(workspace_name.to_string()) || *workspace_name == workspace.id {
-        return Err(OxenError::WorkspaceAlreadyExists(
-            workspace_name.to_string(),
-        ));
+        return Err(OxenError::workspace_already_exists(workspace_name));
     }
     Ok(())
 }

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -75,9 +75,7 @@ pub fn get_by_dir(
         return Ok(None);
     }
 
-    let config_contents = util::fs::read_from_path(&config_path)?;
-    let config: WorkspaceConfig = toml::from_str(&config_contents)
-        .map_err(|e| OxenError::basic_str(format!("Failed to parse workspace config: {e}")))?;
+    let config = read_workspace_config(&config_path)?;
 
     let Some(commit) = repositories::commits::get_by_id(repo, &config.workspace_commit_id)? else {
         return Err(OxenError::basic_str(format!(
@@ -97,6 +95,7 @@ pub fn get_by_dir(
     Ok(Some(Workspace {
         id: config.workspace_id.unwrap_or(workspace_id.to_owned()),
         name: config.workspace_name,
+        metadata: config.metadata,
         base_repo: repo.clone(),
         workspace_repo: LocalRepository::new(workspace_dir, storage_opts)?,
         commit,
@@ -115,9 +114,7 @@ pub fn get_by_name(
         let idx = workspace_name_index::get_index(repo)?;
         let maybe_id = idx.get_id_by_name(workspace_name)?;
         if let Some(id) = maybe_id {
-            let id_hash = util::hasher::hash_str_sha256(&id);
-            let workspace_dir = Workspace::workspace_dir(repo, &id_hash);
-            let result = get_by_dir(repo, &workspace_dir)?;
+            let result = get_by_name_index_value(repo, &id)?;
             if result.is_some() {
                 return Ok(result);
             }
@@ -127,18 +124,10 @@ pub fn get_by_name(
             );
             idx.delete(workspace_name)?;
         }
-        return Ok(None);
+        return get_by_name_via_scan(repo, workspace_name);
     }
 
-    // Slow path: iterate all workspaces (O(n)), used when index hasn't been created yet
-    for workspace in iter_workspaces(repo)? {
-        if let Some(workspace) = workspace?
-            && workspace.name.as_deref() == Some(workspace_name)
-        {
-            return Ok(Some(workspace));
-        }
-    }
-    Ok(None)
+    get_by_name_via_scan(repo, workspace_name)
 }
 
 /// Creates a new workspace and saves it to the filesystem
@@ -209,6 +198,7 @@ fn create_on_disk(
         is_editable,
         workspace_name: workspace_name.clone(),
         workspace_id: Some(workspace_id.to_string()),
+        metadata: None,
     };
 
     let toml_string = match toml::to_string(&workspace_config) {
@@ -228,6 +218,7 @@ fn create_on_disk(
     Ok(Workspace {
         id: workspace_id.to_owned(),
         name: workspace_name,
+        metadata: None,
         base_repo: base_repo.clone(),
         workspace_repo,
         commit: commit.clone(),
@@ -381,13 +372,78 @@ fn iter_workspaces(
 }
 
 pub fn list(repo: &LocalRepository) -> Result<Vec<Workspace>, OxenError> {
+    let idx = workspace_name_index::get_index(repo).ok();
     let mut workspaces = Vec::new();
+    let mut num_backfilled = 0;
     for workspace in iter_workspaces(repo)? {
         if let Some(workspace) = workspace? {
+            if let (Some(idx), Some(name)) = (&idx, workspace.name.as_deref())
+                && sync_workspace_name_index_entry(idx, name, &workspace.id)?
+            {
+                log::debug!(
+                    "workspace::list backfilled workspace name index entry '{}' -> '{}'",
+                    name,
+                    workspace.id
+                );
+                num_backfilled += 1;
+            }
             workspaces.push(workspace);
         }
     }
+
+    if num_backfilled > 0 {
+        log::debug!(
+            "workspace::list finished backfilling workspace name index with {} named workspaces",
+            num_backfilled
+        );
+    }
+
     Ok(workspaces)
+}
+
+fn get_by_name_index_value(
+    repo: &LocalRepository,
+    index_value: &str,
+) -> Result<Option<Workspace>, OxenError> {
+    let workspace_dir = Workspace::workspace_dir(repo, &util::hasher::hash_str_sha256(index_value));
+    if let Some(workspace) = get_by_dir(repo, &workspace_dir)? {
+        return Ok(Some(workspace));
+    }
+
+    // Legacy backfills may store the on-disk workspace directory name directly.
+    let workspace_dir = Workspace::workspace_dir(repo, index_value);
+    get_by_dir(repo, &workspace_dir)
+}
+
+fn get_by_name_via_scan(
+    repo: &LocalRepository,
+    workspace_name: &str,
+) -> Result<Option<Workspace>, OxenError> {
+    for workspace in iter_workspaces(repo)? {
+        if let Some(workspace) = workspace?
+            && workspace.name.as_deref() == Some(workspace_name)
+        {
+            if let Ok(idx) = workspace_name_index::get_index(repo) {
+                idx.put(workspace_name, &workspace.id)?;
+            }
+            return Ok(Some(workspace));
+        }
+    }
+    Ok(None)
+}
+
+fn sync_workspace_name_index_entry(
+    idx: &workspace_name_index::WorkspaceNameIndex,
+    workspace_name: &str,
+    workspace_id: &str,
+) -> Result<bool, OxenError> {
+    let existing = idx.get_id_by_name(workspace_name)?;
+    if existing.as_deref() == Some(workspace_id) {
+        return Ok(false);
+    }
+
+    idx.put(workspace_name, workspace_id)?;
+    Ok(true)
 }
 
 pub fn get_non_editable_by_commit_id(
@@ -454,17 +510,7 @@ pub fn clear(repo: &LocalRepository) -> Result<(), OxenError> {
 
 pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), OxenError> {
     let config_path = workspace.config_path();
-
-    if !config_path.exists() {
-        log::error!("Workspace config not found: {config_path:?}");
-        return Err(OxenError::WorkspaceNotFound(workspace.id.as_str().into()));
-    }
-
-    let config_contents = util::fs::read_from_path(&config_path)?;
-    let mut config: WorkspaceConfig = toml::from_str(&config_contents).map_err(|e| {
-        log::error!("Failed to parse workspace config: {config_path:?}, err: {e}");
-        OxenError::basic_str(format!("Failed to parse workspace config: {e}"))
-    })?;
+    let mut config = read_workspace_config(&config_path)?;
 
     log::debug!(
         "Updating workspace {} commit from {} to {}",
@@ -474,13 +520,48 @@ pub fn update_commit(workspace: &Workspace, new_commit_id: &str) -> Result<(), O
     );
     config.workspace_commit_id = new_commit_id.to_string();
 
-    let toml_string = toml::to_string(&config).map_err(|e| {
+    write_workspace_config(&config_path, &config)?;
+
+    Ok(())
+}
+
+pub fn update_metadata(
+    workspace: &Workspace,
+    metadata: Option<serde_json::Value>,
+) -> Result<(), OxenError> {
+    let config_path = workspace.config_path();
+    let mut config = read_workspace_config(&config_path)?;
+
+    log::debug!("Updating workspace {} metadata", workspace.id);
+    config.metadata = metadata;
+
+    write_workspace_config(&config_path, &config)?;
+
+    Ok(())
+}
+
+fn read_workspace_config(config_path: &Path) -> Result<WorkspaceConfig, OxenError> {
+    if !config_path.exists() {
+        log::error!("Workspace config not found: {config_path:?}");
+        return Err(OxenError::basic_str(format!(
+            "Workspace config not found: {config_path:?}"
+        )));
+    }
+
+    let config_contents = util::fs::read_from_path(config_path)?;
+    toml::from_str(&config_contents).map_err(|e| {
+        log::error!("Failed to parse workspace config: {config_path:?}, err: {e}");
+        OxenError::basic_str(format!("Failed to parse workspace config: {e}"))
+    })
+}
+
+fn write_workspace_config(config_path: &Path, config: &WorkspaceConfig) -> Result<(), OxenError> {
+    let toml_string = toml::to_string(config).map_err(|e| {
         log::error!("Failed to serialize workspace config to TOML: {config_path:?}, err: {e}");
         OxenError::basic_str(format!("Failed to serialize workspace config to TOML: {e}"))
     })?;
 
-    util::fs::write_to_path(&config_path, toml_string)?;
-
+    util::fs::write_to_path(config_path, toml_string)?;
     Ok(())
 }
 
@@ -703,10 +784,207 @@ fn build_file_status_maps_for_file(
 mod tests {
     use super::*;
     use crate::api;
-    use crate::constants::{DEFAULT_BRANCH_NAME, WORKSPACE_NAME_INDEX_DIR};
+    use crate::constants::{
+        DEFAULT_BRANCH_NAME, OXEN_HIDDEN_DIR, WORKSPACE_CONFIG, WORKSPACE_NAME_INDEX_DIR,
+        WORKSPACES_DIR,
+    };
     use crate::repositories;
     use crate::test;
     use crate::util;
+
+    #[tokio::test]
+    async fn test_list_populates_workspace_name_index() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            let commit = repositories::commit(&repo, "init")?;
+
+            create_with_name(
+                &repo,
+                &commit,
+                "ws-id-1",
+                Some("named-ws".to_string()),
+                true,
+            )
+            .await?;
+
+            let index_dir = repo
+                .path
+                .join(OXEN_HIDDEN_DIR)
+                .join(WORKSPACES_DIR)
+                .join(WORKSPACE_NAME_INDEX_DIR);
+            util::fs::remove_dir_all(&index_dir)?;
+            workspace_name_index::remove_from_cache(&repo);
+
+            let workspaces = list(&repo)?;
+            assert_eq!(workspaces.len(), 1);
+
+            let idx = workspace_name_index::get_index(&repo)?;
+            assert_eq!(idx.get_id_by_name("named-ws")?, Some("ws-id-1".to_string()));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_get_by_name_falls_back_when_index_misses() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            let commit = repositories::commit(&repo, "init")?;
+
+            create_with_name(
+                &repo,
+                &commit,
+                "ws-id-1",
+                Some("named-ws".to_string()),
+                true,
+            )
+            .await?;
+
+            let idx = workspace_name_index::get_index(&repo)?;
+            idx.delete("named-ws")?;
+
+            let workspace = get_by_name(&repo, "named-ws")?.expect("workspace should be found");
+            assert_eq!(workspace.name.as_deref(), Some("named-ws"));
+            assert_eq!(workspace.id, "ws-id-1");
+            assert_eq!(idx.get_id_by_name("named-ws")?, Some("ws-id-1".to_string()));
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_name_validation_survives_incomplete_index() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            let commit = repositories::commit(&repo, "init")?;
+
+            let workspace = create_with_name(
+                &repo,
+                &commit,
+                "ws-id-1",
+                Some("named-ws".to_string()),
+                true,
+            )
+            .await?;
+
+            let idx = workspace_name_index::get_index(&repo)?;
+            idx.delete("named-ws")?;
+
+            let result = create_with_name(
+                &repo,
+                &commit,
+                "ws-id-2",
+                Some("named-ws".to_string()),
+                true,
+            )
+            .await;
+            assert!(result.is_err());
+
+            delete(&workspace)?;
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_list_backfills_legacy_named_workspace_lookup() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            let commit = repositories::commit(&repo, "init")?;
+
+            let workspace = create_with_name(
+                &repo,
+                &commit,
+                "ws-id-1",
+                Some("legacy-ws".to_string()),
+                true,
+            )
+            .await?;
+
+            let config_path = workspace.dir().join(OXEN_HIDDEN_DIR).join(WORKSPACE_CONFIG);
+            let config_contents = util::fs::read_from_path(&config_path)?;
+            let mut config: WorkspaceConfig = toml::from_str(&config_contents)
+                .map_err(|err| OxenError::basic_str(format!("failed to parse config: {err}")))?;
+            config.workspace_id = None;
+            let config_contents = toml::to_string(&config).map_err(|err| {
+                OxenError::basic_str(format!("failed to serialize config: {err}"))
+            })?;
+            util::fs::write_to_path(&config_path, config_contents)?;
+
+            let idx = workspace_name_index::get_index(&repo)?;
+            idx.clear()?;
+
+            let workspaces = list(&repo)?;
+            assert_eq!(workspaces.len(), 1);
+            assert_eq!(
+                idx.get_id_by_name("legacy-ws")?,
+                Some(
+                    workspace
+                        .dir()
+                        .file_name()
+                        .unwrap()
+                        .to_string_lossy()
+                        .to_string()
+                )
+            );
+
+            let fetched = get_by_name(&repo, "legacy-ws")?.expect("workspace should be found");
+            assert_eq!(fetched.name.as_deref(), Some("legacy-ws"));
+
+            delete(&workspace)?;
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_update_workspace_metadata_persists_and_clears() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let hello_file = repo.path.join("hello.txt");
+            util::fs::write_to_path(&hello_file, "hello")?;
+            repositories::add(&repo, &hello_file).await?;
+            let commit = repositories::commit(&repo, "init")?;
+
+            let workspace = create_with_name(
+                &repo,
+                &commit,
+                "ws-id-1",
+                Some("named-ws".to_string()),
+                true,
+            )
+            .await?;
+
+            let metadata = serde_json::json!({
+                "label": "experiment-a",
+                "priority": 3,
+                "tags": ["one", "two"]
+            });
+            update_metadata(&workspace, Some(metadata.clone()))?;
+
+            let fetched = get(&repo, "ws-id-1")?.expect("workspace should be found");
+            assert_eq!(fetched.metadata, Some(metadata));
+
+            update_metadata(&workspace, None)?;
+
+            let fetched = get(&repo, "ws-id-1")?.expect("workspace should be found");
+            assert_eq!(fetched.metadata, None);
+
+            Ok(())
+        })
+        .await
+    }
 
     #[tokio::test]
     async fn test_can_commit_different_files_workspaces_without_merge_conflicts()

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -543,9 +543,9 @@ pub fn update_metadata(
 fn read_workspace_config(config_path: &Path) -> Result<WorkspaceConfig, OxenError> {
     if !config_path.exists() {
         log::error!("Workspace config not found: {config_path:?}");
-        return Err(OxenError::basic_str(format!(
-            "Workspace config not found: {config_path:?}"
-        )));
+        return Err(OxenError::WorkspaceNotFound(
+            format!("{config_path:?}").into(),
+        ));
     }
 
     let config_contents = util::fs::read_from_path(config_path)?;

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -817,8 +817,10 @@ mod tests {
                 .join(OXEN_HIDDEN_DIR)
                 .join(WORKSPACES_DIR)
                 .join(WORKSPACE_NAME_INDEX_DIR);
-            util::fs::remove_dir_all(&index_dir)?;
+            // Evict the cached RocksDB handle before removing the directory:
+            // on Windows the open file handles prevent `remove_dir_all`.
             workspace_name_index::remove_from_cache(&repo);
+            util::fs::remove_dir_all(&index_dir)?;
 
             let workspaces = list(&repo)?;
             assert_eq!(workspaces.len(), 1);

--- a/crates/lib/src/view/workspaces.rs
+++ b/crates/lib/src/view/workspaces.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use time::OffsetDateTime;
 use utoipa::ToSchema;
 
-use super::StatusMessage;
+use super::{Pagination, StatusMessage};
 use crate::model::Commit;
 
 #[derive(Deserialize, Serialize, Debug, ToSchema)]
@@ -43,6 +44,8 @@ impl From<WorkspaceCommit> for Commit {
 pub struct WorkspaceResponse {
     pub id: String,
     pub name: Option<String>,
+    #[schema(value_type = Object, nullable = true)]
+    pub metadata: Option<Value>,
     pub commit: WorkspaceCommit,
 }
 
@@ -50,6 +53,7 @@ pub struct WorkspaceResponse {
 pub struct WorkspaceResponseWithStatus {
     pub id: String,
     pub name: Option<String>,
+    pub metadata: Option<Value>,
     pub commit: WorkspaceCommit,
     pub status: String,
 }
@@ -62,10 +66,16 @@ pub struct WorkspaceResponseView {
 }
 
 #[derive(Deserialize, Serialize, Debug, ToSchema)]
+pub struct PaginatedWorkspaces {
+    pub entries: Vec<WorkspaceResponse>,
+    pub pagination: Pagination,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
 pub struct ListWorkspaceResponseView {
     #[serde(flatten)]
     pub status: StatusMessage,
-    pub workspaces: Vec<WorkspaceResponse>,
+    pub workspaces: PaginatedWorkspaces,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -77,4 +87,10 @@ pub struct ValidateUploadFeasibilityRequest {
 pub struct RenameRequest {
     #[schema(example = "path/to/new_file.txt")]
     pub new_path: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+pub struct UpdateWorkspaceMetadataRequest {
+    #[schema(value_type = Object, nullable = true)]
+    pub metadata: Value,
 }

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -118,10 +118,20 @@ impl PyRemoteRepo {
         self.commit_id = Some(commit_id);
     }
 
-    fn list_workspaces(&self) -> Result<Vec<PyWorkspaceResponse>, PyOxenError> {
-        let workspaces = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::workspaces::list(&self.repo).await })?;
-        Ok(workspaces
+    #[pyo3(signature = (page_num=liboxen::constants::DEFAULT_PAGE_NUM, page_size=liboxen::constants::DEFAULT_PAGE_SIZE))]
+    fn list_workspaces(
+        &self,
+        page_num: usize,
+        page_size: usize,
+    ) -> Result<Vec<PyWorkspaceResponse>, PyOxenError> {
+        let page_opts = PaginateOpts {
+            page_num,
+            page_size,
+        };
+        let paginated = pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { api::client::workspaces::list(&self.repo, &page_opts).await })?;
+        Ok(paginated
+            .entries
             .iter()
             .map(|w| PyWorkspaceResponse {
                 id: w.id.clone(),

--- a/crates/server/src/controllers/workspaces.rs
+++ b/crates/server/src/controllers/workspaces.rs
@@ -1,13 +1,18 @@
 use crate::errors::{OxenHttpError, WorkspaceBranch};
 use crate::helpers::get_repo;
-use crate::params::{NameParam, app_data, path_param};
+use crate::params::{WorkspaceListQuery, app_data, path_param};
 
+use liboxen::constants;
 use liboxen::constants::INITIAL_COMMIT_MSG;
 use liboxen::error::OxenError;
 use liboxen::model::{NewCommitBody, User};
 use liboxen::repositories;
+use liboxen::util::paginate;
 use liboxen::view::merge::MergeableResponse;
-use liboxen::view::workspaces::{ListWorkspaceResponseView, NewWorkspace, WorkspaceResponse};
+use liboxen::view::workspaces::{
+    ListWorkspaceResponseView, NewWorkspace, PaginatedWorkspaces, UpdateWorkspaceMetadataRequest,
+    WorkspaceResponse,
+};
 use liboxen::view::{
     CommitResponse, StatusMessage, StatusMessageDescription, WorkspaceResponseView,
 };
@@ -115,6 +120,7 @@ pub async fn get_or_create(
             workspace: WorkspaceResponse {
                 id: workspace_id,
                 name: workspace.name.clone(),
+                metadata: workspace.metadata.clone(),
                 commit: workspace.commit.into(),
             },
         }));
@@ -137,6 +143,7 @@ pub async fn get_or_create(
         workspace: WorkspaceResponse {
             id: workspace_id,
             name: data.name.clone(),
+            metadata: None,
             commit: commit.into(),
         },
     }))
@@ -175,6 +182,7 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
         workspace: WorkspaceResponse {
             id: workspace.id,
             name: workspace.name,
+            metadata: workspace.metadata,
             commit: workspace.commit.into(),
         },
     }))
@@ -202,7 +210,7 @@ pub async fn create(
     params(
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
-        NameParam // Query parameter for optional name filtering
+        WorkspaceListQuery
     ),
     responses(
         (status = 200, description = "List of workspaces", body = ListWorkspaceResponseView),
@@ -211,7 +219,7 @@ pub async fn create(
 )]
 pub async fn list(
     req: HttpRequest,
-    params: web::Query<NameParam>,
+    query: web::Query<WorkspaceListQuery>,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
@@ -219,13 +227,16 @@ pub async fn list(
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     log::debug!("workspaces::list got repo: {:?}", repo.path);
+    let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
+    let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
 
     // When filtering by name, use the indexed O(1) lookup instead of loading all workspaces
-    let workspace_views: Vec<WorkspaceResponse> = if let Some(name) = &params.name {
+    let workspace_views: Vec<WorkspaceResponse> = if let Some(name) = &query.name {
         match repositories::workspaces::get_by_name(&repo, name)? {
             Some(workspace) => vec![WorkspaceResponse {
                 id: workspace.id,
                 name: workspace.name,
+                metadata: workspace.metadata,
                 commit: workspace.commit.into(),
             }],
             None => vec![],
@@ -236,14 +247,19 @@ pub async fn list(
             .map(|workspace| WorkspaceResponse {
                 id: workspace.id,
                 name: workspace.name,
+                metadata: workspace.metadata,
                 commit: workspace.commit.into(),
             })
             .collect()
     };
+    let (entries, pagination) = paginate(workspace_views, page, page_size);
 
     Ok(HttpResponse::Ok().json(ListWorkspaceResponseView {
-        status: StatusMessage::resource_created(),
-        workspaces: workspace_views,
+        status: StatusMessage::resource_found(),
+        workspaces: PaginatedWorkspaces {
+            entries,
+            pagination,
+        },
     }))
 }
 
@@ -306,7 +322,73 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
         workspace: WorkspaceResponse {
             id: workspace_id,
             name: workspace.name,
+            metadata: workspace.metadata,
             commit: workspace.commit.into(),
+        },
+    }))
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/repos/{namespace}/{repo_name}/workspaces/{workspace_id}/metadata",
+    description = "Replace the workspace metadata JSON blob.",
+    tag = "Workspaces",
+    params(
+        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
+        ("workspace_id" = String, Path, description = "ID of the workspace", example = "b3f27f05-0955-4076-805f-39575853b27b"),
+    ),
+    request_body(
+        content = UpdateWorkspaceMetadataRequest,
+        description = "Arbitrary JSON metadata to store on the workspace. Use `null` to clear it.",
+        example = json!({"metadata": {"label": "experiment-a", "priority": 3}})
+    ),
+    responses(
+        (status = 200, description = "Workspace metadata updated", body = WorkspaceResponseView),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Workspace not found")
+    )
+)]
+pub async fn update_metadata(
+    req: HttpRequest,
+    body: String,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?.to_string();
+    let repo_name = path_param(&req, "repo_name")?.to_string();
+    let workspace_id = path_param(&req, "workspace_id")?.to_string();
+
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
+        return Ok(HttpResponse::NotFound()
+            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+    };
+
+    let request: UpdateWorkspaceMetadataRequest = match serde_json::from_str(&body) {
+        Ok(request) => request,
+        Err(err) => {
+            log::error!("Unable to parse workspace metadata body. Err: {err}\n{body}");
+            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
+        }
+    };
+
+    let metadata = if request.metadata.is_null() {
+        None
+    } else {
+        Some(request.metadata)
+    };
+    repositories::workspaces::update_metadata(&workspace, metadata)?;
+
+    let updated_workspace = repositories::workspaces::get(&repo, &workspace_id)?
+        .ok_or_else(|| OxenError::basic_str("workspace disappeared after metadata update"))?;
+
+    Ok(HttpResponse::Ok().json(WorkspaceResponseView {
+        status: StatusMessage::resource_updated(),
+        workspace: WorkspaceResponse {
+            id: updated_workspace.id,
+            name: updated_workspace.name,
+            metadata: updated_workspace.metadata,
+            commit: updated_workspace.commit.into(),
         },
     }))
 }

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -321,6 +321,19 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::NotFound().json(error_json)
                     }
+                    OxenError::WorkspaceAlreadyExists(identifier) => {
+                        log::debug!("Workspace already exists: {identifier}");
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_RESOURCE_ALREADY_EXISTS,
+                                "title": "Workspace already exists",
+                                "detail": format!("A workspace with the identifier '{}' already exists", identifier)
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_RESOURCE_ALREADY_EXISTS,
+                        });
+                        HttpResponse::Conflict().json(error_json)
+                    }
                     OxenError::RemoteRepoNotFound(remote) => {
                         log::debug!("Remote repo not found: {remote}");
                         HttpResponse::NotFound().json(StatusMessageDescription::not_found(format!(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -130,6 +130,7 @@ const START_SERVER_USAGE: &str = "Usage: `oxen-server start -i 0.0.0.0 -p 3000`"
         crate::controllers::workspaces::list,
         crate::controllers::workspaces::clear,
         crate::controllers::workspaces::delete,
+        crate::controllers::workspaces::update_metadata,
         crate::controllers::workspaces::mergeability,
         crate::controllers::workspaces::commit,
         // Workspaces - changes

--- a/crates/server/src/params.rs
+++ b/crates/server/src/params.rs
@@ -25,6 +25,9 @@ pub mod page_num_query;
 pub use page_num_query::PageNumQuery;
 pub use page_num_query::PageNumVersionQuery;
 
+pub mod workspace_list_query;
+pub use workspace_list_query::WorkspaceListQuery;
+
 pub mod df_opts_query;
 pub use df_opts_query::DFOptsQuery;
 

--- a/crates/server/src/params/workspace_list_query.rs
+++ b/crates/server/src/params/workspace_list_query.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+use utoipa::IntoParams;
+
+#[derive(Deserialize, Debug, IntoParams)]
+pub struct WorkspaceListQuery {
+    pub name: Option<String>,
+    pub page: Option<usize>,
+    pub page_size: Option<usize>,
+}

--- a/crates/server/src/services/workspaces.rs
+++ b/crates/server/src/services/workspaces.rs
@@ -15,6 +15,10 @@ pub fn workspace() -> Scope {
         .service(
             web::scope("/{workspace_id}")
                 .route("", web::get().to(controllers::workspaces::get))
+                .route(
+                    "/metadata",
+                    web::put().to(controllers::workspaces::update_metadata),
+                )
                 .route("", web::delete().to(controllers::workspaces::delete))
                 .route(
                     "/changes",

--- a/oxen-python/python/oxen/remote_repo.py
+++ b/oxen-python/python/oxen/remote_repo.py
@@ -545,11 +545,17 @@ class RemoteRepo:
         """
         return self._repo.list_branches()
 
-    def list_workspaces(self):
+    def list_workspaces(self, page_num: int = 1, page_size: int = 100):
         """
-        List all workspaces for a remote repo
+        List a page of workspaces for a remote repo.
+
+        Args:
+            page_num: `int`
+                Page number to fetch. Defaults to 1.
+            page_size: `int`
+                Number of workspaces per page. Defaults to 100.
         """
-        return self._repo.list_workspaces()
+        return self._repo.list_workspaces(page_num, page_size)
 
     def get_branch(self, branch: str):
         """


### PR DESCRIPTION
Right now the hub stores workspace metadata in the database, which means it is easy for the hub and server to get out of sync. This adds a construct for arbitrary user provided json to be stored in the workspace object.

It also adds pagination to the workspaces call.