### PR TITLE
Enable `oxen-server` + `oxen {clone,fork}` to use LMDB Merkle stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5527,6 +5527,7 @@ dependencies = [
  "sanitize-filename",
  "serde",
  "serde_json",
+ "strum 0.28.0",
  "tar",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/cli/src/cmd/clone.rs
+++ b/crates/cli/src/cmd/clone.rs
@@ -1,13 +1,16 @@
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
 
 use liboxen::api;
+use liboxen::config::repository_config::{MerkleStoreKind, RepoConfigError};
 use liboxen::constants::DEFAULT_BRANCH_NAME;
 use liboxen::error::OxenError;
 use liboxen::opts::CloneOpts;
 use liboxen::opts::FetchOpts;
 use liboxen::repositories;
+use strum::VariantNames;
 
 use crate::cmd::RunCmd;
 use crate::helpers::{check_remote_version, check_remote_version_blocking};
@@ -68,6 +71,18 @@ impl RunCmd for CloneCmd {
                     .help("Clone the repo in 'remote mode', pulling the metadata but not the file contents")
                     .action(clap::ArgAction::SetTrue),
             )
+            .arg(
+                Arg::new("merkle-store")
+                    .long("merkle-store")
+                    .help(
+                        "Which Merkle tree store to use locally for the cloned repo. \
+                         'file' is the original on-disk format (default, backwards-compatible). \
+                         'lmdb' uses an LMDB database for the tree store — not supported on \
+                         virtual file systems."
+                    )
+                    .value_parser(<MerkleStoreKind as VariantNames>::VARIANTS.to_vec())
+                    .action(clap::ArgAction::Set),
+            )
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
@@ -88,6 +103,12 @@ impl RunCmd for CloneCmd {
             .transpose()?;
         let is_vfs = args.get_flag("vfs");
         let is_remote = args.get_flag("remote");
+        let merkle_store_kind = match args.get_one::<String>("merkle-store") {
+            Some(token) => {
+                MerkleStoreKind::from_str(token).map_err(RepoConfigError::UnknownMerkleKind)?
+            }
+            None => MerkleStoreKind::default(),
+        };
 
         let current_dir = std::env::current_dir()?;
         let dst: PathBuf = match args.get_one::<String>("DESTINATION") {
@@ -129,6 +150,7 @@ impl RunCmd for CloneCmd {
             },
             is_vfs,
             is_remote,
+            merkle_store_kind,
         };
 
         let (scheme, host) = api::client::get_scheme_and_host_from_url(&opts.url)?;

--- a/crates/cli/src/cmd/create_remote.rs
+++ b/crates/cli/src/cmd/create_remote.rs
@@ -6,10 +6,10 @@ use clap::{Arg, Command};
 use std::str::FromStr;
 
 use liboxen::api;
+use liboxen::api::requests::RepoNew;
 use liboxen::config::UserConfig;
 use liboxen::constants::{DEFAULT_HOST, DEFAULT_SCHEME};
 use liboxen::error::OxenError;
-use liboxen::model::RepoNew;
 use liboxen::model::file::{FileContents, FileNew};
 use liboxen::storage::StorageKind;
 

--- a/crates/cli/src/cmd/init.rs
+++ b/crates/cli/src/cmd/init.rs
@@ -80,7 +80,7 @@ impl RunCmd for InitCmd {
         // that look at enum structure.
         let merkle_store_kind = match args.get_one::<String>("merkle-store") {
             Some(token) => {
-                MerkleStoreKind::from_str(token).map_err(RepoConfigError::UnknownMerkeKind)?
+                MerkleStoreKind::from_str(token).map_err(RepoConfigError::UnknownMerkleKind)?
             }
             None => MerkleStoreKind::default(),
         };

--- a/crates/lib/benches/push.rs
+++ b/crates/lib/benches/push.rs
@@ -1,7 +1,8 @@
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use liboxen::api::requests::RepoNew;
 use liboxen::constants::{DEFAULT_NAMESPACE, DEFAULT_REMOTE_NAME};
 use liboxen::error::OxenError;
-use liboxen::model::{LocalRepository, RepoNew};
+use liboxen::model::LocalRepository;
 use liboxen::repositories;
 use liboxen::test::test_host;
 use liboxen::util;

--- a/crates/lib/src/api.rs
+++ b/crates/lib/src/api.rs
@@ -5,3 +5,4 @@
 
 pub mod client;
 pub mod endpoint;
+pub mod requests;

--- a/crates/lib/src/api/client/repositories.rs
+++ b/crates/lib/src/api/client/repositories.rs
@@ -1,11 +1,11 @@
-use crate::api;
 use crate::api::client;
+use crate::api::requests::RepoNew;
 use crate::constants::DEFAULT_REMOTE_NAME;
 use crate::error::OxenError;
-use crate::model::{Branch, LocalRepository, Remote, RemoteRepository, RepoNew};
-use crate::repositories;
+use crate::model::{Branch, LocalRepository, Remote, RemoteRepository};
 use crate::view::repository::RepositoryCreationResponse;
 use crate::view::{NamespaceView, RepositoryResponse, StatusMessage};
+use crate::{api, repositories};
 use serde_json::json;
 use serde_json::value;
 use std::fmt;
@@ -204,6 +204,11 @@ pub async fn create(repo_new: RepoNew) -> Result<RemoteRepository, OxenError> {
     }
 }
 
+/// Send an HTTP call to re-create a local repository on oxen-server.
+///
+/// NOTE: Ignores the Merkle store kind in the local repository. The server controls which kind
+///       it uses when creating new repositories. A repository can be migrated manually by using
+///       the server's migration endpoint and the file <> lmdb bi-directional optional migration.
 pub async fn create_from_local(
     repository: &LocalRepository,
     mut repo_new: RepoNew,
@@ -221,8 +226,7 @@ pub async fn create_from_local(
     let body = client::parse_json_body(&url, res).await?;
 
     log::debug!("repositories::create_from_local response {body}");
-    let response: Result<RepositoryCreationResponse, serde_json::Error> =
-        serde_json::from_str(&body);
+    let response = serde_json::from_str::<RepositoryCreationResponse>(&body);
     match response {
         Ok(response) => Ok(RemoteRepository::from_creation_view(
             &response.repository,
@@ -235,13 +239,11 @@ pub async fn create_from_local(
                 name: String::from(DEFAULT_REMOTE_NAME),
             },
         )),
-        Err(err) => {
-            let err = format!(
-                "Could not create or find repository [{}]: {err}\n{body}",
-                repo_new.repo_id()
-            );
-            Err(OxenError::basic_str(err))
-        }
+        Err(err) => Err(OxenError::FailCreateOrFindRemoteRepo {
+            repo_id: repo_new.repo_id(),
+            err,
+            body,
+        }),
     }
 }
 
@@ -251,7 +253,7 @@ pub async fn delete(repository: &RemoteRepository) -> Result<StatusMessage, Oxen
     let client = client::new_for_url(&url)?;
     if let Ok(res) = client.delete(&url).send().await {
         let body = client::parse_json_body(&url, res).await?;
-        let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
+        let response = serde_json::from_str::<StatusMessage>(&body);
         match response {
             Ok(val) => Ok(val),
             Err(_) => Err(OxenError::basic_str(format!(
@@ -269,7 +271,7 @@ pub async fn delete_from_url(url: String) -> Result<StatusMessage, OxenError> {
     let client = client::new_for_url(&url)?;
     if let Ok(res) = client.delete(&url).send().await {
         let body = client::parse_json_body(&url, res).await?;
-        let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
+        let response = serde_json::from_str::<StatusMessage>(&body);
         match response {
             Ok(val) => Ok(val),
             Err(_) => Err(OxenError::basic_str(format!(
@@ -296,8 +298,7 @@ pub async fn transfer_namespace(
 
     if let Ok(res) = client.patch(&url).body(params).send().await {
         let body = client::parse_json_body(&url, res).await?;
-        let response: Result<RepositoryResponse, serde_json::Error> = serde_json::from_str(&body);
-
+        let response = serde_json::from_str::<RepositoryResponse>(&body);
         match response {
             Ok(response) => {
                 // Update remote to reflect new namespace
@@ -474,11 +475,11 @@ mod tests {
     use tokio::time::sleep;
 
     use crate::api;
+    use crate::api::requests::RepoNew;
     use crate::config::UserConfig;
     use crate::constants;
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::error::OxenError;
-    use crate::model::RepoNew;
     use crate::model::file::FileContents;
     use crate::model::file::FileNew;
     use crate::repositories;

--- a/crates/lib/src/api/endpoint.rs
+++ b/crates/lib/src/api/endpoint.rs
@@ -1,15 +1,12 @@
 //! # Endpoint - Helpers for creating urls for the remote API
 //!
 
+use crate::api::requests::repo_new::RepoNew;
 use crate::error::OxenError;
-use crate::model::{Remote, RemoteRepository, RepoNew};
+use crate::model::{Remote, RemoteRepository};
 use url::Url;
 
 pub const API_NAMESPACE: &str = "/api/repos";
-
-pub fn get_scheme(host: impl AsRef<str>) -> String {
-    RepoNew::scheme_default(host.as_ref())
-}
 
 pub fn url_from_host_and_scheme(
     host: impl AsRef<str>,
@@ -25,11 +22,17 @@ pub fn url_from_host_and_scheme(
 }
 
 pub fn url_from_host(host: &str, uri: &str) -> String {
-    format!("{}://{host}{API_NAMESPACE}{uri}", get_scheme(host))
+    format!(
+        "{}://{host}{API_NAMESPACE}{uri}",
+        RepoNew::scheme_default(host)
+    )
 }
 
 pub fn remote_url_from_namespace_name(host: &str, namespace: &str, name: &str) -> String {
-    format!("{}://{host}/{namespace}/{name}", get_scheme(host))
+    format!(
+        "{}://{host}/{namespace}/{name}",
+        RepoNew::scheme_default(host)
+    )
 }
 
 pub fn remote_url_from_namespace_name_scheme(
@@ -42,7 +45,7 @@ pub fn remote_url_from_namespace_name_scheme(
 }
 
 pub fn remote_url_from_name(host: &str, name: &str) -> String {
-    format!("{}://{host}/{name}", get_scheme(host))
+    format!("{}://{host}/{name}", RepoNew::scheme_default(host))
 }
 
 pub fn remote_url_from_name_and_scheme(host: &str, name: &str, scheme: &str) -> String {

--- a/crates/lib/src/api/requests.rs
+++ b/crates/lib/src/api/requests.rs
@@ -1,0 +1,5 @@
+//! Defines payloads that the client sends to the server.
+//!
+pub mod repo_new;
+
+pub use repo_new::RepoNew;

--- a/crates/lib/src/api/requests/repo_new.rs
+++ b/crates/lib/src/api/requests/repo_new.rs
@@ -1,3 +1,5 @@
+//! Request payload for creating a new repository. `oxen-cli` sends this to `oxen-server`.
+//!
 use http::Uri;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -8,9 +10,15 @@ use crate::model::commit::Commit;
 use crate::model::file::FileNew;
 use crate::storage::StorageKind;
 
-#[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
+/// Only used between client and server for creating a new remote repository.
+///
+#[derive(Deserialize, Serialize, Debug, Clone, ToSchema, thiserror::Error)]
 pub struct RepoNew {
+    /// The namespace that the repository lives in: dictates application-level repository ownership.
+    /// A namespace can be e.g. a user, a team, or an entire organization. Namespaces must be unique.
     pub namespace: String,
+    /// The name of the repository. When cloned locally, this is the name of the directory.
+    /// This name uniquely identifies it in the namespace.
     pub name: String,
     // All these are optional because you can create a repo with just a namespace and name
     // is_public only applies to OxenHub so is optional
@@ -25,7 +33,7 @@ pub struct RepoNew {
     pub description: Option<String>,
     // Files that you want to seed the repo with
     pub files: Option<Vec<FileNew>>,
-    // Which storage backend the server should use for this repo (e.g. "local", "s3")
+    /// Which storage backend the server should use for this repo (e.g. "local", "s3").
     #[serde(default)]
     pub storage_kind: Option<StorageKind>,
 }
@@ -36,23 +44,24 @@ impl std::fmt::Display for RepoNew {
     }
 }
 
-impl std::error::Error for RepoNew {}
-
 impl RepoNew {
+    /// The `namespace/repository` name.
     pub fn repo_id(&self) -> String {
         format!("{}/{}", self.namespace, self.name)
     }
 
+    /// Either the configured host or the default hostname.
     pub fn host(&self) -> String {
         self.host
             .clone()
             .unwrap_or_else(|| String::from(DEFAULT_HOST))
     }
 
+    /// The URL scheme (i.e. "http" or "https").
     pub fn scheme(&self) -> String {
         self.scheme
             .clone()
-            .unwrap_or_else(|| RepoNew::scheme_default(self.host()))
+            .unwrap_or_else(|| RepoNew::scheme_default(&self.host()))
     }
 
     /// repo_id is the "{namespace}/{repo_name}"
@@ -71,7 +80,7 @@ impl RepoNew {
             name: repo_name,
             is_public: None,
             host: Some(String::from(DEFAULT_HOST)),
-            scheme: Some(RepoNew::scheme_default(String::from(DEFAULT_HOST))),
+            scheme: Some(RepoNew::scheme_default(DEFAULT_HOST)),
             root_commit: None,
             description: None,
             files: None,
@@ -79,8 +88,8 @@ impl RepoNew {
         })
     }
 
-    pub fn scheme_default(host: impl AsRef<str>) -> String {
-        let host = host.as_ref();
+    /// Default using scheme logic: local oxen-server is unencrypted (http). All else is encrypted (https).
+    pub fn scheme_default(host: &str) -> String {
         if host.contains("localhost") || host.contains("127.0.0.1") || host.contains("0.0.0.0") {
             "http".to_string()
         } else {
@@ -97,7 +106,7 @@ impl RepoNew {
             namespace: String::from(namespace.as_ref()),
             name: String::from(name.as_ref()),
             host: Some(String::from(DEFAULT_HOST)),
-            scheme: Some(RepoNew::scheme_default(String::from(DEFAULT_HOST))),
+            scheme: Some(RepoNew::scheme_default(DEFAULT_HOST)),
             is_public: None,
             root_commit: None,
             description: None,
@@ -117,7 +126,7 @@ impl RepoNew {
             name: String::from(name.as_ref()),
             is_public: None,
             host: Some(String::from(host.as_ref())),
-            scheme: Some(RepoNew::scheme_default(host)),
+            scheme: Some(RepoNew::scheme_default(host.as_ref())),
             root_commit: None,
             description: None,
             files: None,
@@ -135,7 +144,7 @@ impl RepoNew {
             name: String::from(name.as_ref()),
             is_public: None,
             host: Some(String::from(DEFAULT_HOST)),
-            scheme: Some(RepoNew::scheme_default(String::from(DEFAULT_HOST))),
+            scheme: Some(RepoNew::scheme_default(DEFAULT_HOST)),
             root_commit: Some(root_commit),
             description: None,
             files: None,
@@ -154,7 +163,7 @@ impl RepoNew {
             name: String::from(name.as_ref()),
             is_public: None,
             host: Some(String::from(DEFAULT_HOST)),
-            scheme: Some(RepoNew::scheme_default(String::from(DEFAULT_HOST))),
+            scheme: Some(RepoNew::scheme_default(DEFAULT_HOST)),
             root_commit: None,
             description: None,
             files: Some(files),
@@ -164,21 +173,25 @@ impl RepoNew {
 
     pub fn from_url(url: &str) -> Result<RepoNew, OxenError> {
         let uri = url.parse::<Uri>()?;
-        let mut split_path: Vec<&str> = uri.path().split('/').collect();
 
-        if split_path.len() < 3 {
-            return Err(OxenError::basic_str("Invalid repo url"));
-        }
+        let (namespace, name) = {
+            let mut split_path: Vec<&str> = uri.path().split('/').collect();
+            if split_path.len() < 3 {
+                return Err(OxenError::NoNamespaceRepoInUrl(uri));
+            }
+            // Pop in reverse to get repo_name then namespace
+            // unwraps are safe because of above length check
+            let repo_name = split_path.pop().unwrap();
+            let namespace = split_path.pop().unwrap();
+            (namespace.to_string(), repo_name.to_string())
+        };
 
-        // Pop in reverse to get repo_name then namespace
-        let repo_name = split_path.pop().unwrap();
-        let namespace = split_path.pop().unwrap();
         Ok(RepoNew {
-            namespace: namespace.to_string(),
-            name: repo_name.to_string(),
+            namespace,
+            name,
             is_public: None,
-            host: Some(uri.host().unwrap().to_string()),
-            scheme: Some(uri.scheme().unwrap().to_string()),
+            host: uri.host().map(|x| x.to_string()),
+            scheme: uri.scheme().map(|x| x.to_string()),
             root_commit: None,
             description: None,
             files: None,

--- a/crates/lib/src/config/repository_config.rs
+++ b/crates/lib/src/config/repository_config.rs
@@ -25,7 +25,7 @@ pub enum RepoConfigError {
     Write(Box<OxenError>),
 
     #[error("[RepositoryConfig] Unsupported Merkle store kind: {kind}. Expected one of {tokens:?}.", kind=.0, tokens=<MerkleStoreKind as VariantNames>::VARIANTS)]
-    UnknownMerkeKind(#[from] strum::ParseError),
+    UnknownMerkleKind(#[from] strum::ParseError),
 
     #[error("Cannot obtain current directory.")]
     CurDir,

--- a/crates/lib/src/core/db/merkle_node/lmdb.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb.rs
@@ -15,11 +15,13 @@ mod writer;
 pub(crate) mod cache;
 
 #[cfg(test)]
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 
+pub use cache::get_or_open;
 pub(in crate::core::db::merkle_node::lmdb) use lmdb_backend::DEFAULT_LMDB_MMAP_SIZE;
 pub use lmdb_backend::LmdbBackend;
-pub(crate) use lmdb_backend::{lmdb_backend_options, lmdb_dir_location};
+pub(crate) use lmdb_backend::{OXEN_LMDB_MERKLE_DIR, lmdb_backend_options, lmdb_dir_location};
 
 use thiserror::Error;
 
@@ -79,6 +81,13 @@ pub enum LmdbError {
 
     #[error("Error writing LMDB Merkle store: {0}")]
     Write(heed::Error),
+
+    #[error("Error copying the LMDB on-disk file to {dst}: {error}")]
+    Copy {
+        dst: PathBuf,
+        #[source]
+        error: heed::Error,
+    },
 
     // ── Cross-table integrity ────────────────────────────────────────────────
     #[error("Missing node, have link for (hex) hash: {0}")]

--- a/crates/lib/src/core/db/merkle_node/lmdb/cache.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/cache.rs
@@ -85,7 +85,7 @@ macro_rules! check_cache {
 /// call — without it, two threads could observe a dead `Weak`, both call
 /// `LmdbBackend::new` on the same path, and one would hit LMDB's
 /// "already open" error.
-pub(crate) fn get_or_open(repo_root: &Path) -> Result<Arc<LmdbBackend>, LmdbError> {
+pub fn get_or_open(repo_root: &Path) -> Result<Arc<LmdbBackend>, LmdbError> {
     // ensure we always have the same key for identifical repositories
     let repo_root =
         util::fs::canonicalize(repo_root).map_err(|e| LmdbError::InitAbs(Box::new(e)))?;

--- a/crates/lib/src/core/db/merkle_node/lmdb/lmdb_backend.rs
+++ b/crates/lib/src/core/db/merkle_node/lmdb/lmdb_backend.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use bytesize::ByteSize;
 use heed::byteorder::LE;
 use heed::types::{Bytes, DecodeIgnore, U128};
-use heed::{AnyTls, Database, Env, EnvOpenOptions, WithTls};
+use heed::{AnyTls, CompactionOption, Database, Env, EnvOpenOptions, WithTls};
 
 use crate::constants::OXEN_HIDDEN_DIR;
 use crate::core::db::merkle_node::lmdb::LmdbError;
@@ -284,6 +284,35 @@ impl LmdbBackend {
         Ok(Some(LmdbLink::decode(bytes)?))
     }
 
+    /// Safe way to copy an LMDB database on disk. Expects the `Path` to be another repository's root.
+    ///
+    /// `opts` selects whether heed compacts while copying. Prefer
+    /// [`CompactionOption::Disabled`] unless you specifically want to reclaim
+    /// free pages: the compacting path (`mdb_env_copyfd1`) walks the B-tree and
+    /// runs an OS-page-size-dependent free-page leak check that can fail with
+    /// `MDB_INCOMPATIBLE` on envs with named sub-DBs (it does so on Windows'
+    /// 4 KiB pages for our two-sub-DB Merkle store). The non-compacting copy
+    /// does a straight used-page copy and is portable.
+    pub fn copy_on_disk(
+        &self,
+        destination_repo_root: &Path,
+        opts: CompactionOption,
+    ) -> Result<(), LmdbError> {
+        let dst_lmdb_dir = lmdb_dir_location(destination_repo_root);
+        util::fs::create_dir_all(&dst_lmdb_dir).map_err(|e| LmdbError::InitDir(Box::new(e)))?;
+
+        // When opened in directory mode (which is how we open _all_ LMDB envs), the
+        // data is expected to live in a file under the dir called "data.mdb". This
+        // file is what heed's `copy_to_file` function expects.
+        let dst = dst_lmdb_dir.join("data.mdb");
+        let _ = self
+            .lmdb_env
+            .copy_to_path(&dst, opts)
+            .map_err(|error| LmdbError::Copy { dst, error })?;
+        // the returned [`File`] is already written and synced to the OS
+        Ok(())
+    }
+
     // /// Flushes LMDB to disk and closes the underlying LMDB environment for this process.
     // pub fn close(self) -> Result<(), heed::Error> {
     //     log::info!("Preparing to close LMDB");
@@ -307,7 +336,7 @@ impl Drop for LmdbBackend {
 
 /// The name of the LMDB directory as it exists in the repository's `.oxen/` hidden directory.
 /// LMDB's actual physical contents and lock files are stored within this directory.
-const OXEN_LMDB_MERKLE_DIR: &str = "lmdb_merkle_tree_store";
+pub(crate) const OXEN_LMDB_MERKLE_DIR: &str = "lmdb_merkle_tree_store";
 
 /// The complete filepath to the LMDB file for the given repository.
 ///

--- a/crates/lib/src/core/v_latest/clone.rs
+++ b/crates/lib/src/core/v_latest/clone.rs
@@ -30,8 +30,12 @@ pub async fn clone_repo(
 
     // save LocalRepository in .oxen directory
     let local_repo = {
-        let mut local_repo =
-            LocalRepository::from_remote(remote_repo.clone(), repo_path, opts.is_vfs)?;
+        let mut local_repo = LocalRepository::from_remote_with_merkle_store_kind(
+            remote_repo.clone(),
+            repo_path,
+            opts.merkle_store_kind,
+            opts.is_vfs,
+        )?;
         local_repo.version_store().init().await?;
         repo_path.clone_into(&mut local_repo.path);
         local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
@@ -90,7 +94,12 @@ pub async fn clone_repo_remote_mode(
     let name = format!("{}: {workspace_id}", branch_name.clone());
 
     // Save LocalRepository in .oxen directory
-    let mut local_repo = LocalRepository::from_remote(remote_repo.clone(), repo_path, opts.is_vfs)?;
+    let mut local_repo = LocalRepository::from_remote_with_merkle_store_kind(
+        remote_repo.clone(),
+        repo_path,
+        opts.merkle_store_kind,
+        opts.is_vfs,
+    )?;
     local_repo.version_store().init().await?;
     repo_path.clone_into(&mut local_repo.path);
     local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -7,6 +7,7 @@ use aws_sdk_s3::error::BuildError;
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use aws_smithy_runtime_api::client::result::SdkError;
 use duckdb::arrow::error::ArrowError;
+use http::Uri;
 use std::fmt::Write;
 use std::io;
 use std::num::ParseIntError;
@@ -14,12 +15,12 @@ use std::path::Path;
 use std::path::PathBuf;
 use tokio::task::JoinError;
 
+use crate::api::requests::RepoNew;
 use crate::command::migrate::Direction;
 use crate::config::repository_config::RepoConfigError;
 use crate::core::db::merkle_node::lmdb::LmdbError;
 use crate::core::db::merkle_node::merkle_node_db::MerkleDbError;
 use crate::model::ParsedResource;
-use crate::model::RepoNew;
 use crate::model::Schema;
 use crate::model::Workspace;
 use crate::model::merkle_tree::merkle_hash::HexHash;
@@ -67,15 +68,35 @@ pub enum OxenError {
     #[error("Invalid repository or namespace name '{0}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+")]
     InvalidRepoName(StringError),
 
+    #[error(
+        "Invalid repository URL. Expecting 3 '/' parts to extract the namespace and repository name in the path of this URL: {0}"
+    )]
+    NoNamespaceRepoInUrl(Uri),
+
     /// When `get_fork_status` cannot obtain the fork status for a repository.
     #[error("No fork status found.")]
     ForkStatusNotFound,
+
+    #[error("A file already exists at the destination path: {0}")]
+    ForkDestinationExists(PathBuf),
+
+    #[error("Could not create or find repository [{repo_id}]: {err}\n{body}")]
+    FailCreateOrFindRemoteRepo {
+        repo_id: String,
+        err: serde_json::Error,
+        body: String,
+    },
 
     // TODO: Once all serialization paths use `*View` instead of `Workspace`, which requires `LocalRepository`
     //       to implement `Serializable`, then these *StoreNotInitialized errors can be deleted.,
     /// The [`MerkleStore`] or [`TransportMerkle`] for a [`LocalRepository`] was not initialized before access.
     #[error("Merkle store not initialized")]
     MerkleStoreNotInitialized,
+
+    /// A repository is misconfigured. Its Merkle tree store setting doesn't match the on-disk state.
+    /// The inner [`PathBuf`] is the local repository's root.
+    #[error("Repository {path} is configured with LMDB Merkle store but the on-disk LMDB files are not present.", path=.0.display())]
+    MisconfiguredMerkleLmdb(PathBuf),
 
     /// LMDB-backed Merkle store was requested on a repository configured for a
     /// virtual file system. LMDB requires a real, byte-addressable mmap target
@@ -784,11 +805,6 @@ impl OxenError {
     /// Makes an OxenError::Upload error.
     pub fn upload(s: &str) -> Self {
         OxenError::Upload(StringError::from(s))
-    }
-
-    /// Make a new OxenError::RepoNotFound error.
-    pub fn repo_not_found(repo: RepoNew) -> Self {
-        OxenError::RepoNotFound(Box::new(repo))
     }
 
     /// Make a new OxenError::FileImportError error.

--- a/crates/lib/src/model.rs
+++ b/crates/lib/src/model.rs
@@ -29,7 +29,6 @@ pub use crate::model::namespace::Namespace;
 // Repository
 pub use crate::model::repository::local_repository::LocalRepository;
 pub use crate::model::repository::remote_repository::RemoteRepository;
-pub use crate::model::repository::repo_new::RepoNew;
 pub use crate::model::repository::repo_stats::{DataTypeStat, RepoStats};
 
 // Commit

--- a/crates/lib/src/model/merkle_tree/merkle_transport.rs
+++ b/crates/lib/src/model/merkle_tree/merkle_transport.rs
@@ -108,6 +108,16 @@ pub trait MerkleUnpacker: Send + Sync {
 }
 
 /// Marker super-trait: a type that can both pack and unpack Merkle tree nodes for transport.
+///
+/// # Backend-independent wire format invariant
+///
+/// The byte format produced by [`MerklePacker`] and consumed by [`MerkleUnpacker`] **MUST**
+/// be independent of the underlying [`crate::model::merkle_tree::MerkleStore`] implementation.
+/// Clients and servers may use different stores (e.g., a file-backend client cloning from
+/// an LMDB-backend server); correctness depends on every backend producing and consuming
+/// the same canonical bytes for the same logical Merkle subtree. A future backend that
+/// ships a non-canonical, backend-specific transport format would silently break
+/// cross-backend interop.
 pub trait MerkleTransport: MerklePacker + MerkleUnpacker {}
 
 /// This blanket impl makes any type that implements [`MerklePacker`] and

--- a/crates/lib/src/model/repository.rs
+++ b/crates/lib/src/model/repository.rs
@@ -1,4 +1,3 @@
 pub mod local_repository;
 pub mod remote_repository;
-pub mod repo_new;
 pub mod repo_stats;

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -292,10 +292,23 @@ impl LocalRepository {
         path: &Path,
         is_vfs: bool,
     ) -> Result<LocalRepository, OxenError> {
+        Self::from_remote_with_merkle_store_kind(repo, path, MerkleStoreKind::default(), is_vfs)
+    }
+
+    /// [`Self::from_remote`] but with an explicit [`MerkleStoreKind`] selection.
+    ///
+    /// The Merkle store choice is a per-disk decision (like the choice an `oxen init`
+    /// caller makes), not a part of the cloned repo's logical state — so a clone is
+    /// free to pick its own backend regardless of what the remote server uses.
+    pub fn from_remote_with_merkle_store_kind(
+        repo: RemoteRepository,
+        path: &Path,
+        merkle_store_kind: MerkleStoreKind,
+        is_vfs: bool,
+    ) -> Result<LocalRepository, OxenError> {
         let path = path.to_owned();
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config)?;
-        let merkle_store_kind = MerkleStoreKind::default();
         let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, is_vfs)?;
         Ok(LocalRepository {
             path,
@@ -715,9 +728,10 @@ mod tests {
 
     use filetime::FileTime;
 
+    use crate::api::requests::RepoNew;
     use crate::config::repository_config::MerkleStoreKind;
     use crate::error::OxenError;
-    use crate::model::{LocalRepository, RepoNew};
+    use crate::model::LocalRepository;
     use crate::test;
     use crate::test::repo_prep::{
         init_test_repo_merkle_init_version_store_async, init_test_repo_with_merkle_store,

--- a/crates/lib/src/opts/clone_opts.rs
+++ b/crates/lib/src/opts/clone_opts.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::config::repository_config::MerkleStoreKind;
 use crate::opts::FetchOpts;
 
 #[derive(Clone, Debug, Default)]
@@ -14,6 +15,11 @@ pub struct CloneOpts {
     pub is_vfs: bool,
     // Flag for remote mode
     pub is_remote: bool,
+    // Which Merkle tree store to use locally for the cloned repo. A per-disk choice
+    // (like the one `oxen init` lets the caller make) — independent of the remote's
+    // backend. Defaults to [`MerkleStoreKind::default()`] (File) so existing callers
+    // are byte-for-byte unchanged.
+    pub merkle_store_kind: MerkleStoreKind,
 }
 
 impl CloneOpts {
@@ -25,6 +31,7 @@ impl CloneOpts {
             fetch_opts: FetchOpts::new(),
             is_vfs: false,
             is_remote: false,
+            merkle_store_kind: MerkleStoreKind::default(),
         }
     }
 
@@ -37,7 +44,32 @@ impl CloneOpts {
             fetch_opts: FetchOpts::from_branch(branch.as_ref()),
             is_vfs: false,
             is_remote: false,
+            merkle_store_kind: MerkleStoreKind::default(),
             ..CloneOpts::new(url, dst)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `CloneOpts::default()` (also reached via `..Default::default()` from
+    /// callers like `oxen-py`) picks the type-level default for
+    /// `merkle_store_kind`, which is `File`. This preserves every existing
+    /// caller byte-for-byte after the Phase I plumbing change.
+    #[test]
+    fn test_clone_opts_default_uses_file_merkle_store() {
+        let opts = CloneOpts::default();
+        assert_eq!(opts.merkle_store_kind, MerkleStoreKind::File);
+        assert!(!opts.is_vfs);
+    }
+
+    /// `CloneOpts::new` is the most commonly used constructor — confirm it
+    /// also defaults to File so existing call sites are unchanged.
+    #[test]
+    fn test_clone_opts_new_uses_file_merkle_store() {
+        let opts = CloneOpts::new("http://example.com/ns/repo", "/tmp/dst");
+        assert_eq!(opts.merkle_store_kind, MerkleStoreKind::File);
     }
 }

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -3,17 +3,19 @@
 //! This module is all the domain logic for repositories, and it's sub-modules.
 //!
 
+use crate::api::requests::RepoNew;
+use crate::config::repository_config::MerkleStoreKind;
 use crate::constants;
 use crate::constants::OXEN_HIDDEN_DIR;
 use crate::core;
 use crate::core::refs::with_ref_manager;
 use crate::error::OxenError;
 use crate::model::Commit;
+use crate::model::LocalRepository;
 use crate::model::MetadataEntry;
 use crate::model::file::FileContents;
 use crate::model::merkle_tree;
 use crate::model::repository::local_repository::LocalRepositoryWithEntries;
-use crate::model::{LocalRepository, RepoNew};
 use crate::repositories;
 use crate::repositories::fork::FORK_STATUS_FILENAME;
 use crate::util;
@@ -169,10 +171,8 @@ pub fn transfer_namespace(
 
     if !repo_dir.exists() {
         log::debug!("Error while transferring repo: repo does not exist: {repo_dir:?}");
-        return Err(OxenError::repo_not_found(RepoNew::from_namespace_name(
-            from_namespace,
-            repo_name,
-            None,
+        return Err(OxenError::RepoNotFound(Box::new(
+            RepoNew::from_namespace_name(from_namespace, repo_name, None),
         )));
     }
 
@@ -208,6 +208,7 @@ fn is_valid_repo_name(name: &str) -> bool {
 pub async fn create(
     root_dir: &Path,
     new_repo: RepoNew,
+    merkle_store_kind: MerkleStoreKind,
 ) -> Result<LocalRepositoryWithEntries, OxenError> {
     // Validate repo name
     if !is_valid_repo_name(&new_repo.name) {
@@ -243,7 +244,8 @@ pub async fn create(
             kind,
             versions_path: None,
         });
-    let local_repo = LocalRepository::new(&repo_dir, storage_config)?;
+    let local_repo =
+        LocalRepository::new_with_merkle_store_kind(&repo_dir, storage_config, merkle_store_kind)?;
     local_repo.save()?;
 
     // Initialize version store
@@ -345,11 +347,13 @@ pub fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {
 
 #[cfg(test)]
 mod tests {
+    use crate::api::requests::RepoNew;
     use crate::config::UserConfig;
+    use crate::config::repository_config::MerkleStoreKind;
     use crate::constants;
     use crate::error::OxenError;
     use crate::model::file::{FileContents, FileNew};
-    use crate::model::{Commit, LocalRepository, RepoNew};
+    use crate::model::{Commit, LocalRepository};
     use crate::repositories;
     use crate::test;
     use crate::util;
@@ -372,7 +376,8 @@ mod tests {
                 timestamp,
             };
             let repo_new = RepoNew::from_root_commit(namespace, name, root_commit);
-            let _repo = repositories::create(&sync_dir, repo_new).await?;
+            let _repo =
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
 
             let repo_path = Path::new(&sync_dir)
                 .join(Path::new(namespace))
@@ -400,7 +405,8 @@ mod tests {
                 user,
             }];
             let repo_new = RepoNew::from_files(namespace, name, files, None);
-            let _repo = repositories::create(&sync_dir, repo_new).await?;
+            let _repo =
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
 
             let repo_path = Path::new(&sync_dir)
                 .join(Path::new(namespace))
@@ -421,7 +427,8 @@ mod tests {
             let namespace: &str = "test-namespace";
             let name: &str = "test-repo-name";
             let repo_new = RepoNew::from_namespace_name(namespace, name, None);
-            let _repo = repositories::create(&sync_dir, repo_new).await?;
+            let _repo =
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
 
             let repo_path = Path::new(&sync_dir)
                 .join(Path::new(namespace))
@@ -431,6 +438,55 @@ mod tests {
             // Test that we can successful load a repository from that dir
             let _repo = LocalRepository::from_dir(&repo_path)?;
 
+            Ok(())
+        })
+        .await
+    }
+
+    /// Default — when `RepoNew.merkle_store_kind` is `None`, the server-side
+    /// repo lands on the File backend, preserving every existing client.
+    #[tokio::test]
+    async fn test_create_defaults_to_file_merkle_store() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|sync_dir| async move {
+            let namespace = "test-namespace";
+            let name = "default-merkle-repo";
+            let repo_new = RepoNew::from_namespace_name(namespace, name, None);
+            let created =
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
+            assert_eq!(
+                created.local_repo.merkle_store_kind(),
+                MerkleStoreKind::File,
+            );
+
+            let repo_path = Path::new(&sync_dir).join(namespace).join(name);
+            let reloaded = LocalRepository::from_dir(&repo_path)?;
+            assert_eq!(reloaded.merkle_store_kind(), MerkleStoreKind::File);
+            Ok(())
+        })
+        .await
+    }
+
+    /// Older clients send a JSON body with no `merkle_store_kind` field. The
+    /// `#[serde(default)]` on `Option<MerkleStoreKind>` keeps that
+    /// deserializing to `None`, and `repositories::create` falls through to
+    /// `File`.
+    #[tokio::test]
+    async fn test_create_deserialized_repo_new_without_field_defaults_to_file()
+    -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|sync_dir| async move {
+            // Pre-`merkle_store_kind` wire shape — old client missing the field.
+            let json = r#"{
+                "namespace": "test-namespace",
+                "name": "old-client-repo"
+            }"#;
+            let repo_new: RepoNew = serde_json::from_str(json).expect("parse RepoNew");
+
+            let created =
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
+            assert_eq!(
+                created.local_repo.merkle_store_kind(),
+                MerkleStoreKind::File,
+            );
             Ok(())
         })
         .await
@@ -473,7 +529,8 @@ mod tests {
             let namespace = "test-namespace";
             let name = "repo with spaces";
             let repo_new = RepoNew::from_namespace_name(namespace, name, None);
-            let result = repositories::create(&sync_dir, repo_new).await;
+            let result =
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await;
 
             assert!(result.is_err(), "Expected error but got: {result:?}");
             match result.unwrap_err() {
@@ -494,7 +551,8 @@ mod tests {
             let namespace = "-invalid-namespace";
             let name = "valid-repo";
             let repo_new = RepoNew::from_namespace_name(namespace, name, None);
-            let result = repositories::create(&sync_dir, repo_new).await;
+            let result =
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await;
 
             assert!(result.is_err(), "Expected error but got: {result:?}");
             match result.unwrap_err() {
@@ -609,7 +667,8 @@ mod tests {
                 timestamp,
             };
             let repo_new = RepoNew::from_root_commit(old_namespace, name, root_commit);
-            let _repo = repositories::create(&sync_dir, repo_new).await?;
+            let _repo =
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
 
             let old_namespace_repos = repositories::list_repos_in_namespace(&old_namespace_dir);
             let new_namespace_repos = repositories::list_repos_in_namespace(&new_namespace_dir);

--- a/crates/lib/src/repositories/clone.rs
+++ b/crates/lib/src/repositories/clone.rs
@@ -49,6 +49,7 @@ async fn _clone(
         fetch_opts,
         is_vfs: false,
         is_remote: false,
+        merkle_store_kind: crate::config::repository_config::MerkleStoreKind::default(),
     };
     clone(&opts).await
 }
@@ -105,12 +106,12 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::api;
+    use crate::api::requests::RepoNew;
     use crate::command;
     use crate::constants;
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::constants::DEFAULT_REMOTE_NAME;
     use crate::error::OxenError;
-    use crate::model::RepoNew;
     use crate::opts::PushOpts;
     use crate::repositories;
     use crate::test;

--- a/crates/lib/src/repositories/fork.rs
+++ b/crates/lib/src/repositories/fork.rs
@@ -1,6 +1,9 @@
+use crate::config::RepositoryConfig;
+use crate::config::repository_config::MerkleStoreKind;
 use crate::constants::{OXEN_HIDDEN_DIR, WORKSPACES_DIR};
+use crate::core::db::merkle_node::lmdb::{OXEN_LMDB_MERKLE_DIR, get_or_open, lmdb_dir_location};
 use crate::error::OxenError;
-use crate::util::fs as oxen_fs;
+use crate::util::fs::{self as oxen_fs, config_filepath};
 use crate::view::fork::{ForkStartResponse, ForkStatus, ForkStatusFile, ForkStatusResponse};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -46,50 +49,126 @@ fn read_status(repo_path: &Path) -> Result<Option<ForkStatus>, OxenError> {
     }))
 }
 
+/// Evict the process-wide cached RocksDB instances for `repo_path` so their
+/// on-disk files are no longer held open. Required before copying a repo's
+/// `.oxen/` tree on Windows, where an open file can't be copied (see the call
+/// site in [`start_fork`]). Covers every cached RocksDB whose files live inside
+/// the copied tree: refs (`.oxen/refs`), staged (`.oxen/staged`), per-commit
+/// dir-hashes (`.oxen/history/<id>/dir_hashes`), and the file-backend Merkle
+/// node cache. The workspace-name index is omitted on purpose — it lives under
+/// `.oxen/workspaces`, which the copy skips. Mirrors the eviction done by
+/// [`crate::repositories::transfer_namespace`] before relocating a repo on disk.
+fn close_cached_dbs(repo_path: &Path) -> Result<(), OxenError> {
+    crate::model::merkle_tree::merkle_tree_node_cache::remove_from_cache(repo_path)?;
+    crate::core::staged::remove_from_cache_with_children(repo_path)?;
+    crate::core::refs::remove_from_cache(repo_path)?;
+    crate::core::db::dir_hashes::dir_hashes_db::remove_from_cache_with_children(repo_path)?;
+    Ok(())
+}
+
 pub fn start_fork(
     original_path: PathBuf,
     new_path: PathBuf,
 ) -> Result<ForkStartResponse, OxenError> {
     if new_path.exists() {
-        return Err(OxenError::basic_str(format!(
-            "A file already exists at the destination path: {}",
-            new_path.to_string_lossy()
-        )));
+        return Err(OxenError::ForkDestinationExists(new_path));
+    }
+
+    let og_config = RepositoryConfig::from_file(config_filepath(&original_path))?;
+
+    let using_lmdb = {
+        let configured_lmdb = matches!(og_config.merkle_store_kind, MerkleStoreKind::Lmdb);
+        if configured_lmdb && !lmdb_dir_location(&original_path).is_dir() {
+            return Err(OxenError::MisconfiguredMerkleLmdb(original_path));
+        }
+        configured_lmdb
+    };
+
+    if og_config.vfs.unwrap_or(false) && using_lmdb {
+        return Err(OxenError::MerkleStoreLmdbNotSupportedOnVfs);
     }
 
     oxen_fs::create_dir_all(&new_path)?;
     write_status(&new_path, &ForkStatus::Counting(0))?;
 
     let new_path_clone = new_path.clone();
-    let mut current_count = 0;
 
     thread::spawn(move || {
-        let total_items = match count_items(&original_path, &new_path, &mut current_count) {
+        let total_items = match count_items(&original_path, &new_path, 0) {
             Ok(count) => count as f32,
             Err(e) => {
                 log::error!("Failed to count items: {e}");
                 write_status(&new_path, &ForkStatus::Failed(e.to_string())).unwrap_or_else(|e| {
-                    log::error!("Failed to write error status: {e}");
+                    log::error!("Failed to write fork error status: {e}");
                 });
                 return;
             }
         };
-        let mut copied_items = 0.0;
-        match copy_dir_recursive(
-            &original_path,
-            &new_path,
-            &new_path,
-            total_items,
-            &mut copied_items,
-        ) {
-            Ok(()) => {
+
+        // if LMDB, then perform a special copy of its database file.
+        if using_lmdb {
+            match get_or_open(&original_path) {
+                Ok(lmdb_backend) => {
+                    // Copy **without** compaction (`CompactionOption::Disabled`). A fork is a
+                    // verbatim copy of the store and compation only works if the physical
+                    // location is unchanged.
+                    if let Err(error) =
+                        lmdb_backend.copy_on_disk(&new_path, heed::CompactionOption::Disabled)
+                    {
+                        log::error!(
+                            "Repository {} uses LMDB but failed to copy its on-disk file: {error}",
+                            original_path.display()
+                        );
+                        write_status(&new_path, &ForkStatus::Failed(error.to_string()))
+                            .unwrap_or_else(|e| {
+                                log::error!("Failed to write fork error status: {e}");
+                            });
+                        return;
+                    }
+                }
+                Err(error) => {
+                    log::error!(
+                        "Repository {} uses LMDB but failed to open its env: {error}",
+                        original_path.display()
+                    );
+                    write_status(&new_path, &ForkStatus::Failed(error.to_string())).unwrap_or_else(
+                        |e| {
+                            log::error!("Failed to write fork error status: {e}");
+                        },
+                    );
+                    return;
+                }
+            }
+        };
+
+        // Close any cached RocksDB instances for the source repo before copying its
+        // files. These DBs (refs, staged, the file-backend Merkle node cache) are
+        // kept open process-wide in LRU caches, and RocksDB holds their files open —
+        // notably the directory `LOCK`. On Windows `fs::copy` (CopyFileExW) then fails
+        // with a sharing violation ("being used by another process", os error 32) when
+        // it reaches a file another handle holds open. Evicting drops the last
+        // `Arc<DB>`, closing the DBs and releasing the handles. Mirrors
+        // `repositories::transfer_namespace`, which evicts the same caches before
+        // relocating a repo on disk. (The LMDB env is unaffected: its dir is skipped by
+        // the copy below and was snapshotted above via `copy_on_disk`.)
+        if let Err(e) = close_cached_dbs(&original_path) {
+            log::error!("Failed to close source repo DB caches before fork copy: {e}");
+            write_status(&new_path, &ForkStatus::Failed(e.to_string())).unwrap_or_else(|e| {
+                log::error!("Failed to write fork error status: {e}");
+            });
+            return;
+        }
+
+        // ignores workspaces and LMDB dirs
+        match copy_dir_recursive(&original_path, &new_path, &new_path, total_items, 0.0) {
+            Ok(_) => {
                 write_status(&new_path, &ForkStatus::Complete).unwrap_or_else(|e| {
-                    log::error!("Failed to write completion status: {e}");
+                    log::error!("Failed to write fork completion status: {e}");
                 });
             }
             Err(e) => {
                 write_status(&new_path, &ForkStatus::Failed(e.to_string())).unwrap_or_else(|e| {
-                    log::error!("Failed to write error status: {e}");
+                    log::error!("Failed to write fork error status: {e}");
                 });
             }
         }
@@ -125,59 +204,62 @@ pub fn get_fork_status(repo_path: &Path) -> Result<ForkStatusResponse, OxenError
     })
 }
 
+/// Copies everything from `src` to `dst`, except for workspaces & LMDB.
 fn copy_dir_recursive(
     src: &Path,
     dst: &Path,
     status_repo: &Path,
     total_items: f32,
-    copied_items: &mut f32,
-) -> Result<(), OxenError> {
+    mut progress: f32,
+) -> Result<f32, OxenError> {
     let workspaces_path = PathBuf::from(OXEN_HIDDEN_DIR).join(WORKSPACES_DIR);
+    let lmdb_path = PathBuf::from(OXEN_HIDDEN_DIR).join(OXEN_LMDB_MERKLE_DIR);
 
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let path = entry.path();
         let dest_path = dst.join(entry.file_name());
 
-        if path.ends_with(&workspaces_path) {
+        if path.ends_with(&workspaces_path) || path.ends_with(&lmdb_path) {
             continue;
         }
 
         if path.is_dir() {
             oxen_fs::create_dir_all(&dest_path)?;
-            copy_dir_recursive(&path, &dest_path, status_repo, total_items, copied_items)?;
+            progress = copy_dir_recursive(&path, &dest_path, status_repo, total_items, progress)?;
         } else {
             fs::copy(&path, &dest_path)?;
-            *copied_items += 1.0;
+            progress += 1.0;
         }
     }
 
-    let progress = if total_items > 0.0 {
-        (*copied_items / total_items) * 100.0
+    let updated_progress = if total_items > 0.0 {
+        (progress / total_items) * 100.0
     } else {
         100.0 // Assume completion if there are no items to copy
     };
-    write_status(status_repo, &ForkStatus::InProgress(progress))?;
-    Ok(())
+    write_status(status_repo, &ForkStatus::InProgress(updated_progress))?;
+    Ok(updated_progress)
 }
 
-fn count_items(path: &Path, status_repo: &Path, current_count: &mut u32) -> Result<u32, OxenError> {
+fn count_items(path: &Path, status_repo: &Path, mut current_count: u32) -> Result<u32, OxenError> {
     let workspaces_path = PathBuf::from(OXEN_HIDDEN_DIR).join(WORKSPACES_DIR);
+    let lmdb_path = PathBuf::from(OXEN_HIDDEN_DIR).join(OXEN_LMDB_MERKLE_DIR);
 
     for entry in fs::read_dir(path)? {
         let entry = entry?;
         let path = entry.path();
-        if path.ends_with(&workspaces_path) {
+        if path.ends_with(&workspaces_path) || path.ends_with(&lmdb_path) {
             continue;
         }
         if path.is_dir() {
-            count_items(&path, status_repo, current_count)?;
+            current_count = count_items(&path, status_repo, current_count)?;
         } else {
-            *current_count += 1;
+            current_count += 1;
         }
     }
-    write_status(status_repo, &ForkStatus::Counting(*current_count))?;
-    Ok(*current_count)
+    write_status(status_repo, &ForkStatus::Counting(current_count))?;
+    Ok(current_count)
 }
 
 #[cfg(test)]
@@ -308,5 +390,106 @@ mod tests {
             }
         })
         .await
+    }
+
+    /// Fork an LMDB-backed repository and verify the forked repo is also LMDB-backed,
+    /// has the canonical snapshotted `data.mdb` on disk, and exposes the same commits
+    /// as the source — i.e. the LMDB merkle store survived the `Env::copy_to_path`
+    /// snapshot path inside `start_fork`.
+    #[tokio::test]
+    async fn test_fork_lmdb_backed_repo_preserves_backend_and_data() -> Result<(), OxenError> {
+        use crate::config::repository_config::MerkleStoreKind;
+        use crate::model::LocalRepository;
+        use crate::test::repo_prep::{init_lmdb_safe_test_repo_with_merkle_store, lmdb_test_base};
+        use crate::test::{add_txt_file_to_dir, generate_random_string};
+
+        let source = init_lmdb_safe_test_repo_with_merkle_store(MerkleStoreKind::Lmdb)?;
+        assert_eq!(source.merkle_store_kind(), MerkleStoreKind::Lmdb);
+
+        // A real commit so the LMDB env actually has merkle nodes to snapshot.
+        // Done inline rather than via `apply_one_commit_local_repo` because the latter uses
+        // `run_async` (a nested `block_on`), which conflicts with this test's tokio runtime.
+        let file_path = add_txt_file_to_dir(&source.path, &generate_random_string(20))?;
+        repositories::add(&source, &file_path).await?;
+        repositories::commit(&source, "Init commit")?;
+        let source_commit_ids: Vec<String> = repositories::commits::list_all(&source)?
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert!(
+            !source_commit_ids.is_empty(),
+            "fresh one-commit repo must expose at least one commit"
+        );
+
+        // Place the fork sibling-of the source under `lmdb_test_base()`, not inside it,
+        // so `copy_dir_recursive` doesn't recurse into its own destination.
+        let forked_path = lmdb_test_base().join(format!("forked-{}", uuid::Uuid::new_v4()));
+
+        start_fork(source.path.clone(), forked_path.clone())?;
+
+        // Poll until the fork reaches a terminal state (`complete` or `failed`),
+        // tolerating the transient `started`/`counting`/`in_progress` states and a
+        // not-yet-created status file. Mirrors `test_fork_operations`.
+        let mut status = get_fork_status(&forked_path).ok();
+        let mut attempts = 0;
+        const MAX_ATTEMPTS: u32 = 30;
+        while !matches!(
+            status.as_ref().map(|s| s.status.as_str()),
+            Some("complete" | "failed")
+        ) && attempts < MAX_ATTEMPTS
+        {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            status = match get_fork_status(&forked_path) {
+                Ok(s) => Some(s),
+                Err(OxenError::ForkStatusNotFound) => None,
+                Err(e) => return Err(e),
+            };
+            attempts += 1;
+        }
+        let status = status.expect("fork status file should exist after polling");
+        assert_eq!(
+            status.status, "complete",
+            "fork should finish in 'complete' state; got {:?} (error: {:?})",
+            status.status, status.error,
+        );
+
+        // The snapshot must land at `<forked>/.oxen/lmdb_merkle_tree_store/data.mdb`,
+        // since heed's `copy_to_path` is called with that exact path in `LmdbBackend::copy_on_disk`.
+        let dst_lmdb_dir = lmdb_dir_location(&forked_path);
+        let dst_data_mdb = dst_lmdb_dir.join("data.mdb");
+        assert!(
+            dst_data_mdb.is_file(),
+            "forked LMDB env should contain data.mdb at {}",
+            dst_data_mdb.display()
+        );
+        assert!(
+            std::fs::metadata(&dst_data_mdb)?.len() > 0,
+            "snapshot data.mdb should be non-empty"
+        );
+
+        // The recursive copy must skip the source's LMDB dir on the destination side —
+        // otherwise it would have clobbered the snapshot with a half-written `data.mdb`.
+        // (We can't easily detect "clobbered", but if the readback below succeeds, it didn't.)
+
+        // Open the forked repo: this exercises the snapshot for real by opening the env.
+        let forked = LocalRepository::from_dir(&forked_path)?;
+        assert_eq!(
+            forked.merkle_store_kind(),
+            MerkleStoreKind::Lmdb,
+            "forked repo must preserve the source's MerkleStoreKind"
+        );
+        let forked_commit_ids: Vec<String> = repositories::commits::list_all(&forked)?
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(
+            forked_commit_ids, source_commit_ids,
+            "forked repo must expose the same commit set as the source"
+        );
+
+        // Release the env mmap before removing the dir so Windows can unlink the file.
+        drop(forked);
+        let _ = std::fs::remove_dir_all(&forked_path);
+        Ok(())
     }
 }

--- a/crates/lib/src/test.rs
+++ b/crates/lib/src/test.rs
@@ -7,6 +7,7 @@ pub mod repo_prep;
 pub mod test_utils;
 
 use crate::api;
+use crate::api::requests::RepoNew;
 use crate::command;
 use crate::constants;
 use crate::constants::DEFAULT_REMOTE_NAME;
@@ -16,7 +17,7 @@ use crate::error::OxenError;
 use crate::model::data_frame::schema::Field;
 use crate::model::file::{FileContents, FileNew};
 use crate::model::merkle_tree::node::merkle_tree_node_cache;
-use crate::model::{LocalRepository, RemoteRepository, RepoNew, Schema, User};
+use crate::model::{LocalRepository, RemoteRepository, Schema, User};
 use crate::opts::RmOpts;
 use crate::repositories;
 use crate::util;

--- a/crates/lib/src/test/repo_prep.rs
+++ b/crates/lib/src/test/repo_prep.rs
@@ -33,7 +33,7 @@ use crate::test::{
 /// This function mirrors `lmdb_test_root` in
 /// `crates/lib/src/core/db/merkle_node/lmdb.rs`, used by the low-level [`LmdbBackend`] tests.
 #[inline(always)]
-fn lmdb_test_base() -> PathBuf {
+pub(crate) fn lmdb_test_base() -> PathBuf {
     std::env::temp_dir().join("oxen-lmdb-tests")
 }
 

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -1,11 +1,12 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
+use liboxen::api::requests::RepoNew;
 use liboxen::config::UserConfig;
 use liboxen::error::OxenError;
 use liboxen::model::commit::NewCommitBody;
 use liboxen::model::file::{FileContents, FileNew};
-use liboxen::model::{Remote, RemoteRepository, RepoNew};
+use liboxen::model::{Remote, RemoteRepository};
 use liboxen::opts::{PaginateOpts, SortOpts};
 use liboxen::storage::StorageKind;
 use liboxen::{api, repositories};

--- a/crates/oxen-py/src/remote.rs
+++ b/crates/oxen-py/src/remote.rs
@@ -4,10 +4,11 @@ use std::path::PathBuf;
 
 use crate::error::PyOxenError;
 use crate::py_remote_repo::PyRemoteRepo;
+use liboxen::api::requests::RepoNew;
 use liboxen::config::UserConfig;
 use liboxen::constants::DEFAULT_BRANCH_NAME;
 use liboxen::error::OxenError;
-use liboxen::model::{RepoNew, file::FileNew};
+use liboxen::model::file::FileNew;
 use liboxen::storage::StorageKind;
 use std::str::FromStr;
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -53,6 +53,7 @@ rocksdb = { workspace = true }
 sanitize-filename = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+strum = { workspace = true }
 tar = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/server/src/app_data.rs
+++ b/crates/server/src/app_data.rs
@@ -1,11 +1,14 @@
 use std::path::PathBuf;
 
+use liboxen::config::repository_config::MerkleStoreKind;
+
 use crate::config::Config;
 
 #[derive(Debug, Clone)]
 pub struct OxenAppData {
     pub path: PathBuf,
     pub config: Config,
+    pub merkle_store_kind: MerkleStoreKind,
 }
 
 impl OxenAppData {
@@ -14,6 +17,7 @@ impl OxenAppData {
         OxenAppData {
             path,
             config: Config::default(),
+            merkle_store_kind: MerkleStoreKind::default(),
         }
     }
 }

--- a/crates/server/src/config/storage_policy.rs
+++ b/crates/server/src/config/storage_policy.rs
@@ -119,7 +119,7 @@ impl StoragePolicy {
     /// - `requested = None`: returns the server's default.
     /// - `requested = Some(k)`: returns `k` iff allowed; otherwise `BadRequest` (400).
     ///
-    /// Callers writing the result back to a `RepoNew` should treat the caller's
+    /// Callers writing the result back to a `ClientRepoCreateRequest` or `RepoNew` should treat the caller's
     /// `storage_kind` as a *request* — the server's policy decides what actually gets
     /// persisted (defense in depth).
     pub fn resolve(&self, requested: Option<StorageKind>) -> Result<StorageKind, OxenHttpError> {

--- a/crates/server/src/controllers/fork.rs
+++ b/crates/server/src/controllers/fork.rs
@@ -94,3 +94,178 @@ pub async fn get_status(req: HttpRequest) -> Result<HttpResponse, OxenHttpError>
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_data::OxenAppData;
+
+    use actix_web::http::StatusCode;
+    use actix_web::test::TestRequest;
+    use liboxen::config::repository_config::MerkleStoreKind;
+    use liboxen::constants::MIN_OXEN_VERSION;
+    use liboxen::model::LocalRepository;
+    use liboxen::repositories;
+    use liboxen::test as oxen_test;
+    use liboxen::util;
+    use liboxen::view::fork::{ForkRequest, ForkStartResponse, ForkStatus, ForkStatusResponse};
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    /// Build a sync dir on the OS temp filesystem (not the per-test `OXEN_TEST_RUN_DIR`,
+    /// which is a Windows ImDisk RAMDisk on CI). LMDB depends on NT memory-section APIs
+    /// that the RAMDisk does not implement — see the long-form rationale in
+    /// `crates/lib/src/test/repo_prep.rs::lmdb_test_base`.
+    fn lmdb_safe_sync_dir() -> Result<PathBuf, OxenError> {
+        let sync_dir = std::env::temp_dir()
+            .join("oxen-server-lmdb-fork-tests")
+            .join(uuid::Uuid::new_v4().to_string());
+        util::fs::create_dir_all(&sync_dir)?;
+        Ok(sync_dir)
+    }
+
+    /// Build a fork `HttpRequest` keyed on the source `{namespace}/{repo_name}`
+    /// path params, with our `OxenAppData` attached so `app_data(&req)` works.
+    fn fork_request(sync_dir: &Path, source_ns: &str, source_repo: &str) -> HttpRequest {
+        TestRequest::with_uri("/")
+            .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+            .param("namespace", source_ns.to_string())
+            .param("repo_name", source_repo.to_string())
+            .to_http_request()
+    }
+
+    /// Build a fork-status `HttpRequest` keyed on the *destination* `{namespace}/{repo_name}`.
+    fn fork_status_request(sync_dir: &Path, dst_ns: &str, dst_repo: &str) -> HttpRequest {
+        TestRequest::with_uri("/")
+            .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+            .param("namespace", dst_ns.to_string())
+            .param("repo_name", dst_repo.to_string())
+            .to_http_request()
+    }
+
+    /// Drive the fork controller against an LMDB-backed source repo and confirm the
+    /// forked repo created under the sync dir is also LMDB-backed and exposes the
+    /// same commit set as the source. This is the end-to-end version of the lib-level
+    /// test in `crates/lib/src/repositories/fork.rs`, exercised through the HTTP
+    /// handler and `get_repo`/`app_data` plumbing rather than the raw `start_fork`.
+    #[actix_web::test]
+    async fn test_fork_endpoint_preserves_lmdb_backend_and_commits() -> Result<(), OxenError> {
+        oxen_test::init_test_env();
+
+        let sync_dir = lmdb_safe_sync_dir()?;
+        let source_ns = "src-ns";
+        let source_repo_name = "src-repo";
+        let dst_ns = "fork-ns";
+        let dst_repo_name = "fork-repo";
+
+        // 1. Create an LMDB-backed source repo under `<sync>/src-ns/src-repo`.
+        let source_repo_dir = sync_dir.join(source_ns).join(source_repo_name);
+        util::fs::create_dir_all(&source_repo_dir)?;
+        let source_repo = repositories::init::init_with_version_and_merkle_store(
+            &source_repo_dir,
+            MIN_OXEN_VERSION,
+            MerkleStoreKind::Lmdb,
+        )?;
+        assert_eq!(source_repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
+
+        // Add and commit a file so the LMDB merkle store has nodes to snapshot.
+        let file_path = source_repo_dir.join("readme.txt");
+        std::fs::write(&file_path, "hello from the lmdb fork test")?;
+        repositories::add(&source_repo, &file_path).await?;
+        let commit = repositories::commit(&source_repo, "seed commit")?;
+        let source_commit_ids = vec![commit.id.clone()];
+
+        // 2. POST /fork via the handler.
+        let req = fork_request(&sync_dir, source_ns, source_repo_name);
+        let body = web::Json(ForkRequest {
+            namespace: dst_ns.to_string(),
+            new_repo_name: Some(dst_repo_name.to_string()),
+        });
+        let resp = fork(req, body)
+            .await
+            .expect("fork handler should return Ok");
+        assert_eq!(
+            resp.status(),
+            StatusCode::ACCEPTED,
+            "fork must accept the request and start a background copy"
+        );
+        // Sanity-check the JSON shape so we'd notice if `start_fork` changed its
+        // initial-response contract from underneath this endpoint.
+        let start_body: ForkStartResponse = serde_json::from_slice(
+            &actix_web::body::to_bytes(resp.into_body())
+                .await
+                .expect("body collected"),
+        )
+        .expect("response body deserializes as ForkStartResponse");
+        assert_eq!(start_body.fork_status, ForkStatus::Started.to_string());
+
+        // 3. Poll GET /fork/status until the background copy reaches a terminal
+        //    state (`complete` or `failed`), tolerating the transient
+        //    `started`/`counting`/`in_progress` states and a not-yet-created
+        //    status file (404).
+        let mut status: Option<ForkStatusResponse> = None;
+        let mut attempts = 0;
+        const MAX_ATTEMPTS: u32 = 30;
+        while !matches!(
+            status.as_ref().map(|s| s.status.as_str()),
+            Some("complete" | "failed")
+        ) && attempts < MAX_ATTEMPTS
+        {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let status_req = fork_status_request(&sync_dir, dst_ns, dst_repo_name);
+            let status_resp = get_status(status_req)
+                .await
+                .expect("get_status handler should return Ok");
+            attempts += 1;
+            // The fork-status route never returns 5xx for an in-progress fork — only
+            // 200 with a body, or 404 if the destination dir hasn't been created yet.
+            if status_resp.status() == StatusCode::NOT_FOUND {
+                continue;
+            }
+            assert_eq!(status_resp.status(), StatusCode::OK);
+            status = Some(
+                serde_json::from_slice(
+                    &actix_web::body::to_bytes(status_resp.into_body())
+                        .await
+                        .expect("status body collected"),
+                )
+                .expect("status body deserializes as ForkStatusResponse"),
+            );
+        }
+        let status = status.expect("fork status should be readable after polling");
+        // On failure, surface the background thread's error (carried in the status
+        // `error` field) instead of just the opaque status string.
+        assert_eq!(
+            status.status, "complete",
+            "fork endpoint should reach 'complete'; got {:?} (error: {:?})",
+            status.status, status.error,
+        );
+
+        // 4. Open the forked repo at its destination path and verify:
+        //    (a) it reports MerkleStoreKind::Lmdb, i.e. the source config.toml was copied,
+        //    (b) listing commits succeeds, which only works if the snapshotted LMDB env
+        //        is readable end-to-end.
+        let dst_repo_path = sync_dir.join(dst_ns).join(dst_repo_name);
+        let forked = LocalRepository::from_dir(&dst_repo_path)?;
+        assert_eq!(
+            forked.merkle_store_kind(),
+            MerkleStoreKind::Lmdb,
+            "forked repo must inherit MerkleStoreKind::Lmdb from the source"
+        );
+        let forked_commit_ids: Vec<String> = repositories::commits::list_all(&forked)?
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(
+            forked_commit_ids, source_commit_ids,
+            "forked repo must expose the same commits as the source"
+        );
+
+        // Release LMDB envs (mmap handles) before unlinking the dir so cleanup
+        // succeeds on Windows.
+        drop(forked);
+        drop(source_repo);
+        let _ = std::fs::remove_dir_all(&sync_dir);
+        Ok(())
+    }
+}

--- a/crates/server/src/controllers/repositories.rs
+++ b/crates/server/src/controllers/repositories.rs
@@ -4,7 +4,9 @@ use crate::helpers::get_repo;
 use crate::params::{app_data, path_param};
 
 use futures_util::TryStreamExt;
-use futures_util::stream::StreamExt; // Import StreamExt for the next() method
+use futures_util::stream::StreamExt;
+use liboxen::api::requests::RepoNew;
+// Import StreamExt for the next() method
 use liboxen::constants::DEFAULT_BRANCH_NAME;
 use liboxen::error::OxenError;
 use liboxen::model::ParsedResource;
@@ -22,7 +24,7 @@ use liboxen::view::{
 };
 
 use actix_multipart::Multipart; // Gives us Multipart
-use liboxen::model::{RepoNew, User};
+use liboxen::model::User;
 
 use actix_web::{HttpRequest, HttpResponse, Result, web};
 use serde_json::from_slice;
@@ -308,12 +310,16 @@ pub async fn create(
 
 async fn handle_json_creation(
     app_data: &OxenAppData,
-    mut data: RepoNew,
+    data: RepoNew,
 ) -> actix_web::Result<HttpResponse, OxenHttpError> {
-    data.storage_kind = Some(app_data.config.storage.resolve(data.storage_kind)?);
+    let data = {
+        let mut data = data;
+        data.storage_kind = Some(app_data.config.storage.resolve(data.storage_kind)?);
+        data
+    };
 
     let repo_new_clone = data.clone();
-    match repositories::create(&app_data.path, data).await {
+    match repositories::create(&app_data.path, data, app_data.merkle_store_kind).await {
         Ok(repo) => match repositories::commits::latest_commit(&repo.local_repo) {
             Ok(latest_commit) => Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                 status: STATUS_SUCCESS.to_string(),
@@ -340,27 +346,12 @@ async fn handle_json_creation(
                 }))
             }
             Err(err) => {
-                println!("Err repositories::create: {err:?}");
                 log::error!("Err repositories::commits::latest_commit: {err:?}");
                 Ok(HttpResponse::InternalServerError()
                     .json(StatusMessage::error("Failed to get latest commit.")))
             }
         },
-        Err(OxenError::RepoAlreadyExists(path)) => {
-            log::debug!("Repo already exists: {path:?}");
-            Ok(HttpResponse::Conflict().json(StatusMessage::error("Repo already exists.")))
-        }
-        Err(OxenError::InvalidRepoName(name)) => {
-            log::debug!("Invalid repo name: {name}");
-            Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!(
-                "Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"
-            ))))
-        }
-        Err(err) => {
-            println!("Err repositories::create: {err:?}");
-            log::error!("Err repositories::create: {err:?}");
-            Ok(HttpResponse::InternalServerError().json(StatusMessage::error("Invalid body.")))
-        }
+        Err(err) => Ok(map_create_error_to_response(err)),
     }
 }
 
@@ -451,17 +442,22 @@ async fn handle_multipart_creation(
     }
 
     // Handle repository creation
-    let Some(mut repo_data) = repo_new else {
-        return Ok(HttpResponse::BadRequest().json(StatusMessage::error("Missing new_repo field")));
-    };
+    let repo_data = {
+        let Some(mut repo_data) = repo_new else {
+            return Ok(
+                HttpResponse::BadRequest().json(StatusMessage::error("Missing new_repo field"))
+            );
+        };
 
-    repo_data.files = if !files.is_empty() { Some(files) } else { None };
-    repo_data.storage_kind = Some(app_data.config.storage.resolve(repo_data.storage_kind)?);
+        repo_data.files = if !files.is_empty() { Some(files) } else { None };
+        repo_data.storage_kind = Some(app_data.config.storage.resolve(repo_data.storage_kind)?);
+        repo_data
+    };
 
     let repo_data_clone = repo_data.clone();
 
     // Create repository
-    match repositories::create(&app_data.path, repo_data).await {
+    match repositories::create(&app_data.path, repo_data, app_data.merkle_store_kind).await {
         Ok(repo) => match repositories::commits::latest_commit(&repo.local_repo) {
             Ok(latest_commit) => Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                 status: STATUS_SUCCESS.to_string(),
@@ -493,19 +489,40 @@ async fn handle_multipart_creation(
                     .json(StatusMessage::error("Failed to get latest commit.")))
             }
         },
-        Err(OxenError::RepoAlreadyExists(path)) => {
+        Err(err) => Ok(map_create_error_to_response(err)),
+    }
+}
+
+/// Map an [`OxenError`] returned by [`repositories::create`] to the HTTP
+/// response that both creation routes (JSON and multipart) send back.
+///
+/// Kept as a free function so both handlers stay byte-identical on the error
+/// path; any new variant only needs to be added here.
+fn map_create_error_to_response(err: OxenError) -> HttpResponse {
+    match err {
+        OxenError::RepoAlreadyExists(path) => {
             log::debug!("Repo already exists: {path:?}");
-            Ok(HttpResponse::Conflict().json(StatusMessage::error("Repo already exists.")))
+            HttpResponse::Conflict().json(StatusMessage::error("Repo already exists."))
         }
-        Err(OxenError::InvalidRepoName(name)) => {
+        OxenError::InvalidRepoName(name) => {
             log::debug!("Invalid repo name: {name}");
-            Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!(
+            HttpResponse::BadRequest().json(StatusMessage::error(format!(
                 "Invalid repository or namespace name '{name}'. Must match [a-zA-Z0-9][a-zA-Z0-9_.-]+"
-            ))))
+            )))
         }
-        Err(err) => {
+        OxenError::MerkleStoreLmdbNotSupportedOnVfs => {
+            log::debug!(
+                "Rejecting LMDB merkle store request: server sync dir is on a virtual file system"
+            );
+            HttpResponse::BadRequest().json(StatusMessage::error(
+                "Cannot create an LMDB-backed repository on a virtual file system. \
+                 Either retarget the server's sync directory at a real filesystem \
+                 or omit `merkle_store_kind` (defaults to file-backend).",
+            ))
+        }
+        err => {
             log::error!("Err repositories::create: {err:?}");
-            Ok(HttpResponse::InternalServerError().json(StatusMessage::error("Invalid body.")))
+            HttpResponse::InternalServerError().json(StatusMessage::error("Invalid body."))
         }
     }
 }

--- a/crates/server/src/helpers.rs
+++ b/crates/server/src/helpers.rs
@@ -3,8 +3,9 @@ use std::path::Path;
 // use liboxen::constants::DEFAULT_REDIS_URL;
 use actix_web::http::header;
 use actix_web::{HttpResponse, HttpResponseBuilder};
+use liboxen::api::requests::RepoNew;
 use liboxen::error::OxenError;
-use liboxen::model::{LocalRepository, RepoNew, User};
+use liboxen::model::{LocalRepository, User};
 use liboxen::repositories;
 
 use crate::errors::OxenHttpError;
@@ -16,10 +17,12 @@ pub fn get_repo(
 ) -> Result<LocalRepository, OxenHttpError> {
     let repo = repositories::get_by_namespace_and_name(path, &namespace, &name)?;
     let Some(repo) = repo else {
-        return Err(OxenError::repo_not_found(RepoNew::from_namespace_name(
-            &namespace, &name, None,
-        ))
-        .into());
+        return Err(
+            OxenError::RepoNotFound(Box::new(RepoNew::from_namespace_name(
+                &namespace, &name, None,
+            )))
+            .into(),
+        );
     };
 
     Ok(repo)

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,6 +1,8 @@
 use dotenvy::dotenv;
 use dotenvy::from_filename;
+use liboxen::api::requests::RepoNew;
 use liboxen::config::UserConfig;
+use liboxen::config::repository_config::MerkleStoreKind;
 use liboxen::constants::OXEN_VERSION;
 use liboxen::error::OxenError;
 use liboxen::model::User;
@@ -41,7 +43,7 @@ use liboxen::model::metadata::{
     MetadataAudio, MetadataDir, MetadataImage, MetadataTabular, MetadataText, MetadataVideo,
     generic_metadata::GenericMetadata,
 };
-use liboxen::model::{Commit, CommitStats, RepoNew};
+use liboxen::model::{Commit, CommitStats};
 use liboxen::view::commit::CommitTreeValidationResponse;
 use liboxen::view::compare::{
     CompareCommits, CompareCommitsResponse, CompareDupes, CompareEntries, CompareEntryResponse,
@@ -343,6 +345,22 @@ enum ServerCommand {
                     (currently: storage policy). When omitted, built-in defaults apply."
         )]
         config: Option<PathBuf>,
+
+        /// The default Merkle tree store to use for new repositories.
+        /// A migration can be run to change any repository's Merkle tree store implementation.
+        #[arg(
+            short = 'm',
+            long = "merkle-store",
+            help = format!(
+                "The Merkle tree store implementation to use for new repositories. \
+                 Possible values: {}. Default: {}.",
+               <MerkleStoreKind as strum::VariantNames>::VARIANTS.join(", "),
+               MerkleStoreKind::default(),
+            ),
+            default_value_t = MerkleStoreKind::default(),
+            value_parser = clap::value_parser!(MerkleStoreKind),
+        )]
+        merkle_store_kind: MerkleStoreKind,
     },
 
     /// Create a new user in the server and output the config file for that user
@@ -456,6 +474,7 @@ async fn server() -> Result<(), ServerError> {
             port,
             auth,
             config,
+            merkle_store_kind,
         } => {
             let _metrics_guard = init_metrics()?;
             let server_config = load_server_config(config.as_deref())?;
@@ -467,10 +486,11 @@ async fn server() -> Result<(), ServerError> {
             start(
                 &ip,
                 port,
-                &ServerOpts {
+                ServerOpts {
                     // TODO: why is this not checking the value of the env var?
                     disable_merkle_cache: env::var("OXEN_DISABLE_MERKLE_CACHE").is_ok(),
                     enable_auth: auth,
+                    merkle_store_kind,
                 },
                 &sync_dir,
                 server_config,
@@ -555,19 +575,21 @@ fn init_metrics() -> Result<Option<MetricsGuard>, ServerError> {
 struct ServerOpts {
     disable_merkle_cache: bool,
     enable_auth: bool,
+    merkle_store_kind: MerkleStoreKind,
 }
 
 async fn start(
     host: &str,
     port: u16,
-    opts: &ServerOpts,
+    opts: ServerOpts,
     sync_dir: &Path,
-    server_config: Config,
+    config: Config,
 ) -> Result<(), std::io::Error> {
     let ServerOpts {
         disable_merkle_cache,
         enable_auth,
-    } = *opts;
+        merkle_store_kind,
+    } = opts;
 
     // Configure merkle tree node caching
     if disable_merkle_cache {
@@ -583,7 +605,8 @@ async fn start(
 
     let data = app_data::OxenAppData {
         path: PathBuf::from(sync_dir),
-        config: server_config,
+        config,
+        merkle_store_kind,
     };
 
     {


### PR DESCRIPTION
**`oxen-server --merkle-store`**
Enables `oxen-server` to use LMDB Merkle tree stores on new repositories via the
server's new `--merkle-tree` flag on startup. This defaults to `file` for existing
behavior. This option controls the `MerkleStore` backend that `oxen-server` uses
when a new repository is created. Note that existing repositories can be migrated
to either the file or LMDB backend using the migration route on the server.

**`oxen-clone --merkle-store`**
Also updates `oxen clone` to select an explicit Merkle tree store kind on clone.
Has the same `--merkle-store` flag. Ensures that the cloned repository is using
that Merkle tree store locally. Servers and clients can use different Merkle
tree stores and still be completely compatible.

**`oxen fork`**
Updates the repository forking code to properly handle copying LMDB's data file.
Uses the weak LmdbBackend cache to get the source fork's LMDB env and uses `heed`'s
`copy_to_path` function (accessed via `LmdbBackend::copy_on_disk`). Fork's recursive
file copying skips over all LMDB files.

**`MerkleStoreLmdbNotSupportedOnVfs`**
Finally, includes a minor refactor to the server repository creation code. Unifies
their custom HTTP error response handling of OxenError and makes them treat
`MerkleStoreLmdbNotSupportedOnVfs` as a HTTP Bad Request. This error is because
LMDB is not officially supported on virtual filesystems.

**`RepoNew`**
Moves `RepoNew` from `liboxen::models` to a new sub-package `liboxen::api::requests`.
Documents this struct as being the HTTP payload for a client requesting creation of
a remote repository on `oxen-server`.