### PR TITLE
bugfix: restore node_db_prefix's previous prefix/suffix calculation

### DIFF
--- a/crates/lib/src/model/merkle_tree/merkle_hash.rs
+++ b/crates/lib/src/model/merkle_tree/merkle_hash.rs
@@ -125,9 +125,9 @@ impl HexHash {
     pub fn node_db_prefix(&self) -> PathBuf {
         let hash_str = &self.0;
         const DIR_PREFIX_LEN: usize = 3;
-        let dir_prefix = &hash_str[0..DIR_PREFIX_LEN];
-        let dir_suffix = &hash_str[DIR_PREFIX_LEN..];
-        Path::new(dir_prefix).join(dir_suffix)
+        let dir_prefix = hash_str.chars().take(DIR_PREFIX_LEN).collect::<String>();
+        let dir_suffix = hash_str.chars().skip(DIR_PREFIX_LEN).collect::<String>();
+        Path::new(&dir_prefix).join(&dir_suffix)
     }
 }
 
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_hex_hash_conversions_and_node_db_prefix() {
-        for _ in [0..1000] {
+        for _ in 0..1000 {
             let random_value: u128 = rand::random();
             let hash = MerkleHash::new(random_value);
 


### PR DESCRIPTION
The hexadecimal formatting for `MerkleHash` does not fix the size of the resulting string.
Leading 0s are dropped. This means that `node_db_prefix` could index into a string that
is shorter than 4 characters, causing a panic. This PR restores the previous hash directory
prefix and suffix calculation. Hash values that are smaller than 4 hex characters can result
in malformed or empty-string named directories.

Additionally, the `test_hex_hash_conversions_and_node_db_prefix` test was fixed to
correctly run 1k randomized `MerkleHash` -> `HexHash` conversions. Before, it was only
running a single randomized conversion.