### PR TITLE
Streaming tar packing & unpacking for Merkle tree operations

### DIFF
--- a/crates/lib/src/core/db/merkle_node/file_backend.rs
+++ b/crates/lib/src/core/db/merkle_node/file_backend.rs
@@ -3,9 +3,7 @@ use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 use flate2::Compression;
-use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use tar::Archive;
 
 use crate::constants::{NODES_DIR, OXEN_HIDDEN_DIR, TREE_DIR};
 use crate::core::db::merkle_node::merkle_node_db::{MerkleDbError, MerkleNodeDB, node_db_path};
@@ -20,6 +18,7 @@ use crate::model::merkle_tree::merkle_writer::{
 use crate::model::merkle_tree::node::MerkleTreeNode;
 use crate::model::{LocalRepository, MerkleHash, TMerkleTreeNode};
 use crate::util;
+use crate::util::tar_stream::{EntryKind, stream_unpack};
 
 /// File-based Merkle node store backend. Implements the [`MerkleStore`] trait.
 ///
@@ -199,6 +198,20 @@ impl NodeWriteSession for FileNodeSession {
 /// `skip_missing_node_dir` is `true`: this matches the existing oxen behavior
 /// of `compress_nodes` / `compress_node` / `compress_commits`. If `false`,
 /// missing node directories result in an `Err(MerkleDbError::MissingNodeDir)`.
+///
+/// **Design note:** unlike the LMDB pack side, this function uses
+/// `tar::Builder::append_dir_all` directly instead of routing through
+/// [`crate::util::tar_stream::stream_pack`]. The file backend's pack already
+/// streams (the archive is never materialized in memory — `append_dir_all`
+/// opens files lazily and pipes them through gzip+tar one chunk at a time), so
+/// the only thing centralizing into `stream_pack` would buy us is a uniform
+/// abstraction. Against that: the byte-compat tests in this file pin the exact
+/// `path → body` map of the emitted archive, and `append_dir_all`'s emission
+/// shape (which intermediate dirs it includes, the order of entries within a
+/// dir) is non-trivial to replicate with a hand-rolled walker. We get the
+/// memory-profile improvement on the LMDB side — where it actually matters,
+/// because that backend used to fully buffer — and leave the already-streaming
+/// file side alone.
 fn write_hashes_tar<W: Write>(
     repo_path: &Path,
     hashes: &HashSet<MerkleHash>,
@@ -303,62 +316,52 @@ fn extract_tar_under<R: Read>(
     oxen_hidden: &Path,
     overwrite_existing: bool,
 ) -> Result<HashSet<MerkleHash>, MerkleDbError> {
-    let mut hashes: HashSet<MerkleHash> = HashSet::new();
-    let decoder = GzDecoder::new(reader);
-    let mut archive = Archive::new(decoder);
-    let entries = archive.entries().map_err(MerkleDbError::CannotReadMerkle)?;
-
-    let tree_nodes_prefix = Path::new(TREE_DIR).join(NODES_DIR);
-
-    for entry in entries {
-        let Ok(mut file) = entry else {
-            log::error!("Could not unpack file in merkle tar archive");
-            // TODO: raise this error to the caller instead!?
-            continue;
-        };
-        let path = file.path()?.into_owned();
-        // Path-traversal guard: refuse any entry whose path resolves above its container.
-        if path.components().any(|c| matches!(c, Component::ParentDir)) {
-            return Err(MerkleDbError::PathTraversal(path.display().to_string()));
-        }
-        // Entry-type validation: only regular files and directories are allowed.
-        let entry_type = file.header().entry_type();
-        if !entry_type.is_file() && !entry_type.is_dir() {
-            return Err(MerkleDbError::UnsupportedTarEntry {
-                path: path.display().to_string(),
-            });
-        }
+    // Streaming variant: path-traversal and unsupported-entry-type guards live
+    // inside [`stream_unpack`] now, so we only handle the file-backend-specific
+    // bits (server-canonical vs legacy-client-push prefix, skip-existing policy,
+    // atomic writes, hash extraction).
+    struct St {
+        hashes: HashSet<MerkleHash>,
+        oxen_hidden: PathBuf,
+        tree_nodes_prefix: PathBuf,
+        overwrite_existing: bool,
+    }
+    let state = St {
+        hashes: HashSet::new(),
+        oxen_hidden: oxen_hidden.to_path_buf(),
+        tree_nodes_prefix: Path::new(TREE_DIR).join(NODES_DIR),
+        overwrite_existing,
+    };
+    let state = stream_unpack::<_, _, _, MerkleDbError>(reader, state, |entry, st| {
         // Server-style entries already contain `tree/nodes/...`; join directly.
         // Legacy client-push entries begin at `{prefix}/{suffix}/...`; prepend `tree/nodes/`.
-        let dst_path = if path.starts_with(&tree_nodes_prefix) {
-            oxen_hidden.join(&path)
+        let dst_path = if entry.path.starts_with(&st.tree_nodes_prefix) {
+            st.oxen_hidden.join(entry.path)
         } else {
-            oxen_hidden.join(&tree_nodes_prefix).join(&path)
+            st.oxen_hidden.join(&st.tree_nodes_prefix).join(entry.path)
         };
-        if dst_path.exists() && !overwrite_existing {
+        if dst_path.exists() && !st.overwrite_existing {
             log::info!("Node already exists at {dst_path:?}, skipping");
-            continue;
-        }
-        if entry_type.is_dir() {
-            std::fs::create_dir_all(&dst_path)?;
         } else {
-            util::fs::atomic_write_from_reader_sync(&dst_path, &mut file)
-                .map_err(|err| MerkleDbError::FsTransport(Box::new(err)))?;
+            match entry.kind {
+                EntryKind::Directory => {
+                    std::fs::create_dir_all(&dst_path)?;
+                }
+                EntryKind::File => {
+                    util::fs::atomic_write_from_reader_sync(&dst_path, entry.body)
+                        .map_err(|err| MerkleDbError::FsTransport(Box::new(err)))?;
+                }
+            }
         }
-
         // Extract the merkle hash from this entry's path, if it identifies one.
-        //
-        // After the path-resolution above, `dst_path` is of the form
-        // `<oxen_hidden>/tree/nodes/<rest>`. We classify entries by the SHAPE
-        // of `<rest>`, never by whether components happen to be hex. We assume that
-        // we have the hex-encoded hash as the `{prefix}/{suffix}` dirs.
-        if let Some(hash) = extract_hash_from_entry_path(&dst_path, oxen_hidden)? {
-            hashes.insert(hash);
+        // `dst_path` is `<oxen_hidden>/tree/nodes/<rest>`; classification is by
+        // the SHAPE of `<rest>`, never by whether components happen to be hex.
+        if let Some(hash) = extract_hash_from_entry_path(&dst_path, &st.oxen_hidden)? {
+            st.hashes.insert(hash);
         }
-        // If we can't extract a path, it's because we're looking at a node or children file.
-        // We will have already obtained the hash from the directory, so this is ok!
-    }
-    Ok(hashes)
+        Ok(())
+    })?;
+    Ok(state.hashes)
 }
 
 /// Classification of a tar entry's path under `tree/nodes/`.
@@ -573,6 +576,8 @@ mod tests {
     use std::path::PathBuf;
 
     use bytesize::ByteSize;
+    use flate2::read::GzDecoder;
+    use tar::Archive;
 
     use super::*;
     use crate::error::OxenError;

--- a/crates/lib/src/core/db/merkle_node/lmdb/pack.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/pack.rs
@@ -1,4 +1,4 @@
-//! [`MerklePacker`] + [`MerkleUnpacker`] implementations for the [`LmdbBackend`].
+//! [`MerklePacker`] implementation for the [`LmdbBackend`].
 //!
 //! The wire format produced/consumed is identical to the one [`super::super::file_backend::FileBackend`]
 //! emits: tar-gz of `tree/nodes/{prefix}/{suffix}/{node,children}` entries, where
@@ -8,28 +8,26 @@
 //!
 //! Pack: for each requested hash (or all hashes in [`MerklePacker::pack_all`]),
 //! the LMDB-side node + link rows are recombined into the file backend's
-//! `node` + `children` byte format and appended to the tar archive.
-//!
-//! Unpack: tar entries are first buffered in-memory and paired up by hash, then
-//! the parent's `node` byte format is decoded to recover {kind, parent_id,
-//! data, children-lookup}; the corresponding `children` blob is sliced via the
-//! lookup to recover each child's full node data; everything is committed in
-//! one [`heed::RwTxn`].
+//! `node` + `children` byte format and streamed through the shared
+//! [`crate::util::tar_stream::stream_pack`] helper. Per-hash work still buffers
+//! that single hash's `node` and `children` blobs (the lookup table's child
+//! offsets need to be known up front), but the archive as a whole is never
+//! materialized — each `PackEntry` flows through gzip+tar one body chunk at a
+//! time.
 
 use std::collections::HashSet;
-use std::io::Write;
+use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 
 use flate2::Compression;
-use flate2::write::GzEncoder;
 
 use crate::constants::{NODES_DIR, TREE_DIR};
 use crate::core::db::merkle_node::lmdb::LmdbError;
 use crate::core::db::merkle_node::lmdb::lmdb_backend::LmdbBackend;
-use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
 use crate::error::OxenError;
 use crate::model::merkle_tree::merkle_transport::{MerklePacker, PackOptions};
 use crate::model::{MerkleHash, MerkleTreeNodeType};
+use crate::util::tar_stream::{EntryKind, PackEntry, stream_pack};
 
 impl MerklePacker for LmdbBackend {
     /// Pack the given node `hashes` into `out`. Layout (and gzip level) follow
@@ -41,33 +39,22 @@ impl MerklePacker for LmdbBackend {
         opts: PackOptions,
         out: &mut dyn Write,
     ) -> Result<(), OxenError> {
-        let enc = GzEncoder::new(out, pack_options_compression(opts));
-        let mut tar = tar::Builder::new(enc);
-        for hash in hashes {
-            append_one_node(self, &mut tar, hash, &opts)?;
-        }
-        tar.finish().map_err(MerkleDbError::Io)?;
-        tar.into_inner()
-            .map_err(MerkleDbError::Io)?
-            .finish()
-            .map_err(MerkleDbError::Io)?;
-        Ok(())
+        let entries = hashes
+            .iter()
+            .copied()
+            .flat_map(|hash| entries_for_hash(self, hash, opts));
+        stream_pack::<_, _, OxenError>(out, pack_options_compression(opts), entries)
     }
 
     /// Pack every node currently in the LMDB store into `out` using the
     /// server-canonical layout — same as [`super::super::file_backend::FileBackend::pack_all`].
     fn pack_all(&self, out: &mut dyn Write) -> Result<(), OxenError> {
-        let enc = GzEncoder::new(out, Compression::fast());
-        let mut tar = tar::Builder::new(enc);
-        for hash in all_node_hashes(self)? {
-            append_one_node(self, &mut tar, &hash, &PackOptions::ServerCanonical)?;
-        }
-        tar.finish().map_err(MerkleDbError::Io)?;
-        tar.into_inner()
-            .map_err(MerkleDbError::Io)?
-            .finish()
-            .map_err(MerkleDbError::Io)?;
-        Ok(())
+        let opts = PackOptions::ServerCanonical;
+        let hashes = all_node_hashes(self)?;
+        let entries = hashes
+            .into_iter()
+            .flat_map(|hash| entries_for_hash(self, hash, opts));
+        stream_pack::<_, _, OxenError>(out, pack_options_compression(opts), entries)
     }
 
     /// Estimate the **uncompressed** packed node tar payload for the LMDB backend.
@@ -77,7 +64,7 @@ impl MerklePacker for LmdbBackend {
     /// since `node` and `children` blobs are hash-dense and compress to ~1.0×.
     ///
     /// Hashes not present in LMDB contribute 0, matching `pack_nodes`'s silent-skip
-    /// behaviour. File / FileChunk nodes also contribute 0 because [`append_one_node`]
+    /// behaviour. File / FileChunk nodes also contribute 0 because [`entries_for_hash`]
     /// skips them — they ride inside a parent's `children` blob, not their own dir.
     fn raw_byte_count(&self, hashes: &HashSet<MerkleHash>) -> u64 {
         const TAR_HEADER_BYTES: u64 = 512;
@@ -154,33 +141,48 @@ fn all_node_hashes(lmdb: &LmdbBackend) -> Result<Vec<MerkleHash>, LmdbError> {
     Ok(hashes)
 }
 
-/// Append `hash`'s `node` + `children` byte payloads to `tar`. Missing
-/// hashes are silently skipped to match the file backend's behaviour.
-/// File / file-chunk hashes are also skipped because the file backend
-/// stores those embedded inside a parent's `children` file, not as their
-/// own `{prefix}/{suffix}/` dir entries.
-fn append_one_node<W: Write>(
+/// Produce the lazy per-hash entry sequence (dir + node-file + children-file)
+/// for the streaming pack pipeline.
+///
+/// Returns an empty Vec for hashes that should be skipped silently (missing
+/// from LMDB, or file-level kinds that don't get their own `{prefix}/{suffix}/`
+/// directory). On any LMDB read error, returns a single `Err` item so the error
+/// surfaces through `stream_pack` without aborting the iterator at panic
+/// boundaries.
+fn entries_for_hash(
     lmdb: &LmdbBackend,
-    tar: &mut tar::Builder<GzEncoder<W>>,
-    hash: &MerkleHash,
-    opts: &PackOptions,
-) -> Result<(), OxenError> {
-    let Some(stored_node) = lmdb.full_get_node(hash)? else {
-        return Ok(());
+    hash: MerkleHash,
+    opts: PackOptions,
+) -> Vec<Result<PackEntry, OxenError>> {
+    match build_entries_for_hash(lmdb, hash, opts) {
+        Ok(entries) => entries.into_iter().map(Ok).collect(),
+        Err(err) => vec![Err(err.into())],
+    }
+}
+
+/// Build the (dir, node, children) tar entries for one hash. Returns an empty
+/// Vec for the silent-skip cases (missing node, file/file-chunk kinds, missing
+/// link row).
+fn build_entries_for_hash(
+    lmdb: &LmdbBackend,
+    hash: MerkleHash,
+    opts: PackOptions,
+) -> Result<Vec<PackEntry>, LmdbError> {
+    let Some(stored_node) = lmdb.full_get_node(&hash)? else {
+        return Ok(Vec::new());
     };
     // File-level nodes don't get their own dir in the file backend's wire
     // format; they only appear embedded in a parent's `children` blob.
-    // Skip here so the LMDB pack stays bit-shape-compatible.
     if matches!(
         stored_node.kind(),
         MerkleTreeNodeType::File | MerkleTreeNodeType::FileChunk
     ) {
-        return Ok(());
+        return Ok(Vec::new());
     }
-    let Some(link) = lmdb.get_links(hash)? else {
+    let Some(link) = lmdb.get_links(&hash)? else {
         // Node row exists but link row doesn't — should be impossible per
         // the writer's invariants. Skip rather than fail the whole pack.
-        return Ok(());
+        return Ok(Vec::new());
     };
 
     let mut children_blob: Vec<u8> = Vec::new();
@@ -217,11 +219,32 @@ fn append_one_node<W: Write>(
         PackOptions::ServerCanonical => Path::new(TREE_DIR).join(NODES_DIR).join(&dir_prefix),
         PackOptions::LegacyClientPush => PathBuf::from(&dir_prefix),
     };
-    // Directory entry first, then `node` & `children` file entries under it.
-    append_tar_dir(tar, &tar_subdir)?;
-    append_tar_file(tar, &tar_subdir.join("node"), &node_blob)?;
-    append_tar_file(tar, &tar_subdir.join("children"), &children_blob)?;
-    Ok(())
+    let node_path = tar_subdir.join("node");
+    let children_path = tar_subdir.join("children");
+
+    Ok(vec![
+        PackEntry {
+            path: tar_subdir,
+            kind: EntryKind::Directory,
+            size: 0,
+            mode: 0o755,
+            body: Box::new(Cursor::new(Vec::new())),
+        },
+        PackEntry {
+            path: node_path,
+            kind: EntryKind::File,
+            size: node_blob.len() as u64,
+            mode: 0o644,
+            body: Box::new(Cursor::new(node_blob)),
+        },
+        PackEntry {
+            path: children_path,
+            kind: EntryKind::File,
+            size: children_blob.len() as u64,
+            mode: 0o644,
+            body: Box::new(Cursor::new(children_blob)),
+        },
+    ])
 }
 
 /// One entry of the parent's `node`-file child lookup table — mirrors the
@@ -259,36 +282,6 @@ fn encode_node_file(
     buf
 }
 
-/// Append a directory entry into a tar builder. Mirrors what `tar::Builder::append_dir_all`
-/// does for a `{prefix}/{suffix}` dir when the file backend builds its tar.
-fn append_tar_dir<W: Write>(
-    tar: &mut tar::Builder<GzEncoder<W>>,
-    path: &Path,
-) -> Result<(), MerkleDbError> {
-    let mut header = tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_mode(0o755);
-    header.set_entry_type(tar::EntryType::Directory);
-    header.set_cksum();
-    tar.append_data(&mut header, path, std::io::Cursor::new(Vec::new()))
-        .map_err(MerkleDbError::Io)
-}
-
-/// Append a regular file entry into a tar builder.
-fn append_tar_file<W: Write>(
-    tar: &mut tar::Builder<GzEncoder<W>>,
-    path: &Path,
-    data: &[u8],
-) -> Result<(), MerkleDbError> {
-    let mut header = tar::Header::new_gnu();
-    header.set_size(data.len() as u64);
-    header.set_mode(0o644);
-    header.set_entry_type(tar::EntryType::Regular);
-    header.set_cksum();
-    tar.append_data(&mut header, path, std::io::Cursor::new(data.to_vec()))
-        .map_err(MerkleDbError::Io)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -296,10 +289,13 @@ mod tests {
     use crate::core::db::merkle_node::lmdb::tests::commit_with_hash;
     use crate::core::db::merkle_node::lmdb::tests::h;
     use crate::core::db::merkle_node::lmdb::tests::with_test_backend;
+    use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
     use crate::model::merkle_tree::UnpackOptions;
     use crate::model::merkle_tree::merkle_writer::MerkleWriter;
     use crate::repositories;
     use crate::test;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
     use std::collections::HashSet;
 
     /// Pack just a parent commit (with one embedded child commit), unpack into
@@ -514,6 +510,260 @@ mod tests {
             let store = target_repo.merkle_store()?;
             assert!(store.exists(&a_h)?);
             assert!(store.exists(&b_h)?);
+            Ok(())
+        })
+    }
+
+    /// Rebuild a tar-gz archive with its entries in a caller-controlled order.
+    ///
+    /// Used to construct streaming-edge-case tarballs (out-of-order pair
+    /// arrival, lone-node, lone-children) without having to hand-build the
+    /// LMDB-encoded node/children blobs from scratch.
+    fn rebuild_tar_with_filter<F>(original: &[u8], keep_and_order: F) -> Vec<u8>
+    where
+        F: Fn(&std::path::Path) -> Option<u32>,
+    {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+        use tar::Archive;
+
+        let decoder = GzDecoder::new(original);
+        let mut archive = Archive::new(decoder);
+        let mut entries: Vec<(std::path::PathBuf, tar::EntryType, Vec<u8>, u32)> = Vec::new();
+        for entry in archive
+            .entries()
+            .expect("rebuild: cannot iterate archive entries")
+        {
+            let mut entry = entry.expect("rebuild: cannot read entry");
+            let path = entry
+                .path()
+                .expect("rebuild: cannot read path")
+                .into_owned();
+            let entry_type = entry.header().entry_type();
+            let mut body = Vec::new();
+            entry
+                .read_to_end(&mut body)
+                .expect("rebuild: cannot read body");
+            if let Some(rank) = keep_and_order(&path) {
+                entries.push((path, entry_type, body, rank));
+            }
+        }
+        entries.sort_by_key(|(_, _, _, rank)| *rank);
+
+        let mut buf = Vec::new();
+        {
+            let enc = GzEncoder::new(&mut buf, Compression::fast());
+            let mut tar = tar::Builder::new(enc);
+            for (path, entry_type, body, _) in &entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(body.len() as u64);
+                header.set_mode(if entry_type.is_dir() { 0o755 } else { 0o644 });
+                header.set_entry_type(*entry_type);
+                header.set_cksum();
+                tar.append_data(&mut header, path, std::io::Cursor::new(body.clone()))
+                    .expect("rebuild: cannot append entry");
+            }
+            tar.finish().expect("rebuild: tar finish");
+            tar.into_inner()
+                .expect("rebuild: tar inner")
+                .finish()
+                .expect("rebuild: gz finish");
+        }
+        buf
+    }
+
+    /// Streaming unpack must handle pairs whose `node` and `children` entries
+    /// are interleaved with other pairs' entries in the tar (the natural
+    /// outcome when iteration order varies across packers). We hand-build an
+    /// archive with `a.children, b.node, a.node, b.children` and verify both
+    /// hashes round-trip correctly.
+    #[test]
+    fn test_lmdb_unpack_handles_out_of_order_pairs() -> Result<(), OxenError> {
+        with_test_backend(|repo, backend| {
+            let a_h = h("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            let b_h = h("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            let a = commit_with_hash(repo, a_h);
+            let b = commit_with_hash(repo, b_h);
+            let session = backend.begin()?;
+            session.create_node(&a, None)?.finish()?;
+            session.create_node(&b, None)?.finish()?;
+            session.finish()?;
+
+            let mut buf = Vec::new();
+            backend.pack_nodes(
+                &HashSet::from_iter([a_h, b_h]),
+                PackOptions::ServerCanonical,
+                &mut buf,
+            )?;
+
+            // Score entries so a-children comes first, then b-node, then
+            // a-node, then b-children, with dirs and anything else trailing.
+            let a_prefix = a_h.to_hex_hash().node_db_prefix();
+            let b_prefix = b_h.to_hex_hash().node_db_prefix();
+            let a_prefix_str = a_prefix.to_string_lossy().replace('\\', "/");
+            let b_prefix_str = b_prefix.to_string_lossy().replace('\\', "/");
+            let reordered = rebuild_tar_with_filter(&buf, |path| {
+                let p = path.to_string_lossy().replace('\\', "/");
+                let in_a = p.contains(&a_prefix_str);
+                let in_b = p.contains(&b_prefix_str);
+                if in_a && p.ends_with("/children") {
+                    Some(0)
+                } else if in_b && p.ends_with("/node") {
+                    Some(1)
+                } else if in_a && p.ends_with("/node") {
+                    Some(2)
+                } else if in_b && p.ends_with("/children") {
+                    Some(3)
+                } else {
+                    Some(4)
+                }
+            });
+
+            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &reordered[..], UnpackOptions::Overwrite)?;
+            assert!(installed.contains(&a_h));
+            assert!(installed.contains(&b_h));
+            let store = target_repo.merkle_store()?;
+            assert!(store.exists(&a_h)?);
+            assert!(store.exists(&b_h)?);
+            Ok(())
+        })
+    }
+
+    /// A tarball with only a `node` entry for a hash (no matching `children`)
+    /// is valid per the file-backend contract: `parse_pair(node, &[])` decodes
+    /// it as a leaf node. The streaming unpack flushes lone-node partials at
+    /// end-of-stream.
+    #[test]
+    fn test_lmdb_unpack_tolerates_node_without_children() -> Result<(), OxenError> {
+        with_test_backend(|repo, backend| {
+            let parent_h = h("11111111111111111111111111111111");
+            let parent = commit_with_hash(repo, parent_h);
+            let session = backend.begin()?;
+            session.create_node(&parent, None)?.finish()?;
+            session.finish()?;
+
+            let mut buf = Vec::new();
+            backend.pack_nodes(
+                &HashSet::from_iter([parent_h]),
+                PackOptions::ServerCanonical,
+                &mut buf,
+            )?;
+
+            // Strip the `children` entry — keep everything else.
+            let stripped = rebuild_tar_with_filter(&buf, |path| {
+                let p = path.to_string_lossy().replace('\\', "/");
+                if p.ends_with("/children") {
+                    None
+                } else {
+                    Some(0)
+                }
+            });
+
+            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &stripped[..], UnpackOptions::Overwrite)?;
+            assert!(
+                installed.contains(&parent_h),
+                "lone-node entry's hash must still be reported: {installed:?}"
+            );
+            let store = target_repo.merkle_store()?;
+            assert!(
+                store.exists(&parent_h)?,
+                "parent commit must be readable after lone-node unpack"
+            );
+            Ok(())
+        })
+    }
+
+    /// A tarball with only a `children` entry for a hash (no matching `node`)
+    /// can't be decoded — `parse_pair` needs the node's lookup table to slice
+    /// the children blob. The streaming unpack drops orphan-children bytes
+    /// silently but still reports the hash through `seen` (matches the
+    /// buffered loop's contract).
+    #[test]
+    fn test_lmdb_unpack_drops_orphan_children_but_reports_hash() -> Result<(), OxenError> {
+        with_test_backend(|repo, backend| {
+            let parent_h = h("22222222222222222222222222222222");
+            let parent = commit_with_hash(repo, parent_h);
+            let session = backend.begin()?;
+            session.create_node(&parent, None)?.finish()?;
+            session.finish()?;
+
+            let mut buf = Vec::new();
+            backend.pack_nodes(
+                &HashSet::from_iter([parent_h]),
+                PackOptions::ServerCanonical,
+                &mut buf,
+            )?;
+
+            // Strip the `node` entry; keep `children` and dirs.
+            let stripped = rebuild_tar_with_filter(&buf, |path| {
+                let p = path.to_string_lossy().replace('\\', "/");
+                if p.ends_with("/node") { None } else { Some(0) }
+            });
+
+            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &stripped[..], UnpackOptions::Overwrite)?;
+            assert!(
+                installed.contains(&parent_h),
+                "orphan-children entry's hash must still be reported: {installed:?}"
+            );
+            // The parent's row was NOT written (no node bytes to decode).
+            let store = target_repo.merkle_store()?;
+            assert!(
+                !store.exists(&parent_h)?,
+                "no row should be written for an orphan-children-only hash"
+            );
+            Ok(())
+        })
+    }
+
+    /// `UnpackOptions::SkipExisting` must not clobber a pre-existing row when
+    /// the same hash arrives in the tarball.
+    #[test]
+    fn test_lmdb_unpack_skip_existing_preserves_existing_row() -> Result<(), OxenError> {
+        with_test_backend(|repo, backend| {
+            let hash = h("33333333333333333333333333333333");
+            let commit = commit_with_hash(repo, hash);
+            let session = backend.begin()?;
+            session.create_node(&commit, None)?.finish()?;
+            session.finish()?;
+
+            // Pack the source.
+            let mut buf = Vec::new();
+            backend.pack_nodes(
+                &HashSet::from_iter([hash]),
+                PackOptions::ServerCanonical,
+                &mut buf,
+            )?;
+
+            // Set up a target with a pre-existing row for the same hash.
+            let target_repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+            let target_store = target_repo.merkle_store()?;
+            {
+                let session = target_store.begin()?;
+                session.create_node(&commit, None)?.finish()?;
+                session.finish()?;
+            }
+            let pre_existing = target_store
+                .get_node(&hash)?
+                .expect("pre-existing row should be readable");
+
+            // SkipExisting unpack — must not overwrite.
+            let installed = target_repo
+                .merkle_transport()?
+                .unpack(&mut &buf[..], UnpackOptions::SkipExisting)?;
+            assert!(installed.contains(&hash));
+            let after = target_store
+                .get_node(&hash)?
+                .expect("hash should still exist");
+            assert_eq!(pre_existing.parent_id, after.parent_id);
             Ok(())
         })
     }

--- a/crates/lib/src/core/db/merkle_node/lmdb/unpack.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/unpack.rs
@@ -1,28 +1,27 @@
-//! [`MerklePacker`] + [`MerkleUnpacker`] implementations for the [`LmdbBackend`].
+//! [`MerkleUnpacker`] implementation for the [`LmdbBackend`].
 //!
-//! The wire format produced/consumed is identical to the one [`super::super::file_backend::FileBackend`]
+//! The wire format consumed is identical to the one [`super::super::file_backend::FileBackend`]
 //! emits: tar-gz of `tree/nodes/{prefix}/{suffix}/{node,children}` entries, where
 //! `node` & `children` follow the [`super::super::merkle_node_db::MerkleNodeDB`]
-//! on-disk byte layout. Cross-backend interop is the requirement — an LMDB-backed
-//! local repo must be able to push to a File-backed server and pull from one.
+//! on-disk byte layout.
 //!
-//! Pack: for each requested hash (or all hashes in [`MerklePacker::pack_all`]),
-//! the LMDB-side node + link rows are recombined into the file backend's
-//! `node` + `children` byte format and appended to the tar archive.
+//! Unpack is **streaming**: we drive [`crate::util::tar_stream::stream_unpack`] and
+//! pair `node` / `children` entries by hash on the fly. As soon as both members of
+//! a pair are available we parse and commit the parent's node + link rows; the
+//! raw bytes get released immediately. Embedded children whose own `{prefix}/
+//! {suffix}/` pair hasn't shown up are deferred and seeded at end-of-stream — same
+//! semantics as the old buffered loop, but without holding every blob in RAM
+//! simultaneously.
 //!
-//! Unpack: tar entries are first buffered in-memory and paired up by hash, then
-//! the parent's `node` byte format is decoded to recover {kind, parent_id,
-//! data, children-lookup}; the corresponding `children` blob is sliced via the
-//! lookup to recover each child's full node data; everything is committed in
-//! one [`heed::RwTxn`].
+//! Memory profile: O(currently-unpaired entries + embedded-children-without-own-
+//! pair). For a well-formed archive whose `node` / `children` entries are
+//! contiguous per hash (file backend's `append_dir_all` and LMDB's pack both
+//! emit them this way), the unpaired set is ~1 hash at any time. Compare with
+//! the old approach which buffered the full archive.
 
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
-
-use flate2::read::GzDecoder;
-use tar::Archive;
 
 use crate::constants::{NODES_DIR, TREE_DIR};
 use crate::core::db::merkle_node::file_backend::{TarEntryKind, classify_tar_entry_path};
@@ -33,6 +32,7 @@ use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
 use crate::error::OxenError;
 use crate::model::merkle_tree::merkle_transport::{MerkleUnpacker, UnpackOptions};
 use crate::model::{MerkleHash, MerkleTreeNodeType};
+use crate::util::tar_stream::{StreamedEntry, stream_unpack};
 
 impl MerkleUnpacker for LmdbBackend {
     /// Unpack a tar-gz wire stream into the LMDB store.
@@ -41,97 +41,274 @@ impl MerkleUnpacker for LmdbBackend {
     /// and the legacy client-push (`{prefix}/{suffix}/...`) layouts — same
     /// behaviour as [`super::super::file_backend::FileBackend::unpack`].
     ///
-    /// `UnpackOptions::SkipExisting` doesn't write entries whose hashes are
+    /// `UnpackOptions::SkipExisting` doesn't overwrite entries whose hashes are
     /// already in the LMDB store; `UnpackOptions::Overwrite` writes everything.
     fn unpack(
         &self,
         reader: &mut dyn Read,
         opts: UnpackOptions,
     ) -> Result<HashSet<MerkleHash>, OxenError> {
-        let buffered = collect_tar_entries(reader)?;
-        write_unpacked_into_lmdb(self, buffered, opts)
-    }
-}
-
-/// Hashes whose `node` + `children` payload bytes have been read out of the tar.
-/// Either side may be absent if the tar archive is incomplete — handled when
-/// we pair them up.
-#[derive(Default)]
-struct BufferedTarPayloads {
-    node_files: HashMap<MerkleHash, Vec<u8>>,
-    children_files: HashMap<MerkleHash, Vec<u8>>,
-    /// Hashes we observed at any path component. Returned to the caller even
-    /// if the entry's bytes were skipped (mirrors the file backend's reporting
-    /// of every parsed hash from the tarball).
-    seen_hashes: HashSet<MerkleHash>,
-}
-
-/// Read every `node` / `children` entry out of the tar archive into memory,
-/// keyed by hash. Path validation (path-traversal, allowed entry types,
-/// well-formed hash dirs) matches [`super::super::file_backend::FileBackend::unpack`].
-fn collect_tar_entries(reader: &mut dyn Read) -> Result<BufferedTarPayloads, OxenError> {
-    let decoder = GzDecoder::new(reader);
-    let mut archive = Archive::new(decoder);
-    let entries = archive.entries().map_err(MerkleDbError::CannotReadMerkle)?;
-
-    let mut buffered = BufferedTarPayloads::default();
-
-    // We classify with the synthetic oxen-hidden root + tree-nodes prefix; the
-    // helper already strips both off. Two virtual roots cover the two layouts
-    // a tar archive can arrive in.
-    let virtual_oxen_hidden = PathBuf::from(".");
-    let server_canonical_root = virtual_oxen_hidden.clone();
-    let legacy_client_push_root = virtual_oxen_hidden.join(TREE_DIR).join(NODES_DIR);
-
-    for entry in entries {
-        let mut entry = entry.map_err(MerkleDbError::CannotReadMerkle)?;
-        let path = entry
-            .path()
-            .map_err(MerkleDbError::CannotReadMerkle)?
-            .into_owned();
-
-        // Mirror file_backend's path-traversal guard.
-        if path
-            .components()
-            .any(|c| matches!(c, std::path::Component::ParentDir))
-        {
-            return Err(MerkleDbError::PathTraversal(path.display().to_string()).into());
-        }
-        let entry_type = entry.header().entry_type();
-        if !entry_type.is_file() && !entry_type.is_dir() {
-            return Err(MerkleDbError::UnsupportedTarEntry {
-                path: path.display().to_string(),
-            }
-            .into());
-        }
-
-        // Classify under both layouts; whichever path validates wins.
-        let classified = if path.starts_with(Path::new(TREE_DIR).join(NODES_DIR)) {
-            classify_tar_entry_path(&server_canonical_root.join(&path), &virtual_oxen_hidden)?
-        } else {
-            classify_tar_entry_path(&legacy_client_push_root.join(&path), &virtual_oxen_hidden)?
+        let wtxn = LmdbBackend::write_txn(&self.lmdb_env)?;
+        let state = UnpackState {
+            backend: self,
+            wtxn,
+            pending_nodes: HashMap::new(),
+            pending_children: HashMap::new(),
+            own_pair_committed: HashSet::new(),
+            deferred_embedded: HashMap::new(),
+            seen: HashSet::new(),
+            overwrite: matches!(opts, UnpackOptions::Overwrite),
         };
 
-        match classified {
-            TarEntryKind::Intermediate => continue,
-            TarEntryKind::HashDir(hash) => {
-                buffered.seen_hashes.insert(hash);
+        let mut state =
+            stream_unpack::<_, _, _, OxenError>(reader, state, |entry, st| on_entry(entry, st))?;
+        flush_partials(&mut state)?;
+        state.wtxn.commit().map_err(LmdbError::Write)?;
+        Ok(state.seen)
+    }
+}
+
+/// Streaming state for [`MerkleUnpacker::unpack`].
+///
+/// Carries the open write transaction, currently-unpaired raw bytes, and the
+/// deferred set of embedded children seen so far without their own pair.
+struct UnpackState<'env> {
+    backend: &'env LmdbBackend,
+    wtxn: heed::RwTxn<'env>,
+    /// `{prefix}/{suffix}/node` raw bytes for hashes whose matching
+    /// `children` entry hasn't yet arrived in the tar stream.
+    pending_nodes: HashMap<MerkleHash, Vec<u8>>,
+    /// `{prefix}/{suffix}/children` raw bytes for hashes whose matching
+    /// `node` entry hasn't yet arrived in the tar stream.
+    pending_children: HashMap<MerkleHash, Vec<u8>>,
+    /// Hashes whose `(node, children)` pair has been parsed and committed to
+    /// LMDB. Embedded-child seeding skips any hash already in this set, since
+    /// the own-pair commit wrote its node + full link.
+    own_pair_committed: HashSet<MerkleHash>,
+    /// Embedded children observed under some parent's `children` blob whose
+    /// own `{prefix}/{suffix}/` pair we haven't (yet) seen. At end-of-stream,
+    /// children still in this map get seeded with a minimal link row pointing
+    /// back at their first-observed parent — matching the file backend's
+    /// "node present, link minimal" tolerance.
+    deferred_embedded: HashMap<MerkleHash, DeferredEmbedded>,
+    /// Hashes parsed out of the tarball — returned to the caller verbatim,
+    /// mirroring [`super::super::file_backend::FileBackend::unpack`]'s contract.
+    seen: HashSet<MerkleHash>,
+    /// `true` for [`UnpackOptions::Overwrite`], `false` for
+    /// [`UnpackOptions::SkipExisting`].
+    overwrite: bool,
+}
+
+/// One embedded child waiting to be seeded if its own pair never shows up.
+struct DeferredEmbedded {
+    parent_hash: MerkleHash,
+    kind: MerkleTreeNodeType,
+    data: Vec<u8>,
+}
+
+/// Drive a single tar entry through the streaming state machine.
+fn on_entry(entry: StreamedEntry<'_>, st: &mut UnpackState<'_>) -> Result<(), OxenError> {
+    let classified = classify_streaming_entry(entry.path)?;
+    match classified {
+        StreamingKind::Intermediate => {
+            // `tree/nodes` / `tree/nodes/{prefix}` directory entries — no body
+            // to read, no hash to record.
+        }
+        StreamingKind::HashDir(hash) => {
+            st.seen.insert(hash);
+        }
+        StreamingKind::Node(hash) => {
+            st.seen.insert(hash);
+            let mut buf = Vec::with_capacity(entry.size as usize);
+            entry.body.read_to_end(&mut buf)?;
+            st.pending_nodes.insert(hash, buf);
+            if st.pending_children.contains_key(&hash) {
+                commit_pair(st, hash)?;
             }
-            TarEntryKind::NodeFile(hash) => {
-                buffered.seen_hashes.insert(hash);
-                let mut bytes = Vec::new();
-                entry.read_to_end(&mut bytes).map_err(MerkleDbError::Io)?;
-                buffered.node_files.insert(hash, bytes);
-            }
-            TarEntryKind::ChildrenFile(hash) => {
-                buffered.seen_hashes.insert(hash);
-                let mut bytes = Vec::new();
-                entry.read_to_end(&mut bytes).map_err(MerkleDbError::Io)?;
-                buffered.children_files.insert(hash, bytes);
+        }
+        StreamingKind::Children(hash) => {
+            st.seen.insert(hash);
+            let mut buf = Vec::with_capacity(entry.size as usize);
+            entry.body.read_to_end(&mut buf)?;
+            st.pending_children.insert(hash, buf);
+            if st.pending_nodes.contains_key(&hash) {
+                commit_pair(st, hash)?;
             }
         }
     }
-    Ok(buffered)
+    Ok(())
+}
+
+/// Both pieces of a hash's `(node, children)` pair are present in the pending
+/// buffers — parse them, commit the parent row, and record any embedded
+/// children that don't yet have their own pair as deferred.
+fn commit_pair(st: &mut UnpackState<'_>, hash: MerkleHash) -> Result<(), OxenError> {
+    let node_bytes = st
+        .pending_nodes
+        .remove(&hash)
+        .expect("commit_pair: pending node bytes must exist");
+    let children_bytes = st
+        .pending_children
+        .remove(&hash)
+        .expect("commit_pair: pending children bytes must exist");
+    let parsed = parse_pair(&node_bytes, &children_bytes)?;
+    finalize_parsed(st, hash, parsed)
+}
+
+/// Write the parent's node + link rows, then update the embedded-children
+/// tracking. Used by both [`commit_pair`] (full pair) and [`flush_partials`]
+/// (node-only pair with empty children blob).
+fn finalize_parsed(
+    st: &mut UnpackState<'_>,
+    hash: MerkleHash,
+    parsed: ParsedEntry,
+) -> Result<(), OxenError> {
+    put_node(st, &hash, parsed.parent_kind, parsed.parent_data)?;
+    let child_hashes: Vec<MerkleHash> = parsed.children.iter().map(|c| c.hash).collect();
+    put_link(st, &hash, parsed.parent_id, child_hashes)?;
+    st.own_pair_committed.insert(hash);
+    // A child whose own pair just arrived (this call) overrides any earlier
+    // deferred-embedded record — drop the stale one so we don't seed twice.
+    st.deferred_embedded.remove(&hash);
+
+    for child in parsed.children {
+        if st.own_pair_committed.contains(&child.hash) {
+            // Own pair already processed for this child — nothing to defer.
+            continue;
+        }
+        // First observation wins: if another parent already deferred this
+        // child, keep that earlier record. Matches the buffered loop's
+        // "key_present guard" behaviour for minimal-link seeding.
+        st.deferred_embedded
+            .entry(child.hash)
+            .or_insert(DeferredEmbedded {
+                parent_hash: hash,
+                kind: child.kind,
+                data: child.data,
+            });
+    }
+    Ok(())
+}
+
+/// End-of-stream housekeeping:
+///   1. Any `node` entry with no matching `children` becomes
+///      `parse_pair(node, &[])` — matches the file backend's "node present,
+///      children absent" tolerance.
+///   2. Any `children` entry with no matching `node` is dropped (can't parse
+///      without the node's lookup table). The hash is still in `seen`.
+///   3. Deferred embedded children that never got an own pair get their
+///      minimal link row seeded.
+fn flush_partials(st: &mut UnpackState<'_>) -> Result<(), OxenError> {
+    let pending_nodes = std::mem::take(&mut st.pending_nodes);
+    for (hash, node_bytes) in pending_nodes {
+        let parsed = parse_pair(&node_bytes, &[])?;
+        finalize_parsed(st, hash, parsed)?;
+    }
+    // `children`-only entries aren't decodable without a node; matches the
+    // buffered loop's behaviour (it built `parsed` keyed on node-present hashes
+    // and ignored orphan `children`).
+    st.pending_children.clear();
+
+    let deferred = std::mem::take(&mut st.deferred_embedded);
+    for (child_hash, dc) in deferred {
+        if st.own_pair_committed.contains(&child_hash) {
+            // Child's own pair already wrote node + link.
+            continue;
+        }
+        put_node(st, &child_hash, dc.kind, dc.data)?;
+        // Minimal-link seeding: only if the link row isn't already there.
+        // Matches the buffered loop's unconditional key-present guard for
+        // embedded children regardless of `opts`.
+        if !LmdbBackend::key_present(&st.wtxn, &st.backend.merkle_links, &child_hash)? {
+            LmdbBackend::put_serialized(
+                &mut st.wtxn,
+                &st.backend.merkle_links,
+                &child_hash,
+                LmdbLink::encode,
+                LmdbLink {
+                    parent_id: Some(dc.parent_hash),
+                    children: Vec::new(),
+                },
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Put a node row into `merkle_tree_nodes`, honouring the `overwrite` flag.
+fn put_node(
+    st: &mut UnpackState<'_>,
+    hash: &MerkleHash,
+    kind: MerkleTreeNodeType,
+    data: Vec<u8>,
+) -> Result<(), LmdbError> {
+    if !st.overwrite && LmdbBackend::key_present(&st.wtxn, &st.backend.merkle_tree_nodes, hash)? {
+        return Ok(());
+    }
+    LmdbBackend::put_serialized(
+        &mut st.wtxn,
+        &st.backend.merkle_tree_nodes,
+        hash,
+        LmdbNode::encode,
+        LmdbNode { kind, data },
+    )
+}
+
+/// Put a link row into `merkle_links`, honouring the `overwrite` flag.
+fn put_link(
+    st: &mut UnpackState<'_>,
+    hash: &MerkleHash,
+    parent_id: Option<MerkleHash>,
+    children: Vec<MerkleHash>,
+) -> Result<(), LmdbError> {
+    if !st.overwrite && LmdbBackend::key_present(&st.wtxn, &st.backend.merkle_links, hash)? {
+        return Ok(());
+    }
+    LmdbBackend::put_serialized(
+        &mut st.wtxn,
+        &st.backend.merkle_links,
+        hash,
+        LmdbLink::encode,
+        LmdbLink {
+            parent_id,
+            children,
+        },
+    )
+}
+
+/// Classification of a tar entry's path under either of the two wire layouts.
+enum StreamingKind {
+    /// `tree/nodes` itself, or `tree/nodes/{prefix}` — intermediate dirs.
+    Intermediate,
+    /// `tree/nodes/{prefix}/{suffix}` — the hash-bearing dir.
+    HashDir(MerkleHash),
+    /// `tree/nodes/{prefix}/{suffix}/node`.
+    Node(MerkleHash),
+    /// `tree/nodes/{prefix}/{suffix}/children`.
+    Children(MerkleHash),
+}
+
+/// Wrap [`super::super::file_backend::classify_tar_entry_path`] so it works for
+/// both the server-canonical (`tree/nodes/...`) and the legacy client-push
+/// (`{prefix}/{suffix}/...`) layouts. The classifier is path-shape-driven, so
+/// we just synthesize a virtual `.oxen/` prefix and pick a layout based on
+/// whether the entry starts with `tree/nodes/`.
+fn classify_streaming_entry(path: &Path) -> Result<StreamingKind, OxenError> {
+    let virtual_oxen_hidden = PathBuf::from(".");
+    let tree_nodes_prefix = Path::new(TREE_DIR).join(NODES_DIR);
+    let synth = if path.starts_with(&tree_nodes_prefix) {
+        virtual_oxen_hidden.join(path)
+    } else {
+        virtual_oxen_hidden.join(&tree_nodes_prefix).join(path)
+    };
+    Ok(
+        match classify_tar_entry_path(&synth, &virtual_oxen_hidden)? {
+            TarEntryKind::Intermediate => StreamingKind::Intermediate,
+            TarEntryKind::HashDir(h) => StreamingKind::HashDir(h),
+            TarEntryKind::NodeFile(h) => StreamingKind::Node(h),
+            TarEntryKind::ChildrenFile(h) => StreamingKind::Children(h),
+        },
+    )
 }
 
 /// Parsed contents of one `tree/nodes/{prefix}/{suffix}/{node,children}` pair.
@@ -240,122 +417,6 @@ fn parse_pair(node_bytes: &[u8], children_bytes: &[u8]) -> Result<ParsedEntry, O
         parent_data,
         children,
     })
-}
-
-/// Drive the LMDB write side of unpack.
-///
-/// For every `{prefix}/{suffix}` pair we have both a `node` and `children`
-/// file for, the parent's row in `merkle_tree_nodes` and `merkle_links` is
-/// written. For every embedded child of such a parent that doesn't itself
-/// have its own pair in the tar, a node row is written and a minimal link
-/// row (parent_id = embedding parent, no children of its own) is written —
-/// so [`super::super::lmdb::lmdb_backend::LmdbBackend::get_node`]'s
-/// "node + link must both exist" invariant is preserved.
-///
-/// `UnpackOptions::SkipExisting` causes hashes already present in the
-/// `merkle_tree_nodes` table to be left untouched (matches the
-/// `repositories::tree::unpack_nodes` use-case in the file backend).
-fn write_unpacked_into_lmdb(
-    backend: &LmdbBackend,
-    buffered: BufferedTarPayloads,
-    opts: UnpackOptions,
-) -> Result<HashSet<MerkleHash>, OxenError> {
-    let BufferedTarPayloads {
-        node_files,
-        children_files,
-        seen_hashes,
-    } = buffered;
-    let overwrite = matches!(opts, UnpackOptions::Overwrite);
-
-    // Pair up hashes that have both a node and children file.
-    let mut parsed: HashMap<MerkleHash, ParsedEntry> = HashMap::with_capacity(node_files.len());
-    for (hash, node_bytes) in &node_files {
-        let empty_children: Vec<u8> = Vec::new();
-        let children_bytes = children_files.get(hash).unwrap_or(&empty_children);
-        let entry = parse_pair(node_bytes, children_bytes)?;
-        parsed.insert(*hash, entry);
-    }
-
-    let mut wtxn = LmdbBackend::write_txn(&backend.lmdb_env)?;
-    let put_node = |wtxn: &mut heed::RwTxn<'_>,
-                    hash: &MerkleHash,
-                    kind: MerkleTreeNodeType,
-                    data: Vec<u8>|
-     -> Result<(), LmdbError> {
-        if !overwrite && LmdbBackend::key_present(wtxn, &backend.merkle_tree_nodes, hash)? {
-            return Ok(());
-        }
-        LmdbBackend::put_serialized(
-            wtxn,
-            &backend.merkle_tree_nodes,
-            hash,
-            LmdbNode::encode,
-            LmdbNode { kind, data },
-        )
-    };
-    let put_link = |wtxn: &mut heed::RwTxn<'_>,
-                    hash: &MerkleHash,
-                    parent_id: Option<MerkleHash>,
-                    children: Vec<MerkleHash>|
-     -> Result<(), LmdbError> {
-        if !overwrite && LmdbBackend::key_present(wtxn, &backend.merkle_links, hash)? {
-            return Ok(());
-        }
-        LmdbBackend::put_serialized(
-            wtxn,
-            &backend.merkle_links,
-            hash,
-            LmdbLink::encode,
-            LmdbLink {
-                parent_id,
-                children,
-            },
-        )
-    };
-
-    for (parent_hash, entry) in &parsed {
-        put_node(
-            &mut wtxn,
-            parent_hash,
-            entry.parent_kind,
-            entry.parent_data.clone(),
-        )?;
-        let child_hashes: Vec<MerkleHash> = entry.children.iter().map(|c| c.hash).collect();
-        put_link(&mut wtxn, parent_hash, entry.parent_id, child_hashes)?;
-
-        // Embedded children: their `node` row is observable through this parent
-        // entry alone. If they don't have a full entry of their own in the tar,
-        // write a node + minimal-link pair so `get_node` doesn't trip its
-        // "node present but no link" integrity check.
-        for child in &entry.children {
-            if parsed.contains_key(&child.hash) {
-                // Will be handled by its own iteration of this loop.
-                continue;
-            }
-            put_node(&mut wtxn, &child.hash, child.kind, child.data.clone())?;
-            // Only seed a minimal link if the link row doesn't already exist —
-            // skip-existing semantics for embedded-only children regardless of
-            // `opts`, so a child observed via two different parents doesn't
-            // get its link clobbered.
-            if !LmdbBackend::key_present(&wtxn, &backend.merkle_links, &child.hash)? {
-                LmdbBackend::put_serialized(
-                    &mut wtxn,
-                    &backend.merkle_links,
-                    &child.hash,
-                    LmdbLink::encode,
-                    LmdbLink {
-                        parent_id: Some(*parent_hash),
-                        children: Vec::new(),
-                    },
-                )?;
-            }
-        }
-    }
-    wtxn.commit().map_err(LmdbError::Write)?;
-
-    // Honour the file backend's contract: return every hash parsed out of the
-    // tarball, even ones whose payloads we skipped via SkipExisting.
-    Ok(seen_hashes)
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/crates/lib/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/lib/src/core/db/merkle_node/merkle_node_db.rs
@@ -143,6 +143,27 @@ impl MerkleDbError {
     }
 }
 
+impl From<crate::util::tar_stream::TarStreamError> for MerkleDbError {
+    fn from(err: crate::util::tar_stream::TarStreamError) -> Self {
+        use crate::util::tar_stream::TarStreamError;
+        match err {
+            TarStreamError::Io(io) => MerkleDbError::Io(io),
+            TarStreamError::PathTraversal { path } => MerkleDbError::PathTraversal(path),
+            TarStreamError::UnsupportedEntry { path } => {
+                MerkleDbError::UnsupportedTarEntry { path }
+            }
+        }
+    }
+}
+
+/// Composed conversion so the streaming tar helpers can be used inside
+/// functions that return [`OxenError`] without intermediate `.map_err`.
+impl From<crate::util::tar_stream::TarStreamError> for OxenError {
+    fn from(err: crate::util::tar_stream::TarStreamError) -> Self {
+        OxenError::from(MerkleDbError::from(err))
+    }
+}
+
 struct MerkleNodeLookup {
     data_type: u8,
     parent_id: u128,

--- a/crates/lib/src/util.rs
+++ b/crates/lib/src/util.rs
@@ -12,6 +12,7 @@ pub mod paginate;
 pub mod perf;
 pub mod progress_bar;
 pub mod str;
+pub mod tar_stream;
 pub mod telemetry;
 
 pub use paginate::{paginate, paginate_with_total};

--- a/crates/lib/src/util/tar_stream.rs
+++ b/crates/lib/src/util/tar_stream.rs
@@ -1,0 +1,548 @@
+//! Generic streaming tar-gz helpers.
+//!
+//! **Pack** ([`stream_pack`]): callers hand us an iterator of [`PackEntry`]s. Each entry's
+//! body is a [`Read`] — payloads flow through gzip+tar one chunk at a time, never
+//! materializing the full archive in memory. The iterator is consumed lazily; only one
+//! `PackEntry` (and its in-flight `body` read state) is alive at a time.
+//!
+//! **Unpack** ([`stream_unpack`]): we drive a per-entry callback that gets a borrowed
+//! [`StreamedEntry`] (with the body exposed as `&mut dyn Read` over the archive's
+//! current entry). The callback decides what to do — buffer, decode, write, batch — and
+//! mutates a caller-supplied `state` value so accumulated data flows back out without
+//! globals. Path-traversal and unsupported entry types are rejected before the callback
+//! ever sees the entry.
+//!
+//! Centralizing the gzip+tar pipeline here means each merkle-store backend keeps only the
+//! "produce/consume entries" logic; the wire framing lives in one place.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use flate2::Compression;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+
+/// Errors from the generic streaming tar-gz pipeline.
+#[derive(Debug, thiserror::Error)]
+pub enum TarStreamError {
+    #[error("tar I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Path traversal detected in tar entry: {path}")]
+    PathTraversal { path: String },
+    #[error("Unsupported tar entry type at {path}: only regular files and directories are allowed")]
+    UnsupportedEntry { path: String },
+}
+
+/// Tar entry kinds we support emitting and consuming. Anything else (symlinks,
+/// device nodes, …) is rejected at the unpack boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    Directory,
+    File,
+}
+
+/// One logical entry the packer is about to write.
+///
+/// `size` must match the exact number of bytes [`body`] will produce. Tar headers
+/// embed the entry length up front, so streaming bodies need their length known
+/// before any byte is read. For directories pass `size: 0`.
+pub struct PackEntry {
+    pub path: PathBuf,
+    pub kind: EntryKind,
+    pub size: u64,
+    pub mode: u32,
+    /// The entry body. `'static` (boxed-dyn-default) so heterogeneous sources
+    /// (`std::io::Cursor<Vec<u8>>` for in-memory blobs, `std::fs::File` for on-
+    /// disk payloads, anything custom) share one iterator item type without
+    /// lifetime gymnastics.
+    pub body: Box<dyn Read>,
+}
+
+/// Stream a sequence of [`PackEntry`]s through gzip+tar into `out`.
+///
+/// `entries` is consumed lazily: at most one `PackEntry` (and its in-flight
+/// `body` read state) is alive at a time, so the producer can yield arbitrarily
+/// many entries without the archive itself ever being materialized.
+///
+/// Each entry's header gets the entry's `mode`, `size`, and an entry-type chosen
+/// from [`EntryKind`]. A GNU-format header is used so long paths still travel
+/// portably.
+///
+/// `E` is the caller's error type — the iterator may surface backend-specific
+/// errors (e.g. LMDB read failures) through `Result<PackEntry, E>` and they
+/// propagate without lossy conversion. Internal tar/gzip I/O errors are wrapped
+/// in [`TarStreamError`] and lifted into `E` via `From`.
+pub fn stream_pack<W, I, E>(out: W, compression: Compression, entries: I) -> Result<(), E>
+where
+    W: Write,
+    I: IntoIterator<Item = Result<PackEntry, E>>,
+    E: From<TarStreamError>,
+{
+    let enc = GzEncoder::new(out, compression);
+    let mut tar = tar::Builder::new(enc);
+    for entry in entries {
+        let mut entry = entry?;
+        let mut header = tar::Header::new_gnu();
+        header.set_size(entry.size);
+        header.set_mode(entry.mode);
+        header.set_entry_type(match entry.kind {
+            EntryKind::Directory => tar::EntryType::Directory,
+            EntryKind::File => tar::EntryType::Regular,
+        });
+        header.set_cksum();
+        tar.append_data(&mut header, &entry.path, entry.body.as_mut())
+            .map_err(TarStreamError::from)?;
+    }
+    tar.finish().map_err(TarStreamError::from)?;
+    tar.into_inner()
+        .map_err(TarStreamError::from)?
+        .finish()
+        .map_err(TarStreamError::from)?;
+    Ok(())
+}
+
+/// Borrowed view of an in-flight tar entry handed to [`stream_unpack`]'s callback.
+///
+/// `body` is a `Read` over the archive's current entry payload. The callback may
+/// read it fully, partially, or not at all — the tar reader advances over any
+/// unread tail automatically before the next entry.
+pub struct StreamedEntry<'a> {
+    pub path: &'a Path,
+    pub kind: EntryKind,
+    pub size: u64,
+    pub body: &'a mut dyn Read,
+}
+
+/// Drive `on_entry` once per tar entry in archive order, threading `state`
+/// through. Returns the final `state` so callers can accumulate parsed data,
+/// batch commits, etc.
+///
+/// Validates each entry before calling the callback:
+///   * Paths containing a `..` component return [`TarStreamError::PathTraversal`].
+///   * Entries that aren't regular files or directories return
+///     [`TarStreamError::UnsupportedEntry`].
+///
+/// Both checks are the chokepoint each merkle-store backend's unpack used to
+/// re-implement; collecting them here means callers can't forget either one.
+///
+/// `E` is the callback's error type — callbacks may surface backend-specific
+/// errors (e.g. database write failures) and they propagate without lossy
+/// conversion. Internal tar/gzip and validation errors are lifted from
+/// [`TarStreamError`] into `E` via `From`.
+pub fn stream_unpack<R, S, F, E>(reader: R, mut state: S, mut on_entry: F) -> Result<S, E>
+where
+    R: Read,
+    F: FnMut(StreamedEntry<'_>, &mut S) -> Result<(), E>,
+    E: From<TarStreamError>,
+{
+    let decoder = GzDecoder::new(reader);
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries().map_err(TarStreamError::from)? {
+        let mut entry = entry.map_err(TarStreamError::from)?;
+        let path = entry.path().map_err(TarStreamError::from)?.into_owned();
+        if path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(TarStreamError::PathTraversal {
+                path: path.display().to_string(),
+            }
+            .into());
+        }
+        let raw_type = entry.header().entry_type();
+        let kind = if raw_type.is_dir() {
+            EntryKind::Directory
+        } else if raw_type.is_file() {
+            EntryKind::File
+        } else {
+            return Err(TarStreamError::UnsupportedEntry {
+                path: path.display().to_string(),
+            }
+            .into());
+        };
+        let size = entry.header().size().map_err(TarStreamError::from)?;
+        let streamed = StreamedEntry {
+            path: &path,
+            kind,
+            size,
+            body: &mut entry,
+        };
+        on_entry(streamed, &mut state)?;
+    }
+    Ok(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    /// Pack three entries (one dir, two files of differing sizes including 0 bytes
+    /// and a multi-MiB body) into an in-memory buffer, then unpack and assert exact
+    /// path / size / body bytes round-trip.
+    #[test]
+    fn test_roundtrip_identity() {
+        let big_body: Vec<u8> = (0u8..=255).cycle().take(5 * 1024 * 1024 + 7).collect();
+        let entries: Vec<Result<PackEntry, TarStreamError>> = vec![
+            Ok(PackEntry {
+                path: PathBuf::from("topdir"),
+                kind: EntryKind::Directory,
+                size: 0,
+                mode: 0o755,
+                body: Box::new(Cursor::new(Vec::new())),
+            }),
+            Ok(PackEntry {
+                path: PathBuf::from("topdir/empty.bin"),
+                kind: EntryKind::File,
+                size: 0,
+                mode: 0o644,
+                body: Box::new(Cursor::new(Vec::<u8>::new())),
+            }),
+            Ok(PackEntry {
+                path: PathBuf::from("topdir/big.bin"),
+                kind: EntryKind::File,
+                size: big_body.len() as u64,
+                mode: 0o644,
+                body: Box::new(Cursor::new(big_body.clone())),
+            }),
+        ];
+
+        let mut buf = Vec::new();
+        stream_pack::<_, _, TarStreamError>(&mut buf, Compression::fast(), entries)
+            .expect("pack failed");
+
+        #[derive(Default)]
+        struct St {
+            entries: Vec<(PathBuf, EntryKind, u64, Vec<u8>)>,
+        }
+        let st = stream_unpack::<_, _, _, TarStreamError>(&buf[..], St::default(), |entry, st| {
+            let mut body = Vec::new();
+            entry.body.read_to_end(&mut body)?;
+            st.entries
+                .push((entry.path.to_path_buf(), entry.kind, entry.size, body));
+            Ok(())
+        })
+        .expect("unpack failed");
+
+        assert_eq!(st.entries.len(), 3, "expected three entries");
+        assert_eq!(st.entries[0].0, PathBuf::from("topdir"));
+        assert_eq!(st.entries[0].1, EntryKind::Directory);
+        assert_eq!(st.entries[1].0, PathBuf::from("topdir/empty.bin"));
+        assert_eq!(st.entries[1].3, Vec::<u8>::new());
+        assert_eq!(st.entries[2].0, PathBuf::from("topdir/big.bin"));
+        assert_eq!(st.entries[2].3, big_body);
+    }
+
+    /// The iterator is consumed lazily: items are only constructed as the tar
+    /// pipeline pulls them. Verified by counting `next()` calls on a custom
+    /// iterator that increments a shared counter.
+    #[test]
+    fn test_iterator_consumed_lazily() {
+        struct CountingIter {
+            counter: Arc<AtomicUsize>,
+            remaining: usize,
+            idx: usize,
+        }
+        impl Iterator for CountingIter {
+            type Item = Result<PackEntry, TarStreamError>;
+            fn next(&mut self) -> Option<Self::Item> {
+                if self.remaining == 0 {
+                    return None;
+                }
+                self.remaining -= 1;
+                self.counter.fetch_add(1, Ordering::SeqCst);
+                let idx = self.idx;
+                self.idx += 1;
+                Some(Ok(PackEntry {
+                    path: PathBuf::from(format!("entry-{idx}")),
+                    kind: EntryKind::File,
+                    size: 4,
+                    mode: 0o644,
+                    body: Box::new(Cursor::new(vec![1u8, 2, 3, 4])),
+                }))
+            }
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let iter = CountingIter {
+            counter: counter.clone(),
+            remaining: 5,
+            idx: 0,
+        };
+
+        let mut buf = Vec::new();
+        stream_pack::<_, _, TarStreamError>(&mut buf, Compression::fast(), iter)
+            .expect("pack failed");
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            5,
+            "iterator should be polled exactly once per entry"
+        );
+    }
+
+    /// Hand-build a tar entry with `..` in its path; stream_unpack must reject
+    /// it with `PathTraversal` before invoking the callback.
+    #[test]
+    fn test_path_traversal_rejected() {
+        let mut buf = Vec::new();
+        {
+            let enc = GzEncoder::new(&mut buf, Compression::fast());
+            let mut tar = tar::Builder::new(enc);
+            let mut header = tar::Header::new_old();
+            header.set_size(0);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            // Bypass tar's path validation by writing the name directly into
+            // the old-style name field.
+            let name_bytes = b"escape/../oops";
+            let old = header.as_old_mut();
+            old.name[..name_bytes.len()].copy_from_slice(name_bytes);
+            header.set_cksum();
+            tar.append(&header, Cursor::new(Vec::new()))
+                .expect("malicious tar build");
+            tar.finish().expect("tar finish");
+            tar.into_inner()
+                .expect("tar inner")
+                .finish()
+                .expect("gz finish");
+        }
+
+        let callback_invocations = Arc::new(AtomicUsize::new(0));
+        let cb = callback_invocations.clone();
+        let result = stream_unpack::<_, _, _, TarStreamError>(&buf[..], (), |_entry, _st| {
+            cb.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        });
+
+        assert!(
+            matches!(result, Err(TarStreamError::PathTraversal { .. })),
+            "expected PathTraversal, got {result:?}"
+        );
+        assert_eq!(
+            callback_invocations.load(Ordering::SeqCst),
+            0,
+            "callback should never see a path-traversal entry"
+        );
+    }
+
+    /// A tar containing a symlink entry must be rejected with `UnsupportedEntry`.
+    #[test]
+    fn test_unsupported_entry_rejected() {
+        let mut buf = Vec::new();
+        {
+            let enc = GzEncoder::new(&mut buf, Compression::fast());
+            let mut tar = tar::Builder::new(enc);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(0);
+            header.set_mode(0o777);
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_link_name("/etc/passwd").expect("set_link_name");
+            header.set_cksum();
+            tar.append_data(&mut header, "evil_link", Cursor::new(Vec::new()))
+                .expect("symlink build");
+            tar.finish().expect("tar finish");
+            tar.into_inner()
+                .expect("tar inner")
+                .finish()
+                .expect("gz finish");
+        }
+
+        let result = stream_unpack::<_, _, _, TarStreamError>(&buf[..], (), |_entry, _st| Ok(()));
+        assert!(
+            matches!(result, Err(TarStreamError::UnsupportedEntry { .. })),
+            "expected UnsupportedEntry, got {result:?}"
+        );
+    }
+
+    /// If the callback returns an error mid-stream, the error propagates and the
+    /// remaining entries are not delivered.
+    #[test]
+    fn test_callback_short_circuits() {
+        let entries: Vec<Result<PackEntry, TarStreamError>> = (0..5)
+            .map(|i| {
+                Ok(PackEntry {
+                    path: PathBuf::from(format!("entry-{i}")),
+                    kind: EntryKind::File,
+                    size: 1,
+                    mode: 0o644,
+                    body: Box::new(Cursor::new(vec![i as u8])),
+                })
+            })
+            .collect();
+        let mut buf = Vec::new();
+        stream_pack::<_, _, TarStreamError>(&mut buf, Compression::fast(), entries)
+            .expect("pack failed");
+
+        let observed = Arc::new(Mutex::new(Vec::<PathBuf>::new()));
+        let observed_clone = observed.clone();
+        let result = stream_unpack::<_, _, _, TarStreamError>(&buf[..], (), move |entry, _st| {
+            let count = {
+                let mut g = observed_clone.lock().unwrap();
+                g.push(entry.path.to_path_buf());
+                g.len()
+            };
+            if count == 2 {
+                Err(TarStreamError::Io(std::io::Error::other(
+                    "stop after 2 entries",
+                )))
+            } else {
+                Ok(())
+            }
+        });
+        assert!(
+            matches!(result, Err(TarStreamError::Io(_))),
+            "expected Io error from callback, got {result:?}"
+        );
+        let seen = observed.lock().unwrap();
+        assert_eq!(seen.len(), 2, "expected exactly two entries delivered");
+    }
+
+    /// State is threaded through `stream_unpack` and returned at the end —
+    /// callers accumulate without static globals.
+    #[test]
+    fn test_state_threading() {
+        let entries: Vec<Result<PackEntry, TarStreamError>> = (0..3)
+            .map(|i| {
+                Ok(PackEntry {
+                    path: PathBuf::from(format!("entry-{i}")),
+                    kind: EntryKind::File,
+                    size: 4,
+                    mode: 0o644,
+                    body: Box::new(Cursor::new(vec![i as u8; 4])),
+                })
+            })
+            .collect();
+        let mut buf = Vec::new();
+        stream_pack::<_, _, TarStreamError>(&mut buf, Compression::fast(), entries)
+            .expect("pack failed");
+
+        let total = stream_unpack::<_, _, _, TarStreamError>(&buf[..], 0u64, |entry, st| {
+            let mut body = Vec::new();
+            entry.body.read_to_end(&mut body)?;
+            *st += body.len() as u64;
+            Ok(())
+        })
+        .expect("unpack failed");
+        assert_eq!(total, 3 * 4, "state must aggregate body sizes");
+    }
+
+    /// If the callback reads only the first few bytes of a large body, the next
+    /// entry must still be parsed correctly — the tar reader skips the unread
+    /// tail.
+    #[test]
+    fn test_partial_body_read_advances_to_next_entry() {
+        let body_a: Vec<u8> = vec![0xAA; 1024];
+        let body_b: Vec<u8> = vec![0xBB; 16];
+        let entries: Vec<Result<PackEntry, TarStreamError>> = vec![
+            Ok(PackEntry {
+                path: PathBuf::from("a.bin"),
+                kind: EntryKind::File,
+                size: body_a.len() as u64,
+                mode: 0o644,
+                body: Box::new(Cursor::new(body_a.clone())),
+            }),
+            Ok(PackEntry {
+                path: PathBuf::from("b.bin"),
+                kind: EntryKind::File,
+                size: body_b.len() as u64,
+                mode: 0o644,
+                body: Box::new(Cursor::new(body_b.clone())),
+            }),
+        ];
+
+        let mut buf = Vec::new();
+        stream_pack::<_, _, TarStreamError>(&mut buf, Compression::fast(), entries)
+            .expect("pack failed");
+
+        #[derive(Default)]
+        struct St {
+            second_entry_body: Vec<u8>,
+        }
+        let st = stream_unpack::<_, _, _, TarStreamError>(&buf[..], St::default(), |entry, st| {
+            if entry.path == Path::new("a.bin") {
+                // Only consume 4 bytes of A's 1024-byte body.
+                let mut sink = [0u8; 4];
+                entry.body.read_exact(&mut sink)?;
+            } else {
+                let mut body = Vec::new();
+                entry.body.read_to_end(&mut body)?;
+                st.second_entry_body = body;
+            }
+            Ok(())
+        })
+        .expect("unpack failed");
+        assert_eq!(
+            st.second_entry_body, body_b,
+            "second entry's body must be intact despite first being partially read"
+        );
+    }
+
+    /// Passing a `size` mismatched to the body bytes is a programming error.
+    /// tar refuses to write more bytes than the header claimed.
+    #[test]
+    fn test_size_smaller_than_body_truncates_at_size() {
+        // Body is 10 bytes but we tell tar size=4. tar will write 4 bytes and
+        // ignore the remaining body bytes; round-tripping should yield 4 bytes.
+        let entries: Vec<Result<PackEntry, TarStreamError>> = vec![Ok(PackEntry {
+            path: PathBuf::from("a.bin"),
+            kind: EntryKind::File,
+            size: 4,
+            mode: 0o644,
+            body: Box::new(Cursor::new(vec![0u8; 10])),
+        })];
+
+        let mut buf = Vec::new();
+        stream_pack::<_, _, TarStreamError>(&mut buf, Compression::fast(), entries)
+            .expect("pack failed");
+
+        let st =
+            stream_unpack::<_, _, _, TarStreamError>(&buf[..], Vec::<u8>::new(), |entry, st| {
+                entry.body.read_to_end(st)?;
+                Ok(())
+            })
+            .expect("unpack failed");
+        assert_eq!(st.len(), 4, "tar honors header size, truncating the body");
+    }
+
+    /// Compression level affects the raw output bytes but not the parsed entry
+    /// set. Both fast and default compression must round-trip the same payload.
+    #[test]
+    fn test_gzip_compression_levels_roundtrip_equally() {
+        let body: Vec<u8> = (0u8..=255).cycle().take(64 * 1024).collect();
+        let build_entries = || -> Vec<Result<PackEntry, TarStreamError>> {
+            vec![Ok(PackEntry {
+                path: PathBuf::from("a.bin"),
+                kind: EntryKind::File,
+                size: body.len() as u64,
+                mode: 0o644,
+                body: Box::new(Cursor::new(body.clone())),
+            })]
+        };
+
+        let mut buf_fast = Vec::new();
+        stream_pack::<_, _, TarStreamError>(&mut buf_fast, Compression::fast(), build_entries())
+            .expect("fast pack failed");
+        let mut buf_default = Vec::new();
+        stream_pack::<_, _, TarStreamError>(
+            &mut buf_default,
+            Compression::default(),
+            build_entries(),
+        )
+        .expect("default pack failed");
+
+        let read_one = |buf: &[u8]| -> Vec<u8> {
+            stream_unpack::<_, _, _, TarStreamError>(buf, Vec::<u8>::new(), |entry, st| {
+                entry.body.read_to_end(st)?;
+                Ok(())
+            })
+            .expect("unpack failed")
+        };
+
+        assert_eq!(read_one(&buf_fast), body);
+        assert_eq!(read_one(&buf_default), body);
+    }
+}


### PR DESCRIPTION
Adds new reusable streaming tar unpacking and packing implementations.
Ensures that the `FileBackend` and `LmdbBackend` Merkle tree store use
these in their `MerklePacker` and `MerkleUnpacker` implementations.

Adds additional tests around streaming implementations. Additional
manual testing ensures that all client <> server operations remain
unaffected. Only change is an `O(max tar entry)` vs. `O(entire archive)`
change for peak memory use.