### PR TITLE
S3 (13.4): Make `LocalRepository.storage_config` the source of truth and immutable

### DIFF
--- a/crates/cli/src/cmd/fsck.rs
+++ b/crates/cli/src/cmd/fsck.rs
@@ -80,7 +80,7 @@ async fn run_clean(repository: &LocalRepository, args: &ArgMatches) -> Result<()
         println!("Scanning and cleaning corrupted version files...");
     }
 
-    let version_store = repository.version_store()?;
+    let version_store = repository.version_store();
     let result = version_store.clean_corrupted_versions(dry_run).await?;
 
     println!("\nResults:");

--- a/crates/lib/src/api/client/entries.rs
+++ b/crates/lib/src/api/client/entries.rs
@@ -237,7 +237,7 @@ pub async fn download_entries_to_repo(
             download_file(remote_repo, &entry, &remote_path, &local_path, revision).await?;
 
             // Save contents to version store
-            let version_store = local_repo.version_store()?;
+            let version_store = local_repo.version_store();
 
             let file_bytes = tokio::fs::read(local_path).await?;
             let hash = util::hasher::hash_buffer(&file_bytes);
@@ -336,7 +336,7 @@ pub async fn pull_large_entry(
     let num_chunks = total_size.div_ceil(chunk_size) as usize;
     let hash = commit_entry.hash.clone();
     let revision = commit_entry.commit_id.clone();
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     let remote_path = remote_path.as_ref();
 

--- a/crates/lib/src/api/client/internal_types.rs
+++ b/crates/lib/src/api/client/internal_types.rs
@@ -4,6 +4,6 @@ use crate::model::LocalRepository;
 
 #[derive(Debug, Clone)]
 pub(crate) enum LocalOrBase {
-    Local(LocalRepository),
+    Local(Box<LocalRepository>),
     Base(PathBuf),
 }

--- a/crates/lib/src/api/client/versions.rs
+++ b/crates/lib/src/api/client/versions.rs
@@ -280,7 +280,7 @@ pub async fn try_download_data_from_version_paths(
         let decoder = GzipDecoder::new(buf_reader);
         let mut archive = Archive::new(decoder);
 
-        let version_store = local_repo.version_store()?;
+        let version_store = local_repo.version_store();
         let mut size: u64 = 0;
 
         // Iterate over archive entries and stream them to version store
@@ -546,7 +546,7 @@ pub async fn multipart_batch_upload(
     client: &reqwest::Client,
     files_to_retry: Vec<ErrorFileInfo>,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
-    let version_store = local_repo.version_store()?;
+    let version_store = local_repo.version_store();
     let mut form = reqwest::multipart::Form::new();
     let mut err_files: Vec<ErrorFileInfo> = vec![];
 

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -102,7 +102,7 @@ pub async fn add_with_opts(
         expanded_paths,
         local_repo
             .clone()
-            .map(|local| LocalOrBase::Local(local.clone()))
+            .map(|local| LocalOrBase::Local(Box::new(local.clone())))
             .as_ref(),
         update_timestamp,
     )

--- a/crates/lib/src/core/v_latest/add.rs
+++ b/crates/lib/src/core/v_latest/add.rs
@@ -114,7 +114,7 @@ pub async fn add<T: AsRef<Path>>(
     }
 
     // Get the version store from the repository
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     // Open the staged db once at the beginning and reuse the connection
     let opts = db::key_val::opts::default();
@@ -288,7 +288,7 @@ pub async fn add_dir_except(
         DBWithThreadMode::open(&opts, dunce::simplified(&db_path))?;
 
     // Get the version store from the repository
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let gitignore = None;
 
     let repo_path = &repo.path;

--- a/crates/lib/src/core/v_latest/branches.rs
+++ b/crates/lib/src/core/v_latest/branches.rs
@@ -240,7 +240,7 @@ pub async fn checkout_subtrees(
 
         let parent_path = subtree_path.parent().unwrap_or(Path::new(""));
         let mut hashes = CheckoutHashes::from_hashes(shared_hashes);
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
 
         let results = walk_target_tree(
             repo,
@@ -380,7 +380,7 @@ pub async fn set_working_repo_to_commit(
     };
 
     let mut hashes = CheckoutHashes::from_hashes(shared_hashes);
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     log::debug!("walk_target_tree");
     // Restore files present in the target commit
@@ -443,7 +443,7 @@ async fn cleanup_removed_files(
 
     // If in remote mode, need to store committed paths before removal
     if repo.is_remote_mode() {
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         for (hash, full_path) in candidates.files_to_store {
             log::debug!("Storing hash {hash:?} and path {full_path:?}");
             let file = tokio::fs::File::open(&full_path).await?;
@@ -599,7 +599,7 @@ async fn apply_dir_replacements(
         return Ok(());
     }
     let version_store = if repo.is_remote_mode() {
-        Some(repo.version_store()?)
+        Some(repo.version_store())
     } else {
         None
     };

--- a/crates/lib/src/core/v_latest/clone.rs
+++ b/crates/lib/src/core/v_latest/clone.rs
@@ -30,7 +30,7 @@ pub async fn clone_repo(
 
     // save LocalRepository in .oxen directory
     let mut local_repo = LocalRepository::from_remote(remote_repo.clone(), repo_path)?;
-    local_repo.version_store()?.init().await?;
+    local_repo.version_store().init().await?;
     repo_path.clone_into(&mut local_repo.path);
     local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
     local_repo.set_min_version(remote_repo.min_version());
@@ -93,7 +93,7 @@ pub async fn clone_repo_remote_mode(
 
     // Save LocalRepository in .oxen directory
     let mut local_repo = LocalRepository::from_remote(remote_repo.clone(), repo_path)?;
-    local_repo.version_store()?.init().await?;
+    local_repo.version_store().init().await?;
     repo_path.clone_into(&mut local_repo.path);
     local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
     local_repo.set_min_version(remote_repo.min_version());

--- a/crates/lib/src/core/v_latest/data_frames.rs
+++ b/crates/lib/src/core/v_latest/data_frames.rs
@@ -92,7 +92,7 @@ pub async fn get_slice(
         return Ok(response);
     }
     // Read the data frame from the version path
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let version_path = version_store
         .get_version_path(&file_node.hash().to_string())
         .await?;

--- a/crates/lib/src/core/v_latest/fetch.rs
+++ b/crates/lib/src/core/v_latest/fetch.rs
@@ -592,7 +592,7 @@ pub async fn pull_entries_to_versions_dir(
         return Ok(());
     }
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let missing_entries = get_missing_entries_for_pull(&version_store, entries).await?;
     log::debug!("Pulling {} missing entries", missing_entries.len());
 

--- a/crates/lib/src/core/v_latest/index/file_chunker.rs
+++ b/crates/lib/src/core/v_latest/index/file_chunker.rs
@@ -396,7 +396,7 @@ impl ChunkShardManager {
 //         entry: &CommitEntry,
 //         csm: &mut ChunkShardManager,
 //     ) -> Result<Vec<u128>, OxenError> {
-//         let version_store = &self.repo.version_store()?;
+//         let version_store = &self.repo.version_store();
 //         let mut read_file = version_store.open_version(&entry.hash)?;
 
 //         // Create a progress bar for larger files

--- a/crates/lib/src/core/v_latest/index/restore.rs
+++ b/crates/lib/src/core/v_latest/index/restore.rs
@@ -26,7 +26,7 @@ pub async fn restore(repo: &LocalRepository, opts: RestoreOpts) -> Result<(), Ox
     }
 
     // Get the version store from the repository
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     let paths = opts.paths;
     log::debug!("restore::restore got {:?} paths", paths.len());

--- a/crates/lib/src/core/v_latest/init.rs
+++ b/crates/lib/src/core/v_latest/init.rs
@@ -58,7 +58,7 @@ pub async fn init_with_version_and_storage_config(
     let repo = LocalRepository::new_from_version(path, version.to_string(), storage_config)?;
     repo.save()?;
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     version_store.init().await?;
 
     Ok(repo)

--- a/crates/lib/src/core/v_latest/merge.rs
+++ b/crates/lib/src/core/v_latest/merge.rs
@@ -683,7 +683,7 @@ async fn fast_forward_merge(
         // earlier for an unrelated reason.
         merge_marker::write(repo, &merge_commit.id).await?;
 
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         for entry in merge_tree_results.entries_to_restore.iter() {
             restore::restore_file(repo, &entry.file_node, &entry.path, &version_store).await?;
         }
@@ -1425,7 +1425,7 @@ pub async fn find_merge_conflicts(
             merge_marker::write(repo, &merge_commits.merge.id).await?;
         }
 
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         for entry in entries_to_restore.iter() {
             restore::restore_file(repo, &entry.file_node, &entry.path, &version_store).await?;
 

--- a/crates/lib/src/core/v_latest/prune.rs
+++ b/crates/lib/src/core/v_latest/prune.rs
@@ -278,7 +278,7 @@ async fn prune_versions(
     stats: &mut PruneStats,
     dry_run: bool,
 ) -> Result<(), OxenError> {
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     let all_versions = version_store.list_versions().await?;
     stats.versions_scanned = all_versions.len();

--- a/crates/lib/src/core/v_latest/push.rs
+++ b/crates/lib/src/core/v_latest/push.rs
@@ -256,7 +256,7 @@ async fn list_and_push_missing_files(
         api::client::commits::list_missing_files(remote_repo, base_commit, &head_commit.id).await?;
 
     if let Some(commit_entry) = missing_files.first() {
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         if !version_store.version_exists(&commit_entry.hash).await? {
             return Err(OxenError::CannotPushShallowClone {
                 commit_id: head_commit.id.clone(),
@@ -436,7 +436,7 @@ async fn push_commits(
     // for the commits that were fetched. Checking one file per commit is enough:
     // fetch operates at the commit level, so either all or none of a commit's
     // unique files will be present.
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     for (commit, info) in &commits_with_info {
         if let Some(commit_entry) = info.unique_file_hashes.first()
             && !version_store.version_exists(&commit_entry.hash).await?
@@ -618,7 +618,7 @@ async fn chunk_and_send_large_entries(
     for entry in entries.iter() {
         queue.try_push(entry.to_owned()).unwrap();
     }
-    let version_store = local_repo.version_store()?;
+    let version_store = local_repo.version_store();
 
     let worker_count = concurrency::num_threads_for_items(entries.len());
     log::debug!(

--- a/crates/lib/src/core/v_latest/revisions.rs
+++ b/crates/lib/src/core/v_latest/revisions.rs
@@ -17,7 +17,7 @@ pub async fn get_version_file_from_commit_id(
     let file_node = repositories::tree::get_file_by_path(repo, &commit, path)?
         .ok_or_else(|| OxenError::entry_does_not_exist_in_commit(path, commit_id))?;
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let hash = file_node.hash().to_string();
     let version_path = version_store.get_version_path(&hash).await?;
     Ok(version_path)

--- a/crates/lib/src/core/v_latest/status.rs
+++ b/crates/lib/src/core/v_latest/status.rs
@@ -933,7 +933,7 @@ async fn walk_paths(
 ) -> Result<WalkOutput, OxenError> {
     let gitignore: Option<Gitignore> = oxenignore::create(repo);
     // Get the version-store handle so walk_status can check existence of version files.
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let mut total_entries = 0;
     let mut out = WalkOutput::empty();
     for dir in opts.paths.iter() {

--- a/crates/lib/src/core/v_latest/workspaces/commit.rs
+++ b/crates/lib/src/core/v_latest/workspaces/commit.rs
@@ -357,7 +357,7 @@ async fn compute_staged_merkle_tree_node(
     let file_size = tokio::fs::metadata(path).await?.len();
     let file = File::open(path).await?;
     let reader = BufReader::new(file);
-    let version_store = workspace.base_repo.version_store()?;
+    let version_store = workspace.base_repo.version_store();
     version_store
         .store_version_from_reader(&hash.to_string(), Box::new(reader), file_size)
         .await?;

--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -139,7 +139,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     };
     util::fs::create_dir_all(parent)?;
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let version_path = version_store
         .get_version_path(&file_hash.to_string())
         .await?;
@@ -227,7 +227,7 @@ pub async fn rename(
         if let Some(existing_file_node) =
             repositories::tree::get_file_by_path(&workspace.base_repo, &workspace.commit, path)?
         {
-            let version_store = workspace.base_repo.version_store()?;
+            let version_store = workspace.base_repo.version_store();
             let hash = existing_file_node.hash().to_string();
             version_store
                 .copy_version_to_path(&hash, &workspace_file_path)

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -256,7 +256,7 @@ pub async fn prepare_modified_or_removed_row(
     );
 
     // let scan_rows = 10000 as usize;
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let committed_df_path = version_store
         .get_version_path(&commit_merkle_tree.hash.to_string())
         .await?;

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -117,7 +117,7 @@ pub async fn add_version_files(
     directory: impl AsRef<str>,
     update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     let directory = directory.as_ref();
     let workspace_repo = &workspace.workspace_repo;
@@ -867,7 +867,7 @@ async fn p_add_file(
     path: &Path,
     update_timestamp: bool,
 ) -> Result<(), OxenError> {
-    let version_store = base_repo.version_store()?;
+    let version_store = base_repo.version_store();
     let mut maybe_dir_node = None;
     if let Some(head_commit) = maybe_head_commit {
         let path = util::fs::path_relative_to_dir(path, &workspace_repo.path)?;

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -200,6 +200,16 @@ pub enum OxenError {
     #[error("S3 storage backend not yet implemented")]
     S3BackendNotImplemented,
 
+    /// A storage operation was attempted on a placeholder `VersionStore` — see
+    /// `NoopVersionStore` in `storage::noop`. The placeholder only exists to satisfy the
+    /// `LocalRepository::version_store` field on `Deserialize` (e.g. for wire-shape stubs
+    /// inside `Workspace` payloads). Constructor-built `LocalRepository`s always carry a
+    /// real backend; reaching for the store on a deserialized stub is a logic bug.
+    #[error(
+        "VersionStore placeholder reached for {operation} — deserialized LocalRepositories are wire-shape stubs and have no real backend"
+    )]
+    VersionStorePlaceholderUsed { operation: &'static str },
+
     /// `oxen restore` finished with one or more file-restore failures. Aggregated rather than
     /// fail-fast so the rest of the files can still be restored. The vector should be non-empty.
     #[error("{}", format_restore_failures(failures))]

--- a/crates/lib/src/model/diff/tabular_diff_summary.rs
+++ b/crates/lib/src/model/diff/tabular_diff_summary.rs
@@ -140,9 +140,7 @@ impl TabularDiffWrapper {
     ) -> Option<DataFrame> {
         match node {
             Some(node) => {
-                let version_store = repo.version_store().expect(
-                    "invariant violation: version store not found in maybe_get_df_from_file_node",
-                );
+                let version_store = repo.version_store();
                 let version_path = version_store
                     .get_version_path(&node.hash().to_string())
                     .await

--- a/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -475,7 +475,7 @@ impl MerkleTreeNode {
         repo: &LocalRepository,
     ) -> Result<HashSet<MerkleHash>, OxenError> {
         let mut missing_hashes = HashSet::new();
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         // Todo: parallelize for S3
         for child in &self.children {
             if let EMerkleTreeNode::File(_) = &child.node {

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -5,7 +5,7 @@ use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::{MetadataEntry, Remote, RemoteRepository};
-use crate::storage::{StorageConfig, StorageKind, VersionStore, create_version_store};
+use crate::storage::{NoopVersionStore, StorageConfig, VersionStore, create_version_store};
 use crate::util;
 use crate::view::RepositoryView;
 
@@ -21,6 +21,16 @@ use utoipa::ToSchema;
 /// once per repo per process via `probe_mtime_drift`.
 static MTIME_TOLERANCE_CACHE: LazyLock<Mutex<HashMap<PathBuf, Duration>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Build the placeholder `version_store` used when a `LocalRepository` arrives via
+/// `Deserialize` (e.g. as part of `Workspace` embedded in a wire response). Real,
+/// constructor-built repositories never use this — they get a `create_version_store`
+/// result wired off `storage_config`. The placeholder errors on every call so a caller
+/// that accidentally reaches for the store on a wire-shape stub gets a loud failure
+/// instead of silent wrong-path operations.
+fn placeholder_version_store() -> Arc<dyn VersionStore> {
+    Arc::new(NoopVersionStore)
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct LocalRepository {
@@ -39,10 +49,19 @@ pub struct LocalRepository {
     pub workspace_name: Option<String>, // ID of the associated workspace for remote mode
     workspaces: Option<Vec<String>>, // List of workspaces for remote mode
 
-    // Skip this field during serialization/deserialization
+    /// Storage backend configuration. Set once at construction and never mutated for the life
+    /// of this `LocalRepository` — the source of truth for which backend `version_store` is.
+    /// Excluded from serde/utoipa so the wire shape isn't a second source of truth (the
+    /// on-disk `config.toml` is). Deserialized stubs get `StorageConfig::default()`.
     #[serde(skip)]
     #[schema(ignore)]
-    version_store: Option<Arc<dyn VersionStore>>,
+    storage_config: StorageConfig,
+    /// Built from `storage_config` at construction. Never replaced. On deserialize this is a
+    /// `NoopVersionStore` placeholder — wire-shape stubs aren't expected to perform real
+    /// storage ops; if a caller reaches for the store anyway, every method errors loudly.
+    #[serde(skip, default = "placeholder_version_store")]
+    #[schema(ignore)]
+    version_store: Arc<dyn VersionStore>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -58,57 +77,33 @@ impl LocalRepository {
         let config_path = util::fs::config_filepath(&path);
         let config = RepositoryConfig::from_file(&config_path)?;
 
-        let mut repo = LocalRepository {
+        let storage_config = config.storage.unwrap_or_default();
+        let version_store = create_version_store(&path, &storage_config)?;
+        Ok(LocalRepository {
             path,
             remote_name: config.remote_name,
             min_version: config.min_version,
             remotes: config.remotes,
             vnode_size: config.vnode_size,
-            subtree_paths: config.subtree_paths.clone(),
+            subtree_paths: config.subtree_paths,
             depth: config.depth,
-            version_store: None,
             vfs: config.vfs,
             remote_mode: config.remote_mode,
             workspace_name: config.workspace_name,
             workspaces: config.workspaces,
-        };
-
-        // Initialize the version store from the persisted config (or defaults)
-        let storage_config = config.storage.unwrap_or_default();
-        let store = create_version_store(&repo.path, &storage_config)?;
-        repo.version_store = Some(store);
-        Ok(repo)
+            storage_config,
+            version_store,
+        })
     }
 
-    /// Get a reference to the version store
-    pub fn version_store(&self) -> Result<Arc<dyn VersionStore>, OxenError> {
-        match &self.version_store {
-            Some(store) => Ok(Arc::clone(store)),
-            None => Err(OxenError::basic_str("Version store not initialized")),
-        }
+    /// Get a reference to the storage configuration this repository was constructed with.
+    pub fn storage_config(&self) -> &StorageConfig {
+        &self.storage_config
     }
 
-    pub fn init_version_store(&mut self, config: &StorageConfig) -> Result<(), OxenError> {
-        let store = create_version_store(&self.path, config)?;
-        self.version_store = Some(store);
-        Ok(())
-    }
-
-    /// Initialize the default version store
-    /// this will be a local storage backend
-    pub fn init_default_version_store(&mut self) -> Result<(), OxenError> {
-        let store = create_version_store(&self.path, &StorageConfig::default())?;
-        self.version_store = Some(store);
-        Ok(())
-    }
-
-    /// Initialize local version store at a new location
-    pub async fn set_version_store(&mut self, config: &StorageConfig) -> Result<(), OxenError> {
-        let version_store = create_version_store(&self.path, config)?;
-        version_store.init().await?;
-        self.version_store = Some(version_store);
-
-        Ok(())
+    /// Get a reference to the version store.
+    pub fn version_store(&self) -> Arc<dyn VersionStore> {
+        Arc::clone(&self.version_store)
     }
 
     /// Load a repository from the current directory
@@ -128,9 +123,11 @@ impl LocalRepository {
         path: impl AsRef<Path>,
         storage_config: Option<StorageConfig>,
     ) -> Result<LocalRepository, OxenError> {
-        let mut repo = LocalRepository {
-            path: path.as_ref().to_path_buf(),
-            // No remotes are set yet
+        let path = path.as_ref().to_path_buf();
+        let storage_config = storage_config.unwrap_or_default();
+        let version_store = create_version_store(&path, &storage_config)?;
+        Ok(LocalRepository {
+            path,
             remotes: vec![],
             remote_name: None,
             // New with a path should default to our current MIN_OXEN_VERSION
@@ -138,19 +135,13 @@ impl LocalRepository {
             vnode_size: None,
             subtree_paths: None,
             depth: None,
-            version_store: None,
             vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
-        };
-
-        if let Some(storage_config) = storage_config {
-            repo.init_version_store(&storage_config)?;
-        } else {
-            repo.init_default_version_store()?;
-        }
-        Ok(repo)
+            storage_config,
+            version_store,
+        })
     }
 
     /// Load an older version of a repository with older oxen core logic
@@ -159,67 +150,66 @@ impl LocalRepository {
         min_version: impl AsRef<str>,
         storage_config: Option<StorageConfig>,
     ) -> Result<LocalRepository, OxenError> {
-        let mut repo = LocalRepository {
-            path: path.as_ref().to_path_buf(),
+        let path = path.as_ref().to_path_buf();
+        let storage_config = storage_config.unwrap_or_default();
+        let version_store = create_version_store(&path, &storage_config)?;
+        Ok(LocalRepository {
+            path,
             remotes: vec![],
             remote_name: None,
             min_version: Some(min_version.as_ref().to_string()),
             vnode_size: None,
             subtree_paths: None,
             depth: None,
-            version_store: None,
             vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
-        };
-
-        if let Some(storage_config) = storage_config {
-            repo.init_version_store(&storage_config)?;
-        } else {
-            repo.init_default_version_store()?;
-        }
-        Ok(repo)
+            storage_config,
+            version_store,
+        })
     }
 
     pub fn from_view(view: RepositoryView) -> Result<LocalRepository, OxenError> {
-        let mut repo = LocalRepository {
-            path: std::env::current_dir()?.join(view.name),
+        let path = std::env::current_dir()?.join(view.name);
+        let storage_config = StorageConfig::default();
+        let version_store = create_version_store(&path, &storage_config)?;
+        Ok(LocalRepository {
+            path,
             remotes: vec![],
             remote_name: None,
             min_version: None,
             vnode_size: None,
             subtree_paths: None,
             depth: None,
-            version_store: None,
             vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
-        };
-
-        repo.init_default_version_store()?;
-        Ok(repo)
+            storage_config,
+            version_store,
+        })
     }
 
     pub fn from_remote(repo: RemoteRepository, path: &Path) -> Result<LocalRepository, OxenError> {
-        let mut local_repo = LocalRepository {
-            path: path.to_owned(),
+        let path = path.to_owned();
+        let storage_config = StorageConfig::default();
+        let version_store = create_version_store(&path, &storage_config)?;
+        Ok(LocalRepository {
+            path,
             remotes: vec![repo.remote],
             remote_name: Some(String::from(constants::DEFAULT_REMOTE_NAME)),
             min_version: None,
             vnode_size: None,
             subtree_paths: None,
             depth: None,
-            version_store: None,
             vfs: None,
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
-        };
-
-        local_repo.init_default_version_store()?;
-        Ok(local_repo)
+            storage_config,
+            version_store,
+        })
     }
 
     pub fn min_version(&self) -> MinOxenVersion {
@@ -302,42 +292,6 @@ impl LocalRepository {
     pub fn save(&self) -> Result<(), OxenError> {
         let config_path = util::fs::config_filepath(&self.path);
 
-        // Determine the current storage kind and versions_path using the trait methods
-        let storage = self
-            .version_store
-            .as_ref()
-            .map(|store| -> Result<StorageConfig, OxenError> {
-                let kind = store.storage_kind();
-                let settings = store.storage_settings();
-                match kind {
-                    StorageKind::Local => {
-                        let path = settings.get("path").ok_or_else(|| {
-                            OxenError::basic_str("Storage settings missing 'path' key")
-                        })?;
-                        let versions_path = if util::fs::is_relative_to_dir(
-                            path,
-                            util::fs::oxen_hidden_dir(&self.path),
-                        ) {
-                            // If path is within .oxen (default location), use the relative path in case the repo was moved
-                            util::fs::path_relative_to_dir(path, &self.path).unwrap()
-                        } else {
-                            // Otherwise, use the absolute path
-                            PathBuf::from(path)
-                        };
-
-                        Ok(StorageConfig {
-                            kind,
-                            versions_path: Some(versions_path),
-                        })
-                    }
-                    StorageKind::S3 => Ok(StorageConfig {
-                        kind,
-                        versions_path: None,
-                    }),
-                }
-            })
-            .transpose()?;
-
         let config = RepositoryConfig {
             remote_name: self.remote_name.clone(),
             remotes: self.remotes.clone(),
@@ -345,7 +299,7 @@ impl LocalRepository {
             depth: self.depth,
             min_version: self.min_version.clone(),
             vnode_size: self.vnode_size,
-            storage,
+            storage: Some(self.storage_config.clone()),
             vfs: self.vfs,
             remote_mode: self.remote_mode,
             workspace_name: self.workspace_name.clone(),
@@ -651,6 +605,7 @@ async fn probe_mtime_drift(probe_dir: &Path) -> Duration {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::time::Duration;
 
     use filetime::FileTime;
@@ -798,6 +753,32 @@ mod tests {
 
         // Can delete previous workspace_name
         repo.delete_workspace(sample_name)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_storage_config_custom_path_round_trip() -> Result<(), OxenError> {
+        // A custom `versions_path` survives save → from_dir. The `.oxen`-prefix join semantics
+        // (relative paths get joined with the repo dir at construction time) preserve the
+        // *configured* value verbatim — only the runtime path passed to `LocalVersionStore`
+        // is joined.
+        use crate::storage::{StorageConfig, StorageKind};
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path().to_path_buf();
+        let custom = StorageConfig {
+            kind: StorageKind::Local,
+            versions_path: Some(PathBuf::from("/mnt/nfs/customer/.oxen/versions/files")),
+        };
+        let repo = LocalRepository::new(&repo_path, Some(custom.clone()))?;
+        repo.save()?;
+
+        let reloaded = LocalRepository::from_dir(&repo_path)?;
+        assert_eq!(reloaded.storage_config().kind, StorageKind::Local);
+        assert_eq!(
+            reloaded.storage_config().versions_path,
+            custom.versions_path
+        );
 
         Ok(())
     }

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -253,7 +253,7 @@ pub async fn create(
     local_repo.save()?;
 
     // Initialize version store
-    let version_store = local_repo.version_store()?;
+    let version_store = local_repo.version_store();
     version_store.init().await?;
 
     // Create history dir

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -148,7 +148,7 @@ pub async fn checkout_combine<P: AsRef<Path>>(
         .find(|c| c.merge_entry.path == path.as_ref())
     {
         if util::fs::is_tabular(&conflict.base_entry.path) {
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let df_base_path = version_store
                 .get_version_path(&conflict.base_entry.hash)
                 .await?;

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -661,7 +661,7 @@ pub async fn diff_tabular_file_and_file_node(
 ) -> Result<TabularDiff, OxenError> {
     let (df_1, df_2) = match file_node {
         Some(file_node) => {
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let file_node_path = version_store
                 .get_version_path(&file_node.hash().to_string())
                 .await?;
@@ -699,7 +699,7 @@ pub async fn diff_tabular_file_nodes(
 ) -> Result<TabularDiff, OxenError> {
     match (file_1, file_2) {
         (Some(file_1), Some(file_2)) => {
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let version_path_1 = version_store
                 .get_version_path(&file_1.hash().to_string())
                 .await?;
@@ -724,7 +724,7 @@ pub async fn diff_tabular_file_nodes(
             diff_dfs(&df_1, &df_2, keys, targets, display)
         }
         (Some(file_1), None) => {
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let version_path_1 = version_store
                 .get_version_path(&file_1.hash().to_string())
                 .await?;
@@ -741,7 +741,7 @@ pub async fn diff_tabular_file_nodes(
             diff_dfs(&df_1, &df_2, keys, targets, display)
         }
         (None, Some(file_2)) => {
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let version_path_2 = version_store
                 .get_version_path(&file_2.hash().to_string())
                 .await?;
@@ -767,7 +767,7 @@ pub async fn diff_text_file_and_node(
     file_node: Option<&FileNode>,
     file_path: impl AsRef<Path>,
 ) -> Result<DiffResult, OxenError> {
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let file_node_content = if let Some(node) = file_node {
         let file_hash = node.hash().to_string();
         Some(read_version_file_to_string(&version_store, &file_hash).await?)
@@ -790,7 +790,7 @@ pub async fn diff_text_file_nodes(
     file_1: Option<&FileNode>,
     file_2: Option<&FileNode>,
 ) -> Result<TextDiff, OxenError> {
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     match (file_1, file_2) {
         (Some(file_1), Some(file_2)) => {
             let file_content_1 =

--- a/crates/lib/src/repositories/entries.rs
+++ b/crates/lib/src/repositories/entries.rs
@@ -261,7 +261,7 @@ pub async fn list_missing_files_in_commit_range(
     base_commit: &Option<Commit>,
     head_commit: &Commit,
 ) -> Result<Vec<CommitEntry>, OxenError> {
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     match base_commit {
         Some(base_commit) => {

--- a/crates/lib/src/repositories/fork.rs
+++ b/crates/lib/src/repositories/fork.rs
@@ -281,15 +281,20 @@ mod tests {
 
                 let forked_config = RepositoryConfig::from_file(&forked_config_path)?;
                 if let Some(storage) = forked_config.storage {
-                    let storage_path = storage.versions_path.expect("Storage path should exist");
-                    let expected_path = PathBuf::from(OXEN_HIDDEN_DIR)
-                        .join("versions")
-                        .join("files");
+                    // `versions_path: None` is the canonical "use the default location" shape:
+                    // `LocalRepository::storage_config` round-trips, and `create_version_store`
+                    // resolves `None` to `.oxen/versions/files`. If the legacy explicit-path
+                    // shape is present, it must match the default.
+                    if let Some(storage_path) = storage.versions_path {
+                        let expected_path = PathBuf::from(OXEN_HIDDEN_DIR)
+                            .join("versions")
+                            .join("files");
 
-                    assert_eq!(
-                        storage_path, expected_path,
-                        "Storage path should be default to relative path"
-                    );
+                        assert_eq!(
+                            storage_path, expected_path,
+                            "Storage path should default to the relative path"
+                        );
+                    }
                 }
 
                 // Fork fails if repo exists

--- a/crates/lib/src/repositories/fsck.rs
+++ b/crates/lib/src/repositories/fsck.rs
@@ -172,7 +172,7 @@ mod tests {
             repositories::add(&repo, &file_path).await?;
             repositories::commit(&repo, "Adding hello.txt")?;
 
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let versions = version_store.list_versions().await?;
             assert!(!versions.is_empty());
 
@@ -208,7 +208,7 @@ mod tests {
             repositories::add(&repo, &file_path).await?;
             repositories::commit(&repo, "Adding hello.txt")?;
 
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let versions = version_store.list_versions().await?;
             assert!(!versions.is_empty());
 
@@ -244,7 +244,7 @@ mod tests {
             repositories::add(&repo, &file_path).await?;
             repositories::commit(&repo, "Adding hello.txt")?;
 
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
 
             // No corruption on a clean repo
             let result = version_store.clean_corrupted_versions(true).await?;

--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -1320,7 +1320,7 @@ mod tests {
                 )?
                 .expect("second.txt must be reachable from the second commit's tree");
                 let blob_hash = second_node.hash.to_string();
-                let version_store = cloned_repo.version_store()?;
+                let version_store = cloned_repo.version_store();
                 let blob_path = version_store.get_version_path(&blob_hash).await?;
                 assert!(blob_path.exists(), "blob should be present after clone");
                 util::fs::remove_file(&*blob_path)?;
@@ -2042,7 +2042,7 @@ mod tests {
                     repositories::clone_url(&remote_repo.remote.url, &repo_dir).await?;
 
                 // Verify the clone has version files
-                let version_store = cloned_repo.version_store()?;
+                let version_store = cloned_repo.version_store();
                 let versions = version_store.list_versions().await?;
                 assert!(
                     !versions.is_empty(),

--- a/crates/lib/src/repositories/remote_mode/checkout.rs
+++ b/crates/lib/src/repositories/remote_mode/checkout.rs
@@ -50,7 +50,7 @@ pub async fn create_checkout(
     )?
     .unwrap();
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     for (path, node) in partial_nodes {
         let full_path = repo.path.join(&path);
 

--- a/crates/lib/src/repositories/status.rs
+++ b/crates/lib/src/repositories/status.rs
@@ -138,7 +138,7 @@ mod tests {
             let head_node = repositories::tree::get_node_by_path(&repo, &commit, "hello.txt")?
                 .expect("hello.txt must be in HEAD's tree");
             let blob_hash = head_node.hash.to_string();
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let blob_path = version_store.get_version_path(&blob_hash).await?;
             assert!(blob_path.exists());
             util::fs::remove_file(&*blob_path)?;

--- a/crates/lib/src/repositories/tree.rs
+++ b/crates/lib/src/repositories/tree.rs
@@ -642,7 +642,7 @@ async fn list_missing_file_hashes_from_hashes(
     hashes: &HashSet<MerkleHash>,
 ) -> Result<HashSet<MerkleHash>, OxenError> {
     let mut results = HashSet::new();
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     // Todo: Parallelize for S3
     for hash in hashes {
         if !version_store.version_exists(&hash.to_string()).await? {

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -1327,7 +1327,7 @@ mod tests {
 
             // Make sure version file is updated
             let entry = repositories::entries::get_commit_entry(&repo, &commit, &path)?.unwrap();
-            let version_store = repo.version_store()?;
+            let version_store = repo.version_store();
             let version_file = version_store.get_version_path(&entry.hash).await?;
             let extension = entry.path.extension().unwrap().to_str().unwrap();
             let data_frame =

--- a/crates/lib/src/storage.rs
+++ b/crates/lib/src/storage.rs
@@ -1,8 +1,10 @@
 pub mod local;
+pub mod noop;
 pub mod s3;
 pub mod version_store;
 
 pub use local::LocalVersionStore;
+pub use noop::NoopVersionStore;
 pub use s3::S3VersionStore;
 pub use version_store::{
     LocalFilePath, StorageConfig, StorageKind, VersionStore, create_version_store,

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -1,5 +1,4 @@
 use std;
-use std::collections::HashMap;
 use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
 
@@ -553,15 +552,6 @@ impl VersionStore for LocalVersionStore {
 
     fn storage_kind(&self) -> crate::storage::StorageKind {
         crate::storage::StorageKind::Local
-    }
-
-    fn storage_settings(&self) -> HashMap<String, String> {
-        let mut settings = HashMap::new();
-
-        let root_path_str = self.root_path.to_str().unwrap_or("").to_string();
-        settings.insert("path".to_string(), root_path_str);
-
-        settings
     }
 }
 

--- a/crates/lib/src/storage/noop.rs
+++ b/crates/lib/src/storage/noop.rs
@@ -1,0 +1,153 @@
+//! THIS FILE WILL BE REMOVED IN THE NEAR FUTURE WHEN WE STOP SERIALIZING `LocalRepository`
+//!
+//! Placeholder `VersionStore` used to satisfy `LocalRepository::version_store`'s non-Option
+//! invariant on `Deserialize`. Wire-shape stubs (e.g. a `LocalRepository` embedded in a
+//! `Workspace` payload) don't carry a real backend; this implementation errors on every call so
+//! a caller that reaches for the store on a deserialized stub gets a loud, specific failure.
+//!
+//! Constructor-built `LocalRepository`s always get a real backend via `create_version_store`.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tokio::io::AsyncRead;
+use tokio_stream::Stream;
+
+use crate::error::OxenError;
+use crate::storage::{LocalFilePath, StorageKind, VersionStore};
+use crate::view::versions::CleanCorruptedVersionsResult;
+
+#[derive(Debug)]
+pub struct NoopVersionStore;
+
+fn err(op: &'static str) -> OxenError {
+    OxenError::VersionStorePlaceholderUsed { operation: op }
+}
+
+#[async_trait]
+impl VersionStore for NoopVersionStore {
+    async fn init(&self) -> Result<(), OxenError> {
+        Err(err("init"))
+    }
+
+    async fn store_version_from_reader(
+        &self,
+        _hash: &str,
+        _reader: Box<dyn AsyncRead + Send + Unpin>,
+        _size: u64,
+    ) -> Result<(), OxenError> {
+        Err(err("store_version_from_reader"))
+    }
+
+    async fn store_version(&self, _hash: &str, _data: &[u8]) -> Result<(), OxenError> {
+        Err(err("store_version"))
+    }
+
+    async fn store_version_chunk(
+        &self,
+        _hash: &str,
+        _offset: u64,
+        _data: Bytes,
+    ) -> Result<(), OxenError> {
+        Err(err("store_version_chunk"))
+    }
+
+    async fn store_version_derived(
+        &self,
+        _orig_hash: &str,
+        _derived_filename: &str,
+        _derived_data: &[u8],
+    ) -> Result<(), OxenError> {
+        Err(err("store_version_derived"))
+    }
+
+    async fn get_version_chunk(
+        &self,
+        _hash: &str,
+        _offset: u64,
+        _size: u64,
+    ) -> Result<Vec<u8>, OxenError> {
+        Err(err("get_version_chunk"))
+    }
+
+    async fn list_version_chunks(&self, _hash: &str) -> Result<Vec<u64>, OxenError> {
+        Err(err("list_version_chunks"))
+    }
+
+    async fn combine_version_chunks(&self, _hash: &str) -> Result<(), OxenError> {
+        Err(err("combine_version_chunks"))
+    }
+
+    async fn get_version_size(&self, _hash: &str) -> Result<u64, OxenError> {
+        Err(err("get_version_size"))
+    }
+
+    async fn get_version(&self, _hash: &str) -> Result<Vec<u8>, OxenError> {
+        Err(err("get_version"))
+    }
+
+    async fn get_version_stream(
+        &self,
+        _hash: &str,
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
+    {
+        Err(err("get_version_stream"))
+    }
+
+    async fn get_version_derived_size(
+        &self,
+        _orig_hash: &str,
+        _derived_filename: &str,
+    ) -> Result<u64, OxenError> {
+        Err(err("get_version_derived_size"))
+    }
+
+    async fn get_version_derived_stream(
+        &self,
+        _orig_hash: &str,
+        _derived_filename: &str,
+    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
+    {
+        Err(err("get_version_derived_stream"))
+    }
+
+    async fn derived_version_exists(
+        &self,
+        _orig_hash: &str,
+        _derived_filename: &str,
+    ) -> Result<bool, OxenError> {
+        Err(err("derived_version_exists"))
+    }
+
+    async fn get_version_path(&self, _hash: &str) -> Result<LocalFilePath, OxenError> {
+        Err(err("get_version_path"))
+    }
+
+    async fn copy_version_to_path(&self, _hash: &str, _dest_path: &Path) -> Result<(), OxenError> {
+        Err(err("copy_version_to_path"))
+    }
+
+    async fn version_exists(&self, _hash: &str) -> Result<bool, OxenError> {
+        Err(err("version_exists"))
+    }
+
+    async fn delete_version(&self, _hash: &str) -> Result<(), OxenError> {
+        Err(err("delete_version"))
+    }
+
+    async fn list_versions(&self) -> Result<Vec<String>, OxenError> {
+        Err(err("list_versions"))
+    }
+
+    async fn clean_corrupted_versions(
+        &self,
+        _dry_run: bool,
+    ) -> Result<CleanCorruptedVersionsResult, OxenError> {
+        Err(err("clean_corrupted_versions"))
+    }
+
+    fn storage_kind(&self) -> StorageKind {
+        StorageKind::Local
+    }
+}

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -9,7 +9,6 @@ use aws_sdk_s3::{Client, config::Region, primitives::ByteStream};
 use bytes::Bytes;
 use futures::StreamExt;
 use log;
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::fs::{File, create_dir_all};
@@ -918,13 +917,6 @@ impl VersionStore for S3VersionStore {
 
     fn storage_kind(&self) -> crate::storage::StorageKind {
         crate::storage::StorageKind::S3
-    }
-
-    fn storage_settings(&self) -> HashMap<String, String> {
-        let mut settings = HashMap::new();
-        settings.insert("bucket".to_string(), self.bucket.clone());
-        settings.insert("prefix".to_string(), self.prefix.clone());
-        settings
     }
 }
 

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -388,9 +387,6 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
 
     /// Which storage backend kind this is.
     fn storage_kind(&self) -> StorageKind;
-
-    /// Get the storage-specific settings
-    fn storage_settings(&self) -> HashMap<String, String>;
 }
 
 /// This only creates a version store struct, it does not initialize it

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -341,7 +341,7 @@ where
     let repo_dir = create_repo_dir(test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     version_store.init().await?;
 
     log::info!(">>>>> run_empty_local_repo_test_async running test");
@@ -1114,7 +1114,7 @@ where
     let repo_dir = create_repo_dir(test_run_dir())?;
     let repo = repositories::init(&repo_dir)?;
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     version_store.init().await?;
 
     // Write all the files

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -1219,7 +1219,7 @@ async fn unpack_entry_tarball_async(
     compressed_data: Vec<u8>,
 ) -> Result<(), OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     // Create async gzip decoder and tar archive
     let reader = Cursor::new(compressed_data);

--- a/crates/server/src/controllers/entries.rs
+++ b/crates/server/src/controllers/entries.rs
@@ -115,7 +115,7 @@ pub async fn download_chunk(
         resource
     );
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let chunk_start: u64 = query.chunk_start.unwrap_or(0);
     let chunk_size: u64 = query.chunk_size.unwrap_or(AVG_CHUNK_SIZE);
 

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -138,7 +138,7 @@ pub async fn get(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let resource = parse_resource(&req, &repo)?;
     let workspace = resource.workspace.as_ref();
     let path = resource.path.clone();
@@ -848,7 +848,7 @@ mod tests {
         let entry =
             repositories::entries::get_file(&repo, &resp.commit, PathBuf::from("data/hello.txt"))?
                 .unwrap();
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         let uploaded_content = version_store.get_version(&entry.hash().to_string()).await?;
         assert_eq!(
             String::from_utf8(uploaded_content).unwrap(),

--- a/crates/server/src/controllers/fsck.rs
+++ b/crates/server/src/controllers/fsck.rs
@@ -104,7 +104,7 @@ pub async fn clean(
     let dry_run = query.dry_run;
     log::info!("fsck clean: {namespace}/{repo_name} dry_run={dry_run}");
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let result = version_store.clean_corrupted_versions(dry_run).await?;
 
     let status_message = if dry_run {

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -536,7 +536,7 @@ mod tests {
 
         let entry =
             repositories::entries::get_file(&repo, &resp.commit, "data/cats_vs_dogs.tsv")?.unwrap();
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         assert!(
             version_store
                 .version_exists(&entry.hash().to_string())
@@ -603,7 +603,7 @@ mod tests {
             PathBuf::from("notebooks/chat.py"),
         )?
         .unwrap();
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         assert!(
             version_store
                 .version_exists(&entry.hash().to_string())

--- a/crates/server/src/controllers/versions.rs
+++ b/crates/server/src/controllers/versions.rs
@@ -57,12 +57,12 @@ pub async fn metadata(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
 
-    let exists = repo.version_store()?.version_exists(&version_id).await?;
+    let exists = repo.version_store().version_exists(&version_id).await?;
     if !exists {
         return Err(OxenHttpError::NotFound);
     }
 
-    let file_size = repo.version_store()?.get_version_size(&version_id).await?;
+    let file_size = repo.version_store().get_version_size(&version_id).await?;
     Ok(HttpResponse::Ok().json(VersionFileResponse {
         status: StatusMessage::resource_found(),
         version: VersionFile {
@@ -78,7 +78,7 @@ pub async fn clean(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(&app_data.path, namespace, &repo_name)?;
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let result = version_store.clean_corrupted_versions(false).await?;
 
     Ok(HttpResponse::Ok().json(CleanCorruptedVersionsResponse {
@@ -119,7 +119,7 @@ pub async fn download(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
     let path = resource.path.clone();
@@ -222,7 +222,7 @@ pub async fn stream_versions_tar_gz(
     repo: &LocalRepository,
     file_hashes: Vec<String>,
 ) -> Result<HttpResponse, OxenHttpError> {
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     // Pre-flight existence check before sending response headers. Once we commit to a
     // 200 streaming response, a missing blob mid-stream truncates the connection and
@@ -366,7 +366,7 @@ pub async fn stream_versions_zip(
     repo: &LocalRepository,
     files: Vec<FileWithHash>,
 ) -> Result<HttpResponse, OxenHttpError> {
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let (writer, reader) = tokio::io::duplex(DOWNLOAD_BUFFER_SIZE);
 
     let version_store_clone = version_store.clone();
@@ -545,10 +545,7 @@ pub async fn save_multiparts(
     repo: &LocalRepository,
 ) -> Result<Vec<ErrorFileInfo>, Error> {
     // Receive a multipart request and save the files to the version store
-    let version_store = repo.version_store().map_err(|oxen_err: OxenError| {
-        log::error!("Failed to get version store: {oxen_err:?}");
-        actix_web::error::ErrorInternalServerError(oxen_err.to_string())
-    })?;
+    let version_store = repo.version_store();
     let gzip_mime: mime::Mime = "application/gzip".parse().unwrap();
 
     let mut err_files: Vec<ErrorFileInfo> = vec![];
@@ -868,7 +865,7 @@ mod tests {
         assert!(response.err_files.is_empty());
 
         // verify file is stored correctly
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
         let stored_data = version_store.get_version(&file_hash).await?;
         assert_eq!(stored_data, file_content.as_bytes());
 

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -40,7 +40,7 @@ pub async fn upload(
         repo.path
     );
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     // Read the chunk from the payload. Chunks are <= 10MB (AVG_CHUNK_SIZE)
     let mut chunk = web::BytesMut::new();
@@ -87,7 +87,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                 )
             })?;
         log::debug!("Client uploaded {num_chunks} chunks");
-        let version_store = repo.version_store()?;
+        let version_store = repo.version_store();
 
         let chunks = version_store.list_version_chunks(&version_id).await?;
         log::debug!("Found {} chunks on server", chunks.len());
@@ -158,7 +158,7 @@ pub async fn download(
         size
     );
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     let chunk_data = version_store
         .get_version_chunk(&version_id, offset, size)

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -87,7 +87,7 @@ pub async fn get(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Err(OxenHttpError::NotFound);
@@ -213,7 +213,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
     };
 
-    let version_store = repo.version_store()?;
+    let version_store = repo.version_store();
 
     let (upload_files, err_files, update_timestamp) = save_parts(payload, &repo).await?;
     log::debug!("Save multiparts found {} err_files", err_files.len());
@@ -481,10 +481,7 @@ pub async fn save_parts(
     repo: &LocalRepository,
 ) -> Result<(Vec<FileWithHash>, Vec<ErrorFileInfo>, bool), Error> {
     // Receive a multipart request and save the files to the version store
-    let version_store = repo.version_store().map_err(|oxen_err: OxenError| {
-        log::error!("Failed to get version store: {oxen_err:?}");
-        actix_web::error::ErrorInternalServerError(oxen_err.to_string())
-    })?;
+    let version_store = repo.version_store();
     let gzip_mime: mime::Mime = "application/gzip".parse().unwrap();
 
     let mut upload_files: Vec<FileWithHash> = vec![];


### PR DESCRIPTION
All of the changes in this PR stem from enforcing setting storage config settings when we load them from disk and removing any way for `LocalRepository` to change it after that.  It just didn't make any sense to allow changing fundamental repository settings on a live `LocalRepository`.

Changed
-------

- **_MOST OF THE CHANGES IN THIS PR_** are just removing the `?` from calls to `version_store()`, because it now returns `Arc<dyn VersionStore>` directly (instead of `Result<...>`).  (Across 41 files!!!)
- `LocalOrBase::Local(LocalRepository)` → `Local(Box<LocalRepository>)` to satisfy `clippy::large_enum_variant` after the struct grew.
- Fork test now accepts `versions_path: None` as the canonical "default location" shape; `save()` round-trips `storage_config` instead of always emitting an explicit path.

Removed
-------

- Public mutators `init_version_store`, `init_default_version_store`, `set_version_store` on `LocalRepository`.
- `VersionStore::storage_settings()` trait method and its `LocalVersionStore` / `S3VersionStore` impls. `save()` reads `self.storage_config` directly.

Added
-----

- `storage::NoopVersionStore` and matching `OxenError::VersionStorePlaceholderUsed` just to satisfy serialization of `LocalRepository`. We will remove this in a later PR by serializing `ParsedResourceView` instead, which will make it so we don't need to serialize things like `LocalRepository` or `Workspace` at all!
- New `storage_config() -> &StorageConfig` accessor.

Refs ENG-1009