### PR TITLE
Remove redundant recreation of LocalRepository instances

### DIFF
--- a/crates/cli/src/cmd/push.rs
+++ b/crates/cli/src/cmd/push.rs
@@ -114,7 +114,7 @@ impl RunCmd for PushCmd {
             println!("Deleted remote branch: {}/{}", opts.remote, opts.branch);
             Ok(())
         } else {
-            let mut repo = LocalRepository::from_current_dir()?;
+            let mut repo = repo;
             repo.set_remote_name(remote);
 
             let (scheme, host) = get_scheme_and_host_from_repo(&repo)?;

--- a/crates/lib/src/config/repository_config.rs
+++ b/crates/lib/src/config/repository_config.rs
@@ -26,6 +26,9 @@ pub enum RepoConfigError {
 
     #[error("[RepositoryConfig] Unsupported Merkle store kind: {kind}. Expected one of {tokens:?}.", kind=.0, tokens=<MerkleStoreKind as VariantNames>::VARIANTS)]
     UnknownMerkeKind(#[from] strum::ParseError),
+
+    #[error("Cannot obtain current directory.")]
+    CurDir,
 }
 
 /// A sort of registry for known [`MerkleStore`] implementations that can be used by [`LocalRepository`].
@@ -144,6 +147,15 @@ impl RepositoryConfig {
     /// The repository config's virtual node size.
     pub fn vnode_size(&self) -> u64 {
         self.vnode_size.unwrap_or(DEFAULT_VNODE_SIZE)
+    }
+
+    /// Loads a repository config from the current active working directory.
+    pub(crate) fn from_current_dir() -> Result<Self, RepoConfigError> {
+        let Some(repo_dir) = util::fs::get_repo_root_from_current_dir() else {
+            return Err(RepoConfigError::CurDir);
+        };
+        let config_path = util::fs::config_filepath(&repo_dir);
+        RepositoryConfig::from_file(&config_path)
     }
 }
 

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -89,6 +89,9 @@ pub enum OxenError {
     #[error("{0}")]
     RepoConfig(#[from] RepoConfigError),
 
+    #[error("Repository not found after attempted transfer")]
+    FailedTransfer,
+
     //
     // Remotes
     //

--- a/crates/lib/src/model/staged_data.rs
+++ b/crates/lib/src/model/staged_data.rs
@@ -3,12 +3,11 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use crate::config::RepositoryConfig;
 use crate::model::{
     StagedEntry, StagedEntryStatus, StagedSchema, SummarizedStagedDirStats,
     merge_conflict::EntryMergeConflict,
 };
-
-use crate::model::LocalRepository;
 
 // TODO: Display if in Remote mode repo;
 
@@ -161,8 +160,8 @@ impl StagedData {
 
         if self.is_clean() {
             // If in remote-mode repo, check for unsynced files
-            if let Ok(repo) = LocalRepository::from_current_dir()
-                && repo.is_remote_mode()
+            if let Ok(repo) = RepositoryConfig::from_current_dir()
+                && repo.remote_mode.unwrap_or(false)
             {
                 self.__collect_unsynced_dirs(&mut outputs, opts);
                 self.__collect_unsynced_files(&mut outputs, opts);

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -191,16 +191,16 @@ pub fn transfer_namespace(
     util::fs::rename(&repo_dir, &new_repo_dir)?;
 
     // Update path in config
-    let repo = LocalRepository::from_dir(&new_repo_dir)?;
-    repo.save()?;
+    {
+        let repo = LocalRepository::from_dir(&new_repo_dir)?;
+        repo.save()?;
+        // ensure drop(repo)
+    }
 
     let updated_repo = get_by_namespace_and_name(sync_dir, to_namespace, repo_name)?;
-
     match updated_repo {
         Some(new_repo) => Ok(new_repo),
-        None => Err(OxenError::basic_str(
-            "Repository not found after attempted transfer",
-        )),
+        None => Err(OxenError::FailedTransfer),
     }
 }
 

--- a/crates/server/src/controllers/branches.rs
+++ b/crates/server/src/controllers/branches.rs
@@ -386,12 +386,10 @@ pub async fn list_entry_versions(
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let branch_name = path_param(&req, "branch_name")?.to_string();
 
-    // Get branch
-    let repo = get_repo(&app_data.path, namespace.clone(), &repo_name)?;
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
     let branch = repositories::branches::get_by_name(&repo, &branch_name)?;
 
     let path = PathBuf::from(path_param(&req, "path")?);
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
 
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);

--- a/crates/server/src/controllers/repositories.rs
+++ b/crates/server/src/controllers/repositories.rs
@@ -576,9 +576,8 @@ pub async fn transfer_namespace(
 
     log::debug!("transfer_namespace from: {from_namespace} to: {to_namespace}");
 
-    repositories::transfer_namespace(&app_data.path, &name, &from_namespace, &to_namespace)?;
     let repo =
-        repositories::get_by_namespace_and_name(&app_data.path, &to_namespace, &name)?.unwrap();
+        repositories::transfer_namespace(&app_data.path, &name, &from_namespace, &to_namespace)?;
 
     // Return repository view under new namespace
     Ok(HttpResponse::Ok().json(RepositoryResponse {


### PR DESCRIPTION
Creating a `LocalRepository` is not a cheap operation: files are read and parsed,
new files and directories are made, and in the case of LMDB, a new mmaped file is
made. Only one of these mmaped files may exist at a time for the entire process:
violating this invariant causes a runtime `panic!` from LMDB.

This change removes redundant recreations of `LocalRepository`, instead using
already constructed instances as much as possible. Some operations only made
an instance to check values in the `RepositoryConfig`: these call sites have been
updated to use new repository config loaders.