### PR TITLE
`oxen migrate` between file and LMDB Merkle backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,6 +4524,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 name = "liboxen"
 version = "0.50.1"
 dependencies = [
+ "anyhow",
  "approx",
  "arrow",
  "astral-tokio-tar",
@@ -4582,6 +4583,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "os_path",
+ "page_size",
  "par-stream",
  "parking_lot",
  "pathdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ actix-multipart = "0.7.2"
 actix-multipart-test = "0.0.3"
 actix-web = { version = "4.9.0", features = ["rustls"] }
 actix-web-httpauth = "0.8.0"
+anyhow = "1.0.102"
 approx = "0.5.1"
 arrow = "=58.1.0"
 astral-tokio-tar = "0.5.2"
@@ -107,6 +108,7 @@ opentelemetry = "0.31"
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-json", "trace"] }
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 os_path = "0.8.0"
+page_size = "0.6.0"
 par-stream = { version = "0.10.2", features = ["runtime-tokio"] }
 parking_lot = "0.12.1"
 pathdiff = "0.2.3"

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -106,3 +106,19 @@ pub fn check_repo_migration_needed(repo: &LocalRepository) -> Result<(), OxenErr
         "Error: Migration required".to_string().into(),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use liboxen::test;
+
+    /// The LMDB merkle-store migration is optional: even on a file-backend repo
+    /// (where it's *applicable*), it must not appear in the auto-block list, or
+    /// every normal CLI operation would refuse to proceed. `run_empty_local_repo_test`
+    /// creates a file-backend repo by default — exactly the case we want to assert
+    /// stays unblocked.
+    #[test]
+    fn test_check_repo_migration_needed_ignores_optional_migrations() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test(|repo| check_repo_migration_needed(&repo))
+    }
+}

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -96,6 +96,7 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 os_path = { workspace = true }
+page_size = { workspace = true }
 par-stream = { workspace = true }
 parking_lot = { workspace = true }
 pathdiff = { workspace = true }
@@ -142,6 +143,7 @@ zerocopy = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 criterion = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }

--- a/crates/lib/src/command/migrate.rs
+++ b/crates/lib/src/command/migrate.rs
@@ -22,6 +22,9 @@ pub use m20260408_add_workspace_name_index::AddWorkspaceNameIndexMigration;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, IntoStaticStr, VariantNames};
 
+pub mod m20260512000000_switch_merkle_store_to_lmdb;
+pub use m20260512000000_switch_merkle_store_to_lmdb::SwitchMerkleStoreToLmdbMigration;
+
 /// Migration direction. Passed to [`Migrate::is_applicable`] so reversible migrations
 /// (like the file ↔ LMDB merkle store transcode) can report applicability separately
 /// for each direction.

