### PR TITLE
Add Python bindings for `oxen clean`

### DIFF
--- a/crates/lib/src/repositories/clean.rs
+++ b/crates/lib/src/repositories/clean.rs
@@ -15,7 +15,7 @@
 //!   `oxen status` already classifies partially-tracked directories differently.
 
 use crate::core;
-use crate::core::v_latest::clean::CleanResult;
+pub use crate::core::v_latest::clean::CleanResult;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::LocalRepository;

--- a/crates/oxen-py/src/lib.rs
+++ b/crates/oxen-py/src/lib.rs
@@ -14,6 +14,7 @@ pub mod df_utils;
 pub mod diff;
 pub mod error;
 pub mod py_branch;
+pub mod py_clean_result;
 pub mod py_commit;
 pub mod py_dataset;
 pub mod py_diff;
@@ -79,6 +80,7 @@ fn oxen_py(m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<diff::py_text_diff::PyLineDiff>()?;
     m.add_class::<diff::py_text_diff::PyTextDiff>()?;
     m.add_class::<py_branch::PyBranch>()?;
+    m.add_class::<py_clean_result::PyCleanResult>()?;
     m.add_class::<py_commit::PyCommit>()?;
     m.add_class::<py_dataset::PyDataset>()?;
     m.add_class::<py_diff::PyDiff>()?;

--- a/crates/oxen-py/src/py_clean_result.rs
+++ b/crates/oxen-py/src/py_clean_result.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+
+use liboxen::repositories::clean::CleanResult;
+use pyo3::prelude::*;
+
+/// Python-visible outcome of `Repo.clean(...)`.
+///
+/// Mirrors `liboxen::repositories::clean::CleanResult` — in dry-run mode (`applied == False`)
+/// the `files` and `dirs` lists describe what *would* be removed; in apply mode (`applied == True`)
+/// they describe what actually was removed.
+#[pyclass]
+pub struct PyCleanResult {
+    inner: CleanResult,
+}
+
+#[pymethods]
+impl PyCleanResult {
+    #[getter]
+    pub fn files(&self) -> Vec<PathBuf> {
+        self.inner.files.clone()
+    }
+
+    #[getter]
+    pub fn dirs(&self) -> Vec<PathBuf> {
+        self.inner.dirs.clone()
+    }
+
+    #[getter]
+    pub fn total_bytes(&self) -> u64 {
+        self.inner.total_bytes
+    }
+
+    #[getter]
+    pub fn applied(&self) -> bool {
+        self.inner.applied
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "CleanResult(files={}, dirs={}, total_bytes={}, applied={})",
+            self.inner.files.len(),
+            self.inner.dirs.len(),
+            self.inner.total_bytes,
+            self.inner.applied,
+        )
+    }
+}
+
+impl From<CleanResult> for PyCleanResult {
+    fn from(inner: CleanResult) -> Self {
+        Self { inner }
+    }
+}

--- a/crates/oxen-py/src/py_repo.rs
+++ b/crates/oxen-py/src/py_repo.rs
@@ -4,7 +4,7 @@
 use liboxen::error::OxenError;
 use liboxen::model::Branch;
 use liboxen::model::LocalRepository;
-use liboxen::opts::{CloneOpts, PushOpts, RmOpts, StorageOpts};
+use liboxen::opts::{CleanOpts, CloneOpts, PushOpts, RmOpts, StorageOpts};
 use pyo3::prelude::*;
 
 use liboxen::api;
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 
 use crate::error::PyOxenError;
 use crate::py_branch::PyBranch;
+use crate::py_clean_result::PyCleanResult;
 use crate::py_commit::PyCommit;
 // use crate::py_diff::PyDiff;
 use crate::py_staged_data::PyStagedData;
@@ -123,6 +124,27 @@ impl PyRepo {
         repositories::rm(&repo, &rm_opts)?;
 
         Ok(())
+    }
+
+    /// Remove untracked files and directories from the working tree.
+    ///
+    /// Without `force=True` this is a dry-run — the returned `PyCleanResult` lists
+    /// what *would* be removed but nothing is deleted. Pass `force=True` to actually
+    /// delete. Matches the shipped `oxen clean` CLI semantics.
+    #[pyo3(signature = (paths = None, force = false))]
+    pub fn clean(
+        &self,
+        paths: Option<Vec<PathBuf>>,
+        force: bool,
+    ) -> Result<PyCleanResult, PyOxenError> {
+        let repo = LocalRepository::from_dir(&self.path)?;
+        let opts = CleanOpts {
+            paths: paths.unwrap_or_default(),
+            force,
+        };
+        let result = pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { repositories::clean::clean(&repo, &opts).await })?;
+        Ok(PyCleanResult::from(result))
     }
 
     pub fn status(&self) -> Result<PyStagedData, PyOxenError> {

--- a/oxen-python/python/oxen/repo.py
+++ b/oxen-python/python/oxen/repo.py
@@ -153,6 +153,30 @@ class Repo:
         """
         self._repo.rm(path, recursive, staged)
 
+    def clean(self, paths=None, force=False):
+        """
+        Remove untracked files and directories from the working tree.
+
+        Without `force=True` this is a dry-run — the returned object lists what
+        *would* be removed but nothing is deleted. Pass `force=True` to actually
+        delete.
+
+        Matches the `oxen clean` CLI: tracked files, `.oxen/`, and
+        `.oxenignore`-matched files are never touched.
+
+        Args:
+            paths: `list[str] | None`
+                Optional list of paths to scope the cleanup. `None` (the default)
+                means the whole working tree.
+            force: `bool`
+                Actually remove. Without this the call is a dry-run. Default: False
+
+        Returns:
+            A `CleanResult` with `.files`, `.dirs`, `.total_bytes`, and `.applied`
+            attributes.
+        """
+        return self._repo.clean(paths, force)
+
     def status(self):
         """
         Check the status of the repo. Returns a StagedData object.

--- a/oxen-python/tests/test_clean.py
+++ b/oxen-python/tests/test_clean.py
@@ -28,7 +28,7 @@ def test_clean_default_is_dry_run(tmp_path):
 
     assert result.applied is False
     assert os.path.exists(untracked), "dry-run must not delete anything"
-    assert "scratch.txt" in {os.path.basename(p) for p in result.files}
+    assert any(filter(lambda p: os.path.basename(p) == "scratch.txt", result.files))
 
 
 def test_clean_force_removes_untracked_file(tmp_path):

--- a/oxen-python/tests/test_clean.py
+++ b/oxen-python/tests/test_clean.py
@@ -1,0 +1,110 @@
+import os
+
+from oxen import Repo
+
+
+def _init_repo_with_one_tracked_file(repo_dir, tracked_name="tracked.txt"):
+    """Init an oxen repo at `repo_dir` with a single committed file, returning
+    the `Repo` plus the absolute path of the tracked file.
+    """
+    os.makedirs(repo_dir, exist_ok=True)
+    repo = Repo(repo_dir)
+    repo.init()
+    tracked = os.path.join(repo_dir, tracked_name)
+    with open(tracked, "w") as f:
+        f.write("tracked contents")
+    repo.add(tracked)
+    repo.commit("add tracked file")
+    return repo, tracked
+
+
+def test_clean_default_is_dry_run(tmp_path):
+    repo, _ = _init_repo_with_one_tracked_file(str(tmp_path / "r"))
+    untracked = os.path.join(repo.path, "scratch.txt")
+    with open(untracked, "w") as f:
+        f.write("stale")
+
+    result = repo.clean()
+
+    assert result.applied is False
+    assert os.path.exists(untracked), "dry-run must not delete anything"
+    assert "scratch.txt" in {os.path.basename(p) for p in result.files}
+
+
+def test_clean_force_removes_untracked_file(tmp_path):
+    repo, _ = _init_repo_with_one_tracked_file(str(tmp_path / "r"))
+    untracked = os.path.join(repo.path, "scratch.txt")
+    with open(untracked, "w") as f:
+        f.write("stale")
+
+    result = repo.clean(force=True)
+
+    assert result.applied is True
+    assert not os.path.exists(untracked)
+    assert "scratch.txt" in {os.path.basename(p) for p in result.files}
+
+
+def test_clean_force_removes_untracked_dir(tmp_path):
+    repo, _ = _init_repo_with_one_tracked_file(str(tmp_path / "r"))
+    junk_dir = os.path.join(repo.path, "junk")
+    os.makedirs(junk_dir)
+    with open(os.path.join(junk_dir, "a.txt"), "w") as f:
+        f.write("a")
+    with open(os.path.join(junk_dir, "b.txt"), "w") as f:
+        f.write("b")
+
+    result = repo.clean(force=True)
+
+    assert result.applied is True
+    assert not os.path.exists(junk_dir)
+    assert "junk" in {os.path.basename(p) for p in result.dirs}
+
+
+def test_clean_preserves_tracked_files_and_oxen(tmp_path):
+    repo, tracked = _init_repo_with_one_tracked_file(str(tmp_path / "r"))
+    untracked = os.path.join(repo.path, "scratch.txt")
+    with open(untracked, "w") as f:
+        f.write("stale")
+
+    repo.clean(force=True)
+
+    assert os.path.exists(tracked), "tracked files must survive clean"
+    assert os.path.isdir(os.path.join(repo.path, ".oxen")), ".oxen/ must survive clean"
+    assert not os.path.exists(untracked)
+
+
+def test_clean_path_scoping(tmp_path):
+    repo, _ = _init_repo_with_one_tracked_file(str(tmp_path / "r"))
+    sub_a = os.path.join(repo.path, "subtree_a")
+    sub_b = os.path.join(repo.path, "subtree_b")
+    os.makedirs(sub_a)
+    os.makedirs(sub_b)
+    with open(os.path.join(sub_a, "x.txt"), "w") as f:
+        f.write("x")
+    with open(os.path.join(sub_b, "y.txt"), "w") as f:
+        f.write("y")
+
+    repo.clean(paths=[sub_a], force=True)
+
+    assert not os.path.exists(sub_a), "subtree_a should be removed (in scope)"
+    assert os.path.exists(os.path.join(sub_b, "y.txt")), (
+        "subtree_b should survive (out of scope)"
+    )
+
+
+def test_clean_result_counts(tmp_path):
+    repo, _ = _init_repo_with_one_tracked_file(str(tmp_path / "r"))
+    with open(os.path.join(repo.path, "a.txt"), "w") as f:
+        f.write("12345")  # 5 bytes
+    with open(os.path.join(repo.path, "b.txt"), "w") as f:
+        f.write("hi")  # 2 bytes
+    junk_dir = os.path.join(repo.path, "junk")
+    os.makedirs(junk_dir)
+    with open(os.path.join(junk_dir, "c.txt"), "w") as f:
+        f.write("xyz")  # 3 bytes
+
+    result = repo.clean()
+
+    assert len(result.files) == 2
+    assert len(result.dirs) == 1
+    assert result.total_bytes == 10


### PR DESCRIPTION
Added Python bindings for the `oxen clean` CLI command we added recently.

```python
repo.clean()            # dry-run — returns a CleanResult listing candidates
repo.clean(force=True)  # actually delete
```

Fixes ENG-926.