### PR TITLE
Refactor oxen's Merkle tree operations: use MerkleStore

### DIFF
--- a/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 use super::Migrate;
 
 use crate::config::RepositoryConfig;
-use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::merkle_tree_node_cache;
+use crate::model::merkle_tree::merkle_writer::MerkleWriteSession;
 use crate::model::merkle_tree::node::vnode::VNodeOpts;
 use crate::model::merkle_tree::node::{
     CommitNode, DirNode, EMerkleTreeNode, MerkleTreeNode, VNode,
@@ -135,14 +135,27 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
     dir_node_opts.num_entries = num_children as u64;
     let dir_node = DirNode::new(&new_repo, dir_node_opts)?;
 
-    // Write a new commit db
+    // Write a new commit node via a session on the old repo.
     let commit_node = CommitNode::from_commit(commit.clone());
-    let mut root_commit_db =
-        MerkleNodeDB::open_read_write(&old_repo.path, &commit_node, root_node.parent_id)?;
-    root_commit_db.add_child(&dir_node)?;
+    let old_store = old_repo.merkle_store();
+    let new_store = new_repo.merkle_store();
+    let old_session = old_store.begin()?;
+    let new_session = new_store.begin()?;
+    let mut root_commit_ns = old_session.create_node(&commit_node, root_node.parent_id)?;
+    root_commit_ns.add_child(&dir_node)?;
+    root_commit_ns.finish()?;
 
     let current_path = Path::new("");
-    rewrite_nodes(&old_repo, &new_repo, &root_node, current_path)?;
+    rewrite_nodes(
+        &old_repo,
+        &new_repo,
+        &*old_session,
+        &*new_session,
+        &root_node,
+        current_path,
+    )?;
+    new_session.finish()?;
+    old_session.finish()?;
 
     // println!("new tree for commit {}", commit);
     // repositories::tree::print_tree(&new_repo, commit)?;
@@ -158,9 +171,12 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
 
 // Forgive me if you are reading this for reference, we don't have great writers for the
 // merkle tree yet - so there is a lot of duplicate logic with `commit_writer.rs`
+#[allow(clippy::too_many_arguments)]
 fn rewrite_nodes(
     old_repo: &LocalRepository,
     new_repo: &LocalRepository,
+    old_session: &dyn MerkleWriteSession,
+    new_session: &dyn MerkleWriteSession,
     node: &MerkleTreeNode,
     current_dir: &Path,
 ) -> Result<(), OxenError> {
@@ -169,18 +185,9 @@ fn rewrite_nodes(
             EMerkleTreeNode::Directory(dir) => {
                 // Load all the children of children (files and folders)
                 // Then redistribute into buckets...
-                // and then just use the MerkleNodeDB to write the nodes
-                // to the new tree
+                // and then just use the session to write the nodes to the new tree
                 let dir_children = repositories::tree::list_files_and_folders(child)?;
                 let current_dir = current_dir.join(dir.name());
-
-                // log::debug!(
-                //     "rewrite_nodes {} children on current_dir {:?} DIRECTORY {} {}",
-                //     dir_children.len(),
-                //     current_dir,
-                //     dir.hash(),
-                //     dir
-                // );
 
                 let total_children = dir_children.len();
                 let vnode_size = old_repo.vnode_size();
@@ -190,16 +197,15 @@ fn rewrite_nodes(
                 let mut dir_node_opts = dir.get_opts();
                 dir_node_opts.num_entries = total_children as u64;
                 let dir = DirNode::new(new_repo, dir_node_opts)?;
-                let mut dir_db =
-                    MerkleNodeDB::open_read_write(&old_repo.path, &dir, node.parent_id)?;
+                let mut dir_ns = old_session.create_node(&dir, node.parent_id)?;
 
-                // log::debug!(
-                //     "rewrite_nodes {} VNodes for {} children in {} with vnode size {}",
-                //     num_vnodes,
-                //     total_children,
-                //     dir,
-                //     vnode_size
-                // );
+                log::trace!(
+                    "rewrite_nodes {} VNodes for {} children in {} with vnode size {}",
+                    num_vnodes,
+                    total_children,
+                    dir,
+                    vnode_size
+                );
 
                 // Compute buckets
                 let mut buckets: Vec<Vec<MerkleTreeNode>> = vec![vec![]; num_vnodes as usize];
@@ -207,14 +213,14 @@ fn rewrite_nodes(
                     let path = current_dir.join(dir_child.maybe_path().unwrap());
                     let hash = hasher::hash_buffer_128bit(path.to_str().unwrap().as_bytes());
                     let bucket_idx = hash % num_vnodes;
-                    // log::debug!(
-                    //     "\trewrite_nodes dir_child {:?} bucket {} num_vnodes {} hash {} {}",
-                    //     path,
-                    //     bucket_idx,
-                    //     num_vnodes,
-                    //     hash,
-                    //     dir_child
-                    // );
+                    log::trace!(
+                        "\trewrite_nodes dir_child {:?} bucket {} num_vnodes {} hash {} {}",
+                        path,
+                        bucket_idx,
+                        num_vnodes,
+                        hash,
+                        dir_child
+                    );
                     buckets[bucket_idx as usize].push(dir_child);
                 }
 
@@ -243,54 +249,59 @@ fn rewrite_nodes(
                     vnodes.push((vnode_id, bucket.clone()));
                 }
 
-                // log::debug!("rewrite_nodes count vnodes: {}", vnodes.len());
+                log::trace!("rewrite_nodes count vnodes: {}", vnodes.len());
                 for (hash, entries) in vnodes.iter() {
-                    // create a new vnode obj and add the the db
+                    // create a new vnode obj and add to the dir session
                     let opts = VNodeOpts {
                         hash: *hash,
                         num_entries: entries.len() as u64,
                     };
                     let vnode_obj = VNode::new(new_repo, opts)?;
-                    // log::debug!("rewrite_nodes adding VNode to DirNode! {:?}", vnode_obj);
-                    dir_db.add_child(&vnode_obj)?;
+                    dir_ns.add_child(&vnode_obj)?;
 
-                    let mut vnode_db = MerkleNodeDB::open_read_write(
-                        &new_repo.path,
-                        &vnode_obj,
-                        Some(dir_db.node_id),
-                    )?;
+                    let dir_ns_id = *dir_ns.node_id();
+                    let mut vnode_ns = new_session.create_node(&vnode_obj, Some(dir_ns_id))?;
 
-                    // log::debug!("rewrite_nodes count entries {}", entries.len());
                     for entry in entries {
                         match &entry.node {
                             EMerkleTreeNode::File(f_node) => {
-                                // log::debug!("rewrite_nodes adding FileNode to VNode! {}", f_node);
-                                vnode_db.add_child(f_node)?;
+                                vnode_ns.add_child(f_node)?;
                             }
                             EMerkleTreeNode::Directory(d_node) => {
                                 let mut d_node_opts = d_node.get_opts();
                                 let d_children = repositories::tree::list_files_and_folders(entry)?;
                                 d_node_opts.num_entries = d_children.len() as u64;
-                                // log::debug!(
-                                //     "rewrite_nodes adding DirNode to VNode with {} num_entries {}",
-                                //     d_node_opts.num_entries,
-                                //     d_node
-                                // );
                                 let d_node = DirNode::new(new_repo, d_node_opts)?;
-                                vnode_db.add_child(&d_node)?;
+                                vnode_ns.add_child(&d_node)?;
                             }
                             _ => {
                                 panic!("Shouldn't reach here.")
                             }
                         }
                     }
+                    vnode_ns.finish()?;
                 }
+                dir_ns.finish()?;
 
-                rewrite_nodes(old_repo, new_repo, child, &current_dir)?;
+                rewrite_nodes(
+                    old_repo,
+                    new_repo,
+                    old_session,
+                    new_session,
+                    child,
+                    &current_dir,
+                )?;
             }
             EMerkleTreeNode::VNode(_) => {
                 // VNode just needs to traverse to the next dirnode
-                rewrite_nodes(old_repo, new_repo, child, current_dir)?;
+                rewrite_nodes(
+                    old_repo,
+                    new_repo,
+                    old_session,
+                    new_session,
+                    child,
+                    current_dir,
+                )?;
             }
             _ => {
                 // pass, FileNode was not changed, so it is on the latest version

--- a/crates/lib/src/core/db/merkle_node/file_backend.rs
+++ b/crates/lib/src/core/db/merkle_node/file_backend.rs
@@ -121,7 +121,7 @@ pub struct FileWriteSession<'repo> {
 /// not return a wrapped `MerkleDbError`.
 impl<'repo> MerkleWriteSession for FileWriteSession<'repo> {
     /// Creates a new session for writing a `node` and `children` file.
-    /// Calls [`MerkleNodeDB::open_read_write`] internally.
+    /// Returns a [`FileNodeSession`] that calls [`MerkleNodeDB::open_read_write`] internally.
     fn create_node<'a>(
         &'a self,
         node: &dyn TMerkleTreeNode,

--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -10,7 +10,6 @@ use time::OffsetDateTime;
 use crate::config::UserConfig;
 use crate::constants::COMMIT_COUNT_DIR;
 use crate::core::db::key_val::{opts, str_val_db};
-use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::refs::with_ref_manager;
 use crate::core::v_latest::index::CommitMerkleTree;
 use crate::error::OxenError;
@@ -290,10 +289,14 @@ pub fn create_empty_commit(
     )?;
 
     let parent_id = Some(existing_node.hash);
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &commit_node, parent_id)?;
+    let store = repo.merkle_store();
+    let session = store.begin()?;
+    let mut commit_ns = session.create_node(&commit_node, parent_id)?;
     // There should always be one child, the root directory
     let dir_node = existing_node.children.first().unwrap().dir()?;
-    commit_db.add_child(&dir_node)?;
+    commit_ns.add_child(&dir_node)?;
+    commit_ns.finish()?;
+    session.finish()?;
 
     // Copy the dir hashes db to the new commit
     repositories::tree::cp_dir_hashes_to(repo, &existing_commit_id, commit_node.hash())?;
@@ -369,9 +372,13 @@ pub fn create_initial_commit(
         },
     )?;
 
-    // Open the commit database and add the root directory
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &commit_node, None)?;
-    commit_db.add_child(&dir_node)?;
+    // Open the commit write session and add the root directory
+    let store = repo.merkle_store();
+    let session = store.begin()?;
+    let mut commit_ns = session.create_node(&commit_node, None)?;
+    commit_ns.add_child(&dir_node)?;
+    commit_ns.finish()?;
+    session.finish()?;
 
     // Initialize the dir_hash_db with the root directory hash
     let commit_id_string = commit_id.to_string();

--- a/crates/lib/src/core/v_latest/entries.rs
+++ b/crates/lib/src/core/v_latest/entries.rs
@@ -1,7 +1,7 @@
 use crate::core;
-use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::error::OxenError;
 use crate::model::entry::metadata_entry::WorkspaceMetadataEntry;
+use crate::model::merkle_tree::merkle_writer::{MerkleWriteSession, NodeWriteSession};
 use crate::model::merkle_tree::node::{DirNode, EMerkleTreeNode, FileNode, MerkleTreeNode};
 use crate::model::metadata::MetadataDir;
 use crate::model::metadata::generic_metadata::GenericMetadata;
@@ -14,6 +14,7 @@ use crate::repositories;
 use crate::util;
 use crate::view::PaginatedDirEntries;
 use crate::view::entries::{EMetadataEntry, ResourceVersion};
+use std::any::type_name_of_val;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -545,15 +546,18 @@ pub fn update_metadata(repo: &LocalRepository, revision: impl AsRef<str>) -> Res
     // Initialize data structures for aggregation
     let mut num_bytes = 0;
 
-    // Start the recursive traversal
-    traverse_and_update_sizes_and_counts(repo, &mut node, &mut num_bytes)?;
+    // One merkle write session covers every node written during the traversal.
+    let store = repo.merkle_store();
+    let session = store.begin()?;
+    traverse_and_update_sizes_and_counts(&*session, &mut node, &mut num_bytes)?;
+    session.finish()?;
 
     Ok(())
 }
 
 #[allow(clippy::type_complexity)]
 fn traverse_and_update_sizes_and_counts(
-    repo: &LocalRepository,
+    session: &dyn MerkleWriteSession,
     node: &mut MerkleTreeNode,
     num_bytes: &mut u64,
 ) -> Result<(HashMap<String, u64>, HashMap<String, u64>), OxenError> {
@@ -566,32 +570,33 @@ fn traverse_and_update_sizes_and_counts(
         EMerkleTreeNode::Commit(commit_node) => {
             log::debug!("Traversing node {commit_node:?}");
             process_children(
-                repo,
+                session,
                 children,
                 &mut local_counts,
                 &mut local_sizes,
                 num_bytes,
             )?;
-            let mut dir_db =
-                MerkleNodeDB::open_read_write(&repo.path, commit_node, node.parent_id)?;
-            add_children_to_db(&mut dir_db, &node.children)?;
+            let mut dir_ns = session.create_node(commit_node, node.parent_id)?;
+            add_children_to_session(&mut *dir_ns, &node.children)?;
+            dir_ns.finish()?;
         }
         EMerkleTreeNode::VNode(vnode) => {
             log::debug!("Traversing vnode {vnode:?}");
             process_children(
-                repo,
+                session,
                 children,
                 &mut local_counts,
                 &mut local_sizes,
                 num_bytes,
             )?;
-            let mut dir_db = MerkleNodeDB::open_read_write(&repo.path, vnode, node.parent_id)?;
-            add_children_to_db(&mut dir_db, &node.children)?;
+            let mut dir_ns = session.create_node(vnode, node.parent_id)?;
+            add_children_to_session(&mut *dir_ns, &node.children)?;
+            dir_ns.finish()?;
         }
         EMerkleTreeNode::Directory(dir_node) => {
             log::debug!("No need to aggregate dir {}", dir_node.name());
             process_children(
-                repo,
+                session,
                 children,
                 &mut local_counts,
                 &mut local_sizes,
@@ -599,8 +604,9 @@ fn traverse_and_update_sizes_and_counts(
             )?;
             dir_node.set_data_type_counts(local_counts.clone());
             dir_node.set_data_type_sizes(local_sizes.clone());
-            let mut dir_db = MerkleNodeDB::open_read_write(&repo.path, dir_node, node.parent_id)?;
-            add_children_to_db(&mut dir_db, &node.children)?;
+            let mut dir_ns = session.create_node(dir_node, node.parent_id)?;
+            add_children_to_session(&mut *dir_ns, &node.children)?;
+            dir_ns.finish()?;
         }
         EMerkleTreeNode::File(file_node) => {
             log::debug!(
@@ -617,6 +623,7 @@ fn traverse_and_update_sizes_and_counts(
                 .or_insert(0) += file_node.num_bytes();
         }
         _ => {
+            // TODO: change to a structured error variant
             return Err(OxenError::basic_str(format!(
                 "compute_dir_node found unexpected node type: {:?}",
                 node.node
@@ -628,7 +635,7 @@ fn traverse_and_update_sizes_and_counts(
 }
 
 fn process_children(
-    repo: &LocalRepository,
+    session: &dyn MerkleWriteSession,
     children: &mut [MerkleTreeNode],
     local_counts: &mut HashMap<String, u64>,
     local_sizes: &mut HashMap<String, u64>,
@@ -636,7 +643,7 @@ fn process_children(
 ) -> Result<(), OxenError> {
     for child in children.iter_mut() {
         let (child_counts, child_sizes) =
-            traverse_and_update_sizes_and_counts(repo, child, num_bytes)?;
+            traverse_and_update_sizes_and_counts(session, child, num_bytes)?;
         for (key, count) in child_counts {
             *local_counts.entry(key).or_insert(0) += count;
         }
@@ -647,26 +654,26 @@ fn process_children(
     Ok(())
 }
 
-fn add_children_to_db(
-    dir_db: &mut MerkleNodeDB,
+fn add_children_to_session(
+    ns: &mut dyn NodeWriteSession,
     children: &[MerkleTreeNode],
 ) -> Result<(), OxenError> {
     for child in children {
         match &child.node {
             EMerkleTreeNode::Commit(commit_node) => {
-                dir_db.add_child(commit_node)?;
+                ns.add_child(commit_node)?;
             }
             EMerkleTreeNode::Directory(dir_node) => {
-                dir_db.add_child(dir_node)?;
+                ns.add_child(dir_node)?;
             }
             EMerkleTreeNode::File(file_node) => {
-                dir_db.add_child(file_node)?;
+                ns.add_child(file_node)?;
             }
             EMerkleTreeNode::VNode(vnode) => {
-                dir_db.add_child(vnode)?;
+                ns.add_child(vnode)?;
             }
-            _ => {
-                return Err(OxenError::basic_str("Unsupported node type"));
+            n => {
+                return Err(OxenError::DisallowedNodeWrite(type_name_of_val(n)));
             }
         }
     }

--- a/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -6,12 +6,9 @@ use std::str;
 use crate::core::db::dir_hashes::dir_hashes_db::{
     dir_hash_db_path, dir_hash_db_path_from_commit_id, with_dir_hash_db_manager,
 };
-use crate::core::db::merkle_node::MerkleNodeDB;
 
-use crate::model::merkle_tree::node::EMerkleTreeNode;
-
-use crate::model::merkle_tree::node::FileNode;
 use crate::model::merkle_tree::node::MerkleTreeNode;
+use crate::model::merkle_tree::node::{EMerkleTreeNode, FileNode};
 
 use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository, MerkleHash, MerkleTreeNodeType, PartialNode};
@@ -207,7 +204,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashSet<MerkleHash>>,
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -232,7 +229,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashMap<(MerkleHash, MerkleTreeNodeType), PathBuf>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -258,7 +255,7 @@ impl CommitMerkleTree {
         partial_nodes: &mut HashMap<PathBuf, PartialNode>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -282,7 +279,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read depth {} node hash [{}]", depth, hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_store().exists(hash)? {
             log::debug!("read_depth merkle node db does not exist for hash: {hash}");
             return Ok(None);
         }
@@ -314,7 +311,7 @@ impl CommitMerkleTree {
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -343,7 +340,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -375,7 +372,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -1,7 +1,6 @@
 use crate::config::UserConfig;
 use crate::constants;
 use crate::core::db;
-use crate::core::db::merkle_node::MerkleNodeDB;
 pub use crate::core::merge::entry_merge_conflict_db_reader::EntryMergeConflictDBReader;
 pub use crate::core::merge::node_merge_conflict_db_reader::NodeMergeConflictDBReader;
 use crate::core::merge::node_merge_conflict_reader::NodeMergeConflictReader;
@@ -1084,7 +1083,7 @@ fn create_empty_merge_commit(
         },
     )?;
 
-    // Open the new commit's MerkleNodeDB and add base's existing root DirNode as the only child.
+    // Add base's existing root DirNode as the only child.
     // Tree is content-addressed, so the new commit's tree equals base's tree without any tree
     // rebuild or copy.
     let base_node = repositories::tree::get_node_by_id_with_children(repo, &base_commit_hash)?
@@ -1094,14 +1093,18 @@ fn create_empty_merge_commit(
                 merge_commits.base.id
             ))
         })?;
-    let mut commit_db =
-        MerkleNodeDB::open_read_write(&repo.path, &commit_node, Some(base_node.hash))?;
+
+    let merkle_store = repo.merkle_store();
+    let session = merkle_store.begin()?;
+    let mut ns = session.create_node(&commit_node, Some(base_node.hash))?;
     let root_dir = base_node
         .children
         .first()
         .expect("base commit must have a root dir as its first child")
         .dir()?;
-    commit_db.add_child(&root_dir)?;
+    ns.add_child(&root_dir)?;
+    ns.finish()?;
+    session.finish()?;
 
     // Copy base's path -> dir hash mapping so path-based tree lookups work for the new commit.
     repositories::tree::cp_dir_hashes_to(repo, &base_commit_hash, commit_node.hash())?;

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -19,6 +19,7 @@ use crate::model::ParsedResource;
 use crate::model::RepoNew;
 use crate::model::Schema;
 use crate::model::Workspace;
+use crate::model::merkle_tree::merkle_hash::HexHash;
 use crate::model::merkle_tree::node_type::InvalidMerkleTreeNodeType;
 
 pub mod path_buf_error;
@@ -174,7 +175,12 @@ pub enum OxenError {
     #[error("Invalid version: {0}")]
     InvalidVersion(StringError),
 
+    //
     // Version Store
+    //
+    #[error("Version store not initialized")]
+    VersionStoreNotInitialized,
+
     /// An error uploading a file to the version store
     #[error("{0}")]
     Upload(StringError),
@@ -237,6 +243,15 @@ pub enum OxenError {
     // Attempting to make a commit with no changes from its parent is an error.
     #[error("No changes to commit")]
     NoChanges,
+
+    #[error("No such commit, dir, or vnode Merkle tree node with hash (hex): {0}")]
+    MerkleNodeNotFound(HexHash),
+
+    #[error(
+        "Unsupported node type adding to a child file. Only accept Commit, Directory, File, or VNode. Found: {0}"
+    )]
+    /// Contains the name of the incompatible type as reported by [`std::any::type_name_of_val`].
+    DisallowedNodeWrite(&'static str),
 
     //
     // Schema (dataframes)

--- a/crates/lib/src/model/merkle_tree/merkle_hash.rs
+++ b/crates/lib/src/model/merkle_tree/merkle_hash.rs
@@ -111,7 +111,7 @@ serde_with::serde_conv!(
 ///
 /// Is a zero-sized struct around an owned `String`. Can only be created from a [`MerkleHash`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct HexHash(String);
+pub struct HexHash(String);
 
 impl HexHash {
     #[inline(always)]
@@ -122,7 +122,7 @@ impl HexHash {
     /// Produces a relative path for the 2-level directory structure used to store Merkle nodes.
     /// The first directory name is the first 3 characters of the hex-encoded hash. The second
     /// is the remaining characters.
-    pub fn node_db_prefix(&self) -> PathBuf {
+    pub(crate) fn node_db_prefix(&self) -> PathBuf {
         let hash_str = &self.0;
         const DIR_PREFIX_LEN: usize = 3;
         let dir_prefix = hash_str.chars().take(DIR_PREFIX_LEN).collect::<String>();

--- a/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use super::*;
-use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::error::OxenError;
+use crate::model::merkle_tree::merkle_reader::MerkleEntry;
 use crate::model::{LocalRepository, MerkleHash, MerkleTreeNodeType};
 
 use serde::{Deserialize, Serialize};
@@ -41,11 +41,13 @@ impl MerkleTreeNode {
 
     /// Private implementation that loads from disk without caching
     fn from_hash_uncached(repo: &LocalRepository, hash: &MerkleHash) -> Result<Self, OxenError> {
-        let node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
-        let parent_id = node_db.parent_id;
+        let MerkleEntry { node, parent_id } = repo
+            .merkle_store()
+            .get_node(hash)?
+            .ok_or_else(|| OxenError::MerkleNodeNotFound(hash.to_hex_hash()))?;
         Ok(MerkleTreeNode {
             hash: *hash,
-            node: node_db.node()?,
+            node,
             parent_id,
             children: Vec::new(),
         })
@@ -74,13 +76,15 @@ impl MerkleTreeNode {
         repo: &LocalRepository,
         hash: &MerkleHash,
     ) -> Result<Vec<(MerkleHash, MerkleTreeNode)>, OxenError> {
-        let Ok(mut node_db) = MerkleNodeDB::open_read_only(&repo.path, hash) else {
-            // We don't return an error here because there are some situations where we won't have all the node files.
-            // For example, when working in a subtree clone.
-            log::warn!("no child node db: {hash:?}");
+        let store = repo.merkle_store();
+        // We don't return an error here because there are some situations where we won't have
+        // all of the node files. For example, when working in a subtree clone.
+        // However, parse/IO errors from an existing node DO still propagate.
+        if !store.exists(hash)? {
+            log::error!("[assuming no children] no child node db for {hash}");
             return Ok(Vec::new());
-        };
-        Ok(node_db.map()?)
+        }
+        repo.merkle_store().get_children(hash)
     }
 
     /// Check if the node is a leaf node (i.e. it has no children)

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -1,8 +1,10 @@
 use crate::config::RepositoryConfig;
 use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
+use crate::core::db::merkle_node::file_backend::FileBackend;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
+use crate::model::merkle_tree::MerkleStore;
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::{MetadataEntry, Remote, RemoteRepository};
 use crate::storage::{NoopVersionStore, StorageConfig, VersionStore, create_version_store};
@@ -32,6 +34,10 @@ fn placeholder_version_store() -> Arc<dyn VersionStore> {
     Arc::new(NoopVersionStore)
 }
 
+// TODO: A `LocalRepository` shouldn't require serialization.
+// TODO: The `merkle}store` fields should **NOT** be Option. It should be impossible to create a
+//       `LocalRepository` without a `version_store` and `merkle_store`. They're only `Option` beacuse of
+//       the serialization derives, which is unused.
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct LocalRepository {
     #[schema(value_type = String)]
@@ -73,14 +79,14 @@ pub struct LocalRepositoryWithEntries {
 impl LocalRepository {
     /// Create a LocalRepository from a directory
     pub fn from_dir(path: impl AsRef<Path>) -> Result<Self, OxenError> {
-        let path = path.as_ref().to_path_buf();
-        let config_path = util::fs::config_filepath(&path);
+        let path = path.as_ref();
+        let config_path = util::fs::config_filepath(path);
         let config = RepositoryConfig::from_file(&config_path)?;
 
         let storage_config = config.storage.unwrap_or_default();
-        let version_store = create_version_store(&path, &storage_config)?;
+        let version_store = create_version_store(path, &storage_config)?;
         Ok(LocalRepository {
-            path,
+            path: path.to_path_buf(),
             remote_name: config.remote_name,
             min_version: config.min_version,
             remotes: config.remotes,
@@ -99,6 +105,30 @@ impl LocalRepository {
     /// Get a reference to the storage configuration this repository was constructed with.
     pub fn storage_config(&self) -> &StorageConfig {
         &self.storage_config
+    }
+
+    /// Loads the Merkle store for the repository at the specified root path.
+    // NOTE: When new backends (e.g. LMDB) are added, branch on the appropriate config
+    // here and return a `Box::new(<that new backend>)`.
+    #[inline]
+    fn load_merkle_store(repo_path: PathBuf) -> Box<dyn MerkleStore> {
+        // TODO: Add reading config to select Merkle store implementation that
+        //       the repository uses.
+        //       => Right now, the only option is the FileBackend.
+        Box::new(FileBackend { repo_path })
+    }
+
+    /// Obtain the Merkle tree store for this repository.
+    ///
+    /// All operations with the repository's Merkle tree store **MUST** go through its
+    /// `MerkleStore` implementation.
+    ///
+    /// Returns a boxed trait object so the trait surface stays simple and dyn-dispatch
+    /// handles backend selection. Callers use it purely through the trait surface
+    /// (read, write); backend selection is an implementation detail of this method.
+    pub fn merkle_store(&self) -> Box<dyn MerkleStore> {
+        // **self.merkle_store
+        Self::load_merkle_store(self.path.clone())
     }
 
     /// Get a reference to the version store.

--- a/crates/lib/src/opts/storage_opts.rs
+++ b/crates/lib/src/opts/storage_opts.rs
@@ -1,0 +1,133 @@
+use crate::error::OxenError;
+use crate::opts::{LocalStorageOpts, S3Opts};
+use crate::storage::StorageConfig;
+use crate::{constants, util};
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use utoipa::ToSchema;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]
+pub struct StorageOpts {
+    pub kind: String,
+    pub local_storage_opts: Option<LocalStorageOpts>,
+    pub s3_opts: Option<S3Opts>,
+}
+
+impl StorageOpts {
+    pub fn from_repo_config(
+        repo_path: &Path,
+        config: &StorageConfig,
+    ) -> Result<StorageOpts, OxenError> {
+        match config.kind.as_str() {
+            "local" => {
+                // Take the version store path from the config if specified
+                // Otherwise, default to the repo hidden dir
+                let version_path = if let Some(path) = &config.versions_path {
+                    path.clone()
+                } else {
+                    util::fs::oxen_hidden_dir(repo_path)
+                        .join(constants::VERSIONS_DIR)
+                        .join(constants::FILES_DIR)
+                };
+
+                let local_storage_opts = LocalStorageOpts {
+                    path: Some(version_path),
+                };
+
+                Ok(StorageOpts {
+                    kind: "local".to_string(),
+                    local_storage_opts: Some(local_storage_opts),
+                    s3_opts: None,
+                })
+            }
+            "s3" => Err(OxenError::basic_str(
+                "S3 storage backend cannot be configured via repo config; use server-side configuration",
+            )),
+            _ => Err(OxenError::basic_str(format!(
+                "Unsupported async storage type: {}",
+                config.kind
+            ))),
+        }
+    }
+
+    pub fn from_path(path: &Path, is_repo_dir: bool) -> StorageOpts {
+        let version_path = if is_repo_dir {
+            let repo_path = util::fs::oxen_hidden_dir(path);
+
+            repo_path
+                .join(constants::VERSIONS_DIR)
+                .join(constants::FILES_DIR)
+        } else {
+            path.to_path_buf()
+        };
+
+        let local_storage_opts = LocalStorageOpts {
+            path: Some(version_path),
+        };
+
+        StorageOpts {
+            kind: "local".to_string(),
+            local_storage_opts: Some(local_storage_opts),
+            s3_opts: None,
+        }
+    }
+
+    pub fn from_args(
+        storage_backend: Option<String>,
+        storage_backend_path: Option<String>,
+        storage_backend_bucket: Option<String>,
+    ) -> Result<Option<StorageOpts>, OxenError> {
+        // parse storage backend options
+        if let Some(backend) = storage_backend {
+            match backend.as_str() {
+                "local" => {
+                    if storage_backend_bucket.is_some() {
+                        return Err(OxenError::basic_str(
+                            "Error: storage-backend-bucket should not be set when storage-backend is local",
+                        ));
+                    }
+                    if let Some(storage_path) = storage_backend_path {
+                        let local_storage_opts = Some(LocalStorageOpts {
+                            path: Some(PathBuf::from(storage_path)),
+                        });
+                        Ok(Some(StorageOpts {
+                            kind: "local".to_string(),
+                            local_storage_opts,
+                            s3_opts: None,
+                        }))
+                    } else {
+                        Ok(None)
+                    }
+                }
+                "s3" => {
+                    let bucket = storage_backend_bucket.ok_or_else(|| {
+                        OxenError::basic_str(
+                            "storage-backend-bucket is required when storage-backend is s3",
+                        )
+                    })?;
+
+                    let prefix = storage_backend_path.ok_or_else(|| {
+                        OxenError::basic_str(
+                            "storage-backend-path is required when storage-backend is s3",
+                        )
+                    })?;
+
+                    Ok(Some(StorageOpts {
+                        kind: "s3".to_string(),
+                        local_storage_opts: None,
+                        s3_opts: Some(S3Opts {
+                            bucket: bucket.clone(),
+                            prefix: Some(prefix.clone()),
+                        }),
+                    }))
+                }
+                _ => Err(OxenError::basic_str(
+                    "storage-backend can only be local or s3",
+                )),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -17,7 +17,6 @@ use crate::constants::ORIG_HEAD_FILE;
 use crate::constants::{HEAD_FILE, STAGED_DIR};
 use crate::core::db;
 use crate::core::db::key_val::str_val_db;
-use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::refs::with_ref_manager;
 use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_latest::status;
@@ -33,6 +32,7 @@ use crate::model::merkle_tree::node::commit_node::CommitNodeOpts;
 use crate::model::merkle_tree::node::dir_node::DirNodeOpts;
 use crate::model::merkle_tree::node::vnode::VNodeOpts;
 use crate::model::{Commit, LocalRepository, StagedEntryStatus};
+use crate::repositories::merkle_tree::merkle_writer::{MerkleWriteSession, NodeWriteSession};
 
 use crate::util::hasher;
 use crate::util::progress_bar::FinishOnDropProgressBar;
@@ -269,15 +269,20 @@ pub(crate) fn commit_dir_entries_with_parents(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, parent_id)?;
+    let store = repo.merkle_store();
+    let session = store.begin()?;
+    let mut commit_ns = session.create_node(&node, parent_id)?;
     write_commit_entries(
         repo,
         commit_id,
-        &mut commit_db,
+        &*session,
+        &mut *commit_ns,
         &dir_hash_db,
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_ns.finish()?;
+    session.finish()?;
 
     Ok(node.to_commit())
 }
@@ -362,16 +367,21 @@ pub fn commit_dir_entries_new(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, parent_id)?;
+    let store = repo.merkle_store();
+    let session = store.begin()?;
+    let mut commit_ns = session.create_node(&node, parent_id)?;
 
     write_commit_entries(
         repo,
         commit_id,
-        &mut commit_db,
+        &*session,
+        &mut *commit_ns,
         &dir_hash_db,
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_ns.finish()?;
+    session.finish()?;
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
@@ -473,15 +483,20 @@ pub fn commit_dir_entries(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, None)?;
+    let store = repo.merkle_store();
+    let session = store.begin()?;
+    let mut commit_ns = session.create_node(&node, None)?;
     write_commit_entries(
         repo,
         commit_id,
-        &mut commit_db,
+        &*session,
+        &mut *commit_ns,
         &dir_hash_db,
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_ns.finish()?;
+    session.finish()?;
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
@@ -758,10 +773,12 @@ pub fn compute_commit_id(new_commit: &NewCommit) -> Result<MerkleHash, OxenError
     Ok(MerkleHash::new(hasher.digest128()))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_commit_entries(
     repo: &LocalRepository,
     commit_id: MerkleHash,
-    commit_db: &mut MerkleNodeDB,
+    session: &dyn MerkleWriteSession,
+    commit_ns: &mut dyn NodeWriteSession,
     dir_hash_db: &DBWithThreadMode<SingleThreaded>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     entries: &HashMap<PathBuf, (Vec<EntryVNode>, Vec<StagedMerkleTreeNode>)>,
@@ -770,7 +787,7 @@ fn write_commit_entries(
     let mut total_written = 0;
     let root_path = PathBuf::from("");
     let dir_node = compute_dir_node(repo, commit_id, entries, dir_hashes, &root_path)?;
-    commit_db.add_child(&dir_node)?;
+    commit_ns.add_child(&dir_node)?;
     total_written += 1;
 
     str_val_db::put(
@@ -778,17 +795,19 @@ fn write_commit_entries(
         root_path.to_str().unwrap(),
         &dir_node.hash().to_string(),
     )?;
-    let dir_db = MerkleNodeDB::open_read_write(&repo.path, &dir_node, Some(commit_id))?;
+    let mut dir_ns = session.create_node(&dir_node, Some(commit_id))?;
     r_create_dir_node(
         repo,
+        session,
         commit_id,
-        &mut Some(dir_db),
+        Some(&mut *dir_ns),
         dir_hash_db,
         dir_hashes,
         entries,
         root_path,
         &mut total_written,
     )?;
+    dir_ns.finish()?;
 
     // The dir_hash_db was pre-populated from the previous commit, so
     // removed directories still have stale entries that must be deleted;
@@ -823,8 +842,9 @@ fn cache_invalidate_dir_hash_db<'a>(
 #[allow(clippy::too_many_arguments)]
 fn r_create_dir_node(
     repo: &LocalRepository,
+    session: &dyn MerkleWriteSession,
     commit_id: MerkleHash,
-    maybe_dir_db: &mut Option<MerkleNodeDB>,
+    mut maybe_parent_ns: Option<&mut dyn NodeWriteSession>,
     dir_hash_db: &DBWithThreadMode<SingleThreaded>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     entries: &HashMap<PathBuf, (Vec<EntryVNode>, Vec<StagedMerkleTreeNode>)>,
@@ -848,75 +868,62 @@ fn r_create_dir_node(
             num_entries: vnode.entries.len() as u64,
         };
         let vnode_obj = VNode::new(repo, opts)?;
-        if let Some(dir_db) = maybe_dir_db {
-            dir_db.add_child(&vnode_obj)?;
+        // Capture the parent's hash before we reborrow `maybe_parent_ns` mutably.
+        let parent_id_for_vnode = maybe_parent_ns.as_deref().map(|ns| *ns.node_id());
+        if let Some(parent_ns) = maybe_parent_ns.as_deref_mut() {
+            parent_ns.add_child(&vnode_obj)?;
             *total_written += 1;
         }
 
-        // log::debug!(
-        //     "Processing vnode {} with {} entries",
-        //     vnode.id,
-        //     vnode.entries.len()
-        // );
+        log::debug!(
+            "Processing vnode {} with {} entries",
+            vnode.id,
+            vnode.entries.len()
+        );
 
-        let mut vnode_db = MerkleNodeDB::open_read_write(
-            &repo.path,
-            &vnode_obj,
-            maybe_dir_db.as_ref().map(|db| db.node_id),
-        )?;
+        let mut vnode_ns = session.create_node(&vnode_obj, parent_id_for_vnode)?;
         for entry in vnode.entries.iter() {
-            // log::debug!("Processing entry {} in vnode {}", entry.node, vnode.id);
+            log::trace!("Processing entry {} in vnode {}", entry.node, vnode.id);
             match &entry.node.node {
                 EMerkleTreeNode::Directory(node) => {
                     // If the dir has updates, we need a new dir db
                     let dir_path = entry.node.maybe_path()?;
-                    // log::debug!("Processing dir node {:?}", dir_path);
                     let dir_node = if entries.contains_key(&dir_path) {
                         let dir_node =
                             compute_dir_node(repo, commit_id, entries, dir_hashes, &dir_path)?;
 
-                        // if let Some(vnode_db) = &mut maybe_vnode_db {
-                        vnode_db.add_child(&dir_node)?;
+                        vnode_ns.add_child(&dir_node)?;
                         *total_written += 1;
-                        // }
 
-                        // if the vnode is new, we need a new dir db
-                        // let mut child_db = if maybe_vnode_db.is_some() {
-                        let mut child_db = Some(MerkleNodeDB::open_read_write(
-                            &repo.path,
-                            &dir_node,
-                            Some(vnode.id),
-                        )?);
-
+                        let mut child_ns = session.create_node(&dir_node, Some(vnode.id))?;
                         r_create_dir_node(
                             repo,
+                            session,
                             commit_id,
-                            &mut child_db,
+                            Some(&mut *child_ns),
                             dir_hash_db,
                             dir_hashes,
                             entries,
                             &dir_path,
                             total_written,
                         )?;
+                        child_ns.finish()?;
+
                         dir_node
                     } else {
-                        // log::debug!("r_create_dir_node skipping {:?}", dir_path);
                         // Look up the old dir node and reference it
                         let Some(old_dir_node) =
                             CommitMerkleTree::read_node(repo, node.hash(), false)?
                         else {
-                            // log::debug!(
-                            //     "r_create_dir_node could not read old dir node {:?}",
-                            //     node.hash
-                            // );
+                            log::trace!(
+                                "r_create_dir_node could not read old dir node {}",
+                                node.hash().to_hex_hash(),
+                            );
                             continue;
                         };
                         let dir_node = old_dir_node.dir()?;
-
-                        // if let Some(vnode_db) = &mut maybe_vnode_db {
-                        vnode_db.add_child(&dir_node)?;
+                        vnode_ns.add_child(&dir_node)?;
                         *total_written += 1;
-                        // }
                         dir_node
                     };
 
@@ -931,12 +938,12 @@ fn r_create_dir_node(
                     let file_path = PathBuf::from(&file_node.name());
                     let file_name = file_path.file_name().unwrap().to_str().unwrap();
 
-                    // log::debug!(
-                    //     "Processing file {:?} in vnode {} in commit {}",
-                    //     path,
-                    //     vnode.id,
-                    //     commit_id
-                    // );
+                    log::trace!(
+                        "Processing file {:?} in vnode {} in commit {}",
+                        path,
+                        vnode.id,
+                        commit_id.to_hex_hash(),
+                    );
 
                     // Just single file chunk for now
                     let chunks = vec![file_node.hash().to_u128()];
@@ -949,9 +956,8 @@ fn r_create_dir_node(
                     file_node.set_last_commit_id(&last_commit_id);
                     file_node.set_name(file_name);
 
-                    vnode_db.add_child(&file_node)?;
+                    vnode_ns.add_child(&file_node)?;
                     *total_written += 1;
-                    // }
                 }
                 _ => {
                     return Err(OxenError::basic_str(format!(
@@ -961,6 +967,7 @@ fn r_create_dir_node(
                 }
             }
         }
+        vnode_ns.finish()?;
     }
 
     log::debug!("Finished processing dir {path:?} total written {total_written} entries");

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -2,13 +2,13 @@ use bytesize::ByteSize;
 use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
+use std::any::type_name_of_val;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str;
 use tar::Archive;
 
 use crate::constants::{NODES_DIR, OXEN_HIDDEN_DIR, TREE_DIR};
-use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::db::merkle_node::merkle_node_db::node_db_path;
 use crate::core::node_sync_status;
 use crate::core::v_latest::index::CommitMerkleTree as CommitMerkleTreeLatest;
@@ -16,6 +16,7 @@ use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_old::v0_19_0::index::CommitMerkleTree as CommitMerkleTreeV0_19_0;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
+use crate::model::merkle_tree::merkle_writer::MerkleWriteSession;
 use crate::model::merkle_tree::node::{
     CommitNode, DirNodeWithPath, EMerkleTreeNode, FileNode, FileNodeWithDir, MerkleTreeNode,
 };
@@ -1017,12 +1018,16 @@ pub fn unpack_nodes(
 }
 
 /// Write a node to disk
+// TODO: this should just accept `&CommitNode`
 pub fn write_tree(repo: &LocalRepository, node: &MerkleTreeNode) -> Result<(), OxenError> {
     let EMerkleTreeNode::Commit(commit_node) = &node.node else {
         return Err(OxenError::basic_str("Expected commit node"));
     };
     let commit_node = CommitNode::new(repo, commit_node.get_opts())?;
-    p_write_tree(repo, node, &commit_node)?;
+    let store = repo.merkle_store();
+    let session = store.begin()?;
+    p_write_tree(&*session, node, &commit_node)?;
+    session.finish()?;
     Ok(())
 }
 
@@ -1030,35 +1035,33 @@ pub fn write_tree(repo: &LocalRepository, node: &MerkleTreeNode) -> Result<(), O
 ///
 /// Recursively writes the node and all its children to disk. To write a full tree, the node
 /// (`node_impl`) **MUST** be the root of the tree -- i.e. a `Commit` node.
-///
-/// [1] https://github.com/rust-lang/rust/issues/20041)
-fn p_write_tree<N: TMerkleTreeNode>(
-    repo: &LocalRepository,
+fn p_write_tree(
+    session: &dyn MerkleWriteSession,
     node: &MerkleTreeNode,
-    node_impl: &N,
+    node_impl: &dyn TMerkleTreeNode,
 ) -> Result<(), OxenError> {
     let parent_id = node.parent_id;
 
-    let mut db = MerkleNodeDB::open_read_write(&repo.path, node_impl, parent_id)?;
+    let mut ns = session.create_node(node_impl, parent_id)?;
     for child in &node.children {
         match &child.node {
             EMerkleTreeNode::VNode(vnode) => {
-                db.add_child(vnode)?;
-                p_write_tree(repo, child, vnode)?;
+                ns.add_child(vnode)?;
+                p_write_tree(session, child, vnode)?;
             }
             EMerkleTreeNode::Directory(dir_node) => {
-                db.add_child(dir_node)?;
-                p_write_tree(repo, child, dir_node)?;
+                ns.add_child(dir_node)?;
+                p_write_tree(session, child, dir_node)?;
             }
             EMerkleTreeNode::File(file_node) => {
-                db.add_child(file_node)?;
+                ns.add_child(file_node)?;
             }
-            node => {
-                panic!("p_write_tree Unexpected node type: {node:?}");
+            n => {
+                return Err(OxenError::DisallowedNodeWrite(type_name_of_val(n)));
             }
         }
     }
-    db.close()?;
+    ns.finish()?;
     Ok(())
 }
 

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -167,6 +167,7 @@ impl<'de> Deserialize<'de> for StorageConfig {
 /// Trait defining operations for version file storage backends
 #[async_trait]
 pub trait VersionStore: Debug + Send + Sync + 'static {
+    // + 'static {
     /// Initialize the storage backend
     async fn init(&self) -> Result<(), OxenError>;
 


### PR DESCRIPTION
**Refactor**
Change all reading & writing of Merkle tree nodes to use the new traits:
- Use `MerkleReader::exists` calls in `commit_merkle_tree.rs`
- Use `MerkleReader::get_{node,children}` in `merkle_tree_node.rs`
- Use `MerkleWriter`'s write sessions in:
    + `create_empty_commit` & `create_initial_commit` (`commits.rs`)
    + `update_metadata` (`entries.rs`)
    + `commit_dir_entires`, `write_commit_entires`, `r_create_dir_node` (`commit_writer.rs`)
    + `run_on_commit`, `rewrite_nodes` (migration `..add_child_counts_to_nodes.rs`)
    + `write_tree`, `p_write_tree` (`tree.rs`)

Access to a `MerkleStore` for these operations is provided via the `LocalRepository`.

**LocalRepository**
Adds method `LocalRepository::merkle_store() -> Box<dyn MerkleStore + '_>`. Provides the
repository's Merkle tree node storage implementation. The return type is dynamic: it
allows for selecting a compatible `MerkleStore` at runtime.

**`OxenError` Updates**
Converts 2 string errors into:
- `MerkleNodeNotFound(HexHash)`: no such commit/dir/vnode in lookup
- `DisallowedNodeWrite(std::any::type_name_of_val)`