### PR TITLE
Publish oxen-cli & oxen-server to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,16 @@ jobs:
           args: --skip-existing ${{ github.workspace }}/oxen-wheels/*.whl
           maturin-version: v1.8.5
 
-  publish_liboxen_crate:
-    # See https://crates.io/docs/trusted-publishing for details
-    name: 🦀 Publish liboxen crate to crates.io
+  publish_crates:
+    # Publishes every workspace crate with `publish = true` (the default) to crates.io:
+    #   - liboxen        → library crate
+    #   - oxen-cli       → installs the `oxen` binary via `cargo install oxen-cli`
+    #   - oxen-server    → installs the `oxen-server` binary via `cargo install oxen-server`
+    # `oxen-py` is skipped automatically because its Cargo.toml sets `publish = false`.
+    # cargo publishes in topological dep order (liboxen first) and waits for index propagation
+    # between crates, so no separate jobs / explicit ordering are needed.
+    # See https://crates.io/docs/trusted-publishing for details on the OIDC auth.
+    name: 🦀 Publish workspace crates to crates.io
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Required for OIDC token exchange
@@ -56,8 +63,9 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
-          cd ${{ github.workspace }}/crates/lib
-          cargo publish
+          cd ${{ github.workspace }}
+          # NOTE: oxen-py is listed as publish=false, but we want defense in depth so we explicitly exclude it here too
+          cargo publish --workspace --exclude oxen-py
 
   publish_homebrew_oxen:
     name: 🍺 Update oxen formula on homebrew-core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ jsonwebtoken = "9.3.0"
 jwalk = "0.8.1"
 lazy_static = "1.4.0"
 libduckdb-sys = { version = "=1.10502.0" }
+# liboxen's `version` is kept in lockstep with `[workspace.package].version` by `bin/bump-version`.
+# `path` is used for local builds; `version` is used by `cargo publish` so oxen-cli and oxen-server
+# resolve liboxen from crates.io when published.
+liboxen = { path = "crates/lib", version = "=0.48.1" }
 lofty = "0.22.2"
 log = "0.4.20"
 lru = "0.14.0"

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -95,11 +95,27 @@ echo "" >&2
 
 # Update the workspace Cargo.toml file
 echo "Updating workspace Cargo.toml file..." >&2
-# Only update the [workspace.package] version line, not dependency versions
+# Update the [workspace.package] version line.
 if [[ "$(uname)" == "Darwin" ]]; then
   sed -i '' '/^\[workspace\.package\]/,/^\[/ s/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
 else
   sed -i '/^\[workspace\.package\]/,/^\[/ s/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
+fi
+# Update the liboxen entry under [workspace.dependencies] so its `version` matches
+# [workspace.package].version. cargo publish for oxen-cli / oxen-server uses this version
+# (the `path` is stripped at publish time) to resolve liboxen from crates.io.
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed -i '' 's|^liboxen = { path = "crates/lib", version = "=.*" }|liboxen = { path = "crates/lib", version = "='"$VERSION"'" }|' Cargo.toml
+else
+  sed -i 's|^liboxen = { path = "crates/lib", version = "=.*" }|liboxen = { path = "crates/lib", version = "='"$VERSION"'" }|' Cargo.toml
+fi
+# Fail fast if the sed silently no-op'd (e.g., the line was reformatted). A stale liboxen
+# version here would cause oxen-cli / oxen-server to publish against the wrong liboxen.
+expected_liboxen_line='liboxen = { path = "crates/lib", version = "='"$VERSION"'" }'
+if ! grep -qxF "$expected_liboxen_line" Cargo.toml; then
+  echo "Error: failed to update [workspace.dependencies].liboxen version in Cargo.toml" >&2
+  echo "       Expected line: $expected_liboxen_line" >&2
+  exit 1
 fi
 echo "  ✓ Cargo.toml" >&2
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,7 +33,7 @@ clap = { workspace = true }
 colored = { workspace = true }
 dialoguer = { workspace = true }
 glob = { workspace = true }
-liboxen = { path = "../lib" }
+liboxen = { workspace = true }
 log = { workspace = true }
 minus = { workspace = true }
 serde_json = { workspace = true }
@@ -45,7 +45,7 @@ url = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-liboxen = { path = "../lib", features = ["test-utils"] }
+liboxen = { workspace = true, features = ["test-utils"] }
 
 [lints]
 workspace = true

--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -21,7 +21,7 @@ otel = ["liboxen/otel"]
 production = ["metrics", "otel", "default"]
 
 [dependencies]
-liboxen = { path = "../lib" }
+liboxen = { workspace = true }
 log = { workspace = true }
 pyo3 = { workspace = true }
 pyo3-async-runtimes = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -40,7 +40,7 @@ flate2 = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
 jsonwebtoken = { workspace = true }
-liboxen = { path = "../lib" }
+liboxen = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 metrics = { workspace = true, optional = true }
@@ -67,7 +67,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 actix-multipart-test = { workspace = true }
-liboxen = { path = "../lib", features = ["test-utils"] }
+liboxen = { workspace = true, features = ["test-utils"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Changes the publish step to publish all crates in the workspace that have `publish=true`
in their `Cargo.toml`s. This now publishes `oxen-cli` (crates/cli) and `oxen-server`
(crates/server) to crates.io. `oxen-py` is **not** published.

Updates the `Cargo.toml` to make `liboxen` a workspace dependency for the CLI and server.
This allows `liboxen` to be a `path` dependency during local development and pinned to
a specific version for resolution on crates.io.

The `bin/bump-version` script has been updated to update the version in `Cargo.toml`
for the `liboxen` workspace dependency.