### PR TITLE
Cleanup: Remove `WorkspaceCommit`

### DIFF
--- a/crates/lib/src/model/commit.rs
+++ b/crates/lib/src/model/commit.rs
@@ -7,7 +7,6 @@ use utoipa::ToSchema;
 use super::MerkleHash;
 use crate::config::UserConfig;
 use crate::error::OxenError;
-use crate::view::workspaces::WorkspaceCommit;
 
 /// NewCommitBody is used to parse the json into a Commit from the API
 #[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
@@ -49,18 +48,6 @@ pub struct Commit {
     pub email: String,
     #[serde(with = "time::serde::rfc3339")]
     pub timestamp: OffsetDateTime,
-}
-
-impl From<Commit> for WorkspaceCommit {
-    fn from(val: Commit) -> Self {
-        WorkspaceCommit {
-            id: val.id,
-            message: val.message,
-            author: val.author,
-            email: val.email,
-            timestamp: val.timestamp,
-        }
-    }
 }
 
 impl fmt::Display for Commit {

--- a/crates/lib/src/view/workspaces.rs
+++ b/crates/lib/src/view/workspaces.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use utoipa::ToSchema;
 
 use super::StatusMessage;
@@ -14,43 +13,19 @@ pub struct NewWorkspace {
     pub name: Option<String>,
     pub force: Option<bool>,
 }
-// HACK to get this to work with our hub where we don't keep parent_ids 🤦‍♂️
-// TODO: it should just be a Commit object
-#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
-pub struct WorkspaceCommit {
-    pub id: String,
-    pub message: String,
-    pub author: String,
-    pub email: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub timestamp: OffsetDateTime,
-}
-
-impl From<WorkspaceCommit> for Commit {
-    fn from(val: WorkspaceCommit) -> Self {
-        Commit {
-            id: val.id,
-            message: val.message,
-            author: val.author,
-            email: val.email,
-            timestamp: val.timestamp,
-            parent_ids: vec![],
-        }
-    }
-}
 
 #[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 pub struct WorkspaceResponse {
     pub id: String,
     pub name: Option<String>,
-    pub commit: WorkspaceCommit,
+    pub commit: Commit,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct WorkspaceResponseWithStatus {
     pub id: String,
     pub name: Option<String>,
-    pub commit: WorkspaceCommit,
+    pub commit: Commit,
     pub status: String,
 }
 

--- a/crates/server/src/controllers/workspaces.rs
+++ b/crates/server/src/controllers/workspaces.rs
@@ -115,7 +115,7 @@ pub async fn get_or_create(
             workspace: WorkspaceResponse {
                 id: workspace_id,
                 name: workspace.name.clone(),
-                commit: workspace.commit.into(),
+                commit: workspace.commit,
             },
         }));
     }
@@ -137,7 +137,7 @@ pub async fn get_or_create(
         workspace: WorkspaceResponse {
             id: workspace_id,
             name: data.name.clone(),
-            commit: commit.into(),
+            commit,
         },
     }))
 }
@@ -175,7 +175,7 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
         workspace: WorkspaceResponse {
             id: workspace.id,
             name: workspace.name,
-            commit: workspace.commit.into(),
+            commit: workspace.commit,
         },
     }))
 }
@@ -226,7 +226,7 @@ pub async fn list(
             Some(workspace) => vec![WorkspaceResponse {
                 id: workspace.id,
                 name: workspace.name,
-                commit: workspace.commit.into(),
+                commit: workspace.commit,
             }],
             None => vec![],
         }
@@ -236,7 +236,7 @@ pub async fn list(
             .map(|workspace| WorkspaceResponse {
                 id: workspace.id,
                 name: workspace.name,
-                commit: workspace.commit.into(),
+                commit: workspace.commit,
             })
             .collect()
     };
@@ -306,7 +306,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
         workspace: WorkspaceResponse {
             id: workspace_id,
             name: workspace.name,
-            commit: workspace.commit.into(),
+            commit: workspace.commit,
         },
     }))
 }


### PR DESCRIPTION
This PR removes `WorkspaceCommit` and just uses `Commit` directly.

A long time ago, the hub didn't include the `parent_ids` field in it's schema for a commit.  The `WorkspaceCommit` struct appears to exist just to drop the `parent_ids` field from `Commit` to send the info up to the hub. Since the hub gained the `parent_ids` field in a migration in Jan 2025, this hacky conversion is no longer necessary--we can just send the `Commit`.

