### PR TITLE
Document error handling patterns for the codebase

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,6 +119,8 @@ oxen push origin main               # Push to remote
 - Make sure there's an `OxenError` variant for every error type. Be liberal in wrapping other modules error types, or other specific error types, in a new variant. Use a `Box<>` wrapper for it and have a `#[from]` to derive.
 - `OxenError` is the top-level type for everything. If you need to unify different error types into one, use `OxenError`. These kinds of functions should return `Result<T, OxenError>`
 - Implement proper error propagation through the `?` operator.
+- Never write code that uses `OxenError::Basic` or `OxenError::InternalError`. Do not use their constructor methods either (`OxenError::basic_str` and `OxenError::internal_error`, respectively). These variants are deprecated and will be removed. As a general principle, never encode an error as a string: it throws away valuable structured information about the error, which makes it impossible for a caller to handle the error programmatically. Instead, make a structured error variant of an appropriate error `enum` that describes the error. Include a `#[error("...")]` on the variant to provide a helpful user-facing error message describing the problem and, if applicable, a possible command or procedure the user can perform to fix the error.
+- If making logically related code that all share the same kind of errors, then strongly consider making a unique error `enum` _for that code only_. If that code is called by other code that has a different error enum, then define an explicit `impl From<SourceError> for TargetError` conversion to convert. If that makes the code messy, then make a conversion into `OxenError` and upgrade the calling function to return `OxenError` instead.
 
 # Making Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing to Oxen! 🐂 This document describes what kinds of contributions we accept, how to structure them, and what to expect from the review process.
 
+Anyone interested in contributing should review the Oxen developer documentation that lives under [`docs/`](./docs/README.md).
+
 Oxen is an actively developed project with a dedicated maintainer team. External contributions are welcome, but every PR costs maintainer time to review, test, and support long-term.
 We apply the guidelines below to keep that cost sustainable and the project focused.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Oxen Developer Documentation
+
+- [Error handling](error_handling.md)
+

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -1,0 +1,50 @@
+# Error Handling in Oxen
+
+This document defines and describes the standards for error handling in the Oxen codebase.
+
+As Oxen is a rapidly developing pre 1.0 codebase, not all of the code adheres to these principles.
+New code, however, must adhere to these principles. And old code should be brought in-line with
+this consistent design pattern on a best-effort approach
+
+
+## Goals
+
+1. All functions that could fail must return a `Result` type. Using `.unwrap()` and `.expect()` are
+   generally disallowed in the code as they cause the calling code to panic. Only tests that are
+   asserting properties may use `.unwrap()` and `.expect()` on `Result` and `Option` typed values.
+
+2. In library code, errors must be as structured and informative as possible. All of the information
+   about the source of the error must be included so that a caller has a reasonable opportunity to
+   understand the error and handle it programmatically. Idiomatic Rust encourages the use of an `enum`
+   defined error type to encapsulate different conditions as variants of the `enum`.
+
+3. Errors that obfuscate the source or transform an error into a simple string message must be avoided.
+   In Rust, errors must either be defined as a `struct` or an `enum` that provides descriptive variants
+   that each describe a specific error condition. For `enum`-defined errors, callers of code that uses
+   these errors must be able to reasonably `match` on the `Err` variant. An error that is a string
+   makes such programmatic introspection and handling of errors impossible.
+
+4. End-user facing code (the CLI and server) must have descriptive error messages that explain the
+   problem clearly. When it's possible to correct the error, the user-facing error message must
+   provide guidance or instructions the user can follow that will rectify the issue.
+
+5. Errors should be defined as close to the using code as possible. Strongly prefer making error `enum`s
+   that are specific to a module, package, or crate. For example, wrappers and helpers on networking
+   code should use a streamlined locally defined error `enum` that is specific to _networking_ errors.
+   Calling code should rely on `From` implementations to convert from one logically related set of code's
+   error type into an appropriate unifying container error type.
+
+6. For `liboxen`, the top-level unifying error type is `OxenError`. All library code must have some
+   conversion(s) that allow a more specific error type to be wrapped as an `OxenError`.
+
+
+## Specific Guidance for Modernization of Existing Oxen Code
+
+The `OxenError::Basic` and `OxenError::InternalError` variants are deprecated. No new code must use these
+string error representations. These throw away all useful error information and encode it as a string,
+making it impossible to `match` on specific error conditions and handle them programmatically. Library users
+are unable to meaningfully handle these variants.
+
+Any refactoring that touches these uses of string-defined OxenError variants should convert them into well-defined
+variants of an error `enum`. At a bare minimum, they should be translated to a new structured _variant_
+on `OxenError`. The existing string message can be used as the `#[error("...")]` on the new variant.


### PR DESCRIPTION
Adds a new `docs/` top-level directory to contain developer documentation for the
entire Oxen codebase. The first entry documents the goals for consitent error
handling in the Rust code. Links to the README's contributing section link here too.