--- a/crates/lib/src/command/migrate/m20260512000000_switch_merkle_store_to_lmdb.rs
+++ b/crates/lib/src/command/migrate/m20260512000000_switch_merkle_store_to_lmdb.rs
@@ -1,0 +1,530 @@
+use std::path::Path;
+
+use bytesize::ByteSize;
+
+use super::{Direction, Migrate};
+
+use crate::config::RepositoryConfig;
+use crate::config::repository_config::MerkleStoreKind;
+use crate::constants::{NODES_DIR, OXEN_HIDDEN_DIR, TREE_DIR};
+use crate::core::db::merkle_node::LmdbBackend;
+use crate::core::db::merkle_node::file_backend::FileBackend;
+use crate::core::db::merkle_node::lmdb::{lmdb_backend_options, lmdb_dir_location};
+use crate::error::OxenError;
+use crate::model::merkle_tree::MerkleReader;
+use crate::model::merkle_tree::merkle_writer::{MerkleWriteSession, MerkleWriter};
+use crate::model::merkle_tree::node::EMerkleTreeNode;
+use crate::model::{LocalRepository, MerkleHash};
+use crate::util::progress_bar::{ProgressBarType, oxen_progress_bar};
+use crate::{repositories, util};
+
+/// Map-size hint for the destination LMDB env when migrating into LMDB. LMDB
+/// only consumes what's actually written (the file is sparse), so this is a
+/// ceiling rather than an allocation. 64 GiB comfortably accommodates the
+/// largest Merkle trees we've seen in practice; users can grow it later by
+/// re-opening the env with a larger map.
+const LMDB_MIGRATION_MAP_SIZE_BYTES: ByteSize = ByteSize::gib(64);
+
+/// Transcodes the repository's Merkle tree node store between the file-based backend
+/// ([`FileBackend`]) and the LMDB backend ([`LmdbBackend`]).
+///
+/// - `up`: file → LMDB. Reads every node out of `.oxen/tree/nodes/...`, writes it into
+///   a freshly-opened LMDB env at `.oxen/lmdb_merkle_tree_store/`, flips
+///   `RepositoryConfig::merkle_store_kind` from `File` to `Lmdb`, then removes the
+///   old tree node directory.
+/// - `down`: LMDB → file. The mirror image: reads from LMDB, writes the file-based
+///   layout, flips the config back to `File`, and removes the LMDB env directory.
+///
+/// Both directions are idempotent: re-running on an already-migrated repo is a no-op
+/// guarded by the per-repo helpers' explicit kind check.
+pub struct SwitchMerkleStoreToLmdbMigration;
+
+impl Migrate for SwitchMerkleStoreToLmdbMigration {
+    fn name(&self) -> &'static str {
+        "switch_merkle_store_to_lmdb"
+    }
+
+    fn description(&self) -> &'static str {
+        "Transcode the repository's Merkle tree node store from the file-based \
+         backend to LMDB. `down` reverts to the file-based backend."
+    }
+
+    /// Migrate from [`FileBackend`] to [`LmdbBackend`].
+    fn up(&self, repo: LocalRepository) -> Result<(), OxenError> {
+        if !SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Up, &repo)? {
+            log::info!(
+                "File → LMDB migration not applicable for repo {:?}",
+                repo.path
+            );
+            println!(
+                "Warning: skipping `switch_merkle_store_to_lmdb` up on {:?}: \
+                 repo is not on the file-based merkle store.",
+                repo.path
+            );
+            return Ok(());
+        }
+
+        log::info!(
+            "Migrating Merkle store: file → LMDB for repo {:?}",
+            repo.path
+        );
+
+        // heed requires the env directory to exist before `open` is called.
+        let env_dir = lmdb_dir_location(&repo.path);
+        util::fs::create_dir_all(&env_dir)?;
+
+        {
+            let options = lmdb_backend_options(LMDB_MIGRATION_MAP_SIZE_BYTES)?;
+            let dest = LmdbBackend::new(repo.path.clone(), options)?;
+            let source = repo.merkle_store()?;
+            copy_all_nodes(&repo, source, &dest)?;
+        }
+
+        {
+            let mut config = RepositoryConfig::from_repo(&repo)?;
+            config.merkle_store_kind = MerkleStoreKind::Lmdb;
+            config.save(util::fs::config_filepath(&repo.path))?;
+        }
+
+        let repo_path = repo.path.clone();
+        drop(repo);
+
+        cleanup_old_file_tree_dir(&repo_path)?;
+
+        Ok(())
+    }
+
+    /// Migrate from [`LmdbBackend`] to [`FileBackend`].
+    fn down(&self, repo: LocalRepository) -> Result<(), OxenError> {
+        if !SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Down, &repo)? {
+            log::info!(
+                "LMDB → File migration not applicable for repo {:?}",
+                repo.path
+            );
+            println!(
+                "Warning: skipping `switch_merkle_store_to_lmdb` down on {:?}: \
+                 repo is not on the LMDB merkle store.",
+                repo.path
+            );
+            return Ok(());
+        }
+
+        log::info!(
+            "Migrating Merkle store: LMDB → File for repo {:?}",
+            repo.path
+        );
+
+        {
+            let dest = FileBackend::new(&repo);
+            let source = repo.merkle_store()?;
+            copy_all_nodes(&repo, source, &dest)?;
+        }
+
+        {
+            let mut config = RepositoryConfig::from_repo(&repo)?;
+            config.merkle_store_kind = MerkleStoreKind::File;
+            config.save(util::fs::config_filepath(&repo.path))?;
+        }
+
+        let repo_path = repo.path.clone();
+        drop(repo);
+
+        cleanup_lmdb_env_dir(&repo_path)?;
+
+        Ok(())
+    }
+
+    /// This migration is optional — it is never auto-required. Use
+    /// `oxen migrate up/down switch_merkle_store_to_lmdb --run-optional` to invoke it
+    /// explicitly; the CLI consults [`Self::is_applicable`] for that path.
+    fn is_needed(&self, _: &LocalRepository) -> Result<bool, OxenError> {
+        Ok(false)
+    }
+
+    /// Up is applicable iff the repo is on the file backend (so we have something to
+    /// transcode forward); down is applicable iff the repo is on LMDB (so we have
+    /// something to transcode back).
+    fn is_applicable(
+        &self,
+        direction: Direction,
+        repo: &LocalRepository,
+    ) -> Result<bool, OxenError> {
+        let kind = repo.merkle_store_kind();
+        Ok(match direction {
+            Direction::Up => kind == MerkleStoreKind::File,
+            Direction::Down => kind == MerkleStoreKind::Lmdb,
+        })
+    }
+}
+
+/// Delete the old `.oxen/tree/nodes/` directory after a successful file → LMDB
+/// migration. The directory is missing in normal post-migration state, so a
+/// missing dir is not an error.
+fn cleanup_old_file_tree_dir(repo_path: &Path) -> Result<(), OxenError> {
+    let dir = repo_path
+        .join(OXEN_HIDDEN_DIR)
+        .join(TREE_DIR)
+        .join(NODES_DIR);
+    if dir.exists() {
+        util::fs::remove_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+/// Delete the LMDB env directory after a successful LMDB → file migration.
+fn cleanup_lmdb_env_dir(repo_path: &Path) -> Result<(), OxenError> {
+    let dir = lmdb_dir_location(repo_path);
+    if dir.exists() {
+        util::fs::remove_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+/// Transcode every Merkle tree node reachable from any of `repo`'s commits from
+/// `source` to `dest`. Opens one [`MerkleWriteSession`] per commit subtree so each
+/// LMDB write transaction stays bounded to a single commit's nodes — both for
+/// memory and for clean restart granularity if the migration is interrupted.
+fn copy_all_nodes(
+    repo: &LocalRepository,
+    source: &dyn MerkleReader,
+    dest: &dyn MerkleWriter,
+) -> Result<(), OxenError> {
+    let commits = repositories::commits::list_all(repo)?;
+    let bar = oxen_progress_bar(commits.len() as u64, ProgressBarType::Counter);
+    for commit in commits {
+        let commit_hash = commit.hash()?;
+        let session = dest.begin()?;
+        walk_subtree(source, &*session, &commit_hash)?;
+        session.finish()?;
+        bar.inc(1);
+    }
+    Ok(())
+}
+
+/// Recursively walk the subtree rooted at `node_hash` from `source` and re-write
+/// each non-leaf node — plus its immediate children — into `session`.
+///
+/// `MerkleReader::get_node` returns `None` for `File` and `FileChunk` nodes by
+/// trait contract; those leaves are persisted to the destination as `add_child`
+/// calls on their parent's `NodeWriteSession`, so this function never recurses
+/// into them.
+///
+/// The stored `parent_id` for the re-written node comes from `entry.parent_id`
+/// (i.e., the value already stored in the source), not from our recursion path —
+/// matching the established pattern in `m20250111083535_add_child_counts_to_nodes`.
+fn walk_subtree(
+    source: &dyn MerkleReader,
+    session: &dyn MerkleWriteSession,
+    node_hash: &MerkleHash,
+) -> Result<(), OxenError> {
+    let Some(entry) = source.get_node(node_hash)? else {
+        return Ok(());
+    };
+    let children = source.get_children(node_hash)?;
+
+    {
+        let mut ns = session.create_node(entry.node.as_t_node(), entry.parent_id)?;
+        for (_child_hash, child_node) in &children {
+            ns.add_child(child_node.node.as_t_node())?;
+        }
+        ns.finish()?;
+    }
+
+    for (child_hash, child_node) in children {
+        if matches!(
+            child_node.node,
+            EMerkleTreeNode::Commit(_) | EMerkleTreeNode::Directory(_) | EMerkleTreeNode::VNode(_)
+        ) {
+            walk_subtree(source, session, &child_hash)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    use crate::config::repository_config::MerkleStoreKind;
+    use crate::model::merkle_tree::{MerkleReader, node::EMerkleTreeNode};
+    use crate::test::repo_guard::RepoDirGuard;
+    use crate::test::repo_prep::{
+        apply_one_commit_local_repo, init_lmdb_safe_test_repo_with_merkle_store,
+    };
+
+    /// A deterministic snapshot of every reachable Merkle tree node in a repo,
+    /// keyed by node hash. Two repos that observe the same set of nodes — same
+    /// node bodies AND same `parent_id` AND same child-hash list — will produce
+    /// equal snapshots. Used to assert round-trip integrity.
+    type NodeSnapshot = BTreeMap<u128, NodeRecord>;
+
+    #[derive(Debug, Eq)]
+    struct NodeRecord {
+        node: EMerkleTreeNode,
+        parent_id: Option<u128>,
+        // Hashes of the immediate children, as exposed by `get_children`. Sorted
+        // for determinism — child ordering inside a vnode is implementation-dependent.
+        children: Vec<u128>,
+    }
+
+    impl PartialEq for NodeRecord {
+        fn eq(&self, other: &Self) -> bool {
+            // The file backend round-trips a missing parent as `Some(0)`, while
+            // LMDB preserves the original `None`. `None` is the semantically
+            // correct value; normalize `Some(0)` to `None` so cross-backend
+            // snapshots compare equal at the root commit.
+            self.node == other.node
+                && normalize_parent_id(self.parent_id) == normalize_parent_id(other.parent_id)
+                && self.children == other.children
+        }
+    }
+
+    fn normalize_parent_id(parent_id: Option<u128>) -> Option<u128> {
+        match parent_id {
+            Some(0) => None,
+            other => other,
+        }
+    }
+
+    fn snapshot_all_reachable_nodes(repo: &LocalRepository) -> Result<NodeSnapshot, OxenError> {
+        let mut snap = NodeSnapshot::new();
+        let store = repo.merkle_store()?;
+        let commits = repositories::commits::list_all(repo)?;
+        for commit in commits {
+            let commit_hash = commit.hash()?;
+            collect(store, &commit_hash, &mut snap)?;
+        }
+        Ok(snap)
+    }
+
+    fn collect(
+        store: &dyn MerkleReader,
+        node_hash: &MerkleHash,
+        snap: &mut NodeSnapshot,
+    ) -> Result<(), OxenError> {
+        if snap.contains_key(&node_hash.to_u128()) {
+            return Ok(());
+        }
+        let Some(entry) = store.get_node(node_hash)? else {
+            return Ok(());
+        };
+        let children = store.get_children(node_hash)?;
+        let mut child_hashes: Vec<u128> = children.iter().map(|(h, _)| h.to_u128()).collect();
+        child_hashes.sort_unstable();
+        snap.insert(
+            node_hash.to_u128(),
+            NodeRecord {
+                node: entry.node,
+                parent_id: entry.parent_id.map(|h| h.to_u128()),
+                children: child_hashes,
+            },
+        );
+        for (child_hash, child_node) in children {
+            if matches!(
+                child_node.node,
+                EMerkleTreeNode::Commit(_)
+                    | EMerkleTreeNode::Directory(_)
+                    | EMerkleTreeNode::VNode(_)
+            ) {
+                collect(store, &child_hash, snap)?;
+            }
+        }
+        Ok(())
+    }
+
+    //
+    //
+    // *** NOTE FOR TESTS ***
+    //
+    // LMDB only permits a single open env per path per process, so each test makes sure to drops a
+    //  `LocalRepository` (which includes its Merkle tree node store) before constructing the next one.
+    // This only applies to repositories at a specific filesystem location: identical content repos at
+    // different locations are fine.
+    //
+    // To automatically drop a repository and its on-disk content, use a [`TestRepoGuard`].
+    // Don't manually manage this. You can drop just the inner [`LocalRepository`] of a guard
+    // while retaining the on-disk directory contents with [`TestRepoGuard::drop_local_repo`].
+    //
+    //
+
+    #[test]
+    fn test_round_trip_file_to_lmdb_to_file_preserves_every_node() -> anyhow::Result<()> {
+        let (repo_path, before) = create_repo_one_commit(MerkleStoreKind::File);
+
+        // Up: file → LMDB
+        SwitchMerkleStoreToLmdbMigration.up(LocalRepository::from_dir(&repo_path as &Path)?)?;
+
+        let mid = {
+            let repo_after_up = check_post_up(&repo_path);
+            snapshot_all_reachable_nodes(&repo_after_up)?
+        };
+        assert_eq!(before, mid, "LMDB backend must observe identical tree");
+
+        // Down: LMDB → file
+        SwitchMerkleStoreToLmdbMigration.down(LocalRepository::from_dir(&repo_path as &Path)?)?;
+
+        let after = {
+            let repo_after_down = check_post_down(&repo_path);
+            snapshot_all_reachable_nodes(&repo_after_down)?
+        };
+        assert_eq!(before, after, "round-trip must preserve every node");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_lmdb_to_file_to_lmdb_preserves_every_node() -> anyhow::Result<()> {
+        let (repo_path, before) = create_repo_one_commit(MerkleStoreKind::Lmdb);
+
+        // Down: LMDB → file
+        SwitchMerkleStoreToLmdbMigration.down(LocalRepository::from_dir(&repo_path as &Path)?)?;
+
+        let mid = {
+            let repo_after_down = check_post_down(&repo_path);
+            snapshot_all_reachable_nodes(&repo_after_down).expect("cannot snapshot nodes")
+        };
+        assert_eq!(before, mid, "File backend must observe identical tree");
+
+        // Up: file → LMDB
+        SwitchMerkleStoreToLmdbMigration.up(LocalRepository::from_dir(&repo_path as &Path)?)?;
+
+        let after = {
+            let repo_after_up = check_post_up(&repo_path);
+            snapshot_all_reachable_nodes(&repo_after_up).expect("cannot snapshot nodes")
+        };
+        assert_eq!(before, after, "round-trip must preserve every node");
+
+        Ok(())
+    }
+
+    fn create_repo_one_commit(kind: MerkleStoreKind) -> (RepoDirGuard, NodeSnapshot) {
+        let repo =
+            init_lmdb_safe_test_repo_with_merkle_store(kind).expect("cannot create fresh repo");
+
+        assert_eq!(repo.merkle_store_kind(), kind);
+
+        apply_one_commit_local_repo(&repo).expect("cannot commit");
+
+        let before = snapshot_all_reachable_nodes(&repo).expect("cannot snapshot nodes");
+        assert!(
+            !before.is_empty(),
+            "fresh one-commit repo should have at least one merkle node"
+        );
+        let repo_path = repo.drop_local_repo();
+        (repo_path, before)
+    }
+
+    fn check_post_up(repo_path: &Path) -> LocalRepository {
+        let repo_after_up = LocalRepository::from_dir(repo_path as &Path)
+            .unwrap_or_else(|_| panic!("cannot load repository at: {}", repo_path.display()));
+        assert_eq!(
+            repo_after_up.merkle_store_kind(),
+            MerkleStoreKind::Lmdb,
+            "repository should report as using LMDB after up"
+        );
+        assert!(
+            !repo_after_up
+                .path
+                .join(OXEN_HIDDEN_DIR)
+                .join(TREE_DIR)
+                .join(NODES_DIR)
+                .exists(),
+            "old file-tree node dir should be gone after up"
+        );
+        assert!(
+            lmdb_dir_location(&repo_after_up.path).exists(),
+            "LMDB env dir should exist after up"
+        );
+        repo_after_up
+    }
+
+    fn check_post_down(repo_path: &Path) -> LocalRepository {
+        let repo_after_down = LocalRepository::from_dir(repo_path)
+            .unwrap_or_else(|_| panic!("cannot load repository at: {}", repo_path.display()));
+        assert_eq!(repo_path, repo_after_down.path);
+        assert_eq!(
+            repo_after_down.merkle_store_kind(),
+            MerkleStoreKind::File,
+            "repository should report as using File after down"
+        );
+        assert!(
+            repo_after_down
+                .path
+                .join(OXEN_HIDDEN_DIR)
+                .join(TREE_DIR)
+                .join(NODES_DIR)
+                .exists(),
+            "file-tree node dir should exist after down"
+        );
+        assert!(
+            !lmdb_dir_location(&repo_after_down.path).exists(),
+            "LMDB env dir should not exist after down"
+        );
+        repo_after_down
+    }
+
+    #[test]
+    fn test_is_needed_always_false() -> anyhow::Result<()> {
+        let repo = init_lmdb_safe_test_repo_with_merkle_store(MerkleStoreKind::File)?;
+        apply_one_commit_local_repo(&repo)?;
+        assert!(!SwitchMerkleStoreToLmdbMigration.is_needed(&repo)?);
+        drop(repo);
+
+        let repo = init_lmdb_safe_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        assert!(!SwitchMerkleStoreToLmdbMigration.is_needed(&repo)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_applicable_tracks_current_backend() -> anyhow::Result<()> {
+        let repo = init_lmdb_safe_test_repo_with_merkle_store(MerkleStoreKind::File)?;
+        apply_one_commit_local_repo(&repo)?;
+
+        assert!(SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Up, &repo)?);
+        assert!(!SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Down, &repo)?);
+        drop(repo);
+
+        let repo = init_lmdb_safe_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        assert!(!SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Up, &repo)?);
+        assert!(SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Down, &repo)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_up_idempotency() -> anyhow::Result<()> {
+        let repo = init_lmdb_safe_test_repo_with_merkle_store(MerkleStoreKind::File)?;
+        apply_one_commit_local_repo(&repo)?;
+        let repo_path = repo.drop_local_repo();
+
+        SwitchMerkleStoreToLmdbMigration.up(LocalRepository::from_dir(&repo_path as &Path)?)?;
+
+        // Re-running on an already-Lmdb repo should be a no-op.
+        SwitchMerkleStoreToLmdbMigration.up(LocalRepository::from_dir(&repo_path as &Path)?)?;
+
+        let reloaded = LocalRepository::from_dir(&repo_path as &Path)?;
+        assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::Lmdb);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_down_idempotency() -> anyhow::Result<()> {
+        let repo = init_lmdb_safe_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        apply_one_commit_local_repo(&repo)?;
+
+        let repo_path = repo.drop_local_repo();
+
+        SwitchMerkleStoreToLmdbMigration
+            .down(LocalRepository::from_dir(&repo_path as &Path).expect("ca"))?;
+
+        SwitchMerkleStoreToLmdbMigration.down(LocalRepository::from_dir(&repo_path as &Path)?)?;
+
+        let reloaded = LocalRepository::from_dir(&repo_path as &Path)?;
+        assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::File);
+
+        Ok(())
+    }
+}

--- a/crates/lib/src/core/db/merkle_node/lmdb.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb.rs
@@ -14,15 +14,12 @@ mod writer;
 /// The cache of open `LMDB` environments in the process.
 pub(crate) mod cache;
 
-pub use lmdb_backend::LmdbBackend;
-pub(in crate::core::db::merkle_node::lmdb) use lmdb_backend::{
-    DEFAULT_LMDB_MMAP_SIZE, lmdb_backend_options,
-};
-// `lmdb_dir_location` is only consulted from `#[cfg(test)]` modules outside
-// the `lmdb` namespace (verifying that the LMDB env dir was created on
-// disk). The lib build target has no production user of it.
 #[cfg(test)]
-pub(crate) use lmdb_backend::lmdb_dir_location;
+use std::path::{Path, PathBuf};
+
+pub(in crate::core::db::merkle_node::lmdb) use lmdb_backend::DEFAULT_LMDB_MMAP_SIZE;
+pub use lmdb_backend::LmdbBackend;
+pub(crate) use lmdb_backend::{lmdb_backend_options, lmdb_dir_location};
 
 use thiserror::Error;
 
@@ -106,18 +103,53 @@ pub enum LmdbError {
     InitDir(Box<OxenError>), // TODO: update to FsError when that refactoring PR lands
 }
 
+/// Uses and returns [`lmdb_test_root`], ensuring that the LMDB dir exists under .oxen/.
+#[cfg(test)]
+pub(crate) fn test_lmdb_repo_root(repo_root: &Path) -> std::io::Result<PathBuf> {
+    let test_root = lmdb_test_root(repo_root);
+    let env_dir = lmdb_dir_location(&test_root);
+    std::fs::create_dir_all(&env_dir)?;
+    Ok(test_root)
+}
+
+/// Map a test repo path to a per-repo directory under the OS temp dir.
+///
+/// The Windows CI runner mounts an ImDisk RAMDisk at `R:\test` and points
+/// `OXEN_TEST_RUN_DIR` there (see `.github/workflows/ci_test.yml`). ImDisk is a
+/// Win32-level emulation that does not fully implement the NT-level memory-section
+/// APIs LMDB depends on: `NtCreateSection` against a file on the ImDisk volume
+/// returns `STATUS_INVALID_DEVICE_REQUEST`, which `mdb_nt2win32` converts to
+/// `ERROR_INVALID_FUNCTION` (Win32 code 1). It surfaces here as
+/// `Lmdb(Access(Io(Os { code: 1, .. })))` and is reported as "Incorrect function.".
+/// `LmdbBackend` already documents `DO NOT USE ON A VIRTUAL FILE SYSTEM`; an ImDisk
+/// volume is exactly that.
+///
+/// Routing the env to the OS temp dir keeps it on the host's real filesystem
+/// (NTFS on Windows runners), where the NT memory-section APIs work normally.
+/// The mapping is stable per repo path so that callers that re-open with the
+/// same `repo_root` (e.g. `test_data_persists_across_env_reopen`) hit the same
+/// env on each open. The repo's UUID-named leaf keeps env paths unique across
+/// concurrent tests.
+#[cfg(test)]
+fn lmdb_test_root(repo_root: &Path) -> PathBuf {
+    let leaf = repo_root
+        .file_name()
+        .expect("test repo_root has a leaf component");
+    std::env::temp_dir().join("oxen-lmdb-tests").join(leaf)
+}
+
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        path::{Path, PathBuf},
-    };
+    use std::{collections::HashMap, path::Path};
 
-    use heed::EnvOpenOptions;
+    use bytesize::ByteSize;
     use time::OffsetDateTime;
 
     use crate::{
-        core::db::merkle_node::{LmdbBackend, lmdb::lmdb_backend::lmdb_dir_location},
+        core::db::merkle_node::{
+            LmdbBackend,
+            lmdb::{lmdb_backend_options, test_lmdb_repo_root},
+        },
         error::OxenError,
         model::{
             EntryDataType, LocalRepository, MerkleHash, MerkleTreeNodeType, TMerkleTreeNode,
@@ -132,57 +164,19 @@ mod tests {
         },
     };
 
-    /// Map a test repo path to a per-repo directory under the OS temp dir.
-    ///
-    /// The Windows CI runner mounts an ImDisk RAMDisk at `R:\test` and points
-    /// `OXEN_TEST_RUN_DIR` there (see `.github/workflows/ci_test.yml`). ImDisk is a
-    /// Win32-level emulation that does not fully implement the NT-level memory-section
-    /// APIs LMDB depends on: `NtCreateSection` against a file on the ImDisk volume
-    /// returns `STATUS_INVALID_DEVICE_REQUEST`, which `mdb_nt2win32` converts to
-    /// `ERROR_INVALID_FUNCTION` (Win32 code 1). It surfaces here as
-    /// `Lmdb(Access(Io(Os { code: 1, .. })))` and is reported as "Incorrect function.".
-    /// `LmdbBackend` already documents `DO NOT USE ON A VIRTUAL FILE SYSTEM`; an ImDisk
-    /// volume is exactly that.
-    ///
-    /// Routing the env to the OS temp dir keeps it on the host's real filesystem
-    /// (NTFS on Windows runners), where the NT memory-section APIs work normally.
-    /// The mapping is stable per repo path so that callers that re-open with the
-    /// same `repo_root` (e.g. `test_data_persists_across_env_reopen`) hit the same
-    /// env on each open. The repo's UUID-named leaf keeps env paths unique across
-    /// concurrent tests.
-    fn lmdb_test_root(repo_root: &Path) -> PathBuf {
-        let leaf = repo_root
-            .file_name()
-            .expect("test repo_root has a leaf component");
-        std::env::temp_dir().join("oxen-lmdb-tests").join(leaf)
-    }
-
-    /// Build a fresh [`LmdbBackend`] for a test [`LocalRepository`].
-    pub(in crate::core::db::merkle_node::lmdb) fn open_lmdb_backend(
-        repo: &LocalRepository,
-    ) -> LmdbBackend {
-        open_lmdb_at(repo.path.clone())
-    }
-
     /// Open the backend keyed by a `repo_root` — used to test persistence across env opens.
     ///
     /// The on-disk env lives under the OS temp dir, not under `repo_root` itself; see
     /// [`lmdb_test_root`] for why. heed (without `NO_SUB_DIR`) treats the env path as a
     /// directory it writes `data.mdb` + `lock.mdb` into, so the leaf must exist, and we
     /// create it here.
-    pub(in crate::core::db::merkle_node::lmdb) fn open_lmdb_at(repo_root: PathBuf) -> LmdbBackend {
-        let test_root = lmdb_test_root(&repo_root);
-        let env_dir = lmdb_dir_location(&test_root);
-        std::fs::create_dir_all(&env_dir).expect("env dir");
-
-        let mut opts = EnvOpenOptions::new();
+    pub(in crate::core::db::merkle_node::lmdb) fn open_lmdb_at(repo_root: &Path) -> LmdbBackend {
+        let test_root =
+            test_lmdb_repo_root(repo_root).expect("could not create test LMDB location");
         // 10 MiB is plenty for the test workloads and lets dozens of
         // independent test envs coexist without exhausting virtual memory.
-        opts.map_size(10 * 1024 * 1024);
-        // `LmdbBackend::new` opens two named databases (DB_NODES, DB_LINKS);
-        // production callers go through `lmdb_backend_options` which sets
-        // this. This test helper bypasses that path, so set it directly.
-        opts.max_dbs(2);
+        let opts = lmdb_backend_options(ByteSize::mib(10))
+            .expect("could not initialize LMDB environment options");
         LmdbBackend::new(test_root, opts).expect("open lmdb backend")
     }
 
@@ -195,7 +189,7 @@ mod tests {
         F: FnOnce(&LocalRepository, &LmdbBackend) -> Result<(), OxenError> + std::panic::UnwindSafe,
     {
         crate::test::run_empty_local_repo_test(|repo| {
-            let backend = open_lmdb_backend(&repo);
+            let backend = open_lmdb_at(&repo.path);
             test_fn(&repo, &backend)
         })
     }

--- a/crates/lib/src/core/db/merkle_node/lmdb/cache.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/cache.rs
@@ -147,7 +147,7 @@ mod tests {
     use crate::config::repository_config::MerkleStoreKind;
     use crate::core::db::merkle_node::lmdb::cache;
     use crate::error::OxenError;
-    use crate::test;
+    use crate::test::repo_prep::init_test_repo_with_merkle_store;
 
     /// Two `get_or_open` calls for the same canonical repo root return the
     /// same `Arc` — i.e. the underlying `LmdbBackend` (and its `Env`,
@@ -155,7 +155,7 @@ mod tests {
     /// have hit LMDB's "already open in this program" error.
     #[test]
     fn test_cache_returns_same_backend_for_concurrent_opens() -> Result<(), OxenError> {
-        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
         let a = cache::get_or_open(&repo.path)?;
         let b = cache::get_or_open(&repo.path)?;
         assert!(
@@ -168,8 +168,8 @@ mod tests {
     /// Two different canonical paths yield two distinct `LmdbBackend`s.
     #[test]
     fn test_cache_distinguishes_different_paths() -> Result<(), OxenError> {
-        let repo_a = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
-        let repo_b = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let repo_a = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let repo_b = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
         let a = cache::get_or_open(&repo_a.path)?;
         let b = cache::get_or_open(&repo_b.path)?;
         assert!(
@@ -183,11 +183,10 @@ mod tests {
     /// tombstone and a subsequent open yields a fresh `Arc`.
     #[test]
     fn test_cache_drops_backend_when_all_handles_released() -> Result<(), OxenError> {
-        let mut repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
-        let repo_path = repo.path.clone();
-        // Free the test helper's strong handle so this test owns the only
-        // live reference at the point of `drop(a)` below.
-        repo.drop_inner();
+        let repo_path = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?
+            // Free the test helper's strong handle so this test owns the only
+            // live reference at the point of `drop(a)` below.
+            .drop_local_repo();
 
         let a = cache::get_or_open(&repo_path)?;
         let weak = Arc::downgrade(&a);
@@ -213,7 +212,7 @@ mod tests {
     /// physical path collapse to one cache entry.
     #[test]
     fn test_cache_canonicalizes_path_shapes() -> Result<(), OxenError> {
-        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
         // Build a non-canonical variant: append a trailing `./.`.
         let nonsense = repo.path.join(".");
         let a = cache::get_or_open(&repo.path)?;

--- a/crates/lib/src/core/db/merkle_node/lmdb/lmdb_backend.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/lmdb_backend.rs
@@ -81,13 +81,39 @@ const _: () = assert!(
 // multiple of any common page size, so it would fail LMDB validation
 pub(crate) const DEFAULT_LMDB_MMAP_SIZE: ByteSize = ByteSize::gib(1);
 
+/// Configures LMDB options for the [`LmdbBackend`] with the given mmap file size.
+///
+/// If the file size is not a multiple of the OS's page size, then the value is
+/// rounded up to the nearest multiple of the page size. LMDB requires the mmap file
+/// to be a multiple of the page size.
+///
+/// If a size greater than the total addressible memory space is provided, then this
+/// function will return an [`LmdbError::InitMmap`] error.
 pub(crate) fn lmdb_backend_options(size: ByteSize) -> Result<EnvOpenOptions, LmdbError> {
+    // The only reason to reject a requested size outright is that it doesn't
+    // fit in this platform's `usize` (the type LMDB's `map_size` takes). On
+    // 64-bit targets this is effectively unreachable; on 32-bit it caps at
+    // ~4 GiB. If the size *does* fit but isn't a multiple of the current OS
+    // page size, round up to the next multiple — LMDB requires page-aligned
+    // map sizes, and silently accepting an unaligned value would surface as a
+    // confusing `EINVAL` from `mdb_env_set_mapsize`.
+    let requested = size.as_u64();
+    let map_size = usize::try_from(requested).map_err(|_| LmdbError::InitMmap(size))?;
+
+    let page_size = page_size::get();
+    let aligned = if map_size.is_multiple_of(page_size) {
+        map_size
+    } else {
+        let rounded = map_size.next_multiple_of(page_size);
+        log::warn!(
+            "LMDB map_size {map_size} is not a multiple of the OS page size {page_size}; \
+             rounding up to {rounded}",
+        );
+        rounded
+    };
+
     let mut options = EnvOpenOptions::new();
-    let map_size = size.as_u64() as usize;
-    if DEFAULT_LMDB_MMAP_SIZE.as_u64() != (map_size as u64) {
-        return Err(LmdbError::InitMmap(size));
-    }
-    options.map_size(map_size);
+    options.map_size(aligned);
     // for LmdbBackend's 2 `Database` fields
     options.max_dbs(2);
     Ok(options)
@@ -110,10 +136,7 @@ impl LmdbBackend {
     ///
     ///             If you're using this function, either use unique LMDB locations or drop this
     ///             struct before opening up the LMDB env again.
-    pub(in crate::core::db::merkle_node::lmdb) fn new(
-        repo_root: PathBuf,
-        options: EnvOpenOptions,
-    ) -> Result<Self, LmdbError> {
+    pub(crate) fn new(repo_root: PathBuf, options: EnvOpenOptions) -> Result<Self, LmdbError> {
         log::info!("Config for LMDB backend: {options:?}");
 
         let lmdb_env = {

--- a/crates/lib/src/core/db/merkle_node/lmdb/pack.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/pack.rs
@@ -300,6 +300,8 @@ mod tests {
     use crate::model::merkle_tree::merkle_writer::MerkleWriter;
     use crate::repositories;
     use crate::test;
+    use crate::test::repo_prep::init_test_repo_merkle_init_version_store_async;
+    use crate::test::repo_prep::init_test_repo_with_merkle_store;
     use std::collections::HashSet;
 
     /// Pack just a parent commit (with one embedded child commit), unpack into
@@ -332,7 +334,7 @@ mod tests {
             // Fresh target repo backed by LMDB; unpack the bytes into it and
             // verify both the parent (with full link) and the child (with
             // minimal link) are observable.
-            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let target_repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
             let target_store = target_repo.merkle_store()?;
             let installed = target_repo
                 .merkle_transport()?
@@ -363,7 +365,7 @@ mod tests {
     #[tokio::test]
     async fn test_lmdb_pack_unpacks_into_file_backend() -> Result<(), OxenError> {
         let source_repo =
-            test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
+            init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
         let parent_h = h("11111111111111111111111111111111");
         let child_h = h("22222222222222222222222222222222");
         let parent = commit_with_hash(&source_repo, parent_h);
@@ -418,7 +420,7 @@ mod tests {
             assert!(!buf.is_empty(), "expected pack_all to produce bytes");
 
             let target_repo =
-                test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
+                init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
             let installed = target_repo
                 .merkle_transport()?
                 .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
@@ -459,7 +461,7 @@ mod tests {
             // overall but no tar entries beyond the gzip terminator.
             // Easiest invariant to check: unpack into a fresh repo and assert
             // the reported hash set is empty.
-            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let target_repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
             let installed = target_repo
                 .merkle_transport()?
                 .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
@@ -478,7 +480,7 @@ mod tests {
         with_test_backend(|_repo, backend| {
             let mut buf = Vec::new();
             backend.pack_all(&mut buf)?;
-            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let target_repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
             let installed = target_repo
                 .merkle_transport()?
                 .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
@@ -505,7 +507,7 @@ mod tests {
             let mut buf = Vec::new();
             backend.pack_all(&mut buf)?;
 
-            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let target_repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
             let installed = target_repo
                 .merkle_transport()?
                 .unpack(&mut &buf[..], UnpackOptions::Overwrite)?;
@@ -543,7 +545,7 @@ mod tests {
                 .finish()
                 .map_err(MerkleDbError::Io)?;
         }
-        let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let target_repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
         let err = target_repo
             .merkle_transport()?
             .unpack(&mut &buf[..], UnpackOptions::Overwrite)

--- a/crates/lib/src/core/db/merkle_node/lmdb/writer.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/writer.rs
@@ -451,12 +451,12 @@ mod tests {
 
             // First open: write, then drop the backend (env close).
             {
-                let backend = open_lmdb_at(repo.path.clone());
+                let backend = open_lmdb_at(&repo.path);
                 write_one(&backend, &commit, None)?;
             }
             // Second open: reopen, read.
             {
-                let backend = open_lmdb_at(repo.path.clone());
+                let backend = open_lmdb_at(&repo.path);
                 assert!(backend.exists(&commit_h)?);
                 assert!(backend.get_node(&commit_h)?.is_some());
             }

--- a/crates/lib/src/model/merkle_tree/node.rs
+++ b/crates/lib/src/model/merkle_tree/node.rs
@@ -73,6 +73,19 @@ impl EMerkleTreeNode {
         )
     }
 
+    /// Borrow the inner typed node as a `&dyn TMerkleTreeNode` so it can be passed
+    /// to APIs (e.g., [`crate::model::merkle_tree::merkle_writer::MerkleWriteSession::create_node`])
+    /// that take a trait object instead of a concrete node type.
+    pub fn as_t_node(&self) -> &dyn TMerkleTreeNode {
+        match self {
+            EMerkleTreeNode::File(file) => file,
+            EMerkleTreeNode::Directory(dir) => dir,
+            EMerkleTreeNode::VNode(vnode) => vnode,
+            EMerkleTreeNode::FileChunk(file_chunk) => file_chunk,
+            EMerkleTreeNode::Commit(commit) => commit,
+        }
+    }
+
     /// Deserialize a Merkle tree node from its on-disk type marker and msgpack-encoded body.
     pub fn from_type_and_bytes(
         dtype: MerkleTreeNodeType,

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -710,7 +710,7 @@ async fn probe_mtime_drift(probe_dir: &Path) -> Duration {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::time::Duration;
 
     use filetime::FileTime;
@@ -719,6 +719,9 @@ mod tests {
     use crate::error::OxenError;
     use crate::model::{LocalRepository, RepoNew};
     use crate::test;
+    use crate::test::repo_prep::{
+        init_test_repo_merkle_init_version_store_async, init_test_repo_with_merkle_store,
+    };
     use tempfile::TempDir;
 
     #[tokio::test]
@@ -962,14 +965,13 @@ mod tests {
     /// the path, drop the original repo to close its env, then reload.
     #[test]
     fn test_lmdb_merkle_store_kind_round_trips_through_config_toml() -> Result<(), OxenError> {
-        let mut repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
         assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
-        let repo_path = repo.path.clone();
         // Release the inner LocalRepository (closing its LMDB env) without
         // tearing down the on-disk dir, so we can reload from the same path.
-        repo.drop_inner();
+        let repo_path = repo.drop_local_repo();
 
-        let reloaded = LocalRepository::from_dir(&repo_path)?;
+        let reloaded = LocalRepository::from_dir(&repo_path as &Path)?;
         assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::Lmdb);
         Ok(())
     }
@@ -978,7 +980,7 @@ mod tests {
     /// with the LMDB merkle store — proves the dispatch hits the LMDB load arm.
     #[test]
     fn test_lmdb_init_creates_env_directory_under_oxen_hidden() -> Result<(), OxenError> {
-        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let repo = init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
         let env_dir = crate::core::db::merkle_node::lmdb::lmdb_dir_location(&repo.path);
         assert!(
             env_dir.exists(),
@@ -995,8 +997,7 @@ mod tests {
     async fn test_lmdb_add_commit_status_roundtrip() -> Result<(), OxenError> {
         use crate::repositories;
         use crate::util;
-        let repo =
-            test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
+        let repo = init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
         let text_path = repo.path.join("hello.txt");
         util::fs::write_to_path(&text_path, "Hello LMDB")?;
 
@@ -1021,8 +1022,7 @@ mod tests {
     async fn test_file_add_commit_status_roundtrip() -> Result<(), OxenError> {
         use crate::repositories;
         use crate::util;
-        let repo =
-            test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::File).await?;
+        let repo = init_test_repo_merkle_init_version_store_async(MerkleStoreKind::File).await?;
         let text_path = repo.path.join("hello.txt");
         util::fs::write_to_path(&text_path, "Hello File")?;
 
@@ -1045,8 +1045,7 @@ mod tests {
     async fn test_lmdb_two_commits_history() -> Result<(), OxenError> {
         use crate::repositories;
         use crate::util;
-        let repo =
-            test::init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
+        let repo = init_test_repo_merkle_init_version_store_async(MerkleStoreKind::Lmdb).await?;
         let dir = repo.path.join("files");
         util::fs::create_dir_all(&dir)?;
         for i in 0..5 {

--- a/crates/lib/src/repositories/init.rs
+++ b/crates/lib/src/repositories/init.rs
@@ -30,16 +30,15 @@ pub fn init_with_version(
     path: impl AsRef<Path>,
     version: MinOxenVersion,
 ) -> Result<LocalRepository, OxenError> {
-    init_with_version_and_merkle_store(path, version, MerkleStoreKind::default())
+    init_with_version_and_merkle_store(path.as_ref(), version, MerkleStoreKind::default())
 }
 
 /// Like [`init_with_version`] but lets the caller pick the Merkle store backend.
 pub fn init_with_version_and_merkle_store(
-    path: impl AsRef<Path>,
+    path: &Path,
     version: MinOxenVersion,
     merkle_store_kind: MerkleStoreKind,
 ) -> Result<LocalRepository, OxenError> {
-    let path = path.as_ref();
     match version {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::init_with_version_and_merkle_store(
@@ -98,13 +97,15 @@ pub async fn init_with_version_storage_and_merkle_store(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use crate::config::repository_config::MerkleStoreKind;
     use crate::constants::MIN_OXEN_VERSION;
     use crate::error::OxenError;
     use crate::model::LocalRepository;
     use crate::repositories;
     use crate::test;
-
+    use crate::test::repo_prep::create_lmdb_safe_empty_dir;
     use crate::util;
 
     #[tokio::test]
@@ -152,34 +153,18 @@ mod tests {
         // LMDB envs can't open on a VFS (e.g. Windows CI's ImDisk RAMDisk at
         // R:\test); route this test's repo dir off OXEN_TEST_RUN_DIR via the
         // dedicated guard helper.
-        let guard = test::create_lmdb_safe_empty_dir()?;
-        let repo_dir = guard.path();
-        let repo = repositories::init::init_with_version_and_merkle_store(
-            repo_dir,
-            MIN_OXEN_VERSION,
-            MerkleStoreKind::Lmdb,
-        )?;
-        assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
-        drop(repo); // close the LMDB env so we can reopen
+        let repo_dir = create_lmdb_safe_empty_dir()?;
+        {
+            let repo = repositories::init::init_with_version_and_merkle_store(
+                &repo_dir,
+                MIN_OXEN_VERSION,
+                MerkleStoreKind::Lmdb,
+            )?;
+            assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
+        } // close the LMDB env so we can reopen
 
-        let reloaded = LocalRepository::from_dir(repo_dir)?;
+        let reloaded = LocalRepository::from_dir(&repo_dir as &Path)?;
         assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::Lmdb);
-        Ok(())
-    }
-
-    /// Async init path (used by the CLI) also respects an explicit
-    /// [`MerkleStoreKind::Lmdb`].
-    #[tokio::test]
-    async fn test_init_with_storage_and_lmdb() -> Result<(), OxenError> {
-        let guard = test::create_lmdb_safe_empty_dir()?;
-        let repo = repositories::init::init_with_version_storage_and_merkle_store(
-            guard.path(),
-            MIN_OXEN_VERSION,
-            None,
-            MerkleStoreKind::Lmdb,
-        )
-        .await?;
-        assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
         Ok(())
     }
 }

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -1,5 +1,10 @@
-//! Helpers for our unit and integration tests
+//! Helpers for Oxen's unit and integration tests
 //!
+//!
+
+pub mod repo_guard;
+pub mod repo_prep;
+pub mod test_utils;
 
 use crate::api;
 use crate::command;
@@ -8,29 +13,21 @@ use crate::constants::DEFAULT_REMOTE_NAME;
 use crate::core;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::RepoNew;
-use crate::model::Schema;
-use crate::model::User;
 use crate::model::data_frame::schema::Field;
-use crate::model::file::FileContents;
-use crate::model::file::FileNew;
+use crate::model::file::{FileContents, FileNew};
 use crate::model::merkle_tree::node::merkle_tree_node_cache;
-use crate::model::{LocalRepository, RemoteRepository};
+use crate::model::{LocalRepository, RemoteRepository, RepoNew, Schema, User};
 use crate::opts::RmOpts;
 use crate::repositories;
 use crate::util;
 use crate::util::telemetry::TracingGuard;
 
-use rand::Rng;
-use rand::distributions::Alphanumeric;
-use std::fs::File;
-use std::fs::OpenOptions;
+use rand::{Rng, distributions::Alphanumeric};
+use std::fs::{File, OpenOptions};
 use std::future::Future;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::LazyLock;
-use std::sync::Mutex;
+use std::sync::{Arc, LazyLock, Mutex};
 use tokio::time::sleep;
 use tracing::level_filters::LevelFilter;
 
@@ -60,7 +57,13 @@ pub fn test_host() -> String {
     }
 }
 
-fn generate_random_string(len: usize) -> String {
+/// Generate a string of `len` random alphanumeric characters.
+/// A length of zero means an empty string is returned.
+#[inline(always)]
+pub(crate) fn generate_random_string(len: usize) -> String {
+    if len == 0 {
+        return "".to_string();
+    }
     rand::thread_rng()
         .sample_iter(&Alphanumeric)
         .take(len)
@@ -301,142 +304,6 @@ where
     // Assert everything okay after we cleanup the repo dir
     assert!(result.is_ok());
     Ok(())
-}
-
-/// RAII cleanup for a test repo directory. Dropping the guard removes the
-/// directory via [`maybe_cleanup_repo`] (errors are swallowed since `Drop`
-/// can't surface them). The same call runs on the normal-exit path *and*
-/// during panic unwind.
-#[cfg(test)]
-pub struct RepoDirGuard {
-    repo_dir: PathBuf,
-}
-
-#[cfg(test)]
-impl RepoDirGuard {
-    pub fn new(repo_dir: PathBuf) -> Self {
-        Self { repo_dir }
-    }
-
-    pub fn path(&self) -> &Path {
-        &self.repo_dir
-    }
-}
-
-#[cfg(test)]
-impl Drop for RepoDirGuard {
-    fn drop(&mut self) {
-        if let Err(e) = maybe_cleanup_repo(&self.repo_dir) {
-            log::warn!("RepoDirGuard cleanup failed for {:?}: {e}", self.repo_dir);
-        }
-    }
-}
-
-/// RAII handle to a freshly-initialized test [`LocalRepository`]. Derefs to
-/// the inner `LocalRepository` so callers can use it as one transparently.
-///
-/// Drop order matters: `repo` is declared before `_guard` so that on drop
-/// the inner `LocalRepository` (and any resources it holds, like an LMDB
-/// `heed::Env`) is released *before* the [`RepoDirGuard`] removes the
-/// on-disk repo directory.
-#[cfg(test)]
-pub struct TestLocalRepo {
-    repo: Option<LocalRepository>,
-    _guard: RepoDirGuard,
-}
-
-#[cfg(test)]
-impl TestLocalRepo {
-    pub fn new(repo: LocalRepository) -> Self {
-        let repo_dir = repo.path.clone();
-        Self {
-            repo: Some(repo),
-            _guard: RepoDirGuard::new(repo_dir),
-        }
-    }
-
-    /// Drop the inner [`LocalRepository`] (e.g. to release an LMDB env)
-    /// while keeping the on-disk repo dir alive for further reads. The
-    /// directory itself is still removed when this handle is dropped.
-    pub fn drop_inner(&mut self) {
-        self.repo.take();
-    }
-}
-
-#[cfg(test)]
-impl std::ops::Deref for TestLocalRepo {
-    type Target = LocalRepository;
-    fn deref(&self) -> &Self::Target {
-        self.repo
-            .as_ref()
-            .expect("TestLocalRepo inner LocalRepository was already dropped via drop_inner")
-    }
-}
-
-/// Base directory under which LMDB-backed test repos are rooted.
-///
-/// LMDB depends on NT memory-section APIs that are not implemented by
-/// virtual filesystems. On Windows CI `OXEN_TEST_RUN_DIR=R:\test` is an
-/// ImDisk RAMDisk (a VFS) and opening an LMDB env there fails with
-/// `Os { code: 1, .. }` → "Incorrect function." Routing LMDB-backed test
-/// repos to the OS temp dir keeps the env on the host's real volume
-/// (NTFS on Windows runners). Mirrors `lmdb_test_root` in
-/// `crates/lib/src/core/db/merkle_node/lmdb.rs`, used by the low-level
-/// `LmdbBackend` tests.
-#[cfg(test)]
-fn lmdb_test_base() -> PathBuf {
-    std::env::temp_dir().join("oxen-lmdb-tests")
-}
-
-/// Create a fresh empty dir suitable for an LMDB-backed test repo and
-/// return a [`RepoDirGuard`] that removes it on Drop. The dir lives under
-/// [`lmdb_test_base`] rather than `OXEN_TEST_RUN_DIR` — see that fn's docs
-/// for why.
-#[cfg(test)]
-pub fn create_lmdb_safe_empty_dir() -> Result<RepoDirGuard, OxenError> {
-    let dir = create_prefixed_dir(lmdb_test_base(), "dir")?;
-    Ok(RepoDirGuard::new(dir))
-}
-
-/// Construct a fresh test repo dir, initialize a [`LocalRepository`] in it
-/// with the given [`crate::config::repository_config::MerkleStoreKind`], and
-/// return a [`TestLocalRepo`] that cleans the dir up on Drop. Mirrors the
-/// repo shape produced by the former
-/// `run_empty_local_repo_test_with_merkle_store` helper.
-///
-/// For `MerkleStoreKind::Lmdb` the repo dir is routed under
-/// [`lmdb_test_base`] so the LMDB env never lands on a VFS like Windows CI's
-/// ImDisk RAMDisk.
-#[cfg(test)]
-pub fn init_test_repo_with_merkle_store(
-    kind: crate::config::repository_config::MerkleStoreKind,
-) -> Result<TestLocalRepo, OxenError> {
-    use crate::config::repository_config::MerkleStoreKind;
-    init_test_env();
-    log::info!("<<<<< init_test_repo_with_merkle_store start ({kind:?})");
-    let repo_dir = match kind {
-        MerkleStoreKind::Lmdb => create_prefixed_dir(lmdb_test_base(), "repo")?,
-        MerkleStoreKind::File => create_repo_dir(test_run_dir())?,
-    };
-    let repo = repositories::init::init_with_version_and_merkle_store(
-        &repo_dir,
-        MinOxenVersion::LATEST,
-        kind,
-    )?;
-    log::info!(">>>>> init_test_repo_with_merkle_store ready");
-    Ok(TestLocalRepo::new(repo))
-}
-
-/// Async variant of [`init_test_repo_with_merkle_store`] — also initializes
-/// the version store, mirroring the former
-/// `run_empty_local_repo_test_with_merkle_store_async` helper.
-#[cfg(test)]
-pub async fn init_test_repo_merkle_init_version_store_async(
-    kind: crate::config::repository_config::MerkleStoreKind,
-) -> Result<TestLocalRepo, OxenError> {
-    let handle = init_test_repo_with_merkle_store(kind)?;
-    handle.version_store().init().await?;
-    Ok(handle)
 }
 
 pub async fn run_empty_local_repo_test_async<T, Fut>(test: T) -> Result<(), OxenError>
@@ -1918,45 +1785,48 @@ pub fn populate_nlp_dir(repo_dir: &Path) -> Result<(), OxenError> {
     Ok(())
 }
 
+/// Populates a directory with multiple differently typed files at some level of nesting.
+///
+/// Features:
+///   - has multiple content types (jpg, txt, md)
+///   - has a few large data files that we have to chunk and transfer
+///   - has multiple directory levels (annotations/train/one_shot.txt)
+///   - has files at top level (README.md)
+///   - has files without extensions (LICENSE)
+///   - has files/dirs at different levels with same names (annotations.txt)
+///
+/// --------------------
+/// Directory Structure:
+/// --------------------
+/// nlp/
+///   classification/
+///     annotations/
+///       train.tsv
+///       test.tsv
+///
+/// train/
+///   dog_1.jpg
+///   dog_2.jpg
+///   dog_3.jpg
+///   cat_1.jpg
+///   cat_2.jpg
+/// test/
+///   1.jpg
+///   2.jpg
+/// annotations/
+///   README.md
+///   train/
+///     bounding_box.csv
+///     one_shot.csv
+///     two_shot.csv
+///     annotations.txt
+///   test/
+///     annotations.csv
+/// prompts.jsonl
+/// labels.txt
+/// LICENSE
+/// README.md
 pub fn populate_dir_with_training_data(repo_dir: &Path) -> Result<(), OxenError> {
-    // Directory Structure
-    // Features:
-    //   - has multiple content types (jpg, txt, md)
-    //   - has a few large data files that we have to chunk and transfer
-    //   - has multiple directory levels (annotations/train/one_shot.txt)
-    //   - has files at top level (README.md)
-    //   - has files without extensions (LICENSE)
-    //   - has files/dirs at different levels with same names (annotations.txt)
-    //
-    // nlp/
-    //   classification/
-    //     annotations/
-    //       train.tsv
-    //       test.tsv
-    //
-    // train/
-    //   dog_1.jpg
-    //   dog_2.jpg
-    //   dog_3.jpg
-    //   cat_1.jpg
-    //   cat_2.jpg
-    // test/
-    //   1.jpg
-    //   2.jpg
-    // annotations/
-    //   README.md
-    //   train/
-    //     bounding_box.csv
-    //     one_shot.csv
-    //     two_shot.csv
-    //     annotations.txt
-    //   test/
-    //     annotations.csv
-    // prompts.jsonl
-    // labels.txt
-    // LICENSE
-    // README.md
-
     // README.md
     populate_readme(repo_dir)?;
 
@@ -2024,24 +1894,35 @@ pub fn populate_select_training_data(repo_dir: &Path, data: &str) -> Result<(), 
     Ok(())
 }
 
-pub fn add_file_to_dir(dir: &Path, contents: &str, extension: &str) -> Result<PathBuf, OxenError> {
+/// Creates a new UUID4 named file  in the directory with the given content.
+///
+/// Returns the full file path. If `extension` is not none, then the filename will
+/// end with `".{extension}"`. Errors if the file cannot be created or written.
+/// Also errors if the `dir` does not exist and it cannot be created.
+pub fn add_file_to_dir(
+    dir: &Path,
+    contents: &[u8],
+    extension: Option<&str>,
+) -> Result<PathBuf, OxenError> {
+    std::fs::create_dir_all(dir)?;
     // Generate random name, because tests run in parallel, then return that name
-    let file_path = PathBuf::from(format!("{}.{extension}", uuid::Uuid::new_v4()));
-    let full_path = dir.join(file_path);
-    // println!("add_txt_file_to_dir: {:?} to {:?}", file_path, full_path);
-
-    let mut file = File::create(&full_path)?;
-    file.write_all(contents.as_bytes())?;
-
+    let filename = match extension {
+        Some(ext) => format!("{}.{ext}", uuid::Uuid::new_v4()),
+        None => uuid::Uuid::new_v4().to_string(),
+    };
+    let full_path = dir.join(filename);
+    std::fs::write(&full_path, contents)?;
     Ok(full_path)
 }
 
+/// Writes the contents to a randomly named ".txt" file in the directory.
 pub fn add_txt_file_to_dir(dir: &Path, contents: &str) -> Result<PathBuf, OxenError> {
-    add_file_to_dir(dir, contents, "txt")
+    add_file_to_dir(dir, contents.as_bytes(), Some("txt"))
 }
 
+/// Writes the contents to a randomly named ".csv" file in the directory.
 pub fn add_csv_file_to_dir(dir: &Path, contents: &str) -> Result<PathBuf, OxenError> {
-    add_file_to_dir(dir, contents, "csv")
+    add_file_to_dir(dir, contents.as_bytes(), Some("csv"))
 }
 
 pub fn write_txt_file_to_path(

--- a/crates/lib/src/test/repo_guard.rs
+++ b/crates/lib/src/test/repo_guard.rs
@@ -1,0 +1,116 @@
+//! Contains RAII handles for structs that map to real resources. Drop deallocates resources.
+//!
+//! Common use cases include:
+//!   - a local repository's directory
+//!   - a [`LocalRepository`] `struct` instance
+//!
+use std::{
+    ops::Deref,
+    path::{Path, PathBuf},
+};
+
+use crate::{error::OxenError, model::LocalRepository, test::maybe_cleanup_repo};
+
+/// RAII cleanup for a test repo directory.
+///
+/// Dropping the guard removes the directory via [`maybe_cleanup_repo`]: errors are swallowed since
+/// [`Drop`] can't surface them. The same call runs on the normal-exit path *and* during panic
+/// unwind.
+///
+/// [`Deref`]s to a [`&Path`] so it can be used transparently as the managed repo dir.
+#[derive(Debug)]
+pub struct RepoDirGuard {
+    repo_dir: PathBuf,
+}
+
+impl RepoDirGuard {
+    pub fn new(repo_dir: PathBuf) -> Self {
+        Self { repo_dir }
+    }
+}
+
+/// Cleanup the guarded directory, attempting to remove it from the filesystem.
+impl Drop for RepoDirGuard {
+    fn drop(&mut self) {
+        if let Err(e) = maybe_cleanup_repo(&self.repo_dir) {
+            log::warn!("RepoDirGuard cleanup failed for {:?}: {e}", self.repo_dir);
+        }
+    }
+}
+
+/// A guarded directory derefs into a [`& Path`].
+impl Deref for RepoDirGuard {
+    type Target = Path;
+    fn deref(&self) -> &Self::Target {
+        &self.repo_dir
+    }
+}
+
+/// RAII handle to a freshly-initialized test [`LocalRepository`].
+///
+/// [`Deref`]s into the inner `LocalRepository` so callers can use it as one transparently.
+///
+/// The [`Drop`] implementation releases the [`LocalRepository`] state first, then deletes
+/// the repository's on-disk directory. Releasing [`LocalRepository`] resources is governed
+/// by that type's own [`Drop`].
+#[derive(Debug)]
+pub struct TestLocalRepo {
+    // Drop order matters: `repo` is declared before `_guard` so that on drop
+    // the inner `LocalRepository` (and any resources it holds, like an LMDB
+    // `heed::Env`) is released *before* the [`RepoDirGuard`] removes the
+    // on-disk repo directory.
+    repo: LocalRepository,
+    _guard: RepoDirGuard,
+}
+
+impl TestLocalRepo {
+    /// Bring a [`LocalRepository`] under automatic resource management.
+    ///
+    /// Uses a supplied single-use constructor function to make a new [`LocalRepository`],
+    /// is then immeately wrapped into the [`TestLocalRepo`] guard.
+    pub fn new<R>(make_repo: R) -> Result<Self, OxenError>
+    where
+        R: FnOnce() -> Result<LocalRepository, OxenError>,
+    {
+        let repo = make_repo()?;
+        let repo_dir = repo.path.clone();
+        Ok(Self {
+            repo,
+            _guard: RepoDirGuard::new(repo_dir),
+        })
+    }
+
+    /// Drop the inner [`LocalRepository`]  while keeping the on-disk repo dir alive for further reads.
+    ///
+    /// Can be used to e.g. release an LMDB env. Calling this method consumes the guard and
+    /// returns the guard around the repository's on-disk directory.
+    ///
+    /// This [`TestLocalRepo`] guard can be reinstated by using the `.try_into()` implementation
+    /// on the returned [`RepoDirGuard`].
+    pub fn drop_local_repo(self) -> RepoDirGuard {
+        let TestLocalRepo { repo, _guard } = self;
+        drop(repo);
+        _guard
+    }
+}
+
+/// A guarded repository dereferences to a [`& LocalRepository`].
+impl Deref for TestLocalRepo {
+    type Target = LocalRepository;
+
+    fn deref(&self) -> &Self::Target {
+        &self.repo
+    }
+}
+
+/// Load a repository from the guarded directory, returning a guarded local repository.
+impl TryFrom<RepoDirGuard> for TestLocalRepo {
+    type Error = OxenError;
+    fn try_from(repo_dir: RepoDirGuard) -> Result<Self, Self::Error> {
+        let repo = LocalRepository::from_dir(&repo_dir as &Path)?;
+        Ok(TestLocalRepo {
+            repo,
+            _guard: repo_dir,
+        })
+    }
+}

--- a/crates/lib/src/test/repo_prep.rs
+++ b/crates/lib/src/test/repo_prep.rs
@@ -1,0 +1,139 @@
+//! Test helpers for preparing repository state.
+//!
+//! Includes both "fresh" (i.e. empty) repositories and functions for making
+//! commits within a repository.
+//!
+//!
+use std::path::PathBuf;
+
+use crate::config::repository_config::MerkleStoreKind;
+use crate::core::v_latest::init_with_version_and_merkle_store;
+use crate::core::versions::MinOxenVersion;
+use crate::error::OxenError;
+use crate::model::LocalRepository;
+use crate::repositories;
+use crate::test::repo_guard::{RepoDirGuard, TestLocalRepo};
+use crate::test::test_utils::run_async;
+use crate::test::{
+    add_txt_file_to_dir, create_prefixed_dir, create_repo_dir, generate_random_string,
+    init_test_env, test_run_dir,
+};
+
+/// Base directory under which LMDB-backed test repos are rooted.
+///
+/// LMDB requires APIs that support the memory-mapped file semantics it requires. Many virtual
+/// filesystems don't implement these APIs, so LMDB in general cannot work on a VFS. However,
+/// RAM disks in Linux and macOS do support the mmap APIs LMDB needs.
+///
+/// On Windows, LMDB depends on NT memory-section APIs that are not implemented by RAM disks.
+/// On Windows CI `OXEN_TEST_RUN_DIR=R:\test` is an ImDisk RAMDisk (a VFS) and opening an LMDB
+/// env there fails with `Os { code: 1, .. }` → "Incorrect function." Routing LMDB-backed test
+/// repos to the OS temp dir keeps the env on the host's real volume (NTFS on Windows runners).
+///
+/// This function mirrors `lmdb_test_root` in
+/// `crates/lib/src/core/db/merkle_node/lmdb.rs`, used by the low-level [`LmdbBackend`] tests.
+#[inline(always)]
+fn lmdb_test_base() -> PathBuf {
+    std::env::temp_dir().join("oxen-lmdb-tests")
+}
+
+/// Create a fresh empty dir suitable for an LMDB-backed test repo that deletes the directory on Drop.
+/// The dir lives under [`lmdb_test_base`] rather than `OXEN_TEST_RUN_DIR`.
+#[allow(dead_code)]
+pub(crate) fn create_lmdb_safe_empty_dir() -> Result<RepoDirGuard, OxenError> {
+    let dir = create_prefixed_dir(lmdb_test_base(), "dir")?;
+    Ok(RepoDirGuard::new(dir))
+}
+
+/// Construct a fresh test repo dir, initialize a [`LocalRepository`] in it
+/// with the given [`crate::config::repository_config::MerkleStoreKind`], and
+/// return a [`TestLocalRepo`] that cleans the dir up on Drop. Mirrors the
+/// repo shape produced by the former
+/// `run_empty_local_repo_test_with_merkle_store` helper.
+///
+/// For `MerkleStoreKind::Lmdb` the repo dir is routed under
+/// [`lmdb_test_base`] so the LMDB env never lands on a VFS like Windows CI's
+/// ImDisk RAMDisk.
+///
+/// For tests that start on `File` but later transcode the same `repo.path`
+/// into LMDB (i.e. the migration tests in
+/// `m20260512000000_switch_merkle_store_to_lmdb`), use
+/// [`init_lmdb_safe_test_repo_with_merkle_store`] instead — its `File` arm
+/// also roots under [`lmdb_test_base`] so the later LMDB open succeeds on
+/// Windows.
+#[allow(dead_code)]
+pub(crate) fn init_test_repo_with_merkle_store(
+    kind: MerkleStoreKind,
+) -> Result<TestLocalRepo, OxenError> {
+    init_test_env();
+    log::info!("<<<<< init_test_repo_with_merkle_store start ({kind:?})");
+    let repo_dir = match kind {
+        MerkleStoreKind::Lmdb => create_prefixed_dir(lmdb_test_base(), "dir")?,
+        MerkleStoreKind::File => create_repo_dir(test_run_dir())?,
+    };
+    let guarded_repo = TestLocalRepo::new(|| {
+        init_with_version_and_merkle_store(&repo_dir, MinOxenVersion::LATEST, false, kind)
+    })?;
+    log::info!(">>>>> init_test_repo_with_merkle_store ready");
+    Ok(guarded_repo)
+}
+
+/// Variant of [`init_test_repo_with_merkle_store`] that roots **both** the
+/// `File` and `Lmdb` arms under [`lmdb_test_base`] (the OS temp dir, i.e. NTFS
+/// on Windows CI) instead of the usual `test_run_dir()`.
+///
+/// Use this for tests that start the repo on the file backend but later open
+/// an LMDB env at the same `repo.path` — currently just the migration tests
+/// in `m20260512000000_switch_merkle_store_to_lmdb`.
+///
+/// **Why this exists.** On the Windows CI runner `OXEN_TEST_RUN_DIR=R:\test`
+/// is an ImDisk RAMDisk — a Win32-level virtual filesystem that does not
+/// implement the NT memory-section APIs LMDB depends on. Opening an LMDB env
+/// there fails with `STATUS_INVALID_DEVICE_REQUEST`, which `mdb_nt2win32`
+/// translates to `ERROR_INVALID_FUNCTION` (Win32 code 1); the resulting
+/// `Lmdb(Access(Io(Os { code: 1, .. })))` is reported as "Incorrect
+/// function." The migration cannot work around this by redirecting LMDB to a
+/// different path, because `LocalRepository::from_dir` (via
+/// `lmdb::cache::get_or_open`) always opens the env at `repo.path`. The only
+/// correct fix is to give the repo an NTFS-backed `repo.path` up front.
+///
+/// All other tests should keep using [`init_test_repo_with_merkle_store`] so
+/// they continue to benefit from the RAMDisk on Windows CI.
+#[allow(dead_code)]
+pub(crate) fn init_lmdb_safe_test_repo_with_merkle_store(
+    kind: MerkleStoreKind,
+) -> Result<TestLocalRepo, OxenError> {
+    init_test_env();
+    log::info!("<<<<< init_lmdb_safe_test_repo_with_merkle_store start ({kind:?})");
+    let prefix = match kind {
+        MerkleStoreKind::Lmdb => "dir",
+        MerkleStoreKind::File => "repo",
+    };
+    let repo_dir = create_prefixed_dir(lmdb_test_base(), prefix)?;
+    let guarded_repo = TestLocalRepo::new(|| {
+        init_with_version_and_merkle_store(&repo_dir, MinOxenVersion::LATEST, false, kind)
+    })?;
+    log::info!(">>>>> init_lmdb_safe_test_repo_with_merkle_store ready");
+    Ok(guarded_repo)
+}
+
+/// Async variant of [`init_test_repo_with_merkle_store`] — also initializes
+/// the version store, mirroring the former
+/// `run_empty_local_repo_test_with_merkle_store_async` helper.
+#[allow(dead_code)]
+pub(crate) async fn init_test_repo_merkle_init_version_store_async(
+    kind: MerkleStoreKind,
+) -> Result<TestLocalRepo, OxenError> {
+    let repo = init_test_repo_with_merkle_store(kind)?;
+    repo.version_store().init().await?;
+    Ok(repo)
+}
+
+#[allow(dead_code)]
+pub(crate) fn apply_one_commit_local_repo(repo: &LocalRepository) -> Result<(), OxenError> {
+    let txt = generate_random_string(20);
+    let file_path = add_txt_file_to_dir(&repo.path, &txt)?;
+    run_async(async { repositories::add(repo, &file_path).await })??;
+    repositories::commit(repo, "Init commit")?;
+    Ok(())
+}

--- a/crates/lib/src/test/test_utils.rs
+++ b/crates/lib/src/test/test_utils.rs
@@ -1,0 +1,32 @@
+//! Utility functions for test helpers.
+//!
+//!
+use tokio::{
+    runtime::{Handle, Runtime, RuntimeFlavor},
+    task::block_in_place,
+};
+
+/// Drive an async future to completion from a sync context.
+///
+/// Uses the current multi-threaded Tokio runtime, if available.
+/// Otherwise, creates a short-lived runtime for the future.
+pub fn run_async<F>(fut: F) -> std::io::Result<F::Output>
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    // If there's a multi-threaded runtime available, we can tell the runtime to move tasks
+    // off of this thread, then block the current thread on running the future.
+    if let Ok(handle) = Handle::try_current()
+        && handle.runtime_flavor() == RuntimeFlavor::MultiThread
+    {
+        return Ok(block_in_place(|| handle.block_on(fut)));
+    };
+
+    // Either two situations exist:
+    //   1. the runtime exists, but it's single threaded, meaning `block_in_place` will panic!
+    //   2. there's no runtime that currently exists
+    //
+    // We need to make a new short-lived runtime to run this future to completion.
+    Runtime::new().map(|rt| rt.block_on(fut))
+}


### PR DESCRIPTION
Adds a new `oxen migrate` command: `switch_merkle_store_to_lmdb`. This `up` migration
allows existing `FileBackend` repos to migrate to the `LmdbBackend`. Also implements a
`down`, migration, allowing LMDB-using repositories to switch back to the custom file
format implementation.

This is an **optional** migration. It is never required to run, so users must supply
`--run-optional` in order to perform the migration if it is applicable. If the
migration isn't applicable (e.g. `up` but it's already using LMDB, or `down` but
it is already using the `FileBackend`), then it is a no-op with an explanatory message.

Also, updates `lmdb_backend_options` to automatically round-up the desired mmap size
to the nearest multiple of the OS's page size. LMDB requires its mmap file to be a
multiple of the page size.