### PR TITLE
Make client-side merges resumable

### DIFF
--- a/crates/lib/src/constants.rs
+++ b/crates/lib/src/constants.rs
@@ -121,6 +121,10 @@ pub const WORKSPACE_NAME_INDEX_DIR: &str = "workspace_name_index";
 pub const MERGE_HEAD_FILE: &str = "MERGE_HEAD";
 /// if we have merge conflicts we write to MERGE_HEAD and ORIG_HEAD to keep track of the parents
 pub const ORIG_HEAD_FILE: &str = "ORIG_HEAD";
+/// Written at the start of a client-side merge and removed after HEAD advances.
+/// Contents are the target commit id. Presence means a merge was interrupted
+/// mid-mutation and a retry targeting the same commit should force-restore.
+pub const MERGE_IN_PROGRESS_FILE: &str = "MERGE_IN_PROGRESS";
 
 /// Key for if something is synced
 pub const IS_SYNCED: &str = "IS_SYNCED";

--- a/crates/lib/src/core/v_latest.rs
+++ b/crates/lib/src/core/v_latest.rs
@@ -14,6 +14,7 @@ pub mod fetch;
 pub mod index;
 pub mod init;
 pub mod merge;
+pub mod merge_marker;
 pub mod metadata;
 pub mod model;
 pub mod prune;

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -6,6 +6,7 @@ use crate::core::merge::{db_path, node_merge_conflict_writer};
 use crate::core::refs::with_ref_manager;
 use crate::core::v_latest::add;
 use crate::core::v_latest::commits::{get_commit_or_head, list_between};
+use crate::core::v_latest::merge_marker;
 use crate::error::OxenError;
 use crate::model::StagedEntryStatus;
 use crate::model::merge_conflict::NodeMergeConflict;
@@ -43,6 +44,28 @@ impl MergeResult {
             entries_to_restore: vec![],
             cannot_overwrite_entries: vec![],
         }
+    }
+}
+
+/// Whether a merge is attached to a local working tree.
+#[derive(Debug, Clone, Copy)]
+pub enum LocalCheckout {
+    /// Server-side merge: operates on tree data only and does not touch the working tree.
+    Absent,
+    /// Client-side merge: restores files on disk and advances HEAD, bracketed by MERGE_IN_PROGRESS.
+    ///
+    /// `is_resume` is true when a prior attempt at this target was interrupted; the restore path
+    /// then force-restores instead of conflict-checking.
+    Present { is_resume: bool },
+}
+
+impl LocalCheckout {
+    pub fn writes_to_disk(self) -> bool {
+        matches!(self, Self::Present { .. })
+    }
+
+    pub fn is_resume(self) -> bool {
+        matches!(self, Self::Present { is_resume: true })
     }
 }
 
@@ -104,7 +127,8 @@ pub async fn can_merge_commits(
     }
 
     let mut _hashes = HashSet::new();
-    let analysis = find_merge_conflicts(repo, &merge_commits, false, &mut _hashes).await?;
+    let analysis =
+        find_merge_conflicts(repo, &merge_commits, LocalCheckout::Absent, &mut _hashes).await?;
     Ok(analysis.conflicts.is_empty())
 }
 
@@ -174,7 +198,8 @@ pub async fn list_conflicts_between_commits(
         merge: merge_commit.clone(),
     };
     let mut _hashes = HashSet::new();
-    let analysis = find_merge_conflicts(repo, &merge_commits, false, &mut _hashes).await?;
+    let analysis =
+        find_merge_conflicts(repo, &merge_commits, LocalCheckout::Absent, &mut _hashes).await?;
     Ok(analysis
         .conflicts
         .iter()
@@ -245,7 +270,13 @@ async fn server_three_way_merge(
 
     // 1. Find conflicts and collect merge entries in a single tree traversal
     let mut shared_hashes = HashSet::new();
-    let analysis = find_merge_conflicts(repo, merge_commits, false, &mut shared_hashes).await?;
+    let analysis = find_merge_conflicts(
+        repo,
+        merge_commits,
+        LocalCheckout::Absent,
+        &mut shared_hashes,
+    )
+    .await?;
 
     if !analysis.conflicts.is_empty() {
         return Err(OxenError::UpstreamMergeConflict(
@@ -339,7 +370,7 @@ pub async fn merge(
         base: base_commit,
         merge: merge_commit,
     };
-    merge_commits(repo, &commits, true).await
+    merge_commits(repo, &commits, LocalCheckout::Present { is_resume: false }).await
 }
 
 /// Server-safe merge of two commits. Does not touch the working directory or
@@ -364,7 +395,7 @@ pub async fn merge_commit_into_base_server_safe(
         merge: merge_commit.to_owned(),
     };
 
-    merge_commits(repo, &commits, false).await
+    merge_commits(repo, &commits, LocalCheckout::Absent).await
 }
 
 /// Client-side merge of two commits. Updates files on disk and advances HEAD.
@@ -387,7 +418,7 @@ pub async fn merge_commit_into_base(
         merge: merge_commit.to_owned(),
     };
 
-    merge_commits(repo, &commits, true).await
+    merge_commits(repo, &commits, LocalCheckout::Present { is_resume: false }).await
 }
 
 /// Server-side merge: merge a commit into a base commit on a specific branch.
@@ -501,7 +532,7 @@ async fn fast_forward_merge(
     repo: &LocalRepository,
     base_commit: &Commit,
     merge_commit: &Commit,
-    update_working_dir: bool,
+    checkout: LocalCheckout,
 ) -> Result<Option<Commit>, OxenError> {
     log::debug!("FF merge!");
 
@@ -510,10 +541,12 @@ async fn fast_forward_merge(
         return Ok(None);
     }
 
-    if !update_working_dir {
+    if !checkout.writes_to_disk() {
         // Server-side: no checkout to update, just return the merge commit.
         return Ok(Some(merge_commit.clone()));
     }
+
+    let is_resume = checkout.is_resume();
 
     // Collect all dir and vnode hashes while loading the merge tree
     // This is done to identify shared dirs/vnodes between the merge and base trees while loading the base tree
@@ -559,6 +592,7 @@ async fn fast_forward_merge(
         &mut partial_nodes,
         &mut shared_hashes,
         &mut seen_files,
+        is_resume,
     )?;
 
     if !merge_tree_results.cannot_overwrite_entries.is_empty() {
@@ -576,11 +610,18 @@ async fn fast_forward_merge(
         &mut base_tree_results,
         &mut shared_hashes,
         &mut seen_files,
+        is_resume,
     )?;
 
     // If there are no conflicts, restore the entries
     // Grouping the processing of merge_tree_results and base_tree_results like this ensures no files are modified if the merge doesn't complete
     if base_tree_results.cannot_overwrite_entries.is_empty() {
+        // All conflict checks have passed; the next lines mutate the working
+        // tree. Write the resume marker *now* so a SIGTERM mid-restore is
+        // recoverable, but no marker is left behind when the merge errors out
+        // earlier for an unrelated reason.
+        merge_marker::write(repo, &merge_commit.id).await?;
+
         let version_store = repo.version_store()?;
         for entry in merge_tree_results.entries_to_restore.iter() {
             restore::restore_file(repo, &entry.file_node, &entry.path, &version_store).await?;
@@ -600,9 +641,13 @@ async fn fast_forward_merge(
     // Move the HEAD forward to this commit
     with_ref_manager(repo, |manager| manager.set_head_commit_id(&merge_commit.id))?;
 
+    // Mutation complete; the marker is no longer load-bearing.
+    merge_marker::clear(repo).await?;
+
     Ok(Some(merge_commit.clone()))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn r_ff_merge_commit(
     repo: &LocalRepository,
     merge_node: &MerkleTreeNode,
@@ -611,6 +656,7 @@ fn r_ff_merge_commit(
     base_files: &mut HashMap<PathBuf, PartialNode>,
     shared_hashes: &mut HashSet<MerkleHash>,
     seen_files: &mut HashSet<PathBuf>,
+    is_resume: bool,
 ) -> Result<(), OxenError> {
     let path = path.as_ref();
     match &merge_node.node {
@@ -626,7 +672,15 @@ fn r_ff_merge_commit(
             // To properly handle moved files, the partial nodes are associated with their path in the base tree
             // I.e., if a file has been moved in the merge tree, this code will find that it shouldn't be restored
 
-            if base_files.contains_key(&file_path) {
+            if is_resume {
+                // Resuming an interrupted merge targeting this same commit:
+                // trust the target and force-restore every file the merge
+                // wants, regardless of working-tree state.
+                results.entries_to_restore.push(FileToRestore {
+                    file_node: merge_file_node.clone(),
+                    path: file_path.clone(),
+                });
+            } else if base_files.contains_key(&file_path) {
                 // if found, use to determine whether the file should be restored
                 let base_file_node = &base_files[&file_path];
 
@@ -692,6 +746,7 @@ fn r_ff_merge_commit(
                     base_files,
                     shared_hashes,
                     seen_files,
+                    is_resume,
                 )?;
             }
         }
@@ -706,6 +761,7 @@ fn r_ff_merge_commit(
                 base_files,
                 shared_hashes,
                 seen_files,
+                is_resume,
             )?;
         }
         _ => {
@@ -725,6 +781,7 @@ fn r_ff_base_dir(
     results: &mut MergeResult,
     shared_hashes: &mut HashSet<MerkleHash>,
     merge_files: &mut HashSet<PathBuf>,
+    is_resume: bool,
 ) -> Result<(), OxenError> {
     let path = path.as_ref();
     match &base_node.node {
@@ -735,7 +792,9 @@ fn r_ff_base_dir(
                 // Here, we don't need partial node representation, as we're only concerned with restoring files that aren't in the merge tree
                 let path = repo.path.join(file_path.clone());
                 if path.exists() {
-                    if restore::should_restore_file(repo, None, base_file_node, &file_path)? {
+                    if is_resume
+                        || restore::should_restore_file(repo, None, base_file_node, &file_path)?
+                    {
                         results.entries_to_restore.push(FileToRestore {
                             file_node: base_file_node.clone(),
                             path: path.clone(),
@@ -770,13 +829,29 @@ fn r_ff_base_dir(
 
             for child in base_children.iter() {
                 //log::debug!("r_ff_base_dir child_path {}", child);
-                r_ff_base_dir(repo, child, &dir_path, results, shared_hashes, merge_files)?;
+                r_ff_base_dir(
+                    repo,
+                    child,
+                    &dir_path,
+                    results,
+                    shared_hashes,
+                    merge_files,
+                    is_resume,
+                )?;
             }
         }
         EMerkleTreeNode::Commit(_) => {
             // If we get a commit node, we need to skip to the root directory
             let root_dir = repositories::tree::get_root_dir(base_node)?;
-            r_ff_base_dir(repo, root_dir, path, results, shared_hashes, merge_files)?;
+            r_ff_base_dir(
+                repo,
+                root_dir,
+                path,
+                results,
+                shared_hashes,
+                merge_files,
+                is_resume,
+            )?;
         }
         _ => {
             log::debug!("r_ff_base_dir unknown node type");
@@ -787,16 +862,16 @@ fn r_ff_base_dir(
 
 /// Perform a merge between commits.
 ///
-/// When `update_working_dir` is `true` (client-side), working-directory files
+/// With `LocalCheckout::Present { .. }` (client-side), working-directory files
 /// are checked, restored/removed, and HEAD is advanced.
 ///
-/// When `update_working_dir` is `false` (server-side), no working-directory or
-/// HEAD operations are performed.  For three-way merges the server-safe
+/// With `LocalCheckout::Absent` (server-side), no working-directory or HEAD
+/// operations are performed. For three-way merges the server-safe
 /// `server_three_way_merge` path is used instead.
 async fn merge_commits(
     repo: &LocalRepository,
     merge_commits: &MergeCommits,
-    update_working_dir: bool,
+    checkout: LocalCheckout,
 ) -> Result<Option<Commit>, OxenError> {
     // User output
     println!(
@@ -817,15 +892,37 @@ async fn merge_commits(
         merge_commits.merge.message,
     );
 
+    // Inspect the resume marker. If a prior mutation was interrupted for this
+    // same target, we'll force-restore merge-target files; if it named a
+    // different target, abort. The marker itself is written/cleared inside the
+    // restore loops (fast_forward_merge / find_merge_conflicts) so that a
+    // merge which errors out cleanly on the conflict check never leaves a
+    // stale marker behind.
+    let checkout = if checkout.writes_to_disk() {
+        match merge_marker::read(repo).await? {
+            Some(existing) if existing != merge_commits.merge.id => {
+                return Err(OxenError::MergeInProgressMismatch {
+                    expected: existing,
+                    found: merge_commits.merge.id.clone(),
+                });
+            }
+            Some(_) => {
+                log::info!(
+                    "Resuming interrupted merge for target commit {}",
+                    merge_commits.merge.id
+                );
+                LocalCheckout::Present { is_resume: true }
+            }
+            None => LocalCheckout::Present { is_resume: false },
+        }
+    } else {
+        LocalCheckout::Absent
+    };
+
     // Check which type of merge we need to do
     if merge_commits.is_fast_forward_merge() {
-        let commit = fast_forward_merge(
-            repo,
-            &merge_commits.base,
-            &merge_commits.merge,
-            update_working_dir,
-        )
-        .await?;
+        let commit =
+            fast_forward_merge(repo, &merge_commits.base, &merge_commits.merge, checkout).await?;
         Ok(commit)
     } else {
         log::debug!(
@@ -834,14 +931,15 @@ async fn merge_commits(
             merge_commits.merge.id
         );
 
-        if !update_working_dir {
+        if !checkout.writes_to_disk() {
             // Server-safe: use the server three-way merge path which operates
             // only on tree data and never touches the working directory.
             return server_three_way_merge(repo, merge_commits).await.map(Some);
         }
 
         let mut shared_hashes = HashSet::new();
-        let analysis = find_merge_conflicts(repo, merge_commits, true, &mut shared_hashes).await?;
+        let analysis =
+            find_merge_conflicts(repo, merge_commits, checkout, &mut shared_hashes).await?;
 
         if !analysis.conflicts.is_empty() {
             println!(
@@ -953,10 +1051,12 @@ pub fn lowest_common_ancestor_from_commits(
 pub async fn find_merge_conflicts(
     repo: &LocalRepository,
     merge_commits: &MergeCommits,
-    write_to_disk: bool,
+    checkout: LocalCheckout,
     shared_hashes: &mut HashSet<MerkleHash>,
 ) -> Result<MergeConflictAnalysis, OxenError> {
     log::debug!("finding merge conflicts");
+    let write_to_disk = checkout.writes_to_disk();
+    let is_resume = checkout.is_resume();
     /*
     https://en.wikipedia.org/wiki/Merge_(version_control)#Three-way_merge
 
@@ -1069,12 +1169,14 @@ pub async fn find_merge_conflicts(
                     // Changed only on merge branch — include in merge result
                     entries.push((entry_path.clone(), merge_file_node.clone(), Modified));
                     if write_to_disk {
-                        if restore::should_restore_file(
-                            repo,
-                            Some(base_file_node.clone()),
-                            merge_file_node,
-                            entry_path,
-                        )? {
+                        if is_resume
+                            || restore::should_restore_file(
+                                repo,
+                                Some(base_file_node.clone()),
+                                merge_file_node,
+                                entry_path,
+                            )?
+                        {
                             entries_to_restore.push(FileToRestore {
                                 file_node: merge_file_node.clone(),
                                 path: entry_path.clone(),
@@ -1128,12 +1230,14 @@ pub async fn find_merge_conflicts(
                         shared_hashes.remove(&dir_node.hash);
                     }
 
-                    if restore::should_restore_file(
-                        repo,
-                        base_file_node,
-                        merge_file_node,
-                        entry_path,
-                    )? {
+                    if is_resume
+                        || restore::should_restore_file(
+                            repo,
+                            base_file_node,
+                            merge_file_node,
+                            entry_path,
+                        )?
+                    {
                         entries_to_restore.push(FileToRestore {
                             file_node: merge_file_node.clone(),
                             path: entry_path.clone(),
@@ -1157,7 +1261,9 @@ pub async fn find_merge_conflicts(
                 // Truly new file on merge branch
                 entries.push((entry_path.clone(), merge_file_node.clone(), Added));
                 if write_to_disk {
-                    if restore::should_restore_file(repo, None, merge_file_node, entry_path)? {
+                    if is_resume
+                        || restore::should_restore_file(repo, None, merge_file_node, entry_path)?
+                    {
                         entries_to_restore.push(FileToRestore {
                             file_node: merge_file_node.clone(),
                             path: entry_path.to_path_buf(),
@@ -1201,6 +1307,14 @@ pub async fn find_merge_conflicts(
 
     // If there are no conflicts, restore the entries
     if cannot_overwrite_entries.is_empty() {
+        // Working-tree mutation starts here. Bracket it with the resume marker
+        // so a SIGTERM mid-restore can be recovered by a subsequent merge
+        // against the same target. Only when write_to_disk=true — the
+        // server-safe paths leave the working tree untouched.
+        if write_to_disk {
+            merge_marker::write(repo, &merge_commits.merge.id).await?;
+        }
+
         let version_store = repo.version_store()?;
         for entry in entries_to_restore.iter() {
             restore::restore_file(repo, &entry.file_node, &entry.path, &version_store).await?;
@@ -1232,6 +1346,10 @@ pub async fn find_merge_conflicts(
                     )?;
                 }
             }
+        }
+
+        if write_to_disk {
+            merge_marker::clear(repo).await?;
         }
     } else {
         // If there are conflicts, return an error without restoring anything

--- a/crates/lib/src/core/v_latest/merge_marker.rs
+++ b/crates/lib/src/core/v_latest/merge_marker.rs
@@ -1,0 +1,48 @@
+//! Marker file written at the start of a client-side merge and removed after
+//! HEAD advances. Its presence on a subsequent merge tells the resumed merge
+//! that a prior attempt left the working tree in a half-applied state for the
+//! same target commit and that it should force-restore target files rather
+//! than flag them as conflicts.
+
+use std::path::PathBuf;
+
+use crate::constants;
+use crate::error::OxenError;
+use crate::model::LocalRepository;
+use crate::util;
+
+fn marker_path(repo: &LocalRepository) -> PathBuf {
+    util::fs::oxen_hidden_dir(&repo.path).join(constants::MERGE_IN_PROGRESS_FILE)
+}
+
+/// Write the marker containing the target commit id.
+pub async fn write(repo: &LocalRepository, target_commit_id: &str) -> Result<(), OxenError> {
+    let path = marker_path(repo);
+    tokio::fs::write(&path, target_commit_id.as_bytes()).await?;
+    Ok(())
+}
+
+/// Read the target commit id from the marker, or `None` if no marker exists.
+pub async fn read(repo: &LocalRepository) -> Result<Option<String>, OxenError> {
+    let path = marker_path(repo);
+    match tokio::fs::read_to_string(&path).await {
+        Ok(contents) => Ok(Some(contents.trim().to_string())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Remove the marker if present. No-op if it does not exist.
+pub async fn clear(repo: &LocalRepository) -> Result<(), OxenError> {
+    let path = marker_path(repo);
+    match tokio::fs::remove_file(&path).await {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Return true if the marker file exists.
+pub async fn exists(repo: &LocalRepository) -> Result<bool, OxenError> {
+    Ok(tokio::fs::try_exists(marker_path(repo)).await?)
+}

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -72,6 +72,11 @@ pub enum OxenError {
     #[error("{0}")]
     UpstreamMergeConflict(StringError),
 
+    /// A prior client-side merge was interrupted before HEAD advanced, and a new merge targets a
+    /// different commit than the in-progress one.
+    #[error("Merge in progress targeting commit {expected}, but new merge targets {found}.")]
+    MergeInProgressMismatch { expected: String, found: String },
+
     /// A remote with the given name was not found.
     #[error(
         "No remote named '{0}' is set. You can set a remote by running:\n\noxen config --set-remote '{0}' <url>\n"
@@ -405,6 +410,9 @@ impl OxenError {
             | ResourceNotFound(_)
             | ParsedResourceNotFound(_)
             | CommitEntryNotFound(_) => "Check the path and current branch with `oxen status`.",
+            MergeInProgressMismatch { .. } => {
+                "Run `oxen merge --abort` to abandon the in-progress merge, or retry the original target."
+            }
             HTTP(req_err) => {
                 if req_err.is_connect() || req_err.is_timeout() {
                     "Check your internet connection and that the remote host is reachable."

--- a/crates/lib/src/repositories/merge.rs
+++ b/crates/lib/src/repositories/merge.rs
@@ -243,6 +243,7 @@ mod tests {
     use crate::core::df::tabular;
     use crate::core::merge::node_merge_conflict_reader::NodeMergeConflictReader;
 
+    use crate::core::v_latest::merge_marker;
     use crate::error::OxenError;
     use crate::model::{Commit, LocalRepository};
     use crate::opts::DFOpts;
@@ -2196,6 +2197,130 @@ mod tests {
             let head_commit = repositories::commits::head_commit(&repo)?;
             assert_eq!(head_commit.id, target_commit.id);
             assert_eq!(util::fs::read_from_path(&world_file)?, "World2");
+            Ok(())
+        })
+        .await
+    }
+
+    // Helper: build a feature branch with a single file-modification commit, return
+    // (branch_name, target_commit_id) back on main.
+    async fn make_feature_branch_with_modification(
+        repo: &LocalRepository,
+        file_name: &str,
+        base_contents: &str,
+        merge_contents: &str,
+        branch: &str,
+    ) -> Result<(String, Commit, Commit), OxenError> {
+        let og_branch = repositories::branches::current_branch(repo)?.unwrap();
+        let path = repo.path.join(file_name);
+        util::fs::write_to_path(&path, base_contents)?;
+        repositories::add(repo, &path).await?;
+        let base_commit = repositories::commit(repo, "base commit")?;
+
+        repositories::branches::create_checkout(repo, branch)?;
+        util::fs::write_to_path(&path, merge_contents)?;
+        repositories::add(repo, &path).await?;
+        let target_commit = repositories::commit(repo, "target commit")?;
+
+        repositories::checkout(repo, &og_branch.name).await?;
+        Ok((og_branch.name, base_commit, target_commit))
+    }
+
+    // A truncated file (content matches neither base nor target) must still resume
+    // cleanly when the MERGE_IN_PROGRESS marker names the same target commit: is_resume
+    // bypasses the conflict check and force-restores the file from the version store.
+    #[tokio::test]
+    async fn test_merge_resume_truncated_fast_forward() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let (_main, _base, target) = make_feature_branch_with_modification(
+                &repo,
+                "world.txt",
+                "World",
+                "World2",
+                "update-world",
+            )
+            .await?;
+
+            let world_file = repo.path.join("world.txt");
+            assert_eq!(util::fs::read_from_path(&world_file)?, "World");
+
+            // Simulate an interrupted merge that truncated the file mid-write:
+            // content matches neither base ("World") nor target ("World2").
+            util::fs::write_to_path(&world_file, "partial")?;
+            merge_marker::write(&repo, &target.id).await?;
+
+            let commit = repositories::merge::merge(&repo, "update-world")
+                .await?
+                .expect("resumed merge should produce a commit");
+            assert_eq!(commit.id, target.id);
+            assert_eq!(util::fs::read_from_path(&world_file)?, "World2");
+            assert!(
+                !merge_marker::exists(&repo).await?,
+                "marker must be cleared after a successful resume"
+            );
+            Ok(())
+        })
+        .await
+    }
+
+    // If the marker names a different target than the current merge, abort with
+    // MergeInProgressMismatch without touching the marker or the working tree.
+    #[tokio::test]
+    async fn test_merge_aborts_on_marker_mismatch() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let (_main, _base, _target) = make_feature_branch_with_modification(
+                &repo,
+                "world.txt",
+                "World",
+                "World2",
+                "update-world",
+            )
+            .await?;
+
+            // A stale marker points at an unrelated commit id (e.g. from a previous
+            // merge against a different branch).
+            let stale = "deadbeefdeadbeefdeadbeefdeadbeef";
+            merge_marker::write(&repo, stale).await?;
+
+            let err = repositories::merge::merge(&repo, "update-world")
+                .await
+                .expect_err("mismatched marker must abort the new merge");
+            match err {
+                OxenError::MergeInProgressMismatch { ref expected, .. } => {
+                    assert_eq!(expected, stale);
+                }
+                other => panic!("expected MergeInProgressMismatch, got {other:?}"),
+            }
+
+            // Marker is untouched so the user can run `oxen merge --abort`.
+            let current = merge_marker::read(&repo).await?;
+            assert_eq!(current.as_deref(), Some(stale));
+            Ok(())
+        })
+        .await
+    }
+
+    // A normal successful merge never leaves MERGE_IN_PROGRESS behind.
+    #[tokio::test]
+    async fn test_merge_clears_marker_on_success() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let (_main, _base, _target) = make_feature_branch_with_modification(
+                &repo,
+                "world.txt",
+                "World",
+                "World2",
+                "update-world",
+            )
+            .await?;
+
+            assert!(!merge_marker::exists(&repo).await?);
+            repositories::merge::merge(&repo, "update-world")
+                .await?
+                .unwrap();
+            assert!(
+                !merge_marker::exists(&repo).await?,
+                "marker must be absent after a clean merge"
+            );
             Ok(())
         })
         .await


### PR DESCRIPTION
Make client-side merges resumable with a MERGE_IN_PROGRESS marker

Builds on #481 (which made the merge idempotent for files that already match the target) to cover the case where a file truncated mid-write hashes to neither base nor target, so an interrupted merge still hits the cannot_overwrite path on the next attempt.

Bracket every client-side working-tree mutation with a `.oxen/MERGE_IN_PROGRESS` marker containing the in-flight target commit id. The marker is written just before the restore loop (not at merge entry) so a merge that errors out cleanly on the conflict check never leaves a stale marker behind. A resumed merge that sees a matching marker force-restores target files; a mismatched marker returns MergeInProgressMismatch.

The fix lives in merge_commits, so it covers both oxen pull and oxen merge (they converge there). Server merge paths go through server_three_way_merge and never touch disk, so they are unchanged.

Along the way, update_working_dir: bool on the merge path becomes LocalCheckout::{Absent, Present { is_resume }} to make the invariant "is_resume only matters when we own a working tree" unrepresentable as an illegal state.

Refs ENG-888.