### PR TITLE
Fix add-row panic and null-drop on workspace list columns

### DIFF
--- a/crates/lib/src/core/db/data_frames/df_db.rs
+++ b/crates/lib/src/core/db/data_frames/df_db.rs
@@ -5,6 +5,7 @@ use crate::constants::{
     DEFAULT_PAGE_SIZE, DUCKDB_DF_TABLE_NAME, OXEN_COLS, OXEN_ID_COL, OXEN_ROW_ID_COL, TABLE_NAME,
 };
 
+use crate::core::db::data_frames::rows;
 use crate::core::df::tabular;
 use crate::core::v_latest::workspaces::data_frames::{
     is_valid_export_extension, wrap_sql_for_export,
@@ -578,14 +579,15 @@ pub fn modify_row_with_polars_df(
     let table_name = table_name.as_ref();
 
     let schema = df.schema();
-    let column_names: Vec<String> = schema
-        .iter_fields()
-        .map(|f| format!("\"{}\"", f.name()))
-        .collect();
+    let field_names: Vec<&str> = schema.iter_names().map(|s| s.as_str()).collect();
+    let column_sql_types = rows::column_sql_types_by_name(conn, table_name)?;
 
-    let set_clauses: String = column_names
+    let set_clauses: String = field_names
         .iter()
-        .map(|col_name| format!("{col_name} = ?"))
+        .map(|name| {
+            let placeholder = rows::placeholder_for_column(&column_sql_types, name);
+            format!("\"{name}\" = {placeholder}")
+        })
         .collect::<Vec<String>>()
         .join(", ");
 
@@ -625,29 +627,30 @@ pub fn modify_rows_with_polars_df(
     let mut all_params: Vec<Box<dyn ToSql>> = Vec::new();
 
     // Construct the SQL query with combined CASE statements
-    let mut column_names: Vec<String> = Vec::new();
-    if let Some((_, df)) = row_map.iter().next() {
-        let schema = df.schema();
-        column_names = schema
-            .iter_fields()
-            .map(|f| format!("\"{}\"", f.name()))
-            .collect();
-    }
+    let column_names: Vec<String> = match row_map.iter().next() {
+        Some((_, df)) => df.schema().iter_names().map(|s| s.to_string()).collect(),
+        None => Vec::new(),
+    };
+
+    let column_sql_types = rows::column_sql_types_by_name(conn, table_name)?;
 
     for col_name in &column_names {
+        let placeholder = rows::placeholder_for_column(&column_sql_types, col_name);
         let mut case_clauses = Vec::new();
         for (id, df) in row_map.iter() {
-            let series = df.column(col_name.trim_matches('"'))?;
+            let series = df.column(col_name)?;
             let value = series.get(0)?;
 
             let boxed_value: Box<dyn ToSql> = Box::new(tabular::value_to_tosql(value));
 
-            case_clauses.push(format!("WHEN \"{OXEN_ID_COL}\" = '{id}' THEN ?"));
+            case_clauses.push(format!(
+                "WHEN \"{OXEN_ID_COL}\" = '{id}' THEN {placeholder}"
+            ));
 
             all_params.push(boxed_value);
         }
         set_clauses.push(format!(
-            "{} = CASE {} END",
+            "\"{}\" = CASE {} END",
             col_name,
             case_clauses.join(" ")
         ));

--- a/crates/lib/src/core/db/data_frames/rows.rs
+++ b/crates/lib/src/core/db/data_frames/rows.rs
@@ -16,6 +16,7 @@ use crate::core::db;
 use crate::core::db::data_frames::row_changes_db;
 use crate::core::db::data_frames::workspace_df_db::schema_without_oxen_cols;
 use crate::core::df::tabular;
+use crate::model::data_frame::schema::DataType;
 use crate::model::staged_row_status::StagedRowStatus;
 use crate::view::data_frames::DataFrameRowChange;
 use crate::{constants::TABLE_NAME, error::OxenError};
@@ -323,14 +324,16 @@ pub fn insert_polars_df(
     let table_name = table_name.as_ref();
 
     let schema = df.schema();
-    let column_names: Vec<String> = schema
-        .iter_fields()
-        .map(|f| format!("\"{}\"", f.name()))
+    let field_names: Vec<&str> = schema.iter_names().map(|s| s.as_str()).collect();
+    let column_names: Vec<String> = field_names
+        .iter()
+        .map(|name| format!("\"{name}\""))
         .collect();
 
-    let placeholders: String = column_names
+    let column_sql_types = column_sql_types_by_name(conn, table_name)?;
+    let placeholders: String = field_names
         .iter()
-        .map(|_| "?".to_string())
+        .map(|name| placeholder_for_column(&column_sql_types, name))
         .collect::<Vec<_>>()
         .join(", ");
     let sql = format!(
@@ -402,4 +405,38 @@ pub fn maybe_revert_row_changes(db: &DB, row_id: String) -> Result<(), OxenError
 
 pub fn revert_row_changes(db: &DB, row_id: String) -> Result<(), OxenError> {
     row_changes_db::delete_data_frame_row_changes(db, &row_id)
+}
+
+/// Build a column-name → SQL type map for the given DuckDB table.
+///
+/// Used to wrap List/Struct/Embedding placeholders in `CAST(? AS <sql_type>)` so that
+/// JSON-encoded payloads bind unambiguously to typed list columns.
+pub(crate) fn column_sql_types_by_name(
+    conn: &duckdb::Connection,
+    table_name: &str,
+) -> Result<HashMap<String, String>, OxenError> {
+    let schema = df_db::get_schema(conn, table_name)?;
+    let mut by_name = HashMap::with_capacity(schema.fields.len());
+    for field in schema.fields {
+        let sql_type = DataType::from_string(&field.dtype).to_sql();
+        by_name.insert(field.name, sql_type);
+    }
+    Ok(by_name)
+}
+
+/// Returns `CAST(? AS <sql_type>)` for List/Struct/Embedding columns and a bare `?` otherwise.
+pub(crate) fn placeholder_for_column(
+    column_sql_types: &HashMap<String, String>,
+    column_name: &str,
+) -> String {
+    match column_sql_types.get(column_name) {
+        Some(sql_type) if needs_explicit_cast(sql_type) => format!("CAST(? AS {sql_type})"),
+        _ => "?".to_string(),
+    }
+}
+
+fn needs_explicit_cast(sql_type: &str) -> bool {
+    // List columns end with `[]` (e.g. INTEGER[], VARCHAR[]); fixed-size arrays / embeddings end with `[N]`.
+    // Structs are stored as JSON (which already accepts string binds), but cast for symmetry / clarity.
+    sql_type.ends_with(']') || sql_type == "JSON"
 }

--- a/crates/lib/src/core/df/tabular.rs
+++ b/crates/lib/src/core/df/tabular.rs
@@ -704,75 +704,7 @@ pub fn any_val_to_json(value: AnyValue) -> Value {
         AnyValue::Float64(f) => json!(f),
         AnyValue::String(s) => Value::String(s.to_string()),
         AnyValue::StringOwned(s) => Value::String(s.to_string()),
-        AnyValue::List(l) => match l.dtype() {
-            polars::prelude::DataType::Int64 => {
-                let vec: Vec<i64> = l.i64().unwrap().into_iter().flatten().collect();
-                json!(vec)
-            }
-            polars::prelude::DataType::Int32 => {
-                let vec: Vec<i32> = l.i32().unwrap().into_iter().flatten().collect();
-                json!(vec)
-            }
-            polars::prelude::DataType::Float64 => {
-                let vec: Vec<f64> = l.f64().unwrap().into_iter().flatten().collect();
-                json!(vec)
-            }
-            polars::prelude::DataType::Float32 => {
-                let vec: Vec<f32> = l.f32().unwrap().into_iter().flatten().collect();
-                json!(vec)
-            }
-            polars::prelude::DataType::String => {
-                let vec: Vec<String> = l
-                    .str()
-                    .unwrap()
-                    .into_iter()
-                    .flatten()
-                    .map(|s| s.to_string())
-                    .collect();
-                json!(vec)
-            }
-            polars::prelude::DataType::Boolean => {
-                let vec: Vec<bool> = l.bool().unwrap().into_iter().flatten().collect();
-                json!(vec)
-            }
-            polars::prelude::DataType::List(_) => {
-                let mut array = Vec::new();
-
-                if let Ok(list_chunked) = l.list() {
-                    for i in 0..list_chunked.len() {
-                        if let Some(inner_series) = list_chunked.get_as_series(i) {
-                            array.push(any_val_to_json(AnyValue::List(inner_series)));
-                        } else {
-                            array.push(Value::Null);
-                        }
-                    }
-                }
-
-                Value::Array(array)
-            }
-            polars::prelude::DataType::Struct(_fields) => {
-                // Convert List(Struct) directly to DataFrame, then to JSON array
-                if let Ok(ca) = l.struct_() {
-                    let series_vec = ca.fields_as_series();
-                    let mut objs = Vec::with_capacity(ca.len());
-
-                    for row_idx in 0..ca.len() {
-                        let mut map = serde_json::Map::new();
-                        for series in series_vec.iter() {
-                            let val = series.get(row_idx).unwrap_or(AnyValue::Null);
-                            map.insert(series.name().to_string(), any_val_to_json(val));
-                        }
-                        objs.push(Value::Object(map));
-                    }
-                    Value::Array(objs)
-                } else {
-                    Value::Null
-                }
-            }
-            dtype => {
-                panic!("Unsupported list dtype: {dtype:?}")
-            }
-        },
+        AnyValue::List(l) => series_to_json_array(&l),
         AnyValue::StructOwned(s) => {
             let mut map = serde_json::Map::new();
 
@@ -794,6 +726,15 @@ pub fn any_val_to_json(value: AnyValue) -> Value {
 
         other => panic!("Unsupported dtype in JSON conversion: {other:?}"),
     }
+}
+
+fn series_to_json_array(series: &polars::prelude::Series) -> Value {
+    let mut array = Vec::with_capacity(series.len());
+    for i in 0..series.len() {
+        let val = series.get(i).unwrap_or(AnyValue::Null);
+        array.push(any_val_to_json(val));
+    }
+    Value::Array(array)
 }
 
 fn struct_array_to_json(
@@ -883,46 +824,7 @@ pub fn value_to_tosql(value: AnyValue) -> Box<dyn ToSql> {
             polars_time_unit_to_duckdb(tu),
             val,
         )),
-        AnyValue::List(l) => {
-            let json_array = match l.dtype() {
-                polars::prelude::DataType::Int64 => {
-                    let vec: Vec<i64> = l.i64().unwrap().into_iter().flatten().collect();
-                    json!(vec)
-                }
-                polars::prelude::DataType::Int32 => {
-                    let vec: Vec<i32> = l.i32().unwrap().into_iter().flatten().collect();
-                    json!(vec)
-                }
-                polars::prelude::DataType::Float64 => {
-                    let vec: Vec<f64> = l.f64().unwrap().into_iter().flatten().collect();
-                    json!(vec)
-                }
-                polars::prelude::DataType::Float32 => {
-                    let vec: Vec<f32> = l.f32().unwrap().into_iter().flatten().collect();
-                    json!(vec)
-                }
-                polars::prelude::DataType::String => {
-                    let vec: Vec<String> = l
-                        .str()
-                        .unwrap()
-                        .into_iter()
-                        .flatten()
-                        .map(|s| s.to_string())
-                        .collect();
-                    json!(vec)
-                }
-                polars::prelude::DataType::Boolean => {
-                    let vec: Vec<bool> = l.bool().unwrap().into_iter().flatten().collect();
-                    json!(vec)
-                }
-                polars::prelude::DataType::List(_) => any_val_to_json(AnyValue::List(l)),
-                polars::prelude::DataType::Struct(_) => any_val_to_json(AnyValue::List(l)),
-                dtype => {
-                    panic!("Unsupported dtype: {dtype:?}")
-                }
-            };
-            Box::new(json_array.to_string())
-        }
+        AnyValue::List(l) => Box::new(series_to_json_array(&l).to_string()),
         AnyValue::StructOwned(s) => {
             let json_value = any_val_to_json(AnyValue::StructOwned(s));
             Box::new(json_value.to_string())

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -1401,4 +1401,184 @@ mod tests {
         assert_eq!(result, "SELECT label, COUNT(*) FROM table GROUP BY label");
         Ok(())
     }
+
+    /// Adds `column_name` of `data_type` (e.g. "list[i64]") to a workspace-indexed dataframe,
+    /// adds a single row whose `column_name` is `list_value`, and returns the polars list series
+    /// for that column read back from the staged DuckDB.
+    async fn add_row_with_list_column(
+        repo: &crate::model::LocalRepository,
+        workspace: &crate::model::Workspace,
+        file_path: &Path,
+        column_name: &str,
+        data_type: &str,
+        list_value: serde_json::Value,
+    ) -> Result<polars::prelude::Series, OxenError> {
+        use crate::view::data_frames::columns::NewColumn;
+
+        let new_column = NewColumn {
+            name: column_name.to_string(),
+            data_type: data_type.to_string(),
+        };
+        workspaces::data_frames::columns::add(repo, workspace, file_path, &new_column)?;
+
+        let json_data = json!({
+            "file": "list_row.jpg",
+            "label": "dog",
+            "min_x": 1.0,
+            "min_y": 2.0,
+            "width": 3,
+            "height": 4,
+            column_name: list_value,
+        });
+        let added = workspaces::data_frames::rows::add(repo, workspace, file_path, &json_data)?;
+        let row_id = added
+            .column(OXEN_ID_COL)?
+            .get(0)?
+            .to_string()
+            .trim_matches('"')
+            .to_string();
+
+        let row = workspaces::data_frames::rows::get_by_id(workspace, file_path, &row_id)?;
+        let column = row.column(column_name)?;
+        Ok(column.as_materialized_series().clone())
+    }
+
+    fn list_typed_add_row_test_paths() -> std::path::PathBuf {
+        Path::new("annotations")
+            .join("train")
+            .join("bounding_box.csv")
+    }
+
+    #[tokio::test]
+    async fn test_add_row_with_list_i64_column() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-list-i64")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let file_path = list_typed_add_row_test_paths();
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+
+            let series = add_row_with_list_column(
+                &repo,
+                &workspace,
+                &file_path,
+                "scores",
+                "list[i64]",
+                json!([10, 20, 30]),
+            )
+            .await?;
+
+            let inner = series.list()?.get_as_series(0).unwrap();
+            let values: Vec<i64> = inner.i64()?.into_iter().map(|v| v.unwrap()).collect();
+            assert_eq!(values, vec![10, 20, 30]);
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_add_row_with_list_str_column_preserves_nulls() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-list-str")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let file_path = list_typed_add_row_test_paths();
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+
+            let series = add_row_with_list_column(
+                &repo,
+                &workspace,
+                &file_path,
+                "tags",
+                "list[str]",
+                json!(["a", null, "b"]),
+            )
+            .await?;
+
+            let inner = series.list()?.get_as_series(0).unwrap();
+            let values: Vec<Option<String>> = inner
+                .str()?
+                .into_iter()
+                .map(|v| v.map(|s| s.to_string()))
+                .collect();
+            assert_eq!(
+                values,
+                vec![Some("a".to_string()), None, Some("b".to_string())]
+            );
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_add_row_with_list_u32_column() -> Result<(), OxenError> {
+        // Regression: previously, list[u32]/list[u8]/etc. panicked in value_to_tosql
+        // because only Int32/Int64/Float32/Float64/String/Boolean were handled.
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-list-u32")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let file_path = list_typed_add_row_test_paths();
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+
+            let series = add_row_with_list_column(
+                &repo,
+                &workspace,
+                &file_path,
+                "ids",
+                "list[u32]",
+                json!([1u32, 2u32, 3u32]),
+            )
+            .await?;
+
+            let inner = series.list()?.get_as_series(0).unwrap();
+            let values: Vec<u32> = inner.u32()?.into_iter().map(|v| v.unwrap()).collect();
+            assert_eq!(values, vec![1, 2, 3]);
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_add_row_with_list_f64_column() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-list-f64")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let file_path = list_typed_add_row_test_paths();
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+
+            let series = add_row_with_list_column(
+                &repo,
+                &workspace,
+                &file_path,
+                "embedding",
+                "list[f64]",
+                json!([0.1, 0.2, 0.3]),
+            )
+            .await?;
+
+            let inner = series.list()?.get_as_series(0).unwrap();
+            let values: Vec<f64> = inner.f64()?.into_iter().map(|v| v.unwrap()).collect();
+            assert_eq!(values, vec![0.1, 0.2, 0.3]);
+            Ok(())
+        })
+        .await
+    }
 }


### PR DESCRIPTION
Adding a row to a typed list column (`list[u32]`, `list[i8]`, `list[date]`, etc.) panicked the server because `value_to_tosql` only handled six element dtypes explicitly and fell through to `panic!` for the rest. Lists of strings or booleans also silently dropped null elements via `into_iter().flatten()`.

Replace the per-dtype branches in `any_val_to_json` and `value_to_tosql` with a single `series_to_json_array` helper that walks the polars `Series` element-by- element and renders `None` as JSON `null`. Wrap list/struct/embedding placeholders in `INSERT`/`UPDATE` SQL with `CAST(? AS <sql_type>)` so the bind target is unambiguous instead of relying on DuckDB's implicit string-to-list cast.

Apply the same placeholder logic to `modify_row_with_polars_df` and `modify_rows_with_polars_df` so update has parity with insert.