### PR TITLE
Repo Integrity (1.4): Atomic version-file writes in LocalVersionStore

### DIFF
--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -84,28 +84,24 @@ impl VersionStore for LocalVersionStore {
         mut reader: Box<dyn tokio::io::AsyncRead + Send + Unpin>,
         _size: u64,
     ) -> Result<(), OxenError> {
-        let version_dir = self.version_dir(hash);
-        fs::create_dir_all(&version_dir).await?;
-
         let version_path = self.version_path(hash);
 
         if !version_path.exists() {
-            let mut file = File::create(&version_path).await?;
-            tokio::io::copy(&mut *reader, &mut file).await?;
+            util::fs::atomic_write_from_async_reader(&version_path, &mut *reader).await?;
         }
 
         Ok(())
     }
 
-    async fn store_version(&self, hash: &str, data: &[u8]) -> Result<(), OxenError> {
-        let version_dir = self.version_dir(hash);
-        fs::create_dir_all(&version_dir).await?;
-
+    async fn store_version(&self, hash: &str, data: Bytes) -> Result<(), OxenError> {
         let version_path = self.version_path(hash);
 
-        if !version_path.exists() {
-            fs::write(&version_path, data).await?;
+        if version_path.exists() {
+            return Ok(());
         }
+
+        tokio::task::spawn_blocking(move || util::fs::atomic_write_to_path(&version_path, &data))
+            .await??;
 
         Ok(())
     }
@@ -114,14 +110,13 @@ impl VersionStore for LocalVersionStore {
         &self,
         orig_hash: &str,
         derived_filename: &str,
-        derived_data: &[u8],
+        derived_data: Bytes,
     ) -> Result<(), OxenError> {
-        let dir = self.version_dir(orig_hash);
-        // TODO: Convert create_dir_all to async
-        util::fs::create_dir_all(&dir)?;
-        let path = dir.join(derived_filename);
-        fs::write(&path, derived_data).await?;
-        log::debug!("Saved derived version file {path:?}");
+        let path = self.version_dir(orig_hash).join(derived_filename);
+        let path_for_log = path.clone();
+        tokio::task::spawn_blocking(move || util::fs::atomic_write_to_path(&path, &derived_data))
+            .await??;
+        log::debug!("Saved derived version file {path_for_log:?}");
         Ok(())
     }
 
@@ -267,14 +262,14 @@ impl VersionStore for LocalVersionStore {
         offset: u64,
         data: Bytes,
     ) -> Result<(), OxenError> {
-        let chunk_dir = self.version_chunk_dir(hash, offset);
-        fs::create_dir_all(&chunk_dir).await?;
-
         let chunk_path = self.version_chunk_file(hash, offset);
 
-        if !chunk_path.exists() {
-            fs::write(&chunk_path, &data).await?;
+        if chunk_path.exists() {
+            return Ok(());
         }
+
+        tokio::task::spawn_blocking(move || util::fs::atomic_write_to_path(&chunk_path, &data))
+            .await??;
 
         Ok(())
     }
@@ -331,23 +326,34 @@ impl VersionStore for LocalVersionStore {
 
     async fn combine_version_chunks(&self, hash: &str) -> Result<(), OxenError> {
         let version_path = self.version_path(hash);
-        let mut output_file = File::create(&version_path).await?;
-
-        let chunks = self.list_version_chunks(hash).await?;
-        log::debug!("combine_version_chunks found {:?} chunks", chunks.len());
-
-        // Process each chunk
-        for chunk_offset in chunks {
-            let chunk_path = self.version_chunk_file(hash, chunk_offset);
-            let mut chunk_file = File::open(&chunk_path).await?;
-            tokio::io::copy(&mut chunk_file, &mut output_file).await?;
-        }
-
-        // Clean up chunks
         let chunks_dir = self.version_chunks_dir(hash);
-        if chunks_dir.exists() {
-            fs::remove_dir_all(&chunks_dir).await?;
-        }
+        let chunk_offsets = self.list_version_chunks(hash).await?;
+        log::debug!(
+            "combine_version_chunks found {} chunks",
+            chunk_offsets.len()
+        );
+        let chunk_paths: Vec<PathBuf> = chunk_offsets
+            .iter()
+            .map(|offset| self.version_chunk_file(hash, *offset))
+            .collect();
+
+        // Run the full read-chunks + atomic-write + cleanup sequence in one `spawn_blocking`
+        // closure: chain each chunk file as a sync `Read` and pipe the concatenation through
+        // `atomic_write_from_reader`.
+        tokio::task::spawn_blocking(move || -> Result<(), OxenError> {
+            let mut combined: Box<dyn std::io::Read> = Box::new(std::io::empty());
+            for chunk_path in &chunk_paths {
+                let chunk_file = std::fs::File::open(chunk_path)?;
+                combined = Box::new(std::io::Read::chain(combined, chunk_file));
+            }
+            util::fs::atomic_write_from_reader(&version_path, &mut combined)?;
+
+            if chunks_dir.exists() {
+                std::fs::remove_dir_all(&chunks_dir)?;
+            }
+            Ok(())
+        })
+        .await??;
 
         Ok(())
     }
@@ -582,7 +588,10 @@ mod tests {
         let data = b"test data";
 
         // Store the version
-        store.store_version(hash, data).await.unwrap();
+        store
+            .store_version(hash, Bytes::from_static(data))
+            .await
+            .unwrap();
 
         // Verify the file exists with correct structure
         let version_path = store.version_path(hash);
@@ -628,7 +637,10 @@ mod tests {
         assert!(!store.version_exists(hash).await.unwrap());
 
         // Store and check again
-        store.store_version(hash, data).await.unwrap();
+        store
+            .store_version(hash, Bytes::from_static(data))
+            .await
+            .unwrap();
         assert!(store.version_exists(hash).await.unwrap());
     }
 
@@ -638,8 +650,14 @@ mod tests {
         let present = "aaaa1111aaaa1111";
         let also_present = "bbbb2222bbbb2222";
         let absent = "cccc3333cccc3333";
-        store.store_version(present, b"x").await.unwrap();
-        store.store_version(also_present, b"y").await.unwrap();
+        store
+            .store_version(present, Bytes::from_static(b"x"))
+            .await
+            .unwrap();
+        store
+            .store_version(also_present, Bytes::from_static(b"y"))
+            .await
+            .unwrap();
 
         let missing = store
             .find_missing_versions(&[
@@ -666,7 +684,10 @@ mod tests {
         let data = b"test data";
 
         // Store and verify
-        store.store_version(hash, data).await.unwrap();
+        store
+            .store_version(hash, Bytes::from_static(data))
+            .await
+            .unwrap();
         assert!(store.version_exists(hash).await.unwrap());
 
         // Delete and verify
@@ -683,7 +704,10 @@ mod tests {
         let data = b"test data";
 
         for hash in &hashes {
-            store.store_version(hash, data).await.unwrap();
+            store
+                .store_version(hash, Bytes::from_static(data))
+                .await
+                .unwrap();
         }
 
         let versions = store.list_versions().await.unwrap();
@@ -727,7 +751,10 @@ mod tests {
         let size = data.len() as u64;
 
         // Store the chunk
-        store.store_version(hash, data).await.unwrap();
+        store
+            .store_version(hash, Bytes::from_static(data))
+            .await
+            .unwrap();
 
         // Verify the file exists with correct structure
         let file_path = store.version_path(hash);
@@ -766,7 +793,11 @@ mod tests {
 
         // Store derived
         store
-            .store_version_derived(orig_hash, derived_filename, derived_data)
+            .store_version_derived(
+                orig_hash,
+                derived_filename,
+                Bytes::from_static(derived_data),
+            )
             .await
             .unwrap();
 
@@ -807,7 +838,11 @@ mod tests {
 
         // Store and check again
         store
-            .store_version_derived(orig_hash, derived_filename, derived_data)
+            .store_version_derived(
+                orig_hash,
+                derived_filename,
+                Bytes::from_static(derived_data),
+            )
             .await
             .unwrap();
         assert!(

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -411,12 +411,12 @@ impl VersionStore for S3VersionStore {
         }
     }
 
-    async fn store_version(&self, hash: &str, data: &[u8]) -> Result<(), OxenError> {
+    async fn store_version(&self, hash: &str, data: Bytes) -> Result<(), OxenError> {
         let client = self.client().await?;
         log::debug!("Storing version to S3");
         let key = self.generate_key(hash);
 
-        let body = ByteStream::from(data.to_vec());
+        let body = ByteStream::from(data);
         client
             .put_object()
             .bucket(&self.bucket)
@@ -433,7 +433,7 @@ impl VersionStore for S3VersionStore {
         &self,
         orig_hash: &str,
         derived_filename: &str,
-        derived_data: &[u8],
+        derived_data: Bytes,
     ) -> Result<(), OxenError> {
         let client = self.client().await?;
         let key = format!("{}/{}", self.version_dir(orig_hash), derived_filename);
@@ -442,7 +442,7 @@ impl VersionStore for S3VersionStore {
             .put_object()
             .bucket(&self.bucket)
             .key(&key)
-            .body(ByteStream::from(derived_data.to_vec()))
+            .body(ByteStream::from(derived_data))
             .send()
             .await
             .map_err(|e| {
@@ -1137,7 +1137,10 @@ mod tests {
         let (store, _tmp, _server) = setup().await;
         let data = b"streamed to destination";
 
-        store.store_version("eeedef1234567890", data).await.unwrap();
+        store
+            .store_version("eeedef1234567890", Bytes::from_static(data))
+            .await
+            .unwrap();
 
         let dest_dir = async_tempfile::TempDir::new().await.unwrap();
         let dest_path = dest_dir.dir_path().join("subdir/output.bin");
@@ -1232,7 +1235,10 @@ mod tests {
         let hash = "abcdef1234567890abcdef1234567890";
 
         // Store main data + two chunks
-        store.store_version(hash, b"main data").await.unwrap();
+        store
+            .store_version(hash, Bytes::from_static(b"main data"))
+            .await
+            .unwrap();
         store
             .store_version_chunk(hash, 0, Bytes::from_static(b"chunk-0"))
             .await
@@ -1337,8 +1343,14 @@ mod tests {
         let hash_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let hash_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
-        store.store_version(hash_a, b"a data").await.unwrap();
-        store.store_version(hash_b, b"b data").await.unwrap();
+        store
+            .store_version(hash_a, Bytes::from_static(b"a data"))
+            .await
+            .unwrap();
+        store
+            .store_version(hash_b, Bytes::from_static(b"b data"))
+            .await
+            .unwrap();
 
         store.delete_version(hash_a).await.unwrap();
 
@@ -1351,7 +1363,10 @@ mod tests {
         let (store, _tmp, _server) = setup().await;
         let hash = "abcdef1234567890abcdef1234567890";
         let data: Vec<u8> = (0..100u8).collect();
-        store.store_version(hash, &data).await.unwrap();
+        store
+            .store_version(hash, Bytes::copy_from_slice(&data))
+            .await
+            .unwrap();
 
         let chunk = store.get_version_chunk(hash, 10, 20).await.unwrap();
         assert_eq!(chunk, data[10..30]);
@@ -1362,7 +1377,10 @@ mod tests {
         let (store, _tmp, _server) = setup().await;
         let hash = "abcdef1234567890abcdef1234567890";
         let data = b"hello world!";
-        store.store_version(hash, data).await.unwrap();
+        store
+            .store_version(hash, Bytes::from_static(data))
+            .await
+            .unwrap();
 
         let chunk = store.get_version_chunk(hash, 0, 5).await.unwrap();
         assert_eq!(&chunk[..], b"hello");
@@ -1381,7 +1399,10 @@ mod tests {
     async fn test_get_version_chunk_past_eof_errors() {
         let (store, _tmp, _server) = setup().await;
         let hash = "abcdef1234567890abcdef1234567890";
-        store.store_version(hash, b"small").await.unwrap();
+        store
+            .store_version(hash, Bytes::from_static(b"small"))
+            .await
+            .unwrap();
 
         let result = store.get_version_chunk(hash, 1000, 10).await;
         assert!(
@@ -1499,9 +1520,18 @@ mod tests {
         let (store, _tmp, _server) = setup().await;
 
         // Insert out of order; list_versions is documented to return sorted results.
-        store.store_version("cccc", b"c data").await.unwrap();
-        store.store_version("aaaa", b"a data").await.unwrap();
-        store.store_version("bbbb", b"b data").await.unwrap();
+        store
+            .store_version("cccc", Bytes::from_static(b"c data"))
+            .await
+            .unwrap();
+        store
+            .store_version("aaaa", Bytes::from_static(b"a data"))
+            .await
+            .unwrap();
+        store
+            .store_version("bbbb", Bytes::from_static(b"b data"))
+            .await
+            .unwrap();
 
         let versions = store.list_versions().await.unwrap();
         assert_eq!(versions, vec!["aaaa", "bbbb", "cccc"]);
@@ -1522,7 +1552,10 @@ mod tests {
         let (store, _tmp, _server) = setup().await;
 
         let hash = "abcdef1234567890abcdef1234567890";
-        store.store_version(hash, b"main").await.unwrap();
+        store
+            .store_version(hash, Bytes::from_static(b"main"))
+            .await
+            .unwrap();
         store
             .store_version_chunk(hash, 0, Bytes::from_static(b"chunk-0"))
             .await
@@ -1532,7 +1565,7 @@ mod tests {
             .await
             .unwrap();
         store
-            .store_version_derived(hash, "thumb.jpg", b"thumbnail bytes")
+            .store_version_derived(hash, "thumb.jpg", Bytes::from_static(b"thumbnail bytes"))
             .await
             .unwrap();
 

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -188,7 +188,7 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// # Arguments
     /// * `hash` - The content hash that identifies this version
     /// * `data` - The raw bytes to store
-    async fn store_version(&self, hash: &str, data: &[u8]) -> Result<(), OxenError>;
+    async fn store_version(&self, hash: &str, data: Bytes) -> Result<(), OxenError>;
 
     /// Store a chunk of a version file
     ///
@@ -213,7 +213,7 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         &self,
         orig_hash: &str,
         derived_filename: &str,
-        derived_data: &[u8],
+        derived_data: Bytes,
     ) -> Result<(), OxenError>;
 
     /// Retrieve a chunk of a version file

--- a/crates/lib/src/util/fs.rs
+++ b/crates/lib/src/util/fs.rs
@@ -1695,13 +1695,16 @@ pub async fn resize_cache_image_version_store(
     let image_format = ImageFormat::from_path(derived_filename)?;
     let mut buf = Vec::new();
     resized_img.write_to(&mut Cursor::new(&mut buf), image_format)?;
+    // Pre-`Bytes::from` once so we can share the same allocation between the version-store write
+    // and the streamed response without copying. `Bytes::clone` is an atomic refcount bump.
+    let bytes = Bytes::from(buf);
+    let content_length = bytes.len() as u64;
     version_store
-        .store_version_derived(img_hash, derived_filename, &buf)
+        .store_version_derived(img_hash, derived_filename, bytes.clone())
         .await?;
-    let content_length = buf.len() as u64;
 
     let stream: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>> =
-        futures::stream::once(async move { Ok(Bytes::from(buf)) }).boxed();
+        futures::stream::once(async move { Ok(bytes) }).boxed();
 
     Ok((stream, content_length))
 }
@@ -1762,7 +1765,7 @@ async fn generate_video_thumbnail_version_store(
 
     // Save the thumbnail image
     version_store
-        .store_version_derived(video_hash, derived_filename, &buf)
+        .store_version_derived(video_hash, derived_filename, buf.into())
         .await?;
 
     log::debug!("saved thumbnail {derived_filename}");

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -587,7 +587,7 @@ pub async fn save_parts(
                 };
 
             match version_store
-                .store_version(&upload_filehash, &data_to_store)
+                .store_version(&upload_filehash, data_to_store.into())
                 .await
             {
                 Ok(_) => {


### PR DESCRIPTION
Migrate `LocalVersionStore` to the atomic-write helpers.

Before this, every writer wrote bytes directly to the canonical hash path. A process killed mid-write left a partially-written file there. `version_exists(hash)` only checks path existence — no size or hash check — so that partial file got treated as a completed download on every subsequent pull/restore. This is the most plausible mechanism behind the "corrupted version-file download" symptom (ENG-922).

I switched some types to `Bytes` to avoid a `Vec::from(&[u8])` copy when moving data across the `spawn_blocking` boundary.

Closes ENG-964