### PR TITLE
Gate `liboxen::test` behind `test-utils` feature

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,6 +81,17 @@ cargo clippy --workspace --no-deps -- -D warnings  # Lint code
 pre-commit run --all-files                         # Run pre-commit hooks (runs format and lint)
 ```
 
+### Benchmarks
+The `liboxen::test` helper module is gated behind the `test-utils` feature so it isn't compiled
+into release builds. Benches that consume it (`download`, `fetch`, `push`, `workspace_add`)
+declare `required-features = ["test-utils"]` and are skipped unless the feature is enabled:
+```bash
+cargo bench --features liboxen/test-utils           # Run all benches
+cargo bench --features liboxen/test-utils --bench push
+```
+Downstream crates (`oxen-cli`, `oxen-server`) enable `test-utils` via dev-dependencies, so their
+own tests can call `liboxen::test::*` as before.
+
 ### Server Development
 ```bash
 ulimit -n 10240                     # Increase file handles before running the server

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -44,5 +44,8 @@ tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 
+[dev-dependencies]
+liboxen = { path = "../lib", features = ["test-utils"] }
+
 [lints]
 workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -36,6 +36,10 @@ otel = [
 ]
 perf-logging = []
 production = ["metrics", "otel", "ffmpeg", "perf-logging", "default"]
+# Enables `liboxen::test`. Automatically on during `cargo test` (via `cfg(test)`); downstream crates
+# must enable this feature explicitly via dev-dependencies to use `liboxen::test::*` in their own
+# integration tests. Benches that consume `liboxen::test` declare `required-features = ["test-utils"]`.
+test-utils = []
 
 [dependencies]
 approx = { workspace = true }
@@ -154,15 +158,19 @@ harness = false
 [[bench]]
 name = "download"
 harness = false
+required-features = ["test-utils"]
 
 [[bench]]
 name = "fetch"
 harness = false
+required-features = ["test-utils"]
 
 [[bench]]
 name = "push"
 harness = false
+required-features = ["test-utils"]
 
 [[bench]]
 name = "workspace_add"
 harness = false
+required-features = ["test-utils"]

--- a/crates/lib/src/config/auth_config.rs
+++ b/crates/lib/src/config/auth_config.rs
@@ -65,7 +65,7 @@ impl AuthConfig {
                 #[cfg(not(test))]
                 log::warn!("TEST env var set but not in test mode");
 
-                crate::test::REPO_ROOT
+                crate::test_paths::REPO_ROOT
                     .join("data")
                     .join("test")
                     .join("config")

--- a/crates/lib/src/config/user_config.rs
+++ b/crates/lib/src/config/user_config.rs
@@ -54,7 +54,7 @@ impl UserConfig {
                 #[cfg(not(test))]
                 log::warn!("TEST env var set but not in test mode");
 
-                crate::test::REPO_ROOT
+                crate::test_paths::REPO_ROOT
                     .join("data")
                     .join("test")
                     .join("config")

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -72,7 +72,8 @@ pub mod repositories;
 pub mod request_context;
 pub mod resource;
 pub mod storage;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test;
+pub mod test_paths;
 pub mod util;
 pub mod view;
-// TODO: move Testing utilities to its own crate.
-pub mod test;

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -36,15 +36,7 @@ use tracing::level_filters::LevelFilter;
 
 pub const DEFAULT_TEST_HOST: &str = "localhost:3000";
 
-pub static REPO_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .unwrap()
-        .to_path_buf()
-});
-
-pub static TEST_DATA_DIR: LazyLock<PathBuf> = LazyLock::new(|| REPO_ROOT.join("data"));
+pub use crate::test_paths::{REPO_ROOT, TEST_DATA_DIR};
 
 pub fn test_run_dir() -> PathBuf {
     match std::env::var("OXEN_TEST_RUN_DIR") {

--- a/crates/lib/src/test_paths.rs
+++ b/crates/lib/src/test_paths.rs
@@ -1,0 +1,18 @@
+//! Paths resolved from `CARGO_MANIFEST_DIR` at build time, used by the test harness
+//! (`crate::test`) and by the dev-mode `TEST` env-var branches in the config getters.
+//!
+//! Kept in its own always-compiled module so the full `crate::test` helper module can stay
+//! gated behind `#[cfg(any(test, feature = "test-utils"))]` without breaking the config getters.
+
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+pub static REPO_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .unwrap()
+        .to_path_buf()
+});
+
+pub static TEST_DATA_DIR: LazyLock<PathBuf> = LazyLock::new(|| REPO_ROOT.join("data"));

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -67,6 +67,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 actix-multipart-test = { workspace = true }
+liboxen = { path = "../lib", features = ["test-utils"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
- Gate the `test` helper module behind a new `test-utils` cargo feature so release builds stop compiling/shipping it. 
- We use dev-dependencies to enable the `test-utils` feature for the other crates during tests and benchmarks.
- I moved `REPO_ROOT` and `TEST_DATA_DIR` to a small `crate::test_paths` module so the dev-mode `TEST` env-var branches in `AuthConfig::get` / `UserConfig::get` keep working in release builds.
  - I plan to refactor this small module away in a follow-up PR to add support for specifying the config directory more explicitly.