### PR TITLE
Allow for optional migrations, fix `--all`, change `up`/`down` to take repo directly

### DIFF
--- a/crates/cli/src/cmd/migrate.rs
+++ b/crates/cli/src/cmd/migrate.rs
@@ -1,11 +1,14 @@
 use std::path::Path;
+use std::str::FromStr;
 
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::{error::OxenError, model::LocalRepository};
+use liboxen::command::migrate::{
+    ALL_MIGRATIONS, MigrationResults, all_migrations, run_on_all_repos, try_apply_migration,
+};
+use liboxen::{command::migrate::Direction, error::OxenError, model::LocalRepository};
 
 use crate::cmd::RunCmd;
-use crate::helpers::migrations;
 
 pub const NAME: &str = "migrate";
 
@@ -14,27 +17,43 @@ pub fn migrate_args(name: &'static str, desc: &'static str) -> Command {
         .about(desc)
         .arg(
             Arg::new("PATH")
-                .help("Directory in which to apply the migration")
+                .help(
+                    "Directory in which to apply the migration. Must be the root \
+                    of the repository, unless --all is specified.",
+                )
                 .required(true),
         )
         .arg(
             Arg::new("all")
                 .long("all")
                 .short('a')
-                .help("Run the migration for all oxen repositories in this directory")
+                .help(
+                    "Run the migration for all oxen repositories in the directory. \
+                    Expects the directory to contain \"namespace/repository\" format. \
+                    The direct directories inside must be namespaces. Each directory \
+                    inside the namespace must be a repository. (Skips directories \
+                    that don't have a .oxen/ directory in them).",
+                )
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("run-optional")
+                .long("run-optional")
+                .help(
+                    "Run an optional migration that wouldn't run by default. The \
+                     migration is invoked iff it is applicable to the repo in this \
+                     direction; otherwise the command prints a notice and exits \
+                     successfully without changes.",
+                )
                 .action(clap::ArgAction::SetTrue),
         )
 }
 
 pub fn subcommands(name: &'static str, desc: &'static str) -> Command {
-    let migrations = migrations();
-
     let mut cmd = Command::new(name).about(desc).subcommand_required(true);
-
-    for (_, migration) in migrations {
+    for migration in ALL_MIGRATIONS {
         cmd = cmd.subcommand(migrate_args(migration.name(), migration.description()))
     }
-
     cmd
 }
 
@@ -57,32 +76,49 @@ impl RunCmd for MigrateCmd {
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
         // Parse Args
-        let migrations = migrations();
-
         if let Some((direction, sub_matches)) = args.subcommand()
             && let Some((migration, sub_matches)) = sub_matches.subcommand()
         {
-            let migration = migrations
-                .get(migration)
-                .ok_or_else(|| OxenError::basic_str(format!("Unknown migration: {migration}")))?;
+            let Some(migration) = all_migrations(migration) else {
+                return Err(OxenError::UnknownMigration(migration.to_string()));
+            };
+
+            let direction = Direction::from_str(direction)?;
+
             let path_str = sub_matches.get_one::<String>("PATH").expect("required");
             let path = Path::new(path_str);
 
             let all = sub_matches.get_flag("all");
+            let run_optional = sub_matches.get_flag("run-optional");
 
-            if direction == "up" {
-                let repo = LocalRepository::from_dir(path)?;
-                if migration.is_needed(&repo)? {
-                    migration.up(path, all)?;
+            if all {
+                let MigrationResults { executed, errored } =
+                    run_on_all_repos(false, migration, direction, run_optional, path)?;
+
+                if errored.is_empty() {
+                    println!(
+                        "\u{2705} Migration completed: successfully migrated {} repositories",
+                        executed.len(),
+                    );
                 } else {
-                    println!("Migration already applied: {}", migration.name());
+                    println!(
+                        "\u{274C} [ERROR] Migration completed with {} success(es) and {} failure(s):",
+                        executed.len(),
+                        errored.len(),
+                    );
+                    for (repo_path, error) in errored {
+                        println!("\t[FAIL] \"{}\" due to: {error}", repo_path.display());
+                    }
+                    return Err(OxenError::MigrationFailed);
                 }
-            } else if direction == "down" {
-                migration.down(path, all)?;
             } else {
-                return Err(OxenError::basic_str(format!(
-                    "Unknown direction: {direction}"
-                )));
+                let mr = try_apply_migration(
+                    migration,
+                    direction,
+                    run_optional,
+                    LocalRepository::from_dir(path)?,
+                )?;
+                println!("{}", mr.as_hint(false));
             }
         }
 

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -1,5 +1,5 @@
 use liboxen::api;
-use liboxen::command::migrate::Migrate;
+use liboxen::command::migrate::ALL_MIGRATIONS;
 use liboxen::config::AuthConfig;
 use liboxen::constants;
 use liboxen::error::OxenError;
@@ -8,7 +8,6 @@ use liboxen::util::oxen_version::OxenVersion;
 
 use colored::Colorize;
 
-use std::collections::HashMap;
 use std::str::FromStr;
 
 pub fn get_scheme_and_host_or_default() -> Result<(String, String), OxenError> {
@@ -81,20 +80,16 @@ pub async fn check_remote_version_blocking(
     Ok(())
 }
 
-pub fn migrations() -> HashMap<String, Box<dyn Migrate>> {
-    liboxen::command::migrate::all_migrations()
-}
-
 pub fn check_repo_migration_needed(repo: &LocalRepository) -> Result<(), OxenError> {
-    let migrations = migrations();
-
-    let mut migrations_needed: Vec<Box<dyn Migrate>> = Vec::new();
-
-    for (_, migration) in migrations {
-        if migration.is_needed(repo)? {
-            migrations_needed.push(migration);
+    let migrations_needed = {
+        let mut migrations_needed = vec![];
+        for migration in ALL_MIGRATIONS {
+            if migration.is_needed(repo)? {
+                migrations_needed.push(migration);
+            }
         }
-    }
+        migrations_needed
+    };
 
     if migrations_needed.is_empty() {
         return Ok(());

--- a/crates/lib/src/command/migrate.rs
+++ b/crates/lib/src/command/migrate.rs
@@ -1,36 +1,312 @@
-use std::collections::HashMap;
-use std::path::Path;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
-use crate::{error::OxenError, model::LocalRepository};
+use crate::{
+    error::OxenError,
+    model::LocalRepository,
+    repositories,
+    util::{
+        self,
+        progress_bar::{ProgressBarType, oxen_progress_bar},
+    },
+};
 
 pub mod m20250111083535_add_child_counts_to_nodes;
+use colored::Colorize;
 pub use m20250111083535_add_child_counts_to_nodes::AddChildCountsToNodesMigration;
 
 pub mod m20260408_add_workspace_name_index;
 pub use m20260408_add_workspace_name_index::AddWorkspaceNameIndexMigration;
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString, IntoStaticStr, VariantNames};
+
+/// Migration direction. Passed to [`Migrate::is_applicable`] so reversible migrations
+/// (like the file ↔ LMDB merkle store transcode) can report applicability separately
+/// for each direction.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    EnumString,
+    VariantNames,
+    Display,
+    IntoStaticStr,
+    Serialize,
+    Deserialize,
+    utoipa::ToSchema,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")] // WARNING!! must mirror serde's `rename_all`
+pub enum Direction {
+    Up,
+    Down,
+}
+
+/// The default direction for a migration is up.
+impl Default for Direction {
+    fn default() -> Self {
+        Direction::Up
+    }
+}
 
 pub trait Migrate {
-    fn up(&self, path: &Path, all: bool) -> Result<(), OxenError>;
-    fn down(&self, path: &Path, all: bool) -> Result<(), OxenError>;
+    /// Apply the migration.
+    fn up(&self, repo: LocalRepository) -> Result<(), OxenError>;
+
+    /// Undo the migration.
+    fn down(&self, repo: LocalRepository) -> Result<(), OxenError>;
+
+    /// If true, then this migraiton must be applied to the repository before it can be used.
     fn is_needed(&self, repo: &LocalRepository) -> Result<bool, OxenError>;
+
+    /// Whether this migration could meaningfully run on `repo` in the given direction.
+    ///
+    /// Used by the `--run-optional` CLI branch to gate explicit invocation of optional
+    /// migrations whose `is_needed` returns `false`.
+    ///
+    /// Defaults to delegating to [`Migrate::is_needed`] for Up migrations and `Ok(true)`
+    /// for a Down migration. By default, Up migrations are only run if needed
+    /// and Down migrations are unconditionally run. Migrations that are either optional
+    /// or need different logic for determining whether or not they can run on a repository
+    /// must override this method.
+    fn is_applicable(
+        &self,
+        direction: Direction,
+        repo: &LocalRepository,
+    ) -> Result<bool, OxenError> {
+        match direction {
+            Direction::Up => self.is_needed(repo),
+            Direction::Down => Ok(true),
+        }
+    }
+
+    /// The name of the migration as referenced from the CLI.
     fn name(&self) -> &'static str;
+
+    /// A human-readable description of what the migration does.
     fn description(&self) -> &'static str;
 }
 
-/// Returns every registered migration keyed by its `name()`.
+/// Every registered migration is identified by its `name()`.
 ///
 /// Used by both the CLI (`oxen migrate up/down`) and the server
 /// (`POST /api/repos/:ns/:name/migrations/:migration_name`) to look up a
-/// migration by name at runtime. New migrations must be appended here.
-pub fn all_migrations() -> HashMap<String, Box<dyn Migrate>> {
-    let mut map: HashMap<String, Box<dyn Migrate>> = HashMap::new();
-    map.insert(
-        AddChildCountsToNodesMigration.name().to_string(),
-        Box::new(AddChildCountsToNodesMigration),
-    );
-    map.insert(
-        AddWorkspaceNameIndexMigration.name().to_string(),
-        Box::new(AddWorkspaceNameIndexMigration),
-    );
-    map
+/// migration by name at runtime. New migrations **MUST** be listed here
+/// for the [`all_migrations`] function to work properly.
+pub const ALL_MIGRATIONS: [&dyn Migrate; 2] = [
+    &AddChildCountsToNodesMigration,
+    &AddWorkspaceNameIndexMigration,
+];
+
+/// Maps a registered migration's name to its implementation.
+/// The name is exactly the same value returned by `<dyn Migrate>::name()`.
+pub fn all_migrations(migration_name: &str) -> Option<&dyn Migrate> {
+    for migration in ALL_MIGRATIONS.iter() {
+        if migration_name == migration.name() {
+            // let m = &**migration;
+            // return Some(m);
+            return Some(*migration);
+        }
+    }
+    None
+}
+
+/// The successful vs. failed migrations per-repository.
+pub struct MigrationResults {
+    pub executed: Vec<(PathBuf, MigrationResult)>,
+    pub errored: Vec<(PathBuf, OxenError)>,
+}
+
+/// Run a migration on all repositories accessible from the given directory.
+///
+/// Assumes that `path` points to oxen repositories in the `namespace/repository`
+/// format. That is, `path`'s contents are only directories: each one of these is
+/// some `namespace`. Within each `namespace` directory is also only directories.
+/// Each one of these is a `repository` in the `namespace`.
+///
+/// This maps onto `oxen-server`'s concept of `namespace/repository`. It allows for
+/// a straightforward way to update all repositories being served.
+///
+/// If `is_sever` is `true`, then the progress bar is not printed and only log statements
+/// are used. If it is `false`, then there's a progress bar and only STDOUT messages.
+pub fn run_on_all_repos(
+    is_server: bool,
+    migration: &dyn Migrate,
+    direction: Direction,
+    run_optional: bool,
+    path: &Path,
+) -> Result<MigrationResults, OxenError> {
+    let msg = |msg: &str| {
+        if is_server {
+            log::info!("{msg}");
+        } else {
+            println!("{msg}");
+        }
+    };
+
+    let path = util::fs::canonicalize(path)?;
+    msg(&format!(
+        "🐂 Collecting namespaces to migrate in {}",
+        path.display()
+    ));
+
+    let namespaces = repositories::list_namespaces(&path)?;
+    msg(&format!("🐂 Migrating {} namespaces", namespaces.len()));
+
+    let bar = if is_server {
+        Arc::new(indicatif::ProgressBar::hidden())
+    } else {
+        oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter)
+    };
+
+    let mut migration_results = MigrationResults {
+        executed: vec![],
+        errored: vec![],
+    };
+
+    for namespace in namespaces {
+        // is canoncial because we made sure `path` is
+        let namespace_path = path.join(namespace);
+        log::debug!(
+            "This is the namespace path we're walking: {}",
+            namespace_path.display()
+        );
+        for repo in repositories::list_repos_in_namespace(&namespace_path) {
+            log::debug!("Migrating repository: {}", repo.path.display());
+
+            let repo_path = repo.path.clone();
+            match try_apply_migration(migration, direction, run_optional, repo) {
+                Ok(mr) => {
+                    if !mr.did_run() {
+                        msg(&format!("Did not run migration: {}", mr.as_hint(is_server)));
+                        migration_results.executed.push((repo_path, mr));
+                    }
+                }
+                Err(err) => {
+                    let message = format!(
+                        "Could not run migration {direction} {} for repo {}\nError: {}",
+                        migration.name(),
+                        repo_path.display(),
+                        err
+                    );
+                    if is_server {
+                        log::error!("{message}");
+                    } else {
+                        println!("[ERROR] {message}");
+                    }
+                    migration_results.errored.push((repo_path, err));
+                }
+            }
+        }
+        bar.inc(1);
+    }
+
+    Ok(migration_results)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MigrationResult {
+    #[error("Nothing to do: '{migration_name}' ({direction}) is applicable, but not needed.")]
+    IsApplicableButOptional {
+        direction: Direction,
+        migration_name: &'static str,
+    },
+
+    #[error("Nothing to do: '{migration_name}' ({direction}) is not needed nor is it applicable.")]
+    NotNeededNorApplicable {
+        direction: Direction,
+        migration_name: &'static str,
+    },
+
+    #[error("Successfully applied migration {direction} {migration_name}")]
+    Success {
+        direction: Direction,
+        migration_name: &'static str,
+    },
+}
+
+impl MigrationResult {
+    pub fn did_run(&self) -> bool {
+        matches!(self, Self::Success { .. })
+    }
+
+    pub fn as_hint(&self, is_server: bool) -> String {
+        let msg = self.to_string();
+        match self {
+            Self::IsApplicableButOptional { .. } => format!(
+                "{msg} You must run with {} to apply it.",
+                (if is_server {
+                    "run_optional=true"
+                } else {
+                    "--run-optional"
+                })
+                .yellow()
+            ),
+            _ => msg,
+        }
+    }
+}
+
+/// Attempt to apply the specified migration to the repository in the options.
+///
+/// Returns:
+///     - Ok(Success): Repository is successfully migrated to new state.
+///     - Ok(...): Not applied and no error was encountered.
+///     - Err(...): Not applied and an error was encountered that prevented it from being applied.
+///
+/// For `Ok`, use `.did_run()` to recover a `bool` for whether or not the migration was performed.
+///
+/// Note that this consumes the [`LocalRepository`]. Post migration, the repository should be
+/// reloaded from its repository path.
+pub fn try_apply_migration(
+    migration: &dyn Migrate,
+    direction: Direction,
+    run_optional: bool,
+    repo: LocalRepository,
+) -> Result<MigrationResult, OxenError> {
+    let migration_name = migration.name();
+
+    // is_needed is only valid in the up direction
+    if matches!(direction, Direction::Up) && migration.is_needed(&repo)? {
+        migration.up(repo)?;
+        return Ok(MigrationResult::Success {
+            direction,
+            migration_name,
+        });
+    }
+
+    // otherwise, we apply the migration if it is applicable
+    if migration.is_applicable(direction, &repo)? {
+        match direction {
+            // always run applicable down migrations
+            Direction::Down => {
+                migration.down(repo)?;
+                Ok(MigrationResult::Success {
+                    direction,
+                    migration_name,
+                })
+            }
+            // only run up migrations if we've requested optional migrations
+            Direction::Up if run_optional => {
+                migration.up(repo)?;
+                Ok(MigrationResult::Success {
+                    direction,
+                    migration_name,
+                })
+            }
+            _ => Ok(MigrationResult::IsApplicableButOptional {
+                direction,
+                migration_name,
+            }),
+        }
+    } else {
+        Ok(MigrationResult::NotNeededNorApplicable {
+            direction,
+            migration_name,
+        })
+    }
 }

--- a/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use super::Migrate;
 
+use crate::command::migrate::Direction;
 use crate::config::RepositoryConfig;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
@@ -14,11 +15,9 @@ use crate::model::merkle_tree::node::{
 use crate::model::{Commit, LocalRepository, MerkleHash};
 
 use crate::util::hasher;
-use crate::util::progress_bar::{ProgressBarType, oxen_progress_bar};
 use crate::{repositories, util};
 
 pub struct AddChildCountsToNodesMigration;
-impl AddChildCountsToNodesMigration {}
 
 impl Migrate for AddChildCountsToNodesMigration {
     fn name(&self) -> &'static str {
@@ -29,18 +28,20 @@ impl Migrate for AddChildCountsToNodesMigration {
         "Re-writes merkle tree with child counts for all directories and vnode nodes"
     }
 
-    fn up(&self, path: &Path, all: bool) -> Result<(), OxenError> {
-        if all {
-            run_on_all_repos(path)?;
-        } else {
-            let repo = LocalRepository::from_dir(path)?;
-            run_on_one_repo(&repo)?;
-        }
-        Ok(())
+    fn up(&self, repo: LocalRepository) -> Result<(), OxenError> {
+        let commits = repositories::commits::list_all(&repo)?;
+
+        merkle_tree_node_cache::with_cache_disabled(|| -> Result<(), OxenError> {
+            for commit in commits {
+                run_on_commit(&repo, &commit)?;
+            }
+
+            Ok(())
+        })
     }
 
-    fn down(&self, _path: &Path, _all: bool) -> Result<(), OxenError> {
-        panic!("Not implemented");
+    fn down(&self, _: LocalRepository) -> Result<(), OxenError> {
+        Err(OxenError::MigrationUnimplemented(Direction::Down))
     }
 
     fn is_needed(&self, repo: &LocalRepository) -> Result<bool, OxenError> {
@@ -52,49 +53,6 @@ impl Migrate for AddChildCountsToNodesMigration {
         );
         Ok(min_version == MinOxenVersion::V0_19_0)
     }
-}
-
-pub fn run_on_all_repos(path: &Path) -> Result<(), OxenError> {
-    println!("🐂 Collecting namespaces to migrate...");
-    let namespaces = repositories::list_namespaces(path)?;
-    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
-    println!("🐂 Migrating {} namespaces", namespaces.len());
-    for namespace in namespaces {
-        let namespace_path = path.join(namespace);
-        // Show the canonical namespace path
-        log::debug!(
-            "This is the namespace path we're walking: {:?}",
-            util::fs::canonicalize(&namespace_path)?
-        );
-        let repos = repositories::list_repos_in_namespace(&namespace_path);
-        for repo in repos {
-            match run_on_one_repo(&repo) {
-                Ok(_) => {}
-                Err(err) => {
-                    log::error!(
-                        "Could not migrate version files for repo {:?}\nErr: {}",
-                        util::fs::canonicalize(&repo.path),
-                        err
-                    )
-                }
-            }
-        }
-        bar.inc(1);
-    }
-
-    Ok(())
-}
-
-fn run_on_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
-    let commits = repositories::commits::list_all(repo)?;
-
-    merkle_tree_node_cache::with_cache_disabled(|| -> Result<(), OxenError> {
-        for commit in commits {
-            run_on_commit(repo, &commit)?;
-        }
-
-        Ok(())
-    })
 }
 
 fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), OxenError> {
@@ -361,12 +319,13 @@ mod tests {
             });
 
             // Run the migration
-            run_on_one_repo(&repo)?;
+            let repo_path = repo.path.clone();
+            AddChildCountsToNodesMigration.up(repo)?;
 
             // Clear the cache after the migration
-            merkle_tree_node_cache::remove_from_cache(&repo.path)?;
+            merkle_tree_node_cache::remove_from_cache(&repo_path)?;
 
-            let repo = LocalRepository::from_dir(&repo.path)?;
+            let repo = LocalRepository::from_dir(&repo_path)?;
             let latest_commit = repositories::commits::latest_commit(&repo)?;
             let commit_node_version =
                 repositories::tree::get_commit_node_version(&repo, &latest_commit)?;
@@ -460,12 +419,13 @@ mod tests {
             });
 
             // Run the migration
-            run_on_one_repo(&repo)?;
+            let repo_path = repo.path.clone();
+            AddChildCountsToNodesMigration.up(repo)?;
 
             // Clear the cache after the migration
-            merkle_tree_node_cache::remove_from_cache(&repo.path)?;
+            merkle_tree_node_cache::remove_from_cache(&repo_path)?;
 
-            let mut repo = LocalRepository::from_dir(&repo.path)?;
+            let mut repo = LocalRepository::from_dir(&repo_path)?;
             repo.set_vnode_size(3);
 
             let latest_commit = repositories::commits::latest_commit(&repo)?;

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -1,14 +1,10 @@
-use std::path::Path;
-
 use super::Migrate;
 
 use crate::core::workspaces::workspace_name_index;
 use crate::error::OxenError;
 use crate::model::LocalRepository;
 use crate::model::Workspace;
-use crate::repositories;
 use crate::util;
-use crate::util::progress_bar::{ProgressBarType, oxen_progress_bar};
 
 pub struct AddWorkspaceNameIndexMigration;
 
@@ -21,22 +17,24 @@ impl Migrate for AddWorkspaceNameIndexMigration {
         "Creates a RocksDB index mapping workspace names to IDs for O(1) lookup"
     }
 
-    fn up(&self, path: &Path, all: bool) -> Result<(), OxenError> {
-        if all {
-            run_on_all_repos(path)?;
-        } else {
-            let repo = LocalRepository::from_dir(path)?;
-            run_on_one_repo(&repo)?;
+    fn up(&self, repo: LocalRepository) -> Result<(), OxenError> {
+        let workspaces_dir = Workspace::workspaces_dir(&repo);
+        if !workspaces_dir.exists() {
+            return Ok(());
         }
+
+        log::info!("Creating workspace name index for repo: {:?}", repo.path);
+
+        let idx = workspace_name_index::get_index(&repo)?;
+        idx.rebuild_from_disk(&repo)?;
         Ok(())
     }
 
-    fn down(&self, path: &Path, all: bool) -> Result<(), OxenError> {
-        if all {
-            revert_all_repos(path)?;
-        } else {
-            let repo = LocalRepository::from_dir(path)?;
-            revert_one_repo(&repo)?;
+    fn down(&self, repo: LocalRepository) -> Result<(), OxenError> {
+        let index_dir = workspace_name_index::index_dir(&repo);
+        workspace_name_index::remove_from_cache(&repo);
+        if index_dir.exists() {
+            util::fs::remove_dir_all(index_dir)?;
         }
         Ok(())
     }
@@ -46,76 +44,4 @@ impl Migrate for AddWorkspaceNameIndexMigration {
         let workspaces_dir = Workspace::workspaces_dir(repo);
         Ok(workspaces_dir.exists() && !workspace_name_index::index_exists(repo))
     }
-}
-
-fn run_on_all_repos(path: &Path) -> Result<(), OxenError> {
-    println!("🐂 Collecting namespaces to migrate...");
-    let namespaces = repositories::list_namespaces(path)?;
-    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
-    println!("🐂 Migrating {} namespaces", namespaces.len());
-    for namespace in namespaces {
-        let namespace_path = path.join(namespace);
-        let repos = repositories::list_repos_in_namespace(&namespace_path);
-        for repo in repos {
-            match run_on_one_repo(&repo) {
-                Ok(_) => {}
-                Err(err) => {
-                    log::error!(
-                        "Could not create workspace name index for repo {:?}\nErr: {}",
-                        util::fs::canonicalize(repo.path),
-                        err
-                    );
-                }
-            }
-        }
-        bar.inc(1);
-    }
-    Ok(())
-}
-
-fn run_on_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
-    let workspaces_dir = Workspace::workspaces_dir(repo);
-    if !workspaces_dir.exists() {
-        return Ok(());
-    }
-
-    log::info!("Creating workspace name index for repo: {:?}", repo.path);
-
-    let idx = workspace_name_index::get_index(repo)?;
-    idx.rebuild_from_disk(repo)?;
-    Ok(())
-}
-
-fn revert_all_repos(path: &Path) -> Result<(), OxenError> {
-    println!("🐂 Collecting namespaces to revert...");
-    let namespaces = repositories::list_namespaces(path)?;
-    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
-    println!("🐂 Reverting {} namespaces", namespaces.len());
-    for namespace in namespaces {
-        let namespace_path = path.join(namespace);
-        let repos = repositories::list_repos_in_namespace(&namespace_path);
-        for repo in repos {
-            match revert_one_repo(&repo) {
-                Ok(_) => {}
-                Err(err) => {
-                    log::error!(
-                        "Could not revert workspace name index for repo {:?}\nErr: {}",
-                        util::fs::canonicalize(repo.path),
-                        err
-                    );
-                }
-            }
-        }
-        bar.inc(1);
-    }
-    Ok(())
-}
-
-fn revert_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
-    let index_dir = workspace_name_index::index_dir(repo);
-    workspace_name_index::remove_from_cache(repo);
-    if index_dir.exists() {
-        util::fs::remove_dir_all(index_dir)?;
-    }
-    Ok(())
 }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use tokio::task::JoinError;
 
+use crate::command::migrate::Direction;
 use crate::config::repository_config::RepoConfigError;
 use crate::core::db::merkle_node::lmdb::LmdbError;
 use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
@@ -26,6 +27,7 @@ use crate::model::merkle_tree::node_type::InvalidMerkleTreeNodeType;
 
 pub mod path_buf_error;
 pub mod string_error;
+pub mod strum_ext;
 
 pub use crate::error::path_buf_error::PathBufError;
 pub use crate::error::string_error::StringError;
@@ -203,6 +205,15 @@ pub enum OxenError {
     /// The version is invalid or unsupported.
     #[error("Invalid version: {0}")]
     InvalidVersion(StringError),
+
+    #[error("Unknown migration: {0}")]
+    UnknownMigration(String),
+
+    #[error("Migration unimplemented for direction: {0}")]
+    MigrationUnimplemented(Direction),
+
+    #[error("Migration failed to run")]
+    MigrationFailed,
 
     //
     // Version Store
@@ -553,7 +564,12 @@ pub enum OxenError {
     #[error("Unknown status [{0}]")]
     UnknownRemoteResponseStatus(StringError),
 
+    #[error("{0}")]
+    Strum(#[from] strum::ParseError),
+
+    //
     // Fallback
+    //
     // TODO: remove all uses of `Basic` and replace with specific errors.
     #[error("{0}")]
     Basic(StringError),

--- a/crates/lib/src/error/strum_ext.rs
+++ b/crates/lib/src/error/strum_ext.rs
@@ -1,0 +1,27 @@
+use std::{marker::PhantomData, str::FromStr};
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "Unknown {type_name}: {input} (expected one of {names})",
+    type_name=std::any::type_name::<X>().rsplit("::").next().unwrap_or(""), // will actually always be non-empty
+    names=<X as strum::VariantNames>::VARIANTS.join(", "),
+)]
+pub struct VariantAwareStrumError<X: strum::VariantNames> {
+    input: String,
+    #[source]
+    e: strum::ParseError,
+    _type: PhantomData<X>,
+}
+
+/// Parse the string into an X, but return a nice error message that lists what the values should have been.
+pub fn parse<X>(value: &str) -> Result<X, VariantAwareStrumError<X>>
+where
+    X: strum::VariantNames,
+    X: FromStr<Err = strum::ParseError>,
+{
+    value.parse().map_err(|e| VariantAwareStrumError {
+        input: value.to_string(),
+        e,
+        _type: PhantomData,
+    })
+}

--- a/crates/lib/src/namespaces.rs
+++ b/crates/lib/src/namespaces.rs
@@ -40,7 +40,8 @@ pub fn get(data_dir: &Path, name: &str) -> Result<Option<Namespace>, OxenError> 
         storage_usage_gb: 0.0,
     };
 
-    let repos = repositories::list_repos_in_namespace(&namespace_path);
+    let repos: Vec<LocalRepository> =
+        repositories::list_repos_in_namespace(&namespace_path).collect();
     // Get storage per repo in parallel and sum up
     namespace.storage_usage_gb = repos
         .par_iter()

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -130,36 +130,30 @@ fn is_namespace_dir(path: &Path) -> bool {
         // Make sure it is a directory, that doesn't start with .oxen and has repositories in it
         return path.is_dir()
             && !name.starts_with(constants::OXEN_HIDDEN_DIR)
-            && !list_repos_in_namespace(path).is_empty();
+            && list_repos_in_namespace(path).next().is_some();
     }
     false
 }
 
-pub fn list_repos_in_namespace(namespace_path: &Path) -> Vec<LocalRepository> {
+/// Lazily-load each repository in a namespace's directory.
+///
+/// Skips sub-directories that either don't have an `.oxen/` dir within them or that
+/// fail to load via [`LocalRepository::from_dir`].
+pub fn list_repos_in_namespace(namespace_path: &Path) -> impl Iterator<Item = LocalRepository> {
     log::debug!(
         "repositories::entries::list_repos_in_namespace repositories for dir: {namespace_path:?}"
     );
-    let mut repos: Vec<LocalRepository> = vec![];
-    for entry in WalkDir::new(namespace_path)
+    WalkDir::new(namespace_path)
         .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        // if the directory has a .oxen dir, let's add it, otherwise ignore
-        let local_dir = entry.path();
-        let oxen_dir = util::fs::oxen_hidden_dir(&local_dir);
-        // log::debug!(
-        //     "repositories::entries::list_repos_in_namespace got local dir {:?}",
-        //     local_dir
-        // );
-
-        if oxen_dir.exists()
-            && let Ok(repository) = LocalRepository::from_dir(&local_dir)
-        {
-            repos.push(repository);
-        }
-    }
-
-    repos
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let local_dir = entry.path();
+            let oxen_dir = util::fs::oxen_hidden_dir(&local_dir);
+            if !oxen_dir.exists() {
+                return None;
+            }
+            LocalRepository::from_dir(&local_dir).ok()
+        })
 }
 
 pub fn transfer_namespace(
@@ -569,7 +563,7 @@ mod tests {
             let _ = repositories::init(namespace_dir.join("testing3"))?;
 
             let repos = repositories::list_repos_in_namespace(&namespace_dir);
-            assert_eq!(repos.len(), 3);
+            assert_eq!(repos.count(), 3);
 
             Ok(())
         })
@@ -620,8 +614,8 @@ mod tests {
             let old_namespace_repos = repositories::list_repos_in_namespace(&old_namespace_dir);
             let new_namespace_repos = repositories::list_repos_in_namespace(&new_namespace_dir);
 
-            assert_eq!(old_namespace_repos.len(), 1);
-            assert_eq!(new_namespace_repos.len(), 0);
+            assert_eq!(old_namespace_repos.count(), 1);
+            assert_eq!(new_namespace_repos.count(), 0);
 
             // Transfer to new namespace
             let updated_repo =
@@ -637,8 +631,8 @@ mod tests {
             let old_namespace_repos = repositories::list_repos_in_namespace(&old_namespace_dir);
             let new_namespace_repos = repositories::list_repos_in_namespace(&new_namespace_dir);
 
-            assert_eq!(old_namespace_repos.len(), 0);
-            assert_eq!(new_namespace_repos.len(), 1);
+            assert_eq!(old_namespace_repos.count(), 0);
+            assert_eq!(new_namespace_repos.count(), 1);
 
             Ok(())
         })

--- a/crates/server/src/controllers/migrations.rs
+++ b/crates/server/src/controllers/migrations.rs
@@ -1,6 +1,6 @@
 use actix_web::{HttpRequest, HttpResponse, web};
 use liboxen::{
-    command::migrate,
+    command::migrate::{self, Direction, try_apply_migration},
     migrations,
     view::{ListRepositoryResponse, StatusMessage},
 };
@@ -29,11 +29,22 @@ pub async fn list_unmigrated(req: HttpRequest) -> Result<HttpResponse, OxenHttpE
 }
 
 /// Request body for `POST /api/repos/:namespace/:repo_name/migrations/:migration_name`.
+///
+/// `deny_unknown_fields` makes serde reject bodies with extra keys, so a typo
+/// like `{"directiom": "up"}` becomes a 400 instead of silently running with
+/// defaults.
 #[derive(Deserialize, Serialize, Default, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RunMigrationRequest {
     /// `"up"` (default) or `"down"`.
     #[serde(default)]
-    pub direction: Option<String>,
+    pub direction: Direction,
+
+    /// If true, then run the migration if it is applicable but not required.
+    /// If false, then only required up migrations are run. Down migrations are
+    /// always run. Defaults to false if unspecified.
+    #[serde(default)]
+    pub run_optional: bool,
 }
 
 /// Runs a named migration's `up` or `down` on a single repository.
@@ -43,35 +54,34 @@ pub struct RunMigrationRequest {
 /// table. OSS users can still invoke the same migrations via the existing
 /// `oxen migrate up <name> <path>` CLI.
 #[tracing::instrument(skip_all)]
-pub async fn run(
-    req: HttpRequest,
-    body: Option<web::Json<RunMigrationRequest>>,
-) -> Result<HttpResponse, OxenHttpError> {
+pub async fn run(req: HttpRequest, body: web::Bytes) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
+
+    // parse path params
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let migration_name = path_param(&req, "migration_name")?.to_string();
 
-    let direction = body
-        .and_then(|b| b.into_inner().direction)
-        .unwrap_or_else(|| "up".to_string());
+    // Parse the body ourselves rather than via `web::Json<_>` so we can tell
+    // "no body at all" (use defaults) apart from "body is present but bad"
+    // (return 400). `Option<web::Json<_>>` collapses both cases to `None`.
+    let RunMigrationRequest {
+        direction,
+        run_optional,
+    } = if body.is_empty() {
+        RunMigrationRequest::default()
+    } else {
+        serde_json::from_slice(&body)
+            .map_err(|e| OxenHttpError::BadRequest(format!("Invalid request body: {e}").into()))?
+    };
 
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
-
-    let migrations = migrate::all_migrations();
-    let migration = migrations.get(&migration_name).ok_or_else(|| {
+    let migration = migrate::all_migrations(&migration_name).ok_or_else(|| {
         OxenHttpError::BadRequest(format!("Unknown migration: {migration_name}").into())
     })?;
 
-    match direction.as_str() {
-        "up" => migration.up(&repo.path, false)?,
-        "down" => migration.down(&repo.path, false)?,
-        other => {
-            return Err(OxenHttpError::BadRequest(
-                format!("Unknown direction: {other} (expected \"up\" or \"down\")").into(),
-            ));
-        }
-    }
+    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+
+    try_apply_migration(migration, direction, run_optional, repo)?;
 
     log::info!(
         "Ran migration {migration_name} {direction} on {namespace}/{repo_name}",
@@ -87,9 +97,9 @@ pub async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_data::OxenAppData;
     use crate::test;
-    use actix_web::http;
-    use actix_web::web;
+    use actix_web::{App, http, web};
     use liboxen::core::workspaces::workspace_name_index;
     use liboxen::error::OxenError;
 
@@ -114,11 +124,15 @@ mod tests {
             "add_workspace_name_index",
         );
 
-        let body = web::Json(RunMigrationRequest {
-            direction: Some("up".to_string()),
-        });
+        let body = web::Bytes::from(
+            serde_json::to_vec(&RunMigrationRequest {
+                direction: Direction::Up,
+                run_optional: false,
+            })
+            .expect("RunMigrationRequest is always serializable"),
+        );
 
-        let resp = run(req, Some(body)).await.unwrap();
+        let resp = run(req, body).await.expect("run handler should succeed");
         assert_eq!(resp.status(), http::StatusCode::OK);
 
         // Index should exist after migration.
@@ -145,7 +159,7 @@ mod tests {
             "does_not_exist",
         );
 
-        let result = run(req, None).await;
+        let result = run(req, web::Bytes::new()).await;
         match result {
             Err(OxenHttpError::BadRequest(msg)) => {
                 assert!(msg.to_string().contains("Unknown migration"));
@@ -165,6 +179,43 @@ mod tests {
 
         let _repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
 
+        // Drive a real App so the `web::Json<RunMigrationRequest>` extractor
+        // runs serde on the body — `Direction` rejects unknown variants, so
+        // the handler should never be reached and the response should be 400.
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.clone()))
+                .route(
+                    "/api/repos/{namespace}/{repo_name}/migrations/{migration_name}",
+                    web::post().to(run),
+                ),
+        )
+        .await;
+
+        let uri = format!("/api/repos/{namespace}/{repo_name}/migrations/add_workspace_name_index");
+        let req = actix_web::test::TestRequest::post()
+            .uri(&uri)
+            .set_json(serde_json::json!({ "direction": "sideways" }))
+            .to_request();
+
+        let resp = actix_web::test::call_service(&app, req).await;
+        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    /// Body with an extra/unknown field must be rejected (not silently
+    /// ignored). Relies on `#[serde(deny_unknown_fields)]` on
+    /// `RunMigrationRequest`.
+    #[actix_web::test]
+    async fn test_run_rejects_unknown_field() -> Result<(), OxenError> {
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Repo";
+        let _repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let body = web::Bytes::from(r#"{"direction":"up","not_a_real_field":42}"#);
         let req = test::repo_request_with_param(
             &sync_dir,
             "/",
@@ -174,16 +225,82 @@ mod tests {
             "add_workspace_name_index",
         );
 
-        let body = web::Json(RunMigrationRequest {
-            direction: Some("sideways".to_string()),
-        });
-
-        let result = run(req, Some(body)).await;
-        match result {
+        match run(req, body).await {
             Err(OxenHttpError::BadRequest(msg)) => {
-                assert!(msg.to_string().contains("Unknown direction"));
+                let msg = msg.to_string();
+                assert!(
+                    msg.contains("Invalid request body") && msg.contains("not_a_real_field"),
+                    "expected error to mention the unknown field, got: {msg}"
+                );
             }
-            other => panic!("expected BadRequest, got {other:?}"),
+            other => panic!("expected BadRequest for unknown field, got {other:?}"),
+        }
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    /// Body with a correctly-named field but the wrong JSON type
+    /// (e.g. a string where a bool is expected) must be rejected.
+    #[actix_web::test]
+    async fn test_run_rejects_wrong_field_type() -> Result<(), OxenError> {
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Repo";
+        let _repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let body = web::Bytes::from(r#"{"run_optional":"yes"}"#);
+        let req = test::repo_request_with_param(
+            &sync_dir,
+            "/",
+            namespace,
+            repo_name,
+            "migration_name",
+            "add_workspace_name_index",
+        );
+
+        match run(req, body).await {
+            Err(OxenHttpError::BadRequest(msg)) => {
+                assert!(
+                    msg.to_string().contains("Invalid request body"),
+                    "expected \"Invalid request body\" prefix, got: {msg}"
+                );
+            }
+            other => panic!("expected BadRequest for wrong type, got {other:?}"),
+        }
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    /// Malformed JSON (not parseable at all) must be rejected. Empty body
+    /// is allowed and falls back to defaults — see
+    /// `test_run_rejects_unknown_migration` for the empty-body path.
+    #[actix_web::test]
+    async fn test_run_rejects_malformed_json() -> Result<(), OxenError> {
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Repo";
+        let _repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let body = web::Bytes::from_static(b"{not json");
+        let req = test::repo_request_with_param(
+            &sync_dir,
+            "/",
+            namespace,
+            repo_name,
+            "migration_name",
+            "add_workspace_name_index",
+        );
+
+        match run(req, body).await {
+            Err(OxenHttpError::BadRequest(msg)) => {
+                assert!(
+                    msg.to_string().contains("Invalid request body"),
+                    "expected \"Invalid request body\" prefix, got: {msg}"
+                );
+            }
+            other => panic!("expected BadRequest for malformed JSON, got {other:?}"),
         }
 
         test::cleanup_sync_dir(&sync_dir)?;

--- a/crates/server/src/controllers/repositories.rs
+++ b/crates/server/src/controllers/repositories.rs
@@ -50,7 +50,6 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let namespace_path = &app_data.path.join(&namespace);
 
     let repos: Vec<RepositoryListView> = repositories::list_repos_in_namespace(namespace_path)
-        .iter()
         .map(|repo| RepositoryListView {
             name: repo.dirname(),
             namespace: namespace.to_string(),


### PR DESCRIPTION
**`--run-optional`**
Adds `is_applicable -> bool` to the oxen migration command trait to indicate that a migration
may or may not apply in a specific scenario. Defaults to use `is_needed` for Up and `true`
for `Down`, mirroring what existing migrations do today.

New `--run-optional` flag on `oxen migrate` will run a migration if it is not needed but
it is applicable on the repository in the given direction.

Updates down migration logic from unconditional to run iff `is_applicable` in the direction.
Existing migrations' behavior is unchanged.

**fix `--all`**
`oxen migrate ... --all` was broken. The logic was supposed to be, when `--all` is present,
treat `--path` as a directory of `namespace/repository` and run the migration on all repos
in all namespaces. Instead, it was loading the path as a repository, then trying to do the
all-migraiton logic: the first load will fail because it's not a repository.

This has been fixed so that the command works correctly. Additionally, all logic around
running a single migration and running all migrations has been centralized to 2 functions.

**Migrate: `up` and `down` take `LocalRepository`**
The `Migrate` trait has been modified so that the `up` and `down` methods consume a
`LocalRepository` directly. The migrate `RunCmd` loads the repository if it's running
on a single one. It handles loading `namespace/repository` if `--all` is provided.

All callsites have been updated. `Migrate` is not part of Oxen's public API so stability
is not guarneteed. Only migrations defined in `liboxen` can be run by `oxen migrate` anyways.

**server migration --run-optional**
Adds a `run_optional: bool` command to the server's repository migration endpoint. This
allows for an optional migration to be run server-side. Defaults to `false` if missing.