### PR TITLE
Add clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ categories = [
 ]
 rust-version = "1.94"
 
+[workspace.lints.clippy]
+disallowed-methods = "deny"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+# Per-lint configuration for clippy. Applies workspace-wide.
+# See https://doc.rust-lang.org/clippy/lint_configuration.html
+
+disallowed-methods = [
+    { path = "std::fs::canonicalize", reason = "Use `liboxen::util::fs::canonicalize` — it falls back to `std::path::absolute` on filesystems that don't support canonicalization (e.g. Windows imdisk ramdisks used in the test suite)." },
+    { path = "std::path::Path::canonicalize", reason = "Use `liboxen::util::fs::canonicalize` — it falls back to `std::path::absolute` on filesystems that don't support canonicalization (e.g. Windows imdisk ramdisks used in the test suite)." },
+]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -43,3 +43,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -144,6 +144,9 @@ s3s = { workspace = true }
 s3s-fs = { workspace = true }
 serial_test = { workspace = true }
 
+[lints]
+workspace = true
+
 [[bench]]
 name = "add"
 harness = false

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -100,7 +100,7 @@ fn revert_all_repos(path: &Path) -> Result<(), OxenError> {
                 Err(err) => {
                     log::error!(
                         "Could not revert workspace name index for repo {:?}\nErr: {}",
-                        repo.path.canonicalize(),
+                        util::fs::canonicalize(repo.path),
                         err
                     );
                 }

--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -36,3 +36,6 @@ bindgen = { version = "0.71.1", default-features = false, features = ["runtime"]
 cc = { version = "1.0", features = ["parallel"] }
 glob = { workspace = true }
 pkg-config = { version = "0.3", optional = true }
+
+[lints]
+workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -67,3 +67,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 actix-multipart-test = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
- Add clippy lint config
- Redirect usage of std lib canonicalize to `util::fs::canonicalize`
- Fix the one place that was affected