### PR TITLE
Add mtime tolerance to `is_modified_from_node`'s async callers

### DIFF
--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -621,7 +621,7 @@ pub(crate) async fn workspace_multipart_batch_upload_versions(
             if let Some((ref head_commit, local_repo)) = head_commit_local_repo_maybe
                 && let Some(file_node) =
                     repositories::tree::get_file_by_path(local_repo, head_commit, &relative_path)?
-                && !util::fs::is_modified_from_node(&path, &file_node)?
+                && !local_repo.is_modified_from_node(&path, &file_node).await?
             {
                 continue;
             }

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -522,9 +522,30 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                 batch.len()
                             );
                             for (path, size) in batch {
-                                let base_or_repo_path_clone = base_or_repo_path_clone.clone();
-                                let head_commit_local_repo_maybe_clone =
-                                    head_commit_local_repo_maybe_clone.clone();
+                                let relative_path = util::fs::path_relative_to_dir(
+                                    &path,
+                                    &base_or_repo_path_clone,
+                                )?;
+
+                                // In remote-mode repos, skip adding files already present in
+                                // the tree unless update_timestamp is set. Done here in async
+                                // context (rather than inside `spawn_blocking` below) so the
+                                // mtime-tolerance comparison can `.await`.
+                                if !update_timestamp
+                                    && let Some((ref head_commit, ref local_repository)) =
+                                        head_commit_local_repo_maybe_clone
+                                    && let Some(file_node) = repositories::tree::get_file_by_path(
+                                        local_repository,
+                                        head_commit,
+                                        &relative_path,
+                                    )?
+                                    && !local_repository
+                                        .is_modified_from_node(&path, &file_node)
+                                        .await?
+                                {
+                                    log::debug!("Skipping add on unmodified path {path:?}");
+                                    continue;
+                                }
 
                                 let file_data_maybe: Option<(
                                     reqwest::multipart::Part,
@@ -532,28 +553,6 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                     PathBuf,
                                     u64,
                                 )> = tokio::task::spawn_blocking(move || {
-                                    let relative_path = util::fs::path_relative_to_dir(
-                                        &path,
-                                        &base_or_repo_path_clone,
-                                    )?;
-
-                                    // In remote-mode repos, skip adding files already present in tree
-                                    // unless update_timestamp is set
-                                    if !update_timestamp
-                                        && let Some((ref head_commit, ref local_repository)) =
-                                            head_commit_local_repo_maybe_clone
-                                        && let Some(file_node) =
-                                            repositories::tree::get_file_by_path(
-                                                local_repository,
-                                                head_commit,
-                                                &relative_path,
-                                            )?
-                                        && !util::fs::is_modified_from_node(&path, &file_node)?
-                                    {
-                                        log::debug!("Skipping add on unmodified path {path:?}");
-                                        return Ok(None);
-                                    }
-
                                     // When preserve_paths is set or in remote-mode repos, use the
                                     // full relative path. Otherwise use just the filename.
                                     let staging_path = if keep_relative_paths {

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -490,8 +490,9 @@ pub async fn process_add_dir(
                                             &path.file_name().unwrap_or_default().to_string_lossy();
                                         let file_status =
                                             core::v_latest::add::determine_file_status(
-                                                &dir_node, file_name, &path,
-                                            )?;
+                                                &repo, &dir_node, file_name, &path,
+                                            )
+                                            .await?;
 
                                         match process_add_file(
                                             &repo,
@@ -669,7 +670,7 @@ async fn add_file_inner(
     };
 
     let file_name = path.file_name().unwrap_or_default().to_string_lossy();
-    let file_status = determine_file_status(&maybe_dir_node, &file_name, path)?;
+    let file_status = determine_file_status(repo, &maybe_dir_node, &file_name, path).await?;
     let file = tokio::fs::File::open(path).await?;
     let size = file.metadata().await?.len();
     let reader = tokio::io::BufReader::new(file);
@@ -694,7 +695,8 @@ async fn add_file_inner(
     )
 }
 
-pub fn determine_file_status(
+pub async fn determine_file_status(
+    repo: &LocalRepository,
     maybe_dir_node: &Option<MerkleTreeNode>,
     file_name: impl AsRef<str>,  // Name of the file in the repository
     data_path: impl AsRef<Path>, // Path to the data file (maybe in the version store)
@@ -717,7 +719,10 @@ pub fn determine_file_status(
         let num_bytes = metadata.len();
 
         previous_oxen_metadata = file_node.metadata();
-        if util::fs::is_modified_from_node_with_metadata(data_path, file_node, Ok(metadata))? {
+        if repo
+            .is_modified_from_node_with_metadata(data_path, file_node, Ok(metadata))
+            .await?
+        {
             (
                 StagedEntryStatus::Modified,
                 MerkleHash::new(hash),
@@ -973,7 +978,7 @@ pub fn add_file_node_to_staged_db(
     Ok(())
 }
 
-pub fn stage_file_with_hash(
+pub async fn stage_file_with_hash(
     workspace: &Workspace,
     data_path: &Path,
     dst_path: &Path,
@@ -999,7 +1004,10 @@ pub fn stage_file_with_hash(
 
     let file_status = if let Some(file_node) = maybe_file_node {
         let previous_metadata = file_node.metadata();
-        let status = if util::fs::is_modified_from_node(data_path, &file_node)? {
+        let status = if base_repo
+            .is_modified_from_node(data_path, &file_node)
+            .await?
+        {
             StagedEntryStatus::Modified
         } else if update_timestamp {
             // Force staging even though the content hasn't changed

--- a/crates/lib/src/core/v_latest/branches.rs
+++ b/crates/lib/src/core/v_latest/branches.rs
@@ -508,7 +508,14 @@ async fn walk_from_tree<'a>(
                             if on_conflict.is_abort() && modified_locally {
                                 candidates.cannot_overwrite_entries.push(file_path);
                             } else {
-                                if repo.is_remote_mode() {
+                                // In remote mode, back up the file under `node.hash` before we
+                                // remove it so future checkouts can restore from the version store.
+                                // Only safe when the on-disk bytes match `node.hash`. The remaining
+                                // case (`OnConflict::Overwrite` + `modified_locally`) is the user
+                                // discarding their working state, so storing those bytes under the
+                                // committed hash would pollute the content-addressable store with
+                                // mismatched content.
+                                if repo.is_remote_mode() && !modified_locally {
                                     candidates
                                         .files_to_store
                                         .push((node.hash, full_path.clone()));
@@ -517,10 +524,13 @@ async fn walk_from_tree<'a>(
                             }
                         }
                     } else if full_path.exists() && repo.is_remote_mode() {
-                        // File exists in both trees at the same path — it may be
-                        // overwritten during restore. Store the current version so future
-                        // checkouts can restore it from the version store.
-                        candidates.files_to_store.push((node.hash, full_path));
+                        // File exists in both trees at the same path — it may be overwritten by the
+                        // restore step. Same gate as above: back up the on-disk bytes only when
+                        // they match `node.hash`. If the user modified the file locally, those
+                        // bytes would pollute the content-addressable store under the wrong hash.
+                        if !repo.is_modified_from_node(&full_path, file_node).await? {
+                            candidates.files_to_store.push((node.hash, full_path));
+                        }
                     }
                 }
                 EMerkleTreeNode::Directory(dir_node) => {

--- a/crates/lib/src/core/v_latest/branches.rs
+++ b/crates/lib/src/core/v_latest/branches.rs
@@ -249,8 +249,7 @@ pub async fn checkout_subtrees(
 
         if let Some(root) = from_root {
             log::debug!("Cleanup_removed_files");
-            cleanup_removed_files(repo, &root, &mut progress, &mut hashes, OnConflict::Abort)
-                .await?;
+            cleanup_removed_files(repo, &root, &mut progress, &hashes, OnConflict::Abort).await?;
         } else {
             log::debug!("head commit missing, no cleanup");
         }
@@ -392,7 +391,7 @@ pub async fn set_working_repo_to_commit(
     // Cleanup files if checking out fr om another commit
     if let Some(from_tree) = from_tree {
         log::debug!("Cleanup_removed_files");
-        cleanup_removed_files(repo, &from_tree, &mut progress, &mut hashes, on_conflict).await?;
+        cleanup_removed_files(repo, &from_tree, &mut progress, &hashes, on_conflict).await?;
     }
 
     for file_to_restore in results.files_to_restore {
@@ -414,35 +413,21 @@ async fn cleanup_removed_files(
     repo: &LocalRepository,
     from_node: &MerkleTreeNode,
     progress: &mut CheckoutProgressBar,
-    hashes: &mut CheckoutHashes,
+    hashes: &CheckoutHashes,
     on_conflict: OnConflict,
 ) -> Result<(), OxenError> {
-    // Compare the nodes in the from tree to the nodes in the target tree
-    // If the file node is in the from tree, but not in the target tree, remove it
+    let candidates = walk_from_tree(repo, from_node, hashes, on_conflict).await?;
 
-    let mut paths_to_remove: Vec<PathBuf> = vec![];
-    let mut files_to_store: Vec<(MerkleHash, PathBuf)> = vec![];
-    let mut cannot_overwrite_entries: Vec<PathBuf> = vec![];
-
-    r_remove_if_not_in_target(
-        repo,
-        from_node,
-        Path::new(""),
-        &mut paths_to_remove,
-        &mut files_to_store,
-        &mut cannot_overwrite_entries,
-        hashes,
-        on_conflict,
-    )?;
-
-    if !cannot_overwrite_entries.is_empty() {
-        return Err(OxenError::cannot_overwrite_files(&cannot_overwrite_entries));
+    if !candidates.cannot_overwrite_entries.is_empty() {
+        return Err(OxenError::cannot_overwrite_files(
+            &candidates.cannot_overwrite_entries,
+        ));
     }
 
     // If in remote mode, need to store committed paths before removal
     if repo.is_remote_mode() {
         let version_store = repo.version_store()?;
-        for (hash, full_path) in files_to_store {
+        for (hash, full_path) in candidates.files_to_store {
             log::debug!("Storing hash {hash:?} and path {full_path:?}");
             let file = tokio::fs::File::open(&full_path).await?;
             let size = file.metadata().await?.len();
@@ -453,7 +438,7 @@ async fn cleanup_removed_files(
         }
     }
 
-    for full_path in paths_to_remove {
+    for full_path in candidates.paths_to_remove {
         // If it's a directory, and it's empty, remove it
         if full_path.is_dir() && full_path.read_dir()?.next().is_none() {
             log::debug!("Removing dir: {full_path:?}");
@@ -468,110 +453,111 @@ async fn cleanup_removed_files(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-fn r_remove_if_not_in_target(
+/// Files and directories the cleanup pass might remove, plus blockers it found.
+#[derive(Default)]
+struct CleanupCandidates {
+    /// Paths to remove, in post-order (children before their parent dir) so that by the
+    /// time we get to a directory entry its files have already been removed and the
+    /// emptiness check in `cleanup_removed_files` succeeds.
+    paths_to_remove: Vec<PathBuf>,
+    /// (hash, full_path) pairs to store in the version store before removal — only
+    /// populated in remote-mode repos.
+    files_to_store: Vec<(MerkleHash, PathBuf)>,
+    /// Files in HEAD that don't appear in the target tree but have local modifications;
+    /// `OnConflict::Abort` upgrades these to a `cannot_overwrite_files` error.
+    cannot_overwrite_entries: Vec<PathBuf>,
+}
+
+/// Stack item for the iterative depth-first search in `walk_from_tree`. `Visit` is the
+/// usual "process this node next"; `FinalizeDir` runs after a directory's subtree is
+/// fully processed so we can append the directory itself to `paths_to_remove` in
+/// post-order. Pushed BEFORE the directory's children so the LIFO `pop()` returns it last.
+enum WalkFromItem<'a> {
+    Visit(PathBuf, &'a MerkleTreeNode),
+    FinalizeDir(PathBuf),
+}
+
+/// Walk the from tree (HEAD) and gather files-and-dirs to remove (anything HEAD has that
+/// the target tree doesn't), files to back up to the version store, and conflict blockers.
+/// Iterative depth-first search over an explicit stack so the file branch can `.await`
+/// `repo.is_modified_from_node` — same shape as `walk_target_tree` and the merge-side
+/// walkers.
+async fn walk_from_tree<'a>(
     repo: &LocalRepository,
-    from_node: &MerkleTreeNode,
-    current_path: &Path,
-    paths_to_remove: &mut Vec<PathBuf>,
-    files_to_store: &mut Vec<(MerkleHash, PathBuf)>,
-    cannot_overwrite_entries: &mut Vec<PathBuf>,
-    hashes: &mut CheckoutHashes,
+    from_root: &'a MerkleTreeNode,
+    hashes: &CheckoutHashes,
     on_conflict: OnConflict,
-) -> Result<(), OxenError> {
-    // Iterate through the from tree, removing files not present in the target tree
-    match &from_node.node {
-        EMerkleTreeNode::File(file_node) => {
-            let file_path = current_path.join(file_node.name());
-            let full_path = repo.path.join(&file_path);
+) -> Result<CleanupCandidates, OxenError> {
+    let mut candidates = CleanupCandidates::default();
+    let mut stack: Vec<WalkFromItem<'a>> = vec![WalkFromItem::Visit(PathBuf::new(), from_root)];
 
-            // Only consider files whose path is not in the target tree
-            // (using path-based check instead of hash-based, because different
-            // files at different paths can share the same content hash)
-            if !hashes.seen_paths.contains(&file_path) {
-                // Before staging for removal, verify the path exists and isn't modified
-                if full_path.exists() {
-                    let modified_locally = util::fs::is_modified_from_node(&full_path, file_node)?;
-                    if on_conflict.is_abort() && modified_locally {
-                        cannot_overwrite_entries.push(file_path.clone());
-                    } else {
-                        // If in remote mode, save file to version store before removing
-                        if repo.is_remote_mode() {
-                            files_to_store.push((from_node.hash, full_path.clone()))
+    while let Some(item) = stack.pop() {
+        match item {
+            WalkFromItem::Visit(path, node) => match &node.node {
+                EMerkleTreeNode::File(file_node) => {
+                    let file_path = path.join(file_node.name());
+                    let full_path = repo.path.join(&file_path);
+
+                    // Only consider files whose path is not in the target tree (using
+                    // path-based check instead of hash-based, because different files at
+                    // different paths can share the same content hash).
+                    if !hashes.seen_paths.contains(&file_path) {
+                        if full_path.exists() {
+                            let modified_locally =
+                                repo.is_modified_from_node(&full_path, file_node).await?;
+                            if on_conflict.is_abort() && modified_locally {
+                                candidates.cannot_overwrite_entries.push(file_path);
+                            } else {
+                                if repo.is_remote_mode() {
+                                    candidates
+                                        .files_to_store
+                                        .push((node.hash, full_path.clone()));
+                                }
+                                candidates.paths_to_remove.push(full_path);
+                            }
                         }
-
-                        paths_to_remove.push(full_path.clone());
+                    } else if full_path.exists() && repo.is_remote_mode() {
+                        // File exists in both trees at the same path — it may be
+                        // overwritten during restore. Store the current version so future
+                        // checkouts can restore it from the version store.
+                        candidates.files_to_store.push((node.hash, full_path));
                     }
                 }
-            } else if full_path.exists() && repo.is_remote_mode() {
-                // File exists in both trees at the same path — it may be overwritten
-                // during restore. Store the current version so future checkouts can
-                // restore it from the version store.
-                files_to_store.push((from_node.hash, full_path.clone()))
-            }
-        }
+                EMerkleTreeNode::Directory(dir_node) => {
+                    if hashes.common_nodes.contains(&node.hash) {
+                        continue;
+                    }
+                    let dir_path = path.join(dir_node.name());
 
-        EMerkleTreeNode::Directory(dir_node) => {
-            let dir_path = current_path.join(dir_node.name());
-            if hashes.common_nodes.contains(&from_node.hash) {
-                return Ok(());
-            };
+                    // Post-order: schedule the directory's "remove if empty" finalize task
+                    // FIRST so that after the LIFO walks every child the FinalizeDir item
+                    // pops last.
+                    stack.push(WalkFromItem::FinalizeDir(dir_path.clone()));
 
-            let children = {
-                // Get vnodes for the from dir node
-                let dir_vnodes = &from_node.children;
-
-                // Only iterate through vnodes not shared between the trees
-                let mut unique_nodes = Vec::new();
-                for vnode in dir_vnodes {
-                    if !hashes.common_nodes.contains(&vnode.hash) {
-                        unique_nodes.extend(vnode.children.iter().cloned());
+                    for vnode in &node.children {
+                        if !hashes.common_nodes.contains(&vnode.hash) {
+                            for child in &vnode.children {
+                                stack.push(WalkFromItem::Visit(dir_path.clone(), child));
+                            }
+                        }
                     }
                 }
-
-                unique_nodes
-            };
-
-            for child in &children {
-                r_remove_if_not_in_target(
-                    repo,
-                    child,
-                    &dir_path,
-                    paths_to_remove,
-                    files_to_store,
-                    cannot_overwrite_entries,
-                    hashes,
-                    on_conflict,
-                )?;
-            }
-            log::debug!(
-                "r_remove_if_not_in_target checked {:?} paths",
-                children.len()
-            );
-
-            // Remove directory if it's empty
-            let full_dir_path = repo.path.join(&dir_path);
-            if full_dir_path.exists() {
-                paths_to_remove.push(full_dir_path.clone());
+                EMerkleTreeNode::Commit(_) => {
+                    let root_dir = repositories::tree::get_root_dir(node)?;
+                    stack.push(WalkFromItem::Visit(path, root_dir));
+                }
+                _ => {}
+            },
+            WalkFromItem::FinalizeDir(dir_path) => {
+                let full_dir_path = repo.path.join(&dir_path);
+                if full_dir_path.exists() {
+                    candidates.paths_to_remove.push(full_dir_path);
+                }
             }
         }
-        EMerkleTreeNode::Commit(_) => {
-            // If we get a commit node, we need to skip to the root directory
-            let root_dir = repositories::tree::get_root_dir(from_node)?;
-            r_remove_if_not_in_target(
-                repo,
-                root_dir,
-                current_path,
-                paths_to_remove,
-                files_to_store,
-                cannot_overwrite_entries,
-                hashes,
-                on_conflict,
-            )?;
-        }
-        _ => {}
     }
-    Ok(())
+
+    Ok(candidates)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -82,7 +82,7 @@ pub async fn rm(
     Ok(err_files)
 }
 
-pub fn add_version_file(
+pub async fn add_version_file(
     workspace: &Workspace,
     version_path: impl AsRef<Path>,
     dst_path: impl AsRef<Path>,
@@ -104,7 +104,8 @@ pub fn add_version_file(
         &staged_db_manager,
         &Arc::new(Mutex::new(HashSet::new())),
         update_timestamp,
-    )?;
+    )
+    .await?;
 
     Ok(dst_path.to_path_buf())
 }
@@ -147,7 +148,9 @@ pub async fn add_version_files(
             &staged_db_manager,
             &seen_dirs,
             update_timestamp,
-        ) {
+        )
+        .await
+        {
             Ok(_) => {
                 // Add parents to staged db
                 // let parent_dirs = item.parents;
@@ -883,8 +886,13 @@ async fn p_add_file(
     }
 
     // See if this is a new file or a modified file
-    let mut file_status =
-        core::v_latest::add::determine_file_status(&maybe_dir_node, &file_name, &full_path)?;
+    let mut file_status = core::v_latest::add::determine_file_status(
+        base_repo,
+        &maybe_dir_node,
+        &file_name,
+        &full_path,
+    )
+    .await?;
 
     // When update_timestamp is set, override Unmodified status to Modified
     // and use the current time so the commit gets a new merkle tree hash

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -3,6 +3,7 @@ use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
+use crate::model::merkle_tree::node::FileNode;
 use crate::model::{MetadataEntry, Remote, RemoteRepository};
 use crate::opts::StorageOpts;
 use crate::storage::{StorageConfig, VersionStore, create_version_store};
@@ -571,6 +572,46 @@ impl LocalRepository {
             node.duration_since(disk).unwrap_or_default()
         };
         diff <= tolerance
+    }
+
+    /// Async, tolerance-aware modification check. Routes the mtime comparison through
+    /// [`Self::mtime_matches`] so it agrees with `restore_file`'s fast-path skip on
+    /// coarse-mtime mounts (FAT/exFAT, HFS+, some NFS). Use this from any caller that has
+    /// access to a `&LocalRepository` and is in an async context.
+    ///
+    /// `oxen status` and its sync chain still use the strict-mtime free function in
+    /// [`crate::util::fs::is_modified_from_node`]; when that path goes async, the free
+    /// functions can be removed in favor of these methods.
+    pub async fn is_modified_from_node(
+        &self,
+        path: &Path,
+        node: &FileNode,
+    ) -> Result<bool, OxenError> {
+        self.is_modified_from_node_with_metadata(path, node, util::fs::metadata(path))
+            .await
+    }
+
+    /// Pre-fetched-metadata variant of [`Self::is_modified_from_node`].
+    pub async fn is_modified_from_node_with_metadata(
+        &self,
+        path: &Path,
+        node: &FileNode,
+        metadata: Result<std::fs::Metadata, OxenError>,
+    ) -> Result<bool, OxenError> {
+        if !path.exists() {
+            log::debug!("is_modified_from_node found non-existent path {path:?}. Returning false");
+            return Ok(false);
+        }
+        let metadata = metadata?;
+        let file_last_modified = filetime::FileTime::from_last_modification_time(&metadata);
+        let node_last_modified = util::fs::last_modified_time(
+            node.last_modified_seconds(),
+            node.last_modified_nanoseconds(),
+        );
+        let mtime_matched = self
+            .mtime_matches(file_last_modified, node_last_modified)
+            .await;
+        util::fs::classify_modified_from_node_with_metadata(path, node, &metadata, mtime_matched)
     }
 
     /// Override the mtime tolerance for this repo path in the per-process cache. Test-only

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1575,6 +1575,15 @@ pub fn remove_paths(src: &Path) -> Result<(), OxenError> {
     }
 }
 
+/// Strict-mtime variant. Treats `disk_mtime != node_mtime` (to the nanosecond) as "different
+/// enough to fall through to the hash check," which on coarse-mtime mounts (FAT/exFAT, HFS+,
+/// some NFS) misclassifies files inside `restore_file`'s tolerance window as modified.
+///
+/// Use [`crate::model::LocalRepository::is_modified_from_node`] /
+/// [`crate::model::LocalRepository::is_modified_from_node_with_metadata`] from any caller
+/// that has access to a `&LocalRepository` and is already in an async context — those use
+/// `repo.mtime_matches`. The sync version remains for `oxen status`, whose walker is
+/// sync-everywhere by design.
 pub fn is_modified_from_node_with_metadata(
     path: &Path,
     node: &FileNode,
@@ -1586,26 +1595,40 @@ pub fn is_modified_from_node_with_metadata(
     }
 
     let metadata = metadata?;
-    // Second, check the length of the file
-    let file_size = metadata.len();
-    let node_size = node.num_bytes();
-
-    if file_size != node_size {
-        return Ok(true);
-    }
-
-    // Third, check the last modified times
     let file_last_modified = FileTime::from_last_modification_time(&metadata);
     let node_last_modified = util::fs::last_modified_time(
         node.last_modified_seconds(),
         node.last_modified_nanoseconds(),
     );
+    let mtime_matched = file_last_modified == node_last_modified;
+    classify_modified_from_node_with_metadata(path, node, &metadata, mtime_matched)
+}
 
-    if file_last_modified == node_last_modified {
+pub fn is_modified_from_node(path: &Path, node: &FileNode) -> Result<bool, OxenError> {
+    is_modified_from_node_with_metadata(path, node, util::fs::metadata(path))
+}
+
+/// Shared between [`is_modified_from_node_with_metadata`] and
+/// [`crate::model::LocalRepository::is_modified_from_node_with_metadata`]. Given the
+/// already-decided mtime equality verdict, applies the size / metadata-hash / content-hash
+/// checks. `path` is assumed to exist and `metadata` to be valid.
+pub(crate) fn classify_modified_from_node_with_metadata(
+    path: &Path,
+    node: &FileNode,
+    metadata: &std::fs::Metadata,
+    mtime_matched: bool,
+) -> Result<bool, OxenError> {
+    // Size check first — different size means definitely modified, no hashing needed.
+    if metadata.len() != node.num_bytes() {
+        return Ok(true);
+    }
+
+    // Mtime equality + matching size is sufficient; trust the FS.
+    if mtime_matched {
         return Ok(false);
     }
 
-    // Fourth, check the metadata hashes
+    // Mtime drifted but size matches — fall back to metadata hash, then content hash.
     let node_metadata_hash = node.metadata_hash();
     let file_metadata_hash = {
         let mime_type = util::fs::file_mime_type(path);
@@ -1622,19 +1645,9 @@ pub fn is_modified_from_node_with_metadata(
         return Ok(true);
     }
 
-    // Finally, check the hashes
     let node_hash = node.hash().to_u128();
-    let working_hash = util::hasher::get_hash_given_metadata(path, &metadata)?;
-
-    if node_hash == working_hash {
-        Ok(false)
-    } else {
-        Ok(true)
-    }
-}
-
-pub fn is_modified_from_node(path: &Path, node: &FileNode) -> Result<bool, OxenError> {
-    is_modified_from_node_with_metadata(path, node, util::fs::metadata(path))
+    let working_hash = util::hasher::get_hash_given_metadata(path, metadata)?;
+    Ok(node_hash != working_hash)
 }
 
 // Calculate a node's last modified time

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -125,7 +125,8 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                 &dst_path,
                 &version_id,
                 request.update_timestamp,
-            )?;
+            )
+            .await?;
         }
 
         return Ok(HttpResponse::Ok().json(StatusMessage::resource_found()));

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -235,7 +235,9 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
             &dst_path,
             &upload_file.hash,
             update_timestamp,
-        ) {
+        )
+        .await
+        {
             Ok(ret_file) => ret_file,
             Err(e) => {
                 log::error!("Error adding file {version_path:?}: {e:?}");


### PR DESCRIPTION
_This PR is really similar to https://github.com/Oxen-AI/Oxen/pull/492, but for the `is_modified_from_node` function in `utils/fs.rs`_

- CLI commands affected by this change: `add`, `checkout <branch>`, `checkout --theirs/--ours`, `push`, and `upload`.
- Server endpoints affected by this change: `versions::chunks::complete`, `workspaces::files::add`, `workspaces::files::add_version_files`

Yet again, this diff looks scary because in order to use the async mtime stuff I needed to convert some sync recursion to async iterative.

The consequential changes are:
- Add the [async `is_modified_from_node*` methods](https://github.com/Oxen-AI/Oxen/pull/494/changes#diff-54874de6772880d4d055a3dbb4d744047c2ea20231e90c3d5111a848205a82c1R577-R616) to `LocalRepository
- [Annotate `util::fs::is_modified_from_node_with_metadata`](https://github.com/Oxen-AI/Oxen/pull/494/changes#diff-2be8c16b8e93be60c2cc8b1730eac943bbdaad100cbfa0beca0c67ba43d5b4e0R1578-R1586) with info about needing to migrate to `LocalRepository` methods (we're not removing this function yet because the `status` command that uses it needs some extensive rework, and we're deferring that to a later PR)
- Switch from the standalone `is_modified_from_node` to the methods on `LocalRepository`

Less consequential:
- The `sync` -> `async` conversion
- The recursive -> iterative conversion
- The out-parameters -> return-values conversion
- The extra structs to organize the new return values

Closes ENG-984.