### PR TITLE
Make PyPI Publish Size 84% smaller

### DIFF
--- a/.github/workflows/build_and_publish_test_pypi.yml
+++ b/.github/workflows/build_and_publish_test_pypi.yml
@@ -19,7 +19,9 @@ permissions:
 env:
   AWS_ROLE: arn:aws:iam::213020545630:role/github-runner-role
   AWS_REGION: us-west-1
-  PYTHON_VERSIONS: "3.14 3.13 3.12 3.11"
+  # The extension uses pyo3's stable abi3 ABI (abi3-py311), so we only need to build
+  # against the floor Python version — the resulting wheel works for 3.11+.
+  PYTHON_VERSIONS: "3.11"
 
 defaults:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ permissions:
 env:
   AWS_ROLE: arn:aws:iam::213020545630:role/github-runner-role
   AWS_REGION: us-west-1
-  PYTHON_VERSIONS: "3.14 3.13 3.12 3.11"
+  # The extension uses pyo3's stable abi3 ABI (abi3-py311), so we only need to build
+  # against the floor Python version — the resulting wheel works for 3.11+.
+  PYTHON_VERSIONS: "3.11"
 
 defaults:
   run:
@@ -183,9 +185,10 @@ jobs:
             The MacOS x86_64 (Intel) binaries require a minimum version of MacOS 10.13 High Sierra.
 
             🐍 Python Wheels
-            The Python wheels are available for the following platforms:
-            - Linux arm64 (Python ${{ env.PYTHON_VERSIONS }})
-            - Linux x86_64 (Python ${{ env.PYTHON_VERSIONS }})
-            - MacOS arm64 [Apple Silicon] (Python ${{ env.PYTHON_VERSIONS }})
-            - MacOS x86_64 [Intel] (Python ${{ env.PYTHON_VERSIONS }})
-            - Windows x86_64 (Python ${{ env.PYTHON_VERSIONS }})
+            The Python wheels are abi3 wheels built against Python 3.11 and compatible with
+            Python 3.11+. They are available for the following platforms:
+            - Linux arm64
+            - Linux x86_64
+            - MacOS arm64 [Apple Silicon]
+            - MacOS x86_64 [Intel]
+            - Windows x86_64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ parking_lot = "0.12.1"
 pathdiff = "0.2.3"
 percent-encoding = "2.1"
 polars = { version = "0.49.0", features = ["lazy", "parquet", "json", "ipc", "ipc_streaming", "dtype-full", "timezones", "random"] }
-pyo3 = { version = "0.25" }
+pyo3 = { version = "0.25", features = ["abi3-py311"] }
 pyo3-async-runtimes = { version = "0.25", features = ["attributes", "tokio-runtime"] }
 pyo3-polars = { version = "0.22", features = ["dtype-full"] }
 qsv-sniffer = "0.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,11 @@ debug-assertions = false
 [profile.release]
 codegen-units = 1
 lto = true
+opt-level = "s"
+strip = true
 
 [profile.profiling]
 inherits = "release"
 debug = true
+# Undo `strip = true` from `release` so debug info actually reaches the binary.
+strip = "none"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,7 +36,7 @@ Pushing the `v*` tag automatically triggers the **Release** workflow ([`release.
 - **Windows x86_64** ([`release_windows.yml`](.github/workflows/release_windows.yml)) — EC2 runner
 - **Docker arm64 and x86_64** ([`release_docker.yml`](.github/workflows/release_docker.yml)) — EC2 runners
 
-Python wheels for versions 3.11, 3.12, 3.13, and 3.14 are built as part of each platform job.
+Python wheels for versions 3.11+ are built as part of each platform job.
 
 When all builds finish, the workflow creates a **draft** GitHub Release named `Release {VERSION}` with all artifacts attached.
 


### PR DESCRIPTION
- Using `pyo3`'s `abi3` feature lets us compile one wheel per platform that supports Python 3.11+. That cuts down build size by 75% right off the top.
- Optimizing for compilation size and stripping release binaries of debug symbols reduces `oxen_py.abi3.so` from 114 MB to 69 MB (-39%), which reduces the final average wheel size from 41.8 MB to 27.5 MB (an additional -34%)

The two changes above reduce our total PyPI publish size per release from ~860 MB to ~138 MB. That's 84% (6.2x) smaller. 🎉 

[Published versions on PyPI](https://pypi.org/project/oxenai/#history) up through version `0.48.3` are "large".