### PR TITLE
Repo Integrity (1.2): Atomic HEAD write

### DIFF
--- a/crates/lib/src/core/refs/ref_manager.rs
+++ b/crates/lib/src/core/refs/ref_manager.rs
@@ -224,9 +224,8 @@ impl RefManager {
 
     // Write operations (from RefWriter)
 
-    pub fn set_head(&self, name: impl AsRef<str>) {
-        let name = name.as_ref();
-        util::fs::write_to_path(&self.head_file, name).expect("Could not write to head");
+    pub fn set_head(&self, name: &str) -> Result<(), OxenError> {
+        util::fs::atomic_write_to_path(&self.head_file, name.as_bytes())
     }
 
     pub fn create_branch(
@@ -319,7 +318,7 @@ impl RefManager {
             if self.has_branch(&head_val) {
                 self.set_head_branch_commit_id(commit_id)?;
             } else {
-                self.set_head(commit_id);
+                self.set_head(commit_id)?;
             }
         }
         Ok(())
@@ -438,7 +437,7 @@ mod tests {
                 let branch_name = "experiment/cat-dog";
                 let commit_id = format!("{}", uuid::Uuid::new_v4());
                 manager.create_branch(branch_name, &commit_id)?;
-                manager.set_head(branch_name);
+                manager.set_head(branch_name)?;
                 assert_eq!(manager.head_commit_id()?, Some(commit_id));
                 Ok(())
             })

--- a/crates/lib/src/core/v_latest/commits.rs
+++ b/crates/lib/src/core/v_latest/commits.rs
@@ -395,7 +395,7 @@ pub fn create_initial_commit(
 
     // Set HEAD to the new branch
     with_ref_manager(repo, |manager| {
-        manager.set_head(branch_name);
+        manager.set_head(branch_name)?;
         Ok(())
     })?;
 

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -256,7 +256,7 @@ pub async fn create(
 
     // Create HEAD file and point it to DEFAULT_BRANCH_NAME
     with_ref_manager(&local_repo, |manager| {
-        manager.set_head(constants::DEFAULT_BRANCH_NAME);
+        manager.set_head(constants::DEFAULT_BRANCH_NAME)?;
         Ok(())
     })?;
 

--- a/crates/lib/src/repositories/branches.rs
+++ b/crates/lib/src/repositories/branches.rs
@@ -89,7 +89,7 @@ pub fn create_checkout(repo: &LocalRepository, name: impl AsRef<str>) -> Result<
 
     with_ref_manager(repo, |manager| {
         let branch = manager.create_branch(&name, &head_commit.id)?;
-        manager.set_head(name);
+        manager.set_head(&name)?;
         Ok(branch)
     })
 }
@@ -215,9 +215,10 @@ pub async fn checkout_commit_from_commit(
 }
 
 pub fn set_head(repo: &LocalRepository, value: impl AsRef<str>) -> Result<(), OxenError> {
-    log::debug!("set_head {}", value.as_ref());
+    let value = value.as_ref();
+    log::debug!("set_head {value}");
     with_ref_manager(repo, |manager| {
-        manager.set_head(value);
+        manager.set_head(value)?;
         Ok(())
     })
 }
@@ -249,7 +250,7 @@ pub fn rename_current_branch(repo: &LocalRepository, new_name: &str) -> Result<(
     if let Ok(Some(branch)) = current_branch(repo) {
         with_ref_manager(repo, |manager| {
             manager.rename_branch(&branch.name, new_name)?;
-            manager.set_head(new_name);
+            manager.set_head(new_name)?;
             Ok(())
         })
     } else {
@@ -427,7 +428,7 @@ mod tests {
 
             // Back to main - hacky to avoid async checkout
             with_ref_manager(&repo, |manager| {
-                manager.set_head(DEFAULT_BRANCH_NAME);
+                manager.set_head(DEFAULT_BRANCH_NAME)?;
                 Ok(())
             })?;
 

--- a/crates/lib/src/repositories/commits/commit_writer.rs
+++ b/crates/lib/src/repositories/commits/commit_writer.rs
@@ -160,7 +160,7 @@ pub(crate) fn commit_with_cfg(
     with_ref_manager(repo, |manager| {
         if !head_path_exists {
             log::debug!("HEAD file does not exist, creating new branch");
-            manager.set_head(&branch_name);
+            manager.set_head(&branch_name)?;
             manager.set_branch_commit_id(&branch_name, &commit_id)?;
         }
         manager.set_head_commit_id(&commit_id)


### PR DESCRIPTION
Use the new atomic write functionality to do HEAD file updates. The current approach was a plain write-and-replace, so a crash between truncate and the bytes hitting disk could leave HEAD empty or half-written. With this change, HEAD is either the old value or the new value — never something in between.

While we're here, fix two adjacent smells:

- `set_head` could panic on `.expect("Could not write to head")` if there was an I/O failure. We now return an error instead.
- Accept a `&str` instead of a `impl AsRef<str>`

Closes ENG-1018