### PR TITLE
MerkleTransport trait for client <> server

### DIFF
--- a/crates/lib/src/model/merkle_tree.rs
+++ b/crates/lib/src/model/merkle_tree.rs
@@ -1,11 +1,15 @@
 pub mod merkle_hash;
 pub mod merkle_reader;
+pub mod merkle_transport;
 pub mod merkle_writer;
 pub mod node;
 pub mod node_type;
 
 pub use crate::model::merkle_tree::merkle_hash::MerkleHash;
 pub use crate::model::merkle_tree::merkle_reader::MerkleReader;
+pub use crate::model::merkle_tree::merkle_transport::{
+    MerklePacker, MerkleTransport, MerkleUnpacker, PackOptions, UnpackOptions,
+};
 pub use crate::model::merkle_tree::merkle_writer::MerkleWriter;
 pub use crate::model::merkle_tree::node::merkle_tree_node_cache;
 pub use crate::model::merkle_tree::node_type::{
@@ -18,3 +22,16 @@ pub trait MerkleStore: MerkleReader + MerkleWriter<Error = <Self as MerkleReader
 /// Any type that implements the Merkle reading and writing traits is automatically an instance
 /// of a MerkleStore, provided that the error types in both the reader & writer align.
 impl<T> MerkleStore for T where T: MerkleReader + MerkleWriter<Error = <T as MerkleReader>::Error> {}
+
+/// A Merkle tree backend that can also be transported (packed/unpacked) over the wire.
+///
+/// The store-side and transport-side `Error` types are intentionally allowed to differ —
+/// transport-layer errors (tar parsing, gzip framing, path-traversal rejection) have a
+/// different shape than store-layer errors (filesystem / database faults), and pinning
+/// them together would force one surface to absorb the other's variants. See
+/// [`MerkleTransport`] for more detail.
+pub trait TransportableMerkleStore: MerkleStore + MerkleTransport {}
+
+/// Any type that implements both [`MerkleStore`] and [`MerkleTransport`] is automatically
+/// a [`TransportableMerkleStore`].
+impl<T> TransportableMerkleStore for T where T: MerkleStore + MerkleTransport {}

--- a/crates/lib/src/model/merkle_tree/merkle_transport.rs
+++ b/crates/lib/src/model/merkle_tree/merkle_transport.rs
@@ -1,0 +1,131 @@
+use std::collections::HashSet;
+use std::io::{Read, Write};
+
+use crate::error::IntoOxenError;
+use crate::model::MerkleHash;
+
+/// Wire-format selector for [`MerklePacker::pack_nodes`].
+///
+/// Two on-the-wire tar-gz layouts have coexisted as long as the merkle transport has
+/// existed. Each call site must pick the variant that matches the peer it's writing
+/// to; the trait makes no claim that a single canonical format exists.
+///
+/// **No `Default` impl on purpose.** Picking a wire format is a protocol decision and
+/// must be made explicitly at every call site. **No `#[non_exhaustive]` on purpose.**
+/// Adding a future variant should be a deliberate breaking change that surfaces at
+/// every match arm — compile errors are the forcing function.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PackOptions {
+    /// Entries appear under `tree/nodes/{prefix}/{suffix}/...`. Compressed with
+    /// [`flate2::Compression::fast`]. Used by all `repositories::tree::compress_*`
+    /// helpers — the bytes any server download endpoint emits.
+    ///
+    /// [`flate2::Compression::fast`]: https://docs.rs/flate2/latest/flate2/struct.Compression.html#method.fast
+    ServerCanonical,
+    /// Entries appear under `{prefix}/{suffix}/...` with no `tree/nodes/` prefix.
+    /// Compressed with [`flate2::Compression::default`]. Required by
+    /// [`api::client::tree::create_nodes`] so older `oxen-server` deployments
+    /// (which pre-pend `tree/nodes/` server-side at install time) install entries at
+    /// the right paths.
+    ///
+    /// [`flate2::Compression::default`]: https://docs.rs/flate2/latest/flate2/struct.Compression.html#method.default
+    /// [`api::client::tree::create_nodes`]: crate::api::client::tree::create_nodes
+    LegacyClientPush,
+}
+
+/// Per-call extraction policy for [`MerkleUnpacker::unpack`].
+///
+/// **No `Default` impl on purpose.** The choice between overwriting and skipping is
+/// path-dependent and must be made explicitly at every call site. **No
+/// `#[non_exhaustive]` on purpose** for the same reason as [`PackOptions`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum UnpackOptions {
+    /// Overwrite files that already exist on disk. Matches `main`'s
+    /// `util::fs::unpack_async_tar_archive` — the client download path's behaviour.
+    Overwrite,
+    /// Skip files that already exist on disk. Matches `main`'s
+    /// `repositories::tree::unpack_nodes` — the server-side upload-consumer path.
+    SkipExisting,
+}
+
+/// Produce transport-ready bytes from some subset (or all) of the backend's Merkle tree nodes.
+///
+/// Writes a tar-gz wire stream directly into the caller-provided sink. No buffer is
+/// materialized inside the trait, so memory use is O(compressor window). Callers can
+/// plug in HTTP response bodies, pipes, files, or in-memory `Vec<u8>` sinks as the writer.
+pub trait MerklePacker: Send + Sync {
+    /// Native backend error. Must be convertible into an [`OxenError`] via [`IntoOxenError`]
+    /// so callers returning [`OxenError`] can use `?` directly.
+    ///
+    /// [`OxenError`]: crate::error::OxenError
+    type Error: std::error::Error + IntoOxenError;
+
+    /// Pack the given node `hashes` into `out` as a tar-gz stream, in the layout
+    /// selected by `opts`.
+    ///
+    /// Hashes not present in the store are silently skipped, and an empty `hashes`
+    /// produces a valid but empty tarball. See [`PackOptions`] for the per-variant
+    /// wire-format details.
+    fn pack_nodes<W: Write>(
+        &self,
+        hashes: &HashSet<MerkleHash>,
+        opts: PackOptions,
+        out: W,
+    ) -> Result<(), Self::Error>;
+
+    /// Pack every node the backend currently holds into `out` as a tar-gz stream.
+    ///
+    /// Single-format: only the server-canonical layout has ever been emitted for a
+    /// whole-tree pack on `main`. There is no legacy whole-tree variant, so this
+    /// method does not accept [`PackOptions`].
+    fn pack_all<W: Write>(&self, out: W) -> Result<(), Self::Error>;
+}
+
+/// Consume transport bytes and install the nodes they contain into the backend.
+///
+/// Reads the tar-gz wire format incrementally from `reader`. Nothing buffers the full
+/// payload inside the trait. Async callers bridge a `Stream<Item = Bytes>` to a sync
+/// [`Read`] via [`tokio_util::io::SyncIoBridge`] inside a [`tokio::task::spawn_blocking`].
+pub trait MerkleUnpacker: Send + Sync {
+    /// Native backend error. Must be convertible into an [`OxenError`] via [`IntoOxenError`]
+    /// so callers returning [`OxenError`] can use `?` directly.
+    ///
+    /// [`OxenError`]: crate::error::OxenError
+    type Error: std::error::Error + IntoOxenError;
+
+    /// Unpack the tar-gz stream from `reader` into the store, applying the existing-file
+    /// policy in `opts`.
+    ///
+    /// Returns the set of hashes parsed from the tarball (not necessarily only those
+    /// newly installed — entries skipped per [`UnpackOptions::SkipExisting`] still appear
+    /// in the result, matching `main`'s `repositories::tree::unpack_nodes` behaviour).
+    fn unpack<R: Read>(
+        &self,
+        reader: R,
+        opts: UnpackOptions,
+    ) -> Result<HashSet<MerkleHash>, Self::Error>;
+}
+
+/// Marker super-trait: a backend that can both pack and unpack with a single error type.
+///
+/// Note: [`MerkleTransport`]'s shared error type is intentionally **separate** from any
+/// store-side error type (e.g. on a [`MerkleStore`]-also implementor). Transport errors
+/// (tar parse, gzip, path traversal) and store errors (RocksDB / filesystem layout)
+/// have different shapes and decoupling them lets each surface report what it knows
+/// without leaking unrelated variants. See the
+/// `transport errors != merkle store errors` discussion in the merkle-tree refactor
+/// branch for the historical motivation.
+///
+/// The blanket impl below makes any type that implements [`MerklePacker`] and
+/// [`MerkleUnpacker`] with matching error types automatically a [`MerkleTransport`].
+///
+/// [`MerkleStore`]: crate::model::merkle_tree::MerkleStore
+pub trait MerkleTransport:
+    MerklePacker + MerkleUnpacker<Error = <Self as MerklePacker>::Error>
+{
+}
+
+impl<T> MerkleTransport for T where
+    T: MerklePacker + MerkleUnpacker<Error = <T as MerklePacker>::Error>
+{
+}


### PR DESCRIPTION
Adds new traits for defining how `MerkleStore`s can encode Merkle tree
nodes to send and receive between the `oxen-cli` client and `oxen-server`.
The `MerklePacker` trait collects a subset of nodes and allows a writer to
encode them.

The `MerkleUnpacker` trait uses a provided reader to decode Merkle tree
nodes and update the underlying physical store. Provided that they have the
same `Error` type, combining these two traits is a `MerkleTransport`. A
blanket `impl` for any such unified traits is included here too.

Also defines a `TransportableMerkleStore`, which is a `MerkleStore` + a
`MerkleTransport`. A blanket impl. is provided to unify, so long as the
type's implementation's `Error`s are all the same.