### PR TITLE
Use .py extension & use `--script` in shebang for Python scripts

### DIFF
--- a/bin/batch-workspace-upload.py
+++ b/bin/batch-workspace-upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [

--- a/bin/generate-dataset.py
+++ b/bin/generate-dataset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/bin/reorganize-dataset.py
+++ b/bin/reorganize-dataset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [

--- a/bin/reupload-single.py
+++ b/bin/reupload-single.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [


### PR DESCRIPTION
The Python pre-commit hooks filter on the `py` file extension.

The `--script` flag is supposed to be used when using `uv` as the shebang:
https://docs.astral.sh/uv/guides/scripts/#using-a-shebang-to-create-an-executable-file