### PR TITLE
--no-ramdisk for bin/test-rust

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -127,6 +127,7 @@ oxen push origin main               # Push to remote
 - When calling `get_staged_db_manager`, follow the doc comment on that function: drop the returned `StagedDBManager` as soon as possible (via a block scope or explicit `drop()`) to avoid holding the shared database handle longer than necessary.
 - When altering the `OxenError` enum, consider whether a hint needs to be added or updated in the `hint` method.
 - Instead of using `cargo test` to test Rust code, use the `bin/test-rust` script. The script usage is documented in a comment at the top of its file.
+- If the ram disk is not able to be mounted in `bin/test-rust`, then use the `--no-ramdisk` option.
 - The `bin/test-rust` script does not install prerequisites by default. If any dependencies turn out to be missing, prompt the user to run `bin/install-prereqs` (or re-run `bin/test-rust --install-deps`).
 - Prefer using inline code over creating a new function when the function would only be called once and the function body would be less than 15 lines.
 - Do not use "out parameters" (functions that take an `&mut Vec` / `&mut HashMap` / etc. for the callee to fill). Return the value directly instead. Exceptions: the user explicitly asks for an out parameter, or the caller genuinely needs to reuse a pre-allocated buffer across many calls to avoid allocation churn in a measured hot path.

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -2,13 +2,14 @@
 #
 # Build, configure, and run the Oxen test suite.
 #
-# Usage: test-rust [--ffmpeg] [--keep] [--install-deps] [-p|--python] [extra args...]
+# Usage: test-rust [--ffmpeg] [--keep] [--install-deps] [--no-ramdisk] [-p|--python] [extra args...]
 #
 #   --ffmpeg        Enable the "ffmpeg" cargo feature for build and test commands.
 #   --keep          Do not remove test data (in data/ox and data/test/runs) on cleanup — useful for
 #                   debugging failed tests.
 #   --install-deps  Check and install prerequisites (install-prereqs) before running tests.
 #                   By default, prereqs are not checked.
+#   --no-ramdisk    Skip ramdisk setup and run tests against the regular filesystem.
 #   -p|--python     Run the oxen-python test suite (via pytest) instead of the Rust test suite.
 #                   Builds the native extension with maturin.
 #   All remaining arguments are forwarded to `cargo nextest run` or `pytest` (with -p).
@@ -24,11 +25,13 @@ FEATURE_ARGS=""
 KEEP_DATA=false
 INSTALL_DEPS=false
 RUN_PYTHON=false
+USE_RAMDISK=true
 while true; do
     case "${1:-}" in
         --ffmpeg)        FEATURE_ARGS="-F ffmpeg"; shift ;;
         --keep)          KEEP_DATA=true; shift ;;
         --install-deps)  INSTALL_DEPS=true; shift ;;
+        --no-ramdisk)    USE_RAMDISK=false; shift ;;
         -p|--python)     RUN_PYTHON=true; shift ;;
         *) break ;;
     esac
@@ -113,8 +116,12 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Set up ramdisk for test data
-if ! setup_ramdisk; then
-    echo "==> Ramdisk setup failed, using regular filesystem."
+if [ "$USE_RAMDISK" = true ]; then
+    if ! setup_ramdisk; then
+        echo "==> Ramdisk setup failed, using regular filesystem."
+    fi
+else
+    echo "==> Skipping ramdisk setup (--no-ramdisk), using regular filesystem."
 fi
 
 # Ensure all prerequisites are installed (opt-in via --install-deps)


### PR DESCRIPTION
Add a new flag, `--no-ramdisk`, to `bin/test-rust` that disables setting up
a RAM disk for the test's filesystem operaitons. OS sandboxes (seatbelt, 
bubblewrap) disallow setting up and ejecting drives.