### PR TITLE
Per-process `LmdbBackend` cache with `Weak` and `Arc`

### DIFF
--- a/crates/lib/src/core/db/merkle_node/lmdb.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb.rs
@@ -11,12 +11,26 @@ mod value_structs;
 /// The [`MerkleWriter`] implementation.
 mod writer;
 
+/// The cache of open `LMDB` environments in the process.
+pub(crate) mod cache;
+
 pub use lmdb_backend::LmdbBackend;
+pub(in crate::core::db::merkle_node::lmdb) use lmdb_backend::{
+    DEFAULT_LMDB_MMAP_SIZE, lmdb_backend_options,
+};
+// `lmdb_dir_location` is only consulted from `#[cfg(test)]` modules outside
+// the `lmdb` namespace (verifying that the LMDB env dir was created on
+// disk). The lib build target has no production user of it.
+#[cfg(test)]
 pub(crate) use lmdb_backend::lmdb_dir_location;
 
 use thiserror::Error;
 
-use crate::model::merkle_tree::{merkle_hash::HexHash, node_type::InvalidMerkleTreeNodeType};
+use crate::{
+    error::OxenError,
+    model::merkle_tree::{merkle_hash::HexHash, node_type::InvalidMerkleTreeNodeType},
+};
+use bytesize::ByteSize;
 
 /// Errors that the LMDB backend's operations can encounter.
 ///
@@ -78,6 +92,18 @@ pub enum LmdbError {
 
     #[error("Stored a child for (hex) hash ({0}) but node for hash does not exist.")]
     IntegrityNoHash(HexHash),
+
+    // ── Initialization Errors ────────────────────────────────────────────────
+    #[error(
+        "Cannot create LMDB mmap file of size {0}: it is larger than this system's supported memory."
+    )]
+    InitMmap(ByteSize),
+
+    #[error("Cannot create an absolute path for the LMDB mmap file: {0}")]
+    InitAbs(Box<OxenError>), // TODO: update to FsError when that refactoring PR lands
+
+    #[error("Cannot create directory for LMDB's memory mapped file: {0}")]
+    InitDir(Box<OxenError>), // TODO: update to FsError when that refactoring PR lands
 }
 
 #[cfg(test)]
@@ -150,7 +176,13 @@ mod tests {
         std::fs::create_dir_all(&env_dir).expect("env dir");
 
         let mut opts = EnvOpenOptions::new();
+        // 10 MiB is plenty for the test workloads and lets dozens of
+        // independent test envs coexist without exhausting virtual memory.
         opts.map_size(10 * 1024 * 1024);
+        // `LmdbBackend::new` opens two named databases (DB_NODES, DB_LINKS);
+        // production callers go through `lmdb_backend_options` which sets
+        // this. This test helper bypasses that path, so set it directly.
+        opts.max_dbs(2);
         LmdbBackend::new(test_root, opts).expect("open lmdb backend")
     }
 

