### PR TITLE
Pass-in commit write progress, `OxenError::NoChanges`, tidy `commit_with_*`

### DIFF
--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -1,29 +1,28 @@
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::str;
 
 use glob::Pattern;
+use rocksdb::{DBWithThreadMode, MultiThreaded, SingleThreaded};
 use time::OffsetDateTime;
 
+use crate::config::UserConfig;
+use crate::constants::COMMIT_COUNT_DIR;
 use crate::core;
+use crate::core::db::key_val::{opts, str_val_db};
+use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::refs::with_ref_manager;
+use crate::core::v_latest::index::CommitMerkleTree;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::commit_node::CommitNodeOpts;
 use crate::model::merkle_tree::node::dir_node::DirNodeOpts;
 use crate::model::merkle_tree::node::{CommitNode, DirNode, EMerkleTreeNode};
 use crate::model::{Commit, LocalRepository, MerkleHash, User};
 use crate::opts::PaginateOpts;
+use crate::repositories::commits::commit_writer;
 use crate::view::{PaginatedCommits, StatusMessage};
 use crate::{repositories, util};
-
-use std::path::PathBuf;
-use std::str;
-
-use crate::constants::COMMIT_COUNT_DIR;
-use crate::core::db::key_val::{opts, str_val_db};
-use crate::core::db::merkle_node::MerkleNodeDB;
-use crate::core::v_latest::index::CommitMerkleTree;
-use rocksdb::{DBWithThreadMode, MultiThreaded, SingleThreaded};
 
 /// Configuration for commit traversal operations
 struct CommitTraversalConfig<'a> {
