### PR TITLE
Cleanup Migration and CLI

### DIFF
--- a/crates/cli/src/cli_error.rs
+++ b/crates/cli/src/cli_error.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 use liboxen::error::OxenError;
 
 /// Print an OxenError to stderr with colored prefix and optional hints.
-pub fn print_error(err: &OxenError) {
+pub(crate) fn print_error(err: &OxenError) {
     eprintln!("{} {}", "Error:".red().bold(), err);
 
     if let Some(hint) = err.hint() {

--- a/crates/cli/src/cmd/add.rs
+++ b/crates/cli/src/cmd/add.rs
@@ -29,6 +29,7 @@ pub fn add_args() -> Command {
 
 #[async_trait]
 impl RunCmd for AddCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         ADD
     }

--- a/crates/cli/src/cmd/branch.rs
+++ b/crates/cli/src/cmd/branch.rs
@@ -18,6 +18,7 @@ pub struct BranchCmd;
 
 #[async_trait]
 impl RunCmd for BranchCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/checkout.rs
+++ b/crates/cli/src/cmd/checkout.rs
@@ -10,6 +10,7 @@ pub struct CheckoutCmd;
 
 #[async_trait]
 impl RunCmd for CheckoutCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/clean.rs
+++ b/crates/cli/src/cmd/clean.rs
@@ -16,6 +16,7 @@ pub struct CleanCmd;
 
 #[async_trait]
 impl RunCmd for CleanCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/clone.rs
+++ b/crates/cli/src/cmd/clone.rs
@@ -17,6 +17,7 @@ pub struct CloneCmd;
 
 #[async_trait]
 impl RunCmd for CloneCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/commit.rs
+++ b/crates/cli/src/cmd/commit.rs
@@ -16,6 +16,7 @@ pub struct CommitCmd;
 
 #[async_trait]
 impl RunCmd for CommitCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/config.rs
+++ b/crates/cli/src/cmd/config.rs
@@ -12,6 +12,7 @@ pub struct ConfigCmd;
 
 #[async_trait]
 impl RunCmd for ConfigCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/create_remote.rs
+++ b/crates/cli/src/cmd/create_remote.rs
@@ -19,6 +19,7 @@ pub struct CreateRemoteCmd;
 
 #[async_trait]
 impl RunCmd for CreateRemoteCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/db.rs
+++ b/crates/cli/src/cmd/db.rs
@@ -21,6 +21,7 @@ pub struct DbCmd;
 
 #[async_trait]
 impl RunCmd for DbCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/db/count.rs
+++ b/crates/cli/src/cmd/db/count.rs
@@ -13,6 +13,7 @@ pub struct DbCountCmd;
 
 #[async_trait]
 impl RunCmd for DbCountCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/db/get.rs
+++ b/crates/cli/src/cmd/db/get.rs
@@ -8,6 +8,7 @@ pub struct DbGetCmd;
 
 #[async_trait]
 impl RunCmd for DbGetCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/db/list.rs
+++ b/crates/cli/src/cmd/db/list.rs
@@ -13,6 +13,7 @@ pub struct DbListCmd;
 
 #[async_trait]
 impl RunCmd for DbListCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/delete_remote.rs
+++ b/crates/cli/src/cmd/delete_remote.rs
@@ -12,6 +12,7 @@ pub struct DeleteRemoteCmd;
 
 #[async_trait]
 impl RunCmd for DeleteRemoteCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/df.rs
+++ b/crates/cli/src/cmd/df.rs
@@ -14,6 +14,7 @@ pub struct DFCmd;
 
 #[async_trait]
 impl RunCmd for DFCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/diff.rs
+++ b/crates/cli/src/cmd/diff.rs
@@ -31,6 +31,7 @@ fn writeln_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
 
 #[async_trait]
 impl RunCmd for DiffCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/download.rs
+++ b/crates/cli/src/cmd/download.rs
@@ -18,6 +18,7 @@ pub struct DownloadCmd;
 
 #[async_trait]
 impl RunCmd for DownloadCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/embeddings.rs
+++ b/crates/cli/src/cmd/embeddings.rs
@@ -17,6 +17,7 @@ pub struct EmbeddingsCmd;
 
 #[async_trait]
 impl RunCmd for EmbeddingsCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/embeddings/index.rs
+++ b/crates/cli/src/cmd/embeddings/index.rs
@@ -12,6 +12,7 @@ pub struct EmbeddingsIndexCmd;
 
 #[async_trait]
 impl RunCmd for EmbeddingsIndexCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/embeddings/query.rs
+++ b/crates/cli/src/cmd/embeddings/query.rs
@@ -16,6 +16,7 @@ pub struct EmbeddingsQueryCmd;
 
 #[async_trait]
 impl RunCmd for EmbeddingsQueryCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/fetch.rs
+++ b/crates/cli/src/cmd/fetch.rs
@@ -15,6 +15,7 @@ pub struct FetchCmd;
 
 #[async_trait]
 impl RunCmd for FetchCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/fsck.rs
+++ b/crates/cli/src/cmd/fsck.rs
@@ -51,6 +51,7 @@ pub fn fsck_args() -> Command {
 
 #[async_trait]
 impl RunCmd for FsckCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/info.rs
+++ b/crates/cli/src/cmd/info.rs
@@ -13,6 +13,7 @@ pub struct InfoCmd;
 
 #[async_trait]
 impl RunCmd for InfoCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/init.rs
+++ b/crates/cli/src/cmd/init.rs
@@ -27,6 +27,7 @@ pub struct InitCmd;
 
 #[async_trait]
 impl RunCmd for InitCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         INIT
     }

--- a/crates/cli/src/cmd/load.rs
+++ b/crates/cli/src/cmd/load.rs
@@ -11,6 +11,7 @@ pub struct LoadCmd;
 
 #[async_trait]
 impl RunCmd for LoadCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/log.rs
+++ b/crates/cli/src/cmd/log.rs
@@ -20,6 +20,7 @@ fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
 
 #[async_trait]
 impl RunCmd for LogCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/ls.rs
+++ b/crates/cli/src/cmd/ls.rs
@@ -18,6 +18,7 @@ pub struct LsCmd;
 // TODO: Support options besides the base 'ls' functionality -- file stats, etc;
 #[async_trait]
 impl RunCmd for LsCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/merge.rs
+++ b/crates/cli/src/cmd/merge.rs
@@ -13,6 +13,7 @@ pub struct MergeCmd;
 
 #[async_trait]
 impl RunCmd for MergeCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/migrate.rs
+++ b/crates/cli/src/cmd/migrate.rs
@@ -55,6 +55,7 @@ pub struct MigrateCmd;
 
 #[async_trait]
 impl RunCmd for MigrateCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/moo.rs
+++ b/crates/cli/src/cmd/moo.rs
@@ -8,6 +8,7 @@ pub struct MooCmd;
 
 #[async_trait]
 impl RunCmd for MooCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/node.rs
+++ b/crates/cli/src/cmd/node.rs
@@ -12,6 +12,7 @@ pub struct NodeCmd;
 
 #[async_trait]
 impl RunCmd for NodeCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/pack.rs
+++ b/crates/cli/src/cmd/pack.rs
@@ -10,6 +10,7 @@ pub struct PackCmd;
 
 #[async_trait]
 impl RunCmd for PackCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/prune.rs
+++ b/crates/cli/src/cmd/prune.rs
@@ -36,6 +36,7 @@ pub fn prune_args() -> Command {
 
 #[async_trait]
 impl RunCmd for PruneCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/pull.rs
+++ b/crates/cli/src/cmd/pull.rs
@@ -17,6 +17,7 @@ pub struct PullCmd;
 
 #[async_trait]
 impl RunCmd for PullCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/push.rs
+++ b/crates/cli/src/cmd/push.rs
@@ -19,6 +19,7 @@ pub struct PushCmd;
 
 #[async_trait]
 impl RunCmd for PushCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/remote.rs
+++ b/crates/cli/src/cmd/remote.rs
@@ -10,6 +10,7 @@ pub struct RemoteCmd;
 
 #[async_trait]
 impl RunCmd for RemoteCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/remote_mode.rs
+++ b/crates/cli/src/cmd/remote_mode.rs
@@ -25,6 +25,7 @@ pub struct RemoteModeCmd;
 
 #[async_trait]
 impl RunCmd for RemoteModeCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/remote_mode/checkout.rs
+++ b/crates/cli/src/cmd/remote_mode/checkout.rs
@@ -12,6 +12,7 @@ pub struct RemoteModeCheckoutCmd;
 
 #[async_trait]
 impl RunCmd for RemoteModeCheckoutCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/remote_mode/commit.rs
+++ b/crates/cli/src/cmd/remote_mode/commit.rs
@@ -14,6 +14,7 @@ pub struct RemoteModeCommitCmd;
 
 #[async_trait]
 impl RunCmd for RemoteModeCommitCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/remote_mode/restore.rs
+++ b/crates/cli/src/cmd/remote_mode/restore.rs
@@ -14,6 +14,7 @@ pub struct RemoteModeRestoreCmd;
 
 #[async_trait]
 impl RunCmd for RemoteModeRestoreCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/remote_mode/status.rs
+++ b/crates/cli/src/cmd/remote_mode/status.rs
@@ -21,6 +21,7 @@ pub struct RemoteModeStatusCmd;
 
 #[async_trait]
 impl RunCmd for RemoteModeStatusCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/restore.rs
+++ b/crates/cli/src/cmd/restore.rs
@@ -42,6 +42,7 @@ pub fn restore_args() -> Command {
 
 #[async_trait]
 impl RunCmd for RestoreCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/rm.rs
+++ b/crates/cli/src/cmd/rm.rs
@@ -39,6 +39,7 @@ pub fn rm_args() -> Command {
 
 #[async_trait]
 impl RunCmd for RmCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/save.rs
+++ b/crates/cli/src/cmd/save.rs
@@ -13,6 +13,7 @@ pub struct SaveCmd;
 
 #[async_trait]
 impl RunCmd for SaveCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/schemas.rs
+++ b/crates/cli/src/cmd/schemas.rs
@@ -25,6 +25,7 @@ pub struct SchemasCmd;
 
 #[async_trait]
 impl RunCmd for SchemasCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/schemas/add.rs
+++ b/crates/cli/src/cmd/schemas/add.rs
@@ -15,6 +15,7 @@ pub struct SchemasAddCmd;
 
 #[async_trait]
 impl RunCmd for SchemasAddCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/schemas/list.rs
+++ b/crates/cli/src/cmd/schemas/list.rs
@@ -15,6 +15,7 @@ pub struct SchemasListCmd;
 
 #[async_trait]
 impl RunCmd for SchemasListCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/schemas/rm.rs
+++ b/crates/cli/src/cmd/schemas/rm.rs
@@ -12,6 +12,7 @@ pub struct SchemasRmCmd;
 
 #[async_trait]
 impl RunCmd for SchemasRmCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/schemas/show.rs
+++ b/crates/cli/src/cmd/schemas/show.rs
@@ -12,6 +12,7 @@ pub struct SchemasShowCmd;
 
 #[async_trait]
 impl RunCmd for SchemasShowCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/status.rs
+++ b/crates/cli/src/cmd/status.rs
@@ -17,6 +17,7 @@ pub struct StatusCmd;
 
 #[async_trait]
 impl RunCmd for StatusCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/tree.rs
+++ b/crates/cli/src/cmd/tree.rs
@@ -12,6 +12,7 @@ pub struct TreeCmd;
 
 #[async_trait]
 impl RunCmd for TreeCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/unpack.rs
+++ b/crates/cli/src/cmd/unpack.rs
@@ -19,6 +19,7 @@ pub struct UnpackCmd;
 
 #[async_trait]
 impl RunCmd for UnpackCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/upload.rs
+++ b/crates/cli/src/cmd/upload.rs
@@ -19,6 +19,7 @@ pub struct UploadCmd;
 
 #[async_trait]
 impl RunCmd for UploadCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace.rs
+++ b/crates/cli/src/cmd/workspace.rs
@@ -46,6 +46,7 @@ pub struct WorkspaceCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/add.rs
+++ b/crates/cli/src/cmd/workspace/add.rs
@@ -11,6 +11,7 @@ pub struct WorkspaceAddCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceAddCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/clear.rs
+++ b/crates/cli/src/cmd/workspace/clear.rs
@@ -11,6 +11,7 @@ pub struct WorkspaceClearCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceClearCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/commit.rs
+++ b/crates/cli/src/cmd/workspace/commit.rs
@@ -15,6 +15,7 @@ pub struct WorkspaceCommitCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceCommitCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/create.rs
+++ b/crates/cli/src/cmd/workspace/create.rs
@@ -15,6 +15,7 @@ pub struct WorkspaceCreateCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceCreateCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/delete.rs
+++ b/crates/cli/src/cmd/workspace/delete.rs
@@ -11,6 +11,7 @@ pub struct WorkspaceDeleteCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceDeleteCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/df.rs
+++ b/crates/cli/src/cmd/workspace/df.rs
@@ -19,6 +19,7 @@ pub struct WorkspaceDfCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceDfCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/df/get.rs
+++ b/crates/cli/src/cmd/workspace/df/get.rs
@@ -17,6 +17,7 @@ pub struct WorkspaceDFGetCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceDFGetCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/df/index.rs
+++ b/crates/cli/src/cmd/workspace/df/index.rs
@@ -16,6 +16,7 @@ pub struct WorkspaceDFIndexCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceDFIndexCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/diff.rs
+++ b/crates/cli/src/cmd/workspace/diff.rs
@@ -17,6 +17,7 @@ pub struct WorkspaceDiffCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceDiffCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/download.rs
+++ b/crates/cli/src/cmd/workspace/download.rs
@@ -14,6 +14,7 @@ pub struct WorkspaceDownloadCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceDownloadCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/list.rs
+++ b/crates/cli/src/cmd/workspace/list.rs
@@ -10,6 +10,7 @@ pub struct WorkspaceListCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceListCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/restore.rs
+++ b/crates/cli/src/cmd/workspace/restore.rs
@@ -17,6 +17,7 @@ pub struct WorkspaceRestoreCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceRestoreCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/rm.rs
+++ b/crates/cli/src/cmd/workspace/rm.rs
@@ -11,6 +11,7 @@ pub struct WorkspaceRmCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceRmCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/cmd/workspace/status.rs
+++ b/crates/cli/src/cmd/workspace/status.rs
@@ -24,6 +24,7 @@ pub struct WorkspaceStatusCmd;
 
 #[async_trait]
 impl RunCmd for WorkspaceStatusCmd {
+    #[inline(always)]
     fn name(&self) -> &str {
         NAME
     }

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -111,3 +111,19 @@ pub fn check_repo_migration_needed(repo: &LocalRepository) -> Result<(), OxenErr
         "Error: Migration required".to_string().into(),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use liboxen::test;
+
+    /// The LMDB merkle-store migration is optional: even on a file-backend repo
+    /// (where it's *applicable*), it must not appear in the auto-block list, or
+    /// every normal CLI operation would refuse to proceed. `run_empty_local_repo_test`
+    /// creates a file-backend repo by default — exactly the case we want to assert
+    /// stays unblocked.
+    #[test]
+    fn test_check_repo_migration_needed_ignores_optional_migrations() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test(|repo| check_repo_migration_needed(&repo))
+    }
+}

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -11,7 +11,7 @@ use colored::Colorize;
 use std::collections::HashMap;
 use std::str::FromStr;
 
-pub fn get_scheme_and_host_or_default() -> Result<(String, String), OxenError> {
+pub(crate) fn get_scheme_and_host_or_default() -> Result<(String, String), OxenError> {
     let config = AuthConfig::get_or_create()?;
     let mut default_host = (
         constants::DEFAULT_SCHEME.to_string(),
@@ -25,7 +25,7 @@ pub fn get_scheme_and_host_or_default() -> Result<(String, String), OxenError> {
     Ok(default_host)
 }
 
-pub fn get_scheme_and_host_from_repo(
+pub(crate) fn get_scheme_and_host_from_repo(
     repo: &LocalRepository,
 ) -> Result<(String, String), OxenError> {
     if let Some(remote) = repo.remote() {
@@ -36,7 +36,7 @@ pub fn get_scheme_and_host_from_repo(
     get_scheme_and_host_or_default()
 }
 
-pub async fn check_remote_version(
+pub(crate) async fn check_remote_version(
     scheme: impl AsRef<str>,
     host: impl AsRef<str>,
 ) -> Result<(), OxenError> {
@@ -58,7 +58,7 @@ pub async fn check_remote_version(
     Ok(())
 }
 
-pub async fn check_remote_version_blocking(
+pub(crate) async fn check_remote_version_blocking(
     scheme: impl AsRef<str>,
     host: impl AsRef<str>,
 ) -> Result<(), OxenError> {
@@ -81,24 +81,25 @@ pub async fn check_remote_version_blocking(
     Ok(())
 }
 
-pub fn migrations() -> HashMap<String, Box<dyn Migrate>> {
-    liboxen::command::migrate::all_migrations()
+pub(crate) fn migrations() -> &'static HashMap<String, Box<dyn Migrate>> {
+    &liboxen::command::migrate::ALL_MIGRATIONS
 }
 
-pub fn check_repo_migration_needed(repo: &LocalRepository) -> Result<(), OxenError> {
-    let migrations = migrations();
-
-    let mut migrations_needed: Vec<Box<dyn Migrate>> = Vec::new();
-
-    for (_, migration) in migrations {
-        if migration.is_needed(repo)? {
-            migrations_needed.push(migration);
+pub(crate) fn check_repo_migration_needed(repo: &LocalRepository) -> Result<(), OxenError> {
+    let migrations_needed = {
+        let mut migrations_needed: Vec<&dyn Migrate> = Vec::new();
+        for (_, migration) in migrations() {
+            if migration.is_needed(repo)? {
+                migrations_needed.push(&**migration);
+            }
         }
-    }
+        migrations_needed
+    };
 
     if migrations_needed.is_empty() {
         return Ok(());
     }
+
     let warning = "\nWarning: 🐂 This repo requires a migration to the latest Oxen version. \n\nPlease run the following to update:".to_string().yellow();
     eprintln!("{warning}\n");
     for migration in migrations_needed {
@@ -107,9 +108,7 @@ pub fn check_repo_migration_needed(repo: &LocalRepository) -> Result<(), OxenErr
             format!("  oxen migrate up {} .\n", migration.name()).yellow()
         );
     }
-    Err(OxenError::MigrationRequired(
-        "Error: Migration required".to_string().into(),
-    ))
+    Err(OxenError::MigrationRequired)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,11 +9,10 @@ use clap::{Arg, Command};
 use liboxen::model::LocalRepository;
 use liboxen::util;
 use tracing::level_filters::LevelFilter;
-// use env_logger::Env;
 
-pub mod cli_error;
+mod cli_error;
 pub mod cmd;
-pub mod helpers;
+mod helpers;
 
 const SHORT_ABOUT: &str = "🐂 is the AI and machine learning data management toolchain";
 

--- a/crates/lib/src/command/migrate.rs
+++ b/crates/lib/src/command/migrate.rs
@@ -10,6 +10,9 @@ pub mod m20260408_add_workspace_name_index;
 pub use m20260408_add_workspace_name_index::AddWorkspaceNameIndexMigration;
 use strum::{Display, EnumString, IntoStaticStr, VariantNames};
 
+pub mod m20260512000000_switch_merkle_store_to_lmdb;
+pub use m20260512000000_switch_merkle_store_to_lmdb::SwitchMerkleStoreToLmdbMigration;
+
 /// Migration direction. Passed to [`Migrate::is_applicable`] so reversible migrations
 /// (like the file ↔ LMDB merkle store transcode) can report applicability separately
 /// for each direction.
@@ -65,6 +68,10 @@ pub fn all_migrations() -> HashMap<String, Box<dyn Migrate>> {
     map.insert(
         AddWorkspaceNameIndexMigration.name().to_string(),
         Box::new(AddWorkspaceNameIndexMigration),
+    );
+    map.insert(
+        SwitchMerkleStoreToLmdbMigration.name().to_string(),
+        Box::new(SwitchMerkleStoreToLmdbMigration),
     );
     map
 }

--- a/crates/lib/src/command/migrate.rs
+++ b/crates/lib/src/command/migrate.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use crate::{error::OxenError, model::LocalRepository};
 
 pub mod m20250111083535_add_child_counts_to_nodes;
+use lazy_static::lazy_static;
 pub use m20250111083535_add_child_counts_to_nodes::AddChildCountsToNodesMigration;
 
 pub mod m20260408_add_workspace_name_index;
@@ -23,7 +24,7 @@ pub enum Direction {
     Down,
 }
 
-pub trait Migrate {
+pub trait Migrate: Sync + Send {
     /// Apply the migration.
     fn up(&self, path: &Path, all: bool) -> Result<(), OxenError>;
 
@@ -54,24 +55,26 @@ pub trait Migrate {
     fn description(&self) -> &'static str;
 }
 
-/// Returns every registered migration keyed by its `name()`.
-///
-/// Used by both the CLI (`oxen migrate up/down`) and the server
-/// (`POST /api/repos/:ns/:name/migrations/:migration_name`) to look up a
-/// migration by name at runtime. New migrations must be appended here.
-pub fn all_migrations() -> HashMap<String, Box<dyn Migrate>> {
-    let mut map: HashMap<String, Box<dyn Migrate>> = HashMap::new();
-    map.insert(
-        AddChildCountsToNodesMigration.name().to_string(),
-        Box::new(AddChildCountsToNodesMigration),
-    );
-    map.insert(
-        AddWorkspaceNameIndexMigration.name().to_string(),
-        Box::new(AddWorkspaceNameIndexMigration),
-    );
-    map.insert(
-        SwitchMerkleStoreToLmdbMigration.name().to_string(),
-        Box::new(SwitchMerkleStoreToLmdbMigration),
-    );
-    map
+lazy_static! {
+    /// Returns every registered migration keyed by its `name()`.
+    ///
+    /// Used by both the CLI (`oxen migrate up/down`) and the server
+    /// (`POST /api/repos/:ns/:name/migrations/:migration_name`) to look up a
+    /// migration by name at runtime. New migrations must be appended here.
+    pub static ref ALL_MIGRATIONS: HashMap<String, Box<dyn Migrate>> = {
+        let mut map: HashMap<String, Box<dyn Migrate>> = HashMap::new();
+        map.insert(
+            AddChildCountsToNodesMigration.name().to_string(),
+            Box::new(AddChildCountsToNodesMigration),
+        );
+        map.insert(
+            AddWorkspaceNameIndexMigration.name().to_string(),
+            Box::new(AddWorkspaceNameIndexMigration),
+        );
+        map.insert(
+            SwitchMerkleStoreToLmdbMigration.name().to_string(),
+            Box::new(SwitchMerkleStoreToLmdbMigration),
+        );
+        map
+    };
 }

--- a/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -17,14 +17,16 @@ use crate::util::hasher;
 use crate::util::progress_bar::{ProgressBarType, oxen_progress_bar};
 use crate::{repositories, util};
 
+// Re-writes merkle tree with child counts for all directories and vnode nodes.
 pub struct AddChildCountsToNodesMigration;
-impl AddChildCountsToNodesMigration {}
 
 impl Migrate for AddChildCountsToNodesMigration {
+    #[inline(always)]
     fn name(&self) -> &'static str {
         "add_child_counts_to_nodes"
     }
 
+    #[inline(always)]
     fn description(&self) -> &'static str {
         "Re-writes merkle tree with child counts for all directories and vnode nodes"
     }

--- a/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
+++ b/crates/lib/src/command/migrate/m20260408_add_workspace_name_index.rs
@@ -10,13 +10,16 @@ use crate::repositories;
 use crate::util;
 use crate::util::progress_bar::{ProgressBarType, oxen_progress_bar};
 
+// Creates a RocksDB index mapping workspace names to IDs for O(1) lookup.
 pub struct AddWorkspaceNameIndexMigration;
 
 impl Migrate for AddWorkspaceNameIndexMigration {
+    #[inline(always)]
     fn name(&self) -> &'static str {
         "add_workspace_name_index"
     }
 
+    #[inline(always)]
     fn description(&self) -> &'static str {
         "Creates a RocksDB index mapping workspace names to IDs for O(1) lookup"
     }

--- a/crates/lib/src/command/migrate/m20260512000000_switch_merkle_store_to_lmdb.rs
+++ b/crates/lib/src/command/migrate/m20260512000000_switch_merkle_store_to_lmdb.rs
@@ -1,0 +1,614 @@
+use std::path::{Path, PathBuf};
+
+use heed::EnvOpenOptions;
+
+use super::{Direction, Migrate};
+
+use crate::config::RepositoryConfig;
+use crate::config::repository_config::MerkleStoreKind;
+use crate::constants::{NODES_DIR, OXEN_HIDDEN_DIR, TREE_DIR};
+use crate::core::db::merkle_node::LmdbBackend;
+use crate::core::db::merkle_node::file_backend::FileBackend;
+use crate::core::db::merkle_node::lmdb::lmdb_dir_location;
+use crate::error::OxenError;
+use crate::model::merkle_tree::MerkleReader;
+use crate::model::merkle_tree::merkle_writer::{MerkleWriteSession, MerkleWriter};
+use crate::model::merkle_tree::node::EMerkleTreeNode;
+use crate::model::{LocalRepository, MerkleHash};
+use crate::util::progress_bar::{ProgressBarType, oxen_progress_bar};
+use crate::{repositories, util};
+
+/// Map-size hint for the destination LMDB env when migrating into LMDB. LMDB
+/// only consumes what's actually written (the file is sparse), so this is a
+/// ceiling rather than an allocation. 64 GiB comfortably accommodates the
+/// largest Merkle trees we've seen in practice; users can grow it later by
+/// re-opening the env with a larger map.
+const LMDB_MIGRATION_MAP_SIZE_BYTES: usize = 64 * 1024 * 1024 * 1024;
+
+/// Transcodes the repository's Merkle tree node store between the file-based backend
+/// ([`FileBackend`]) and the LMDB backend ([`LmdbBackend`]).
+///
+/// - `up`: file → LMDB. Reads every node out of `.oxen/tree/nodes/...`, writes it into
+///   a freshly-opened LMDB env at `.oxen/lmdb_merkle_tree_store/`, flips
+///   `RepositoryConfig::merkle_store_kind` from `File` to `Lmdb`, then removes the
+///   old tree node directory.
+/// - `down`: LMDB → file. The mirror image: reads from LMDB, writes the file-based
+///   layout, flips the config back to `File`, and removes the LMDB env directory.
+///
+/// Both directions are idempotent: re-running on an already-migrated repo is a no-op
+/// guarded by the per-repo helpers' explicit kind check.
+pub struct SwitchMerkleStoreToLmdbMigration;
+
+impl Migrate for SwitchMerkleStoreToLmdbMigration {
+    fn name(&self) -> &'static str {
+        "switch_merkle_store_to_lmdb"
+    }
+
+    fn description(&self) -> &'static str {
+        "Transcode the repository's Merkle tree node store from the file-based \
+         backend to LMDB. `down` reverts to the file-based backend."
+    }
+
+    /// Migrate from [`FileBackend`] to [`LmdbBackend`].
+    fn up(&self, path: &Path, all: bool) -> Result<(), OxenError> {
+        if all {
+            let mr = run_up_on_all_repos(path)?;
+            print_status_all(&mr)
+        } else {
+            run_up_on_one_repo_at(path)
+        }
+    }
+
+    /// Migrate from [`LmdbBackend`] to [`FileBackend`].
+    fn down(&self, path: &Path, all: bool) -> Result<(), OxenError> {
+        if all {
+            let mr = run_down_on_all_repos(path)?;
+            print_status_all(&mr)
+        } else {
+            run_down_on_one_repo_at(path)
+        }
+    }
+
+    /// This migration is optional — it is never auto-required. Use
+    /// `oxen migrate up/down switch_merkle_store_to_lmdb --run-optional` to invoke it
+    /// explicitly; the CLI consults [`Self::is_applicable`] for that path.
+    fn is_needed(&self, _: &LocalRepository) -> Result<bool, OxenError> {
+        Ok(false)
+    }
+
+    /// Up is applicable iff the repo is on the file backend (so we have something to
+    /// transcode forward); down is applicable iff the repo is on LMDB (so we have
+    /// something to transcode back).
+    fn is_applicable(
+        &self,
+        direction: Direction,
+        repo: &LocalRepository,
+    ) -> Result<bool, OxenError> {
+        let kind = repo.merkle_store_kind();
+        Ok(match direction {
+            Direction::Up => kind == MerkleStoreKind::File,
+            Direction::Down => kind == MerkleStoreKind::Lmdb,
+        })
+    }
+}
+
+fn print_status_all(migration_result: &MigrateResult) -> Result<(), OxenError> {
+    let MigrateResult {
+        failures,
+        successes,
+        ignored,
+    } = migration_result;
+
+    let extra_store: String;
+    let extra = if !ignored.is_empty() {
+        extra_store = format!(" (ignored {})", ignored.len());
+        &extra_store
+    } else {
+        ""
+    };
+
+    if !failures.is_empty() {
+        println!(
+            "\u{274C} Migration completed with {} success(es) and {} failure(s){extra}:",
+            successes.len(),
+            failures.len(),
+        );
+        for (repo_path, err) in failures {
+            println!("  • {:?}: {}", repo_path, err);
+        }
+        Err(OxenError::MigrationFail)
+    } else {
+        println!(
+            "\u{2705} Migration completed: successfully migrated {} repositories{extra}",
+            successes.len(),
+        );
+        Ok(())
+    }
+}
+
+/// Driver for a single repo at the given path. Loads the repo, calls
+/// [`run_up_on_one_repo`], then drops the repo (closing any held merkle store
+/// handles) and finally deletes the now-empty file-based tree directory.
+fn run_up_on_one_repo_at(path: &Path) -> Result<(), OxenError> {
+    let repo = LocalRepository::from_dir(path)?;
+    let repo_path = repo.path.clone();
+    let did_migrate = run_up_on_one_repo(&repo)?;
+    drop(repo);
+    if did_migrate {
+        cleanup_old_file_tree_dir(&repo_path)?;
+    }
+    Ok(())
+}
+
+/// Driver for a single repo at the given path; mirrors [`run_up_on_one_repo_at`].
+fn run_down_on_one_repo_at(path: &Path) -> Result<(), OxenError> {
+    let repo = LocalRepository::from_dir(path)?;
+    let repo_path = repo.path.clone();
+    let did_migrate = run_down_on_one_repo(&repo)?;
+    drop(repo);
+    if did_migrate {
+        cleanup_lmdb_env_dir(&repo_path)?;
+    }
+    Ok(())
+}
+
+/// Perform the file → LMDB transcode for a single repository. Returns `Ok(true)`
+/// when a transcode actually happened (and the caller still needs to clean up
+/// the old file-tree directory), or `Ok(false)` when the repo was already on
+/// LMDB and this is a no-op.
+///
+/// Does **not** delete the old file-tree directory — that has to happen after the
+/// caller has dropped `repo` so any held merkle store handles are gone. See
+/// [`run_up_on_one_repo_at`] for the full lifecycle.
+fn run_up_on_one_repo(repo: &LocalRepository) -> Result<bool, OxenError> {
+    if !SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Up, repo)? {
+        log::info!(
+            "File → LMDB migration not applicable for repo {:?}",
+            repo.path
+        );
+        println!(
+            "Warning: skipping `switch_merkle_store_to_lmdb` up on {:?}: \
+             repo is not on the file-based merkle store.",
+            repo.path
+        );
+        return Ok(false);
+    }
+
+    log::info!(
+        "Migrating Merkle store: file → LMDB for repo {:?}",
+        repo.path
+    );
+
+    // heed requires the env directory to exist before `open` is called.
+    let env_dir = lmdb_dir_location(&repo.path);
+    util::fs::create_dir_all(&env_dir)?;
+
+    {
+        let mut options = EnvOpenOptions::new();
+        options.map_size(LMDB_MIGRATION_MAP_SIZE_BYTES);
+        let dest = LmdbBackend::new(repo.path.clone(), options)?;
+        let source = repo.merkle_store()?;
+        copy_all_nodes(repo, source, &dest)?;
+    }
+
+    let mut config = RepositoryConfig::from_repo(repo)?;
+    config.merkle_store_kind = MerkleStoreKind::Lmdb;
+    config.save(util::fs::config_filepath(&repo.path))?;
+
+    Ok(true)
+}
+
+/// Perform the LMDB → file transcode for a single repository. See
+/// [`run_up_on_one_repo`] for the lifecycle.
+fn run_down_on_one_repo(repo: &LocalRepository) -> Result<bool, OxenError> {
+    if !SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Down, repo)? {
+        log::info!(
+            "LMDB → File migration not applicable for repo {:?}",
+            repo.path
+        );
+        println!(
+            "Warning: skipping `switch_merkle_store_to_lmdb` down on {:?}: \
+             repo is not on the LMDB merkle store.",
+            repo.path
+        );
+        return Ok(false);
+    }
+
+    log::info!(
+        "Migrating Merkle store: LMDB → File for repo {:?}",
+        repo.path
+    );
+
+    {
+        let dest = FileBackend::new(repo);
+        let source = repo.merkle_store()?;
+        copy_all_nodes(repo, source, &dest)?;
+    }
+
+    let mut config = RepositoryConfig::from_repo(repo)?;
+    config.merkle_store_kind = MerkleStoreKind::File;
+    config.save(util::fs::config_filepath(&repo.path))?;
+
+    Ok(true)
+}
+
+/// Delete the old `.oxen/tree/nodes/` directory after a successful file → LMDB
+/// migration. The directory is missing in normal post-migration state, so a
+/// missing dir is not an error.
+fn cleanup_old_file_tree_dir(repo_path: &Path) -> Result<(), OxenError> {
+    let dir = repo_path
+        .join(OXEN_HIDDEN_DIR)
+        .join(TREE_DIR)
+        .join(NODES_DIR);
+    if dir.exists() {
+        util::fs::remove_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+/// Delete the LMDB env directory after a successful LMDB → file migration.
+fn cleanup_lmdb_env_dir(repo_path: &Path) -> Result<(), OxenError> {
+    let dir = lmdb_dir_location(repo_path);
+    if dir.exists() {
+        util::fs::remove_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+struct MigrateResult {
+    failures: Vec<(PathBuf, OxenError)>,
+    successes: Vec<PathBuf>,
+    ignored: Vec<PathBuf>,
+}
+
+fn run_up_on_all_repos(path: &Path) -> Result<MigrateResult, OxenError> {
+    println!("🐂 Collecting namespaces to migrate (file backend → LMDB)...");
+    let namespaces = repositories::list_namespaces(path)?;
+    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
+    println!("🐂 Migrating {} namespaces", namespaces.len());
+
+    let mut failures = vec![];
+    let mut successes = vec![];
+    let mut ignored = vec![];
+
+    for namespace in namespaces {
+        let namespace_path = path.join(namespace);
+        for repo in repositories::list_repos_in_namespace(&namespace_path) {
+            let repo_path = util::fs::canonicalize(&repo.path)?;
+            match run_up_on_one_repo(&repo) {
+                Ok(did_migrate) => {
+                    drop(repo);
+                    if did_migrate {
+                        if let Err(err) = cleanup_old_file_tree_dir(&repo_path) {
+                            log::error!(
+                                "Could not clean up old file-tree dir for repo {}\nErr: {}",
+                                repo_path.display(),
+                                err
+                            );
+                            failures.push((repo_path, err));
+                        } else {
+                            successes.push(repo_path);
+                        }
+                    } else {
+                        ignored.push(repo_path);
+                    }
+                }
+                Err(err) => {
+                    log::error!(
+                        "Could not migrate merkle store (file → LMDB) for repo {}\nErr: {}",
+                        repo_path.display(),
+                        err
+                    );
+                    failures.push((repo_path, err));
+                }
+            }
+        }
+        bar.inc(1);
+    }
+    Ok(MigrateResult {
+        failures,
+        successes,
+        ignored,
+    })
+}
+
+fn run_down_on_all_repos(path: &Path) -> Result<MigrateResult, OxenError> {
+    println!("🐂 Collecting namespaces to migrate (LMDB → file)...");
+    let namespaces = repositories::list_namespaces(path)?;
+    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
+    println!("🐂 Reverting {} namespaces", namespaces.len());
+
+    let mut failures = vec![];
+    let mut successes = vec![];
+    let mut ignored = vec![];
+
+    for namespace in namespaces {
+        let namespace_path = path.join(namespace);
+        let repos = repositories::list_repos_in_namespace(&namespace_path);
+        for repo in repos {
+            let repo_path = util::fs::canonicalize(&repo.path)?;
+            match run_down_on_one_repo(&repo) {
+                Ok(did_migrate) => {
+                    drop(repo);
+                    if did_migrate {
+                        if let Err(err) = cleanup_lmdb_env_dir(&repo_path) {
+                            log::error!(
+                                "Could not clean up LMDB env dir for repo {}\nErr: {}",
+                                repo_path.display(),
+                                err
+                            );
+                            failures.push((repo_path, err));
+                        } else {
+                            successes.push(repo_path);
+                        }
+                    } else {
+                        ignored.push(repo_path);
+                    }
+                }
+                Err(err) => {
+                    log::error!(
+                        "Could not migrate merkle store (LMDB → file) for repo {}\nErr: {}",
+                        repo_path.display(),
+                        err
+                    );
+                    failures.push((repo_path, err));
+                }
+            }
+        }
+        bar.inc(1);
+    }
+    Ok(MigrateResult {
+        failures,
+        successes,
+        ignored,
+    })
+}
+
+/// Transcode every Merkle tree node reachable from any of `repo`'s commits from
+/// `source` to `dest`. Opens one [`MerkleWriteSession`] per commit subtree so each
+/// LMDB write transaction stays bounded to a single commit's nodes — both for
+/// memory and for clean restart granularity if the migration is interrupted.
+fn copy_all_nodes(
+    repo: &LocalRepository,
+    source: &dyn MerkleReader,
+    dest: &dyn MerkleWriter,
+) -> Result<(), OxenError> {
+    let commits = repositories::commits::list_all(repo)?;
+    let bar = oxen_progress_bar(commits.len() as u64, ProgressBarType::Counter);
+    for commit in commits {
+        let commit_hash = commit.hash()?;
+        let session = dest.begin()?;
+        walk_subtree(source, &*session, &commit_hash)?;
+        session.finish()?;
+        bar.inc(1);
+    }
+    Ok(())
+}
+
+/// Recursively walk the subtree rooted at `node_hash` from `source` and re-write
+/// each non-leaf node — plus its immediate children — into `session`.
+///
+/// `MerkleReader::get_node` returns `None` for `File` and `FileChunk` nodes by
+/// trait contract; those leaves are persisted to the destination as `add_child`
+/// calls on their parent's `NodeWriteSession`, so this function never recurses
+/// into them.
+///
+/// The stored `parent_id` for the re-written node comes from `entry.parent_id`
+/// (i.e., the value already stored in the source), not from our recursion path —
+/// matching the established pattern in `m20250111083535_add_child_counts_to_nodes`.
+fn walk_subtree(
+    source: &dyn MerkleReader,
+    session: &dyn MerkleWriteSession,
+    node_hash: &MerkleHash,
+) -> Result<(), OxenError> {
+    let Some(entry) = source.get_node(node_hash)? else {
+        return Ok(());
+    };
+    let children = source.get_children(node_hash)?;
+
+    {
+        let mut ns = session.create_node(entry.node.as_t_node(), entry.parent_id)?;
+        for (_child_hash, child_node) in &children {
+            ns.add_child(child_node.node.as_t_node())?;
+        }
+        ns.finish()?;
+    }
+
+    for (child_hash, child_node) in children {
+        if matches!(
+            child_node.node,
+            EMerkleTreeNode::Commit(_) | EMerkleTreeNode::Directory(_) | EMerkleTreeNode::VNode(_)
+        ) {
+            walk_subtree(source, session, &child_hash)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    use crate::config::repository_config::MerkleStoreKind;
+    use crate::model::merkle_tree::MerkleReader;
+    use crate::model::merkle_tree::node::EMerkleTreeNode;
+    use crate::test;
+
+    /// A deterministic snapshot of every reachable Merkle tree node in a repo,
+    /// keyed by node hash. Two repos that observe the same set of nodes — same
+    /// node bodies AND same `parent_id` AND same child-hash list — will produce
+    /// equal snapshots. Used to assert round-trip integrity.
+    type NodeSnapshot = BTreeMap<u128, NodeRecord>;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct NodeRecord {
+        node: EMerkleTreeNode,
+        parent_id: Option<u128>,
+        // Hashes of the immediate children, as exposed by `get_children`. Sorted
+        // for determinism — child ordering inside a vnode is implementation-dependent.
+        children: Vec<u128>,
+    }
+
+    fn snapshot_all_reachable_nodes(repo: &LocalRepository) -> Result<NodeSnapshot, OxenError> {
+        let mut snap = NodeSnapshot::new();
+        let store = repo.merkle_store()?;
+        let commits = repositories::commits::list_all(repo)?;
+        for commit in commits {
+            let commit_hash = commit.hash()?;
+            collect(store, &commit_hash, &mut snap)?;
+        }
+        Ok(snap)
+    }
+
+    fn collect(
+        store: &dyn MerkleReader,
+        node_hash: &MerkleHash,
+        snap: &mut NodeSnapshot,
+    ) -> Result<(), OxenError> {
+        if snap.contains_key(&node_hash.to_u128()) {
+            return Ok(());
+        }
+        let Some(entry) = store.get_node(node_hash)? else {
+            return Ok(());
+        };
+        let children = store.get_children(node_hash)?;
+        let mut child_hashes: Vec<u128> = children.iter().map(|(h, _)| h.to_u128()).collect();
+        child_hashes.sort_unstable();
+        snap.insert(
+            node_hash.to_u128(),
+            NodeRecord {
+                node: entry.node,
+                parent_id: entry.parent_id.map(|h| h.to_u128()),
+                children: child_hashes,
+            },
+        );
+        for (child_hash, child_node) in children {
+            if matches!(
+                child_node.node,
+                EMerkleTreeNode::Commit(_)
+                    | EMerkleTreeNode::Directory(_)
+                    | EMerkleTreeNode::VNode(_)
+            ) {
+                collect(store, &child_hash, snap)?;
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_round_trip_file_to_lmdb_to_file_preserves_every_node() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test(|repo| {
+            // LMDB only permits a single open env per path per process, so each
+            // phase below drops the prior `LocalRepository` (and its merkle
+            // store handle) before constructing the next one — otherwise the
+            // migration's internal `from_dir` would race against a live env.
+            let repo_path = repo.path.clone();
+
+            // Sanity: fresh repo defaults to the file backend.
+            assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::File);
+            let before = snapshot_all_reachable_nodes(&repo)?;
+            assert!(
+                !before.is_empty(),
+                "fresh one-commit repo should have at least one merkle node"
+            );
+            drop(repo);
+
+            // Up: file → LMDB
+            SwitchMerkleStoreToLmdbMigration.up(&repo_path, false)?;
+            let mid = {
+                let repo_after_up = LocalRepository::from_dir(&repo_path)?;
+                assert_eq!(
+                    repo_after_up.merkle_store_kind(),
+                    MerkleStoreKind::Lmdb,
+                    "config should report Lmdb after up"
+                );
+                assert!(
+                    !repo_after_up
+                        .path
+                        .join(OXEN_HIDDEN_DIR)
+                        .join(TREE_DIR)
+                        .join(NODES_DIR)
+                        .exists(),
+                    "old file-tree node dir should be gone after up"
+                );
+                assert!(
+                    lmdb_dir_location(&repo_after_up.path).exists(),
+                    "LMDB env dir should exist after up"
+                );
+                snapshot_all_reachable_nodes(&repo_after_up)?
+            };
+            assert_eq!(before, mid, "LMDB backend must observe identical tree");
+
+            // Down: LMDB → file
+            SwitchMerkleStoreToLmdbMigration.down(&repo_path, false)?;
+            let after = {
+                let repo_after_down = LocalRepository::from_dir(&repo_path)?;
+                assert_eq!(
+                    repo_after_down.merkle_store_kind(),
+                    MerkleStoreKind::File,
+                    "config should report File after down"
+                );
+                assert!(
+                    !lmdb_dir_location(&repo_after_down.path).exists(),
+                    "LMDB env dir should be gone after down"
+                );
+                snapshot_all_reachable_nodes(&repo_after_down)?
+            };
+            assert_eq!(before, after, "round-trip must preserve every node");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[test]
+    fn test_is_needed_always_false() -> Result<(), OxenError> {
+        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::File)?;
+        assert!(!SwitchMerkleStoreToLmdbMigration.is_needed(&repo)?);
+        drop(repo);
+        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        assert!(!SwitchMerkleStoreToLmdbMigration.is_needed(&repo)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_applicable_tracks_current_backend() -> Result<(), OxenError> {
+        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::File)?;
+        assert!(SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Up, &repo)?);
+        assert!(!SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Down, &repo)?);
+        drop(repo);
+        let repo = test::init_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        assert!(!SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Up, &repo)?);
+        assert!(SwitchMerkleStoreToLmdbMigration.is_applicable(Direction::Down, &repo)?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_up_is_idempotent_after_first_run() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test(|repo| {
+            let repo_path = repo.path.clone();
+            drop(repo);
+            SwitchMerkleStoreToLmdbMigration.up(&repo_path, false)?;
+            // Re-running on an already-Lmdb repo should be a no-op.
+            SwitchMerkleStoreToLmdbMigration.up(&repo_path, false)?;
+            let reloaded = LocalRepository::from_dir(&repo_path)?;
+            assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::Lmdb);
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_down_on_file_backend_is_a_noop() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test(|repo| {
+            assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::File);
+            SwitchMerkleStoreToLmdbMigration.down(&repo.path, false)?;
+            let reloaded = LocalRepository::from_dir(&repo.path)?;
+            assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::File);
+            Ok(())
+        })
+        .await
+    }
+}

--- a/crates/lib/src/command/migrate/m20260512000000_switch_merkle_store_to_lmdb.rs
+++ b/crates/lib/src/command/migrate/m20260512000000_switch_merkle_store_to_lmdb.rs
@@ -40,10 +40,12 @@ const LMDB_MIGRATION_MAP_SIZE_BYTES: usize = 64 * 1024 * 1024 * 1024;
 pub struct SwitchMerkleStoreToLmdbMigration;
 
 impl Migrate for SwitchMerkleStoreToLmdbMigration {
+    #[inline(always)]
     fn name(&self) -> &'static str {
         "switch_merkle_store_to_lmdb"
     }
 
+    #[inline(always)]
     fn description(&self) -> &'static str {
         "Transcode the repository's Merkle tree node store from the file-based \
          backend to LMDB. `down` reverts to the file-based backend."

--- a/crates/lib/src/core/v_latest/model/merkle_tree/node/dir_node.rs
+++ b/crates/lib/src/core/v_latest/model/merkle_tree/node/dir_node.rs
@@ -47,6 +47,7 @@ impl TDirNode for DirNodeData {
         &self.hash
     }
 
+    #[inline(always)]
     fn name(&self) -> &str {
         &self.name
     }

--- a/crates/lib/src/core/v_latest/model/merkle_tree/node/file_node.rs
+++ b/crates/lib/src/core/v_latest/model/merkle_tree/node/file_node.rs
@@ -59,6 +59,7 @@ impl TFileNode for FileNodeData {
         &self.hash
     }
 
+    #[inline(always)]
     fn name(&self) -> &str {
         &self.name
     }

--- a/crates/lib/src/core/v_old/v0_19_0/model/merkle_tree/node/dir_node.rs
+++ b/crates/lib/src/core/v_old/v0_19_0/model/merkle_tree/node/dir_node.rs
@@ -46,6 +46,7 @@ impl TDirNode for DirNodeData {
         &self.hash
     }
 
+    #[inline(always)]
     fn name(&self) -> &str {
         &self.name
     }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -204,6 +204,9 @@ pub enum OxenError {
     #[error("Unknown migration: {0}")]
     UnknownMigration(String),
 
+    #[error("Failure applying migration.")]
+    MigrationFail,
+
     //
     // Version Store
     //

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -190,8 +190,8 @@ pub enum OxenError {
     /// The repository must be migrated before it can be used.
     /// This is due to the repository being at an older version than the oxen server or client
     /// being used on it.
-    #[error("{0}")]
-    MigrationRequired(StringError),
+    #[error("Error: Migration required.")]
+    MigrationRequired,
 
     /// The oxen client or server must be updated before it can be used.
     #[error("{0}")]

--- a/crates/lib/src/model/merkle_tree/node.rs
+++ b/crates/lib/src/model/merkle_tree/node.rs
@@ -73,6 +73,19 @@ impl EMerkleTreeNode {
         )
     }
 
+    /// Borrow the inner typed node as a `&dyn TMerkleTreeNode` so it can be passed
+    /// to APIs (e.g., [`crate::model::merkle_tree::merkle_writer::MerkleWriteSession::create_node`])
+    /// that take a trait object instead of a concrete node type.
+    pub fn as_t_node(&self) -> &dyn TMerkleTreeNode {
+        match self {
+            EMerkleTreeNode::File(file) => file,
+            EMerkleTreeNode::Directory(dir) => dir,
+            EMerkleTreeNode::VNode(vnode) => vnode,
+            EMerkleTreeNode::FileChunk(file_chunk) => file_chunk,
+            EMerkleTreeNode::Commit(commit) => commit,
+        }
+    }
+
     /// Deserialize a Merkle tree node from its on-disk type marker and msgpack-encoded body.
     pub fn from_type_and_bytes(
         dtype: MerkleTreeNodeType,

--- a/crates/server/src/controllers/migrations.rs
+++ b/crates/server/src/controllers/migrations.rs
@@ -58,10 +58,11 @@ pub async fn run(
 
     let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
 
-    let migrations = migrate::all_migrations();
-    let migration = migrations.get(&migration_name).ok_or_else(|| {
-        OxenHttpError::BadRequest(format!("Unknown migration: {migration_name}").into())
-    })?;
+    let migration = migrate::ALL_MIGRATIONS
+        .get(&migration_name)
+        .ok_or_else(|| {
+            OxenHttpError::BadRequest(format!("Unknown migration: {migration_name}").into())
+        })?;
 
     match direction.as_str() {
         "up" => migration.up(&repo.path, false)?,


### PR DESCRIPTION
Initializes the migrations map (ALL_MIGRATIONS) once and reuses. Uses `lazy_static!` and
adds `Sync` and` Send` markers to the `Migrate` trait. Updated callsites.

Lowered visibility in CLI crate: helpers and cli_error modules are not pub. Their members
are `pub(crate)` now. Made all `RunCmd::name()` implementations inline their `&'static str`.
Also made `Migrate::{name,description}()` inline as well.