### PR TITLE
Add `--script` argument to `generate-dataset`

### DIFF
--- a/bin/generate-dataset
+++ b/bin/generate-dataset
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
@@ -18,13 +18,12 @@ import argparse
 import os
 import random
 import sys
+import tempfile
 import time
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Callable, Mapping
-import tempfile
-
+from typing import Callable, Literal, Mapping
 
 import numpy as np
 import scipy.stats


### PR DESCRIPTION
The `bin/generate-dataset` script wouldn't run on my local setup without adding the `--script` flag to the first line.

The other changes were done automatically by whatever python-formatter Zed uses by default. 🤷🏻‍♂️ 