@@ -46,7 +45,7 @@ struct CommitTraversalConfig<'a> {
 }
 
 pub fn commit(repo: &LocalRepository, message: impl AsRef<str>) -> Result<Commit, OxenError> {
-    repositories::commits::commit_writer::commit(repo, message)
+    commit_writer::commit(repo, message)
 }
 
 pub fn commit_with_user(
@@ -54,7 +53,17 @@ pub fn commit_with_user(
     message: impl AsRef<str>,
     user: &User,
 ) -> Result<Commit, OxenError> {
-    repositories::commits::commit_writer::commit_with_user(repo, message, user)
+    commit_writer::commit_with_cfg(
+        repo,
+        message,
+        &UserConfig {
+            name: user.name.clone(),
+            email: user.email.clone(),
+            editor: None,
+        },
+        None,
+        &commit_writer::default_commit_progress_bar(),
+    )
 }
 
 pub async fn commit_allow_empty(
@@ -69,7 +78,7 @@ pub async fn commit_allow_empty(
 
     if has_changes {
         // If there are changes, commit normally
-        repositories::commits::commit_writer::commit(repo, message)
+        commit_writer::commit(repo, message)
     } else {
         // No changes, create an empty commit
         let cfg = crate::config::UserConfig::get()?;
@@ -89,8 +98,7 @@ pub async fn commit_allow_empty(
         };
 
         // Compute the commit hash
-        let commit_hash =
-            repositories::commits::commit_writer::compute_commit_id(&new_commit_data)?;
+        let commit_hash = commit_writer::compute_commit_id(&new_commit_data)?;
 
         let new_commit = Commit::from_new_and_id(&new_commit_data, commit_hash.to_string());
 
@@ -330,7 +338,7 @@ pub fn create_initial_commit(
     };
 
     // Compute the commit hash
-    let commit_id = repositories::commits::commit_writer::compute_commit_id(&new_commit)?;
+    let commit_id = commit_writer::compute_commit_id(&new_commit)?;
 
     // Create the commit node
     let commit_node = CommitNode::new(

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -1,3 +1,4 @@
+use crate::config::UserConfig;
 use crate::constants;
 use crate::core::db;
 use crate::core::db::merkle_node::MerkleNodeDB;
@@ -340,7 +341,7 @@ async fn server_three_way_merge(
     // that initiated the merge request. If initiated from the client, the client should send it's
     // local user. If initiated from the hub, the hub should send the user/email of the user who
     // initiated the merge request.
-    let cfg = crate::config::UserConfig::get()?;
+    let cfg = UserConfig::get()?;
     let new_commit = crate::model::NewCommitBody {
         message: merge_commits.commit_message(),
         author: cfg.name.clone(),
@@ -354,13 +355,11 @@ async fn server_three_way_merge(
 
     // Pass the base commit ID as the target revision so the existing tree comes from the base
     // commit (revisions::get resolves commit IDs)
-    let progress = indicatif::ProgressBar::hidden();
     let commit = commit_writer::commit_dir_entries_with_parents(
         repo,
         parent_ids,
         dir_entries,
         &new_commit,
-        &progress,
         &merge_commits.base.id,
     )?;
 
@@ -1030,11 +1029,13 @@ async fn create_merge_commit(
         merge_commits.merge.id.to_owned(),
     ];
 
-    let commit = commit_writer::commit_with_parent_ids(repo, &commit_msg, parent_ids)?;
-
-    // rm::remove_staged(repo, &HashSet::from([PathBuf::from("/")]))?;
-
-    Ok(commit)
+    commit_writer::commit_with_cfg(
+        repo,
+        commit_msg,
+        &UserConfig::get()?,
+        Some(parent_ids),
+        &commit_writer::default_commit_progress_bar(),
+    )
 }
 
 /// Create an empty merge commit: a commit with two parents whose tree is identical to base's
@@ -1052,7 +1053,7 @@ fn create_empty_merge_commit(
     repo: &LocalRepository,
     merge_commits: &MergeCommits,
 ) -> Result<Commit, OxenError> {
-    let cfg = crate::config::UserConfig::get()?;
+    let cfg = UserConfig::get()?;
     let timestamp = time::OffsetDateTime::now_utc();
     let new_commit_data = NewCommit {
         parent_ids: vec![

--- a/crates/lib/src/core/v_latest/workspaces/commit.rs
+++ b/crates/lib/src/core/v_latest/workspaces/commit.rs
@@ -19,6 +19,7 @@ use crate::model::{
 };
 use crate::repositories;
 use crate::util;
+use crate::util::progress_bar::FinishOnDropProgressBar;
 use crate::view::merge::{MergeConflictFile, Mergeable};
 
 use filetime::FileTime;
@@ -47,7 +48,7 @@ pub async fn commit(
 
     log::debug!("workspaces::commit staged db path: {staged_db_path:?}");
     let commit = {
-        let commit_progress_bar = ProgressBar::new_spinner();
+        let commit_progress_bar = FinishOnDropProgressBar(ProgressBar::new_spinner());
 
         // Read all the staged entries
         let (dir_entries, _) = core::v_latest::status::read_staged_entries_with_staged_db_manager(
@@ -67,7 +68,6 @@ pub async fn commit(
             dir_entries,
             new_commit,
             branch_name,
-            &commit_progress_bar,
         )?
     };
 

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -195,8 +195,13 @@ pub enum OxenError {
     #[error("{0}")]
     MerkleTreeError(#[from] InvalidMerkleTreeNodeType),
 
+    /// An error from the [`FileBackend`] implementation of a [`MerkleStore`].
     #[error("{0}")]
     MerkleDbError(#[from] MerkleDbError),
+
+    // Attempting to make a commit with no changes from its parent is an error.
+    #[error("No changes to commit")]
+    NoChanges,
 
     //
     // Schema (dataframes)

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -26,7 +26,6 @@ use crate::model::MerkleHash;
 use crate::model::MerkleTreeNodeType;
 use crate::model::NewCommit;
 use crate::model::NewCommitBody;
-use crate::model::User;
 use crate::model::merkle_tree::node::EMerkleTreeNode;
 use crate::model::merkle_tree::node::StagedMerkleTreeNode;
 use crate::model::merkle_tree::node::VNode;
@@ -36,6 +35,7 @@ use crate::model::merkle_tree::node::vnode::VNodeOpts;
 use crate::model::{Commit, LocalRepository, StagedEntryStatus};
 
 use crate::util::hasher;
+use crate::util::progress_bar::FinishOnDropProgressBar;
 use crate::{repositories, util};
 
 use crate::model::merkle_tree::node::MerkleTreeNode;
@@ -75,36 +75,24 @@ impl EntryVNode {
 
 pub fn commit(repo: &LocalRepository, message: impl AsRef<str>) -> Result<Commit, OxenError> {
     let cfg = UserConfig::get()?;
-    commit_with_cfg(repo, message, &cfg, None)
+    commit_with_cfg(repo, message, &cfg, None, &default_commit_progress_bar())
 }
 
-pub fn commit_with_parent_ids(
-    repo: &LocalRepository,
-    message: impl AsRef<str>,
-    parent_ids: Vec<String>,
-) -> Result<Commit, OxenError> {
-    let cfg = UserConfig::get()?;
-    commit_with_cfg(repo, message, &cfg, Some(parent_ids))
+/// A default style spinner with a 100ms tick rate. Callers must set the message.
+/// NOTE: ProgressBar uses interior mutibility.
+pub(crate) fn default_commit_progress_bar() -> FinishOnDropProgressBar {
+    let commit_progress_bar = ProgressBar::new_spinner();
+    commit_progress_bar.set_style(ProgressStyle::default_spinner());
+    commit_progress_bar.enable_steady_tick(Duration::from_millis(100));
+    FinishOnDropProgressBar(commit_progress_bar)
 }
 
-pub fn commit_with_user(
-    repo: &LocalRepository,
-    message: impl AsRef<str>,
-    user: &User,
-) -> Result<Commit, OxenError> {
-    let cfg = UserConfig {
-        name: user.name.clone(),
-        email: user.email.clone(),
-        editor: None,
-    };
-    commit_with_cfg(repo, message, &cfg, None)
-}
-
-pub fn commit_with_cfg(
+pub(crate) fn commit_with_cfg(
     repo: &LocalRepository,
     message: impl AsRef<str>,
     cfg: &UserConfig,
     parent_ids: Option<Vec<String>>,
+    commit_progress_bar: &ProgressBar,
 ) -> Result<Commit, OxenError> {
     // time the commit
     let start_time = Instant::now();
@@ -117,19 +105,15 @@ pub fn commit_with_cfg(
     let staged_db: DBWithThreadMode<SingleThreaded> =
         DBWithThreadMode::open(&opts, dunce::simplified(&staged_db_path))?;
 
-    let commit_progress_bar = ProgressBar::new_spinner();
-    commit_progress_bar.set_style(ProgressStyle::default_spinner());
-    commit_progress_bar.enable_steady_tick(Duration::from_millis(100));
-
     // Read all the staged entries
     let (dir_entries, total_changes) =
-        status::read_staged_entries(repo, &staged_db, &commit_progress_bar)?;
+        status::read_staged_entries(repo, &staged_db, commit_progress_bar)?;
     commit_progress_bar.set_message(format!("Committing {total_changes} changes"));
 
     log::debug!("got dir entries: {:?}", dir_entries.len());
 
     if dir_entries.is_empty() {
-        return Err(OxenError::basic_str("No changes to commit"));
+        return Err(OxenError::NoChanges);
     }
 
     // let mut dir_tree = entries_to_dir_tree(&dir_entries)?;
@@ -151,14 +135,13 @@ pub fn commit_with_cfg(
             parent_ids,
             dir_entries,
             &new_commit,
-            &commit_progress_bar,
             maybe_branch_name
                 .clone()
                 .unwrap_or(DEFAULT_BRANCH_NAME.to_string()),
         )?
     } else {
         log::debug!("no parent ids, committing new");
-        commit_dir_entries_new(repo, dir_entries, &new_commit, &commit_progress_bar)?
+        commit_dir_entries_new(repo, dir_entries, &new_commit)?
     };
 
     // Clear the staged db
@@ -195,12 +178,11 @@ pub fn commit_with_cfg(
     Ok(commit)
 }
 
-pub fn commit_dir_entries_with_parents(
+pub(crate) fn commit_dir_entries_with_parents(
     repo: &LocalRepository,
     parent_commits: Vec<String>,
     dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>>,
     new_commit: &NewCommitBody,
-    commit_progress_bar: &ProgressBar,
     target_branch: impl AsRef<str>,
 ) -> Result<Commit, OxenError> {
     let message = &new_commit.message;
@@ -296,7 +278,6 @@ pub fn commit_dir_entries_with_parents(
         &dir_hashes,
         &vnode_entries,
     )?;
-    commit_progress_bar.finish_and_clear();
 
     Ok(node.to_commit())
 }
@@ -305,7 +286,6 @@ pub fn commit_dir_entries_new(
     repo: &LocalRepository,
     dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>>,
     new_commit: &NewCommitBody,
-    commit_progress_bar: &ProgressBar,
 ) -> Result<Commit, OxenError> {
     let message = &new_commit.message;
     // if the HEAD commit exists, we have parents
@@ -393,8 +373,6 @@ pub fn commit_dir_entries_new(
         &vnode_entries,
     )?;
 
-    commit_progress_bar.finish_and_clear();
-
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
 
@@ -406,7 +384,6 @@ pub fn commit_dir_entries(
     dir_entries: HashMap<PathBuf, Vec<StagedMerkleTreeNode>>,
     new_commit: &NewCommitBody,
     target_branch: impl AsRef<str>,
-    commit_progress_bar: &ProgressBar,
 ) -> Result<Commit, OxenError> {
     log::debug!("commit_dir_entries got {} entries", dir_entries.len());
     if log::max_level() == log::Level::Debug {
@@ -505,7 +482,6 @@ pub fn commit_dir_entries(
         &dir_hashes,
         &vnode_entries,
     )?;
-    commit_progress_bar.finish_and_clear();
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;

--- a/crates/lib/src/util/progress_bar.rs
+++ b/crates/lib/src/util/progress_bar.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 use tokio::time::Duration;
 
 use indicatif::{ProgressBar, ProgressStyle};
@@ -60,5 +60,24 @@ pub fn progress_type_to_template(progress_type: ProgressBarType) -> String {
             "{spinner:.green} [{elapsed_precise}] [{wide_bar}] {bytes}/{total_bytes}".to_string()
         }
         ProgressBarType::None => "{spinner:.green} [{elapsed_precise}] [{wide_bar}]".to_string(),
+    }
+}
+
+/// Wraps a [`ProgressBar`] with a `Drop` impl that calls the `finish_and_clear` method.
+/// This is so that the progress bar is always finished even if it's used in a context
+/// where a function early-returns e.g. on an error.
+pub(crate) struct FinishOnDropProgressBar(pub ProgressBar);
+
+impl Drop for FinishOnDropProgressBar {
+    fn drop(&mut self) {
+        self.0.finish_and_clear();
+    }
+}
+
+impl Deref for FinishOnDropProgressBar {
+    type Target = ProgressBar;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }


### PR DESCRIPTION
Makes the commit writing progress bar something that is passed in instead of created
by the `repositories::commits::commit_writer::commit_with_cfg` function. There's a new
`pub(crate) fn` to make the same one and `commit_with_cfg` still sets the same message.
This now allows callers to pass-in a no-op progress bar if desired.

Add a new `pub(crate) FinishOnDropProgressBar`, which wraps a `ProgressBar` and
calls `.finish_and_clear()` on `drop`.

Refactor a basic string error into a new `OxenError::NoChanges` variant with the same
user-facing error message.

Slimmed-down the `commit_with_*` functions to just use `commit_with_cfg` directly.
Took a change to tidy-up some formatting in the files that were updated.