--- a/crates/lib/src/core/db/merkle_node/lmdb/cache.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/cache.rs
@@ -1,0 +1,227 @@
+//! Process-wide cache of open [`LmdbBackend`] instances, keyed by the repository root path.
+//! Use the [`get_or_open`] function to manage creation and access to all [`LmdbBackend`]s.
+//!
+//! LMDB rejects opening the same database directory twice in one process (`mdb_env_open`
+//! returns `MDB_BUSY`). Since a [`LocalRepository`] contains a Merkle tree store, it
+//! may end up holding an [`Arc`] to an [`LmdbBackend`]. Creating another [`LocalRepoistory`]
+//! at the same location while holding onto a previously created one will create a runtime `panic!`.
+//!
+//! The cache makes the constructing multiple `LocalRepository` instances pointing at the same
+//! on-disk repo safe by maintaing a mapping of repository to a weak reference to the
+//! [`LmdbBackend`] that it uses. Users of the cache only get [`Arc<LmdbBackend>`]. Overlapping
+//! callers that want to re-create a [`LocalRepository`] or a [`LmdbBackend`] more specifically
+//! must use this function to ensure that the process only ever has exactly one open LMDB per
+//! repository.
+//!
+//! The cache does not hold the returned [`Arc`]. If the caller drops the only reference to the
+//! `Arc`, then the [`LmdbBackend`] and its underlying [`heed::Env`] will also be dropped. At
+//! which point, it is safe to re-open LMDB at the repository. The cache holds [`Weak`] references
+//! to the [`LmdbBackend`] that it returns. This allows the process to deallocate the LMDB env
+//! when it is possible, keeping the cache from holding onto unused LMDB environments and growing
+//! without bound. If a requested [`LmdbBackend`] for a particular repository no longer exists,
+//! it is recreated and put back into the cache. Each access of the cache incurs a sweep to
+//! evict tombstoned [`Weak<LmdbBackend>`] references.
+//!
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock, PoisonError, RwLock, Weak};
+
+use crate::core::db::merkle_node::lmdb::lmdb_backend::LmdbBackend;
+use crate::core::db::merkle_node::lmdb::{DEFAULT_LMDB_MMAP_SIZE, LmdbError, lmdb_backend_options};
+use crate::util;
+
+/// Repository's root => Weak reference to its LMDB backend.
+type LmdbCache = HashMap<PathBuf, Weak<LmdbBackend>>;
+
+/// Process-wide cache of open LMDB backends, keyed by **canonicalized** repository root.
+static LMDB_BACKEND_CACHE: OnceLock<RwLock<LmdbCache>> = OnceLock::new();
+
+/// Return `Some(Arc(.))` that a weak pointer behind the cache's guard, or none.
+///
+/// Use a read or a read-write lock `guard` on a [`LmdbCache`] to check if there's
+/// (a) an existing [`Weak`] pointer for the `repo_root` and (b) that it still exists.
+/// If so, it returns a `Some(Arc(..))` to that existing [`LmdbBackend`]. `None` otherwise.
+///
+/// `guard` can either be [`RwLockReadGuard`] or [`RwLockWriteGuard`].
+///
+/// NOTE: This is for use **internal to this file**. Do not `#[macro_export]` this!
+macro_rules! check_cache {
+    ($guard:expr, $repo_root:expr) => {
+        if let Some(weak) = $guard.get($repo_root)
+            && let Some(strong) = weak.upgrade()
+        {
+            log::debug!("LMDB backend cache hit: {:?}", $repo_root);
+            Some(strong)
+        } else {
+            None
+        }
+    };
+}
+
+/// Single entry point for obtaining an [`Arc<LmdbBackend>`] for a repository.
+///
+/// Either returns the cached one (bumping its strong refcount) or opens a new LMDB
+/// environment for the given [`LocalRepository`]'s root and installs a [`Weak`]
+/// reference to it in the cache.
+///
+/// Using this cache is safe, provided that all LMDB env creation is managed through
+/// this function.
+///
+/// Internally:
+///   1. Canonicalizes `repo_root` so two unequal path shapes for the same physical repo.
+///      This is critical to ensure that two repositories never have duplicate LMDB envs.
+///   2. On cache hit, it increments the strong refcount and returns the Arc.
+///   3. On cache miss:
+///      a. Builds default LMDB open options [`lmdb_backend_options`]` with the default size
+///         for the memory-mapped LMDB file ([`DEFAULT_LMDB_MMAP_SIZE`]).
+///      b. `create_dir_all`s `.oxen/lmdb_merkle_tree_store/` to ensure the open works.
+///      c. Calls [`LmdbBackend::new`] with these options and
+///
+/// # Concurrency
+/// The [`RwLock`] is held across the entire lookup-and-insert, which serializes
+/// `LmdbBackend::new` calls process-wide. Opens are infrequent (one per repo
+/// per process) and the serialization is what closes the race between
+/// `Weak::upgrade` returning `None` and the subsequent `LmdbBackend::new`
+/// call — without it, two threads could observe a dead `Weak`, both call
+/// `LmdbBackend::new` on the same path, and one would hit LMDB's
+/// "already open" error.
+pub(crate) fn get_or_open(repo_root: &Path) -> Result<Arc<LmdbBackend>, LmdbError> {
+    // ensure we always have the same key for identifical repositories
+    let repo_root =
+        util::fs::canonicalize(repo_root).map_err(|e| LmdbError::InitAbs(Box::new(e)))?;
+
+    let cache = LMDB_BACKEND_CACHE.get_or_init(|| RwLock::new(HashMap::new()));
+
+    // read lock and check cache: return if it already exists
+    {
+        let guard = cache.read().unwrap_or_else(recover_lock);
+        // check if we have created an LMDB backend for this repository
+        // or if the one we created is still alive
+        if let Some(existing) = check_cache!(&guard, &repo_root) {
+            return Ok(existing);
+        }
+        // note: drop(guard) here
+    }
+
+    // otherwise, we need to create and insert it
+    // acquire a write lock for this
+    // AND someone could have come in, gotten a write lock and done what we're about to do,
+    // so once we get the write lock, we need to re-check and bail early if necessary
+    let mut guard = cache.write().unwrap_or_else(recover_lock);
+
+    if let Some(existing) = check_cache!(&guard, &repo_root) {
+        return Ok(existing);
+    }
+    // we know that no one else has gotten the write lock before us and updated,
+    // so we're safe to update
+
+    // Tombstone sweep: remove any of our weak references that no longer point
+    // to a live LmdbBackend. This keeps the map size from growing unbounded.
+    guard.retain(|_, w| w.strong_count() > 0);
+
+    log::info!("LMDB backend cache miss: opening {}", repo_root.display());
+    let options = lmdb_backend_options(DEFAULT_LMDB_MMAP_SIZE)?;
+    let backend = Arc::new(LmdbBackend::new(repo_root.clone(), options)?);
+    guard.insert(repo_root, Arc::downgrade(&backend));
+    Ok(backend)
+    // note: drop(guard) here
+}
+
+/// Recover the guard whether the lock is poisoned or not.
+///
+/// Poisoning in this cache here is benign: it means an earlier opener panicked mid-`get_or_open`
+/// — the worst the map can contain is a stale `Weak` (which the tombstone sweep in the function prunes)
+/// or a missing entry (which causes a reopen, also safe). There's no scenario where poisoned state lies
+/// about which envs are shared.
+fn recover_lock<T>(p: PoisonError<T>) -> T {
+    log::error!(
+        "A previous acces of the LMDB cache had a panic while the mutex was locked. Attempting to clean up stale data, if applicable, and continue."
+    );
+    p.into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::config::repository_config::MerkleStoreKind;
+    use crate::core::db::merkle_node::lmdb::cache;
+    use crate::error::OxenError;
+    use crate::test;
+
+    /// Two `get_or_open` calls for the same canonical repo root return the
+    /// same `Arc` — i.e. the underlying `LmdbBackend` (and its `Env`,
+    /// `Database` handles) are shared. Pre-cache the second call would
+    /// have hit LMDB's "already open in this program" error.
+    #[test]
+    fn test_cache_returns_same_backend_for_concurrent_opens() -> Result<(), OxenError> {
+        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let a = cache::get_or_open(&repo.path)?;
+        let b = cache::get_or_open(&repo.path)?;
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "expected same Arc<LmdbBackend> for two opens of the same path",
+        );
+        Ok(())
+    }
+
+    /// Two different canonical paths yield two distinct `LmdbBackend`s.
+    #[test]
+    fn test_cache_distinguishes_different_paths() -> Result<(), OxenError> {
+        let repo_a = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let repo_b = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let a = cache::get_or_open(&repo_a.path)?;
+        let b = cache::get_or_open(&repo_b.path)?;
+        assert!(
+            !Arc::ptr_eq(&a, &b),
+            "two distinct repos must produce distinct LmdbBackends",
+        );
+        Ok(())
+    }
+
+    /// Drop the only strong handle, then verify the cache's `Weak` is a
+    /// tombstone and a subsequent open yields a fresh `Arc`.
+    #[test]
+    fn test_cache_drops_backend_when_all_handles_released() -> Result<(), OxenError> {
+        let mut repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        let repo_path = repo.path.clone();
+        // Free the test helper's strong handle so this test owns the only
+        // live reference at the point of `drop(a)` below.
+        repo.drop_inner();
+
+        let a = cache::get_or_open(&repo_path)?;
+        let weak = Arc::downgrade(&a);
+        drop(a);
+        assert_eq!(
+            weak.strong_count(),
+            0,
+            "dropping the last Arc must drop the LmdbBackend",
+        );
+
+        // Reopening must succeed (proves close-then-reopen) and must not
+        // hand back the same allocation as before.
+        let b = cache::get_or_open(&repo_path)?;
+        assert!(
+            weak.upgrade().is_none(),
+            "the prior backend must be fully gone after the last Arc drops",
+        );
+        drop(b);
+        Ok(())
+    }
+
+    /// Two open requests via path shapes that canonicalize to the same
+    /// physical path collapse to one cache entry.
+    #[test]
+    fn test_cache_canonicalizes_path_shapes() -> Result<(), OxenError> {
+        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        // Build a non-canonical variant: append a trailing `./.`.
+        let nonsense = repo.path.join(".");
+        let a = cache::get_or_open(&repo.path)?;
+        let b = cache::get_or_open(&nonsense)?;
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "different path shapes for the same physical repo must share the cache entry",
+        );
+        Ok(())
+    }
+}

--- a/crates/lib/src/core/db/merkle_node/lmdb/lmdb_backend.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/lmdb_backend.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use bytesize::ByteSize;
 use heed::byteorder::LE;
 use heed::types::{Bytes, DecodeIgnore, U128};
 use heed::{AnyTls, Database, Env, EnvOpenOptions, WithTls};
@@ -7,8 +8,8 @@ use heed::{AnyTls, Database, Env, EnvOpenOptions, WithTls};
 use crate::constants::OXEN_HIDDEN_DIR;
 use crate::core::db::merkle_node::lmdb::LmdbError;
 use crate::core::db::merkle_node::lmdb::value_structs::{LmdbLink, LmdbNode};
-use crate::error::OxenError;
 use crate::model::MerkleHash;
+use crate::util;
 
 /// Keys are merkle hashes, which are `u128` values.
 /// MUST USE LITTLE ENDIAN (LE) so the byte layout matches
@@ -26,11 +27,12 @@ const DB_LINKS: &str = "merkle_links";
 /// Merkle tree node storage that is backed by LMDB.
 ///
 /// NOTE: DO NOT USE ON A VIRTUAL FILE SYSTEM !!
+///       DO NOT OPEN AN MORE THAN ONE [`LmdbBackend`] PER REPOSITORY IN A PROCESS.
 pub struct LmdbBackend {
     /// The filesystem location of the local repository.
     pub(super) repo_root: PathBuf,
     /// The LMDB environment that contains the [`Database`] fields.
-    pub(super) lmdb_env: Env<WithTls>, // note: WithTls makes this !Send. Use AnyTls if need to send between threads.
+    pub(super) lmdb_env: Env<WithTls>,
 
     /// Stores every kind of merkle tree node: any concrete [`MerkleTreeNode`].
     /// This includes files nodes! Note that there is no other data but the Merkle
@@ -51,18 +53,74 @@ pub struct LmdbBackend {
     pub(super) merkle_links: Database<KeyLmdb, ValueLmdb>,
 }
 
+// on every platform.
+const WORST_CASE_PAGE_SIZE_BYTES: u64 = 64 * 1024;
+const _: () = assert!(
+    ByteSize::gib(1)
+        .as_u64()
+        .is_multiple_of(WORST_CASE_PAGE_SIZE_BYTES),
+    "DEFAULT_LMDB_MMAP_SIZE must be aligned to the worst-case OS page size \
+     (64 KiB); change it to a multiple of 65536 if you adjust the value."
+);
+
+// 1 GiB ceiling — large enough for typical Merkle trees,
+// small enough to keep sparse-file disk usage in check. Can
+// be revisited if/when we have repos that exceed it.
+//
+// LMDB requires `map_size` to be a multiple of the OS page size. The OS
+// page size is a runtime value — there's no stable Rust API exposing it
+// in `const` — so we can't dynamically pick a "next multiple of page
+// size" here. Instead we hardcode 1 GiB (= 2^30 bytes), and `const-assert`
+// it's a multiple of the worst-case page size any real OS uses (64 KiB,
+// = 2^16, on PPC64; macOS arm64 is 16 KiB; x86_64 Linux/Windows is 4 KiB).
+// 2^30 is divisible by 2^16, so it's also divisible by 2^14 and 2^12,
+// which covers every real platform.
+//
+// Must use `gib` (binary, 2^30 = 1_073_741_824) and not `gb` (decimal
+// 10^9 = 1_000_000_000): 10^9 is not a power of two and is not a
+// multiple of any common page size, so it would fail LMDB validation
+pub(crate) const DEFAULT_LMDB_MMAP_SIZE: ByteSize = ByteSize::gib(1);
+
+pub(crate) fn lmdb_backend_options(size: ByteSize) -> Result<EnvOpenOptions, LmdbError> {
+    let mut options = EnvOpenOptions::new();
+    let map_size = size.as_u64() as usize;
+    if DEFAULT_LMDB_MMAP_SIZE.as_u64() != (map_size as u64) {
+        return Err(LmdbError::InitMmap(size));
+    }
+    options.map_size(map_size);
+    // for LmdbBackend's 2 `Database` fields
+    options.max_dbs(2);
+    Ok(options)
+}
+
 impl LmdbBackend {
-    pub fn new(repo_root: PathBuf, options: EnvOpenOptions) -> Result<Self, OxenError> {
-        let options = {
-            let mut options = options;
-            options.max_dbs(2);
-            log::debug!("Config for LMDB backend: {options:?}");
-            options
-        };
+    /// Constructs a new LMDB environment and uses it as a Merkle tree node store.
+    ///
+    /// Saves the LMDB file to under the `.oxen/` directory of the supplied repository root
+    /// (`repo_root`). LMDB internally mmaps this file. This [`LmdbBackend`] struct holds on
+    /// to a mmap handle. This handle is dropped when this struct is dropped.
+    ///
+    /// **NOT THE PUBLIC ENTRY POINT.** All in-crate construction must go through
+    /// [`crate::core::db::merkle_node::lmdb::cache::get_or_open`], which serializes
+    /// opens process-wide and shares one `Arc<LmdbBackend>` across overlapping callers.
+    ///
+    /// **SAFETY**: LMDB rejects opening the same env directory twice in one process. The
+    ///             [`lmdb::cache::get_or_open`] function caches weak references to [`LmdbBackend`]
+    ///             instances and their LMDB environment.
+    ///
+    ///             If you're using this function, either use unique LMDB locations or drop this
+    ///             struct before opening up the LMDB env again.
+    pub(in crate::core::db::merkle_node::lmdb) fn new(
+        repo_root: PathBuf,
+        options: EnvOpenOptions,
+    ) -> Result<Self, LmdbError> {
+        log::info!("Config for LMDB backend: {options:?}");
 
         let lmdb_env = {
             let db_location = lmdb_dir_location(&repo_root);
-            log::debug!("Opening LMDB backend at: {}", db_location.display());
+            util::fs::create_dir_all(&db_location).map_err(|e| LmdbError::InitDir(Box::new(e)))?;
+
+            log::info!("Opening LMDB backend at: {}", db_location.display());
             // SAFETY: LMDB uses a memory mapped file. If this file is modified in or out of process,
             //         it can cause undefined behavior. There is nothing else in the Oxen codebase that
             //         modifies this mmap'd file. Nothing else access `db_location` except for this code.
@@ -72,7 +130,6 @@ impl LmdbBackend {
             unsafe { options.open(db_location).map_err(LmdbError::Access)? }
         };
 
-        // create these two key-value tables
         let mut wtxn = lmdb_env.write_txn().map_err(LmdbError::Access)?;
         let merkle_tree_nodes = lmdb_env
             .create_database::<KeyLmdb, ValueLmdb>(&mut wtxn, Some(DB_NODES))
@@ -81,9 +138,6 @@ impl LmdbBackend {
             .create_database::<KeyLmdb, ValueLmdb>(&mut wtxn, Some(DB_LINKS))
             .map_err(LmdbError::Write)?;
         wtxn.commit().map_err(LmdbError::Write)?;
-        log::debug!(
-            "Ensure tables '{DB_NODES}' (Merkle nodes) and '{DB_LINKS}' (tree connections) exist"
-        );
 
         Ok(Self {
             repo_root,
@@ -206,6 +260,26 @@ impl LmdbBackend {
         };
         Ok(Some(LmdbLink::decode(bytes)?))
     }
+
+    // /// Flushes LMDB to disk and closes the underlying LMDB environment for this process.
+    // pub fn close(self) -> Result<(), heed::Error> {
+    //     log::info!("Preparing to close LMDB");
+    //     // drop everything but the LMDB env: we prepare that for closing and wait on it instead
+    //     let LmdbBackend { repo_root:_ , lmdb_env, merkle_tree_nodes: _, merkle_links: _ } = self;
+    //     lmdb_env.force_sync()?;
+    //     let signal_event = lmdb_env.prepare_for_closing();
+    //     log::info!("Waiting for the LMDB environment to close");
+    //     signal_event.wait();
+    //     Ok(())
+    // }
+}
+
+impl Drop for LmdbBackend {
+    fn drop(&mut self) {
+        if let Err(e) = self.lmdb_env.force_sync() {
+            log::error!("Could not flush LMDB state to disk! Error: {e}");
+        }
+    }
 }
 
 /// The name of the LMDB directory as it exists in the repository's `.oxen/` hidden directory.
@@ -213,6 +287,11 @@ impl LmdbBackend {
 const OXEN_LMDB_MERKLE_DIR: &str = "lmdb_merkle_tree_store";
 
 /// The complete filepath to the LMDB file for the given repository.
+///
+/// `pub(crate)` because test modules outside the `lmdb` namespace (e.g.
+/// `repositories::tests`, `local_repository::tests`) consult it to assert
+/// that the env directory was created on disk. The actual production
+/// users are inside `lmdb/` and would only need `pub(super)`.
 pub(crate) fn lmdb_dir_location(repo_root: &Path) -> PathBuf {
     repo_root.join(OXEN_HIDDEN_DIR).join(OXEN_LMDB_MERKLE_DIR)
 }

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -2,9 +2,8 @@ use crate::config::RepositoryConfig;
 use crate::config::repository_config::MerkleStoreKind;
 use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
-use crate::core::db::merkle_node::LmdbBackend;
 use crate::core::db::merkle_node::file_backend::FileBackend;
-use crate::core::db::merkle_node::lmdb::lmdb_dir_location;
+use crate::core::db::merkle_node::lmdb;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
@@ -128,7 +127,10 @@ impl LocalRepository {
     ///
     /// Dispatches on `merkle_store_kind`:
     ///   - [`MerkleStoreKind::File`] → [`FileBackend`], honouring `is_vfs`.
-    ///   - [`MerkleStoreKind::Lmdb`] → [`LmdbBackend`], rejecting `is_vfs == true`
+    ///   - [`MerkleStoreKind::Lmdb`] → [`LmdbBackend`] via the process-wide
+    ///     cache at [`lmdb::cache::get_or_open`], which serializes opens and
+    ///     shares one `Arc<LmdbBackend>` across overlapping `LocalRepository`
+    ///     instances for the same canonical path. Rejects `is_vfs == true`
     ///     because LMDB's memory-mapped storage isn't safe on virtual file
     ///     systems (the mmap pages may not back to a real, byte-addressable
     ///     file). VFS-on-LMDB returns [`OxenError::MerkleStoreLmdbNotSupportedOnVfs`].
@@ -143,21 +145,7 @@ impl LocalRepository {
                 if is_vfs {
                     return Err(OxenError::MerkleStoreLmdbNotSupportedOnVfs);
                 }
-                // Canonicalize so two `LocalRepository`s opened with different
-                // path shapes for the same physical repo (e.g. `./repo` vs
-                // `/abs/repo`, trailing slash, symlinked parent) end up at the
-                // same `heed::Env`. heed/LMDB does not deduplicate `Env`
-                // handles, and two envs on one database directory is
-                // undefined behavior per LMDB.
-                let repo_path = util::fs::canonicalize(&repo_path)?;
-                let env_dir = lmdb_dir_location(&repo_path);
-                util::fs::create_dir_all(&env_dir)?;
-                let mut options = heed::EnvOpenOptions::new();
-                // 1 GiB ceiling — large enough for typical Merkle trees,
-                // small enough to keep sparse-file disk usage in check. Can
-                // be revisited if/when we have repos that exceed it.
-                options.map_size(1024 * 1024 * 1024);
-                Arc::new(LmdbBackend::new(repo_path, options)?)
+                lmdb::cache::get_or_open(&repo_path)?
             }
         };
         Ok(store)


### PR DESCRIPTION
Creates a new `static` cache of opened LMDB environments in `lmdb::cache`. Internally,
it maps  maps each repository's root path (absolute) to a `Weak<LmdbBackend>` reference.

All creation management and access of `LmdbBackend` in oxen now goes through the cache
access function, `lmdb::cache::get_or_open`. This function hands out an `Arc<LmdbBackend>`,
allowing callers to reuse the same instance. When accessing, the internal `Weak` reference
is checked for outstanding holders of its `Arc`. The common path is to return a refcount-
bumped `Arc`. First time creation will return the only `Arc<LmdbBackend>`.

However, if the original caller ever drops this `Arc` and there are no other holders of
it, then the underyling `LmdbBackend` and its LMDB env is also dropped. Subsequent access
via `get_or_open` will re-create the LMDB environment, which is safe since the previous
LMDB env was dropped.

Accessing the cache checks for tombstoned `Weak` references and removes them. This keeps
the cache from growing unbounded and lets LMDB envs drop when they're no longer needed.

The `LmdbBackend::new` constructor is now restricted from `pub` to the `lmdb` module only.