### PR TITLE
Refactor DF operations to return new `DataFrameError`

### DIFF
--- a/crates/cli/src/cmd/embeddings/index.rs
+++ b/crates/cli/src/cmd/embeddings/index.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 
@@ -67,10 +69,11 @@ impl RunCmd for EmbeddingsIndexCmd {
             repositories::workspaces::data_frames::index(&repository, &workspace, path).await?;
             repositories::workspaces::data_frames::embeddings::index(
                 &workspace,
-                path,
+                Path::new(path),
                 column,
                 use_background_thread,
-            )
+            )?;
+            Ok(())
         } else {
             Err(OxenError::basic_str("Data frame is already indexed."))
         }

--- a/crates/lib/src/core/db/data_frames.rs
+++ b/crates/lib/src/core/db/data_frames.rs
@@ -1,6 +1,153 @@
+use strum::VariantNames;
+
+use crate::{
+    error::OxenError,
+    model::{Schema, staged_row_status::StagedRowStatus},
+};
+
 pub mod column_changes_db;
 pub mod columns;
 pub mod df_db;
 pub mod row_changes_db;
 pub mod rows;
 pub mod workspace_df_db;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DataFrameError {
+    #[error("df must have exactly one row to be used for modification")]
+    ModifyOnly1Row,
+
+    /// A column name was requested in a dataframe, but no such column exists.
+    #[error("Column name not found: {0}")]
+    ColumnNameNotFound(String),
+
+    /// A column name already exists in the dataframe's schema and cannot be added again.
+    #[error("Column name already exists: {0}")]
+    ColumnNameAlreadyExists(String),
+
+    #[error("Failed to create df db directory: {0}")]
+    FailCreateDfDbDir(std::io::Error),
+
+    #[error("Failed to open df db: {0}")]
+    FailOpenDfDb(Box<Self>),
+
+    #[error("No rows in table {0}")]
+    NoRowsInTable(String),
+
+    #[error("Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson")]
+    InvalidFileType,
+
+    #[error("modify_row incompatible_schemas {table_schema:?}\n{df_cols:?}")]
+    IncompatibleSchemas {
+        table_schema: Schema,
+        df_cols: Vec<String>,
+    },
+
+    #[error("Diff status column is not a string")]
+    DiffStatusColNotStr,
+
+    #[error("Missing diff status column")]
+    MissingDiffStatusCol,
+
+    #[error("Diff hash column is not a string")]
+    DiffHashColNotStr,
+
+    #[error("Expected {expected} rows to be modified, but got {actual}")]
+    UnexpectedModifications { expected: usize, actual: usize },
+
+    #[error("Invalid row status: \"{0}\". Expecting one of: {valid}", valid=<StagedRowStatus as VariantNames>::VARIANTS.join(", "))]
+    InvalidRowStatus(String),
+
+    #[error("Row status not found")]
+    RowStatusNotFound,
+
+    #[error("DataFrame with UUID {0} not found.")]
+    MissingDataFrame(String),
+
+    #[error("Must index embeddings before querying")]
+    MustIndexEmbeddings,
+
+    #[error("All embeddings must be the same length")]
+    EmbeddingLengthMismatch,
+
+    #[error("Expected Float32Array inside ListArray")]
+    ExpectedF32ArrayInside,
+
+    #[error("Expected arrow::datatypes::DataType::Float32 inside List")]
+    ExpectedF32,
+
+    #[error("Failed to downcast to FixedSizeListArray")]
+    FailFixedSizeDowncast,
+
+    #[error("Column FixedSizeList must be a float32 type")]
+    ExpectF32FixedSizeList,
+
+    #[error("Expected arrow::datatypes::DataType::List inside as data type")]
+    ExpectListInside,
+
+    #[error("Failed to downcast to ListArray")]
+    FailListDowncast,
+
+    #[error("Expected Float64Array inside ListArray")]
+    ExpectF64ArrayInside,
+
+    #[error("Column must be a list of float32 or float64")]
+    ExpectColFloats,
+
+    #[error("Column must be a list type")]
+    ExpectList,
+
+    /// No rows were found for a given SQL query.
+    #[error("Query returned no rows")]
+    NoRowsFound,
+
+    #[error("Vectors must have a length greater than 0")]
+    EmptyEmbedding,
+
+    #[error("Column does not exist in embedding configuration: {0}")]
+    ColNotFoundInConfig(String),
+
+    #[error("Failed to read embedding configuration file: {0}")]
+    FailReadConfig(Box<OxenError>), // TODO: change to FsError when PR lands
+
+    #[error("Failed to write embedding configuration: {0}")]
+    FailWriteConfig(std::io::Error),
+
+    #[error("No SELECT found in query")]
+    NoSelectInQuery,
+
+    #[error("No FROM found in query")]
+    NoFromInQuery,
+
+    #[error("Dataset is not indexed")]
+    NotIndexed,
+
+    #[error("Could not create parent directory for DuckDB file: {0}")]
+    CreateParent(Box<OxenError>), // TODO: change to FsError when PR lands
+
+    // #[error("Resource not found: {0}")]
+    // ResourceNotFound(String),
+    #[error("{0}")]
+    DuckDb(#[from] duckdb::Error),
+
+    #[error("{0}")]
+    Arrow(#[from] arrow::error::ArrowError),
+
+    #[error("{0}")]
+    Polars(#[from] polars::error::PolarsError),
+
+    #[error("Failed to parse SQL: {0}")]
+    SqlParse(#[from] sqlparser::parser::ParserError),
+
+    #[error("{0}")]
+    RocksDb(#[from] rocksdb::Error),
+
+    #[error("{0}")]
+    SerdeJson(#[from] serde_json::error::Error),
+
+    #[error("{0}")]
+    TomlDe(#[from] toml::de::Error),
+
+    #[error("{0}")]
+    TomlSer(#[from] toml::ser::Error),
+}

--- a/crates/lib/src/core/db/data_frames/column_changes_db.rs
+++ b/crates/lib/src/core/db/data_frames/column_changes_db.rs
@@ -1,18 +1,18 @@
 use rocksdb::DB;
 
-use crate::{error::OxenError, view::data_frames::DataFrameColumnChange};
+use crate::{core::db::data_frames::DataFrameError, view::data_frames::DataFrameColumnChange};
 
 pub fn write_data_frame_column_change(
     data_frame_column_change: &DataFrameColumnChange,
     db: &DB,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     save_data_frame_column_changes(db, data_frame_column_change)
 }
 
 pub fn save_data_frame_column_changes(
     db: &DB,
     data_frame_column_change: &DataFrameColumnChange,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     let column_name = match &data_frame_column_change.column_after {
         Some(column_after) => column_after.column_name.clone(),
         None => data_frame_column_change
@@ -33,7 +33,7 @@ pub fn save_data_frame_column_changes(
     Ok(())
 }
 
-pub fn delete_data_frame_column_changes(db: &DB, column_name: &str) -> Result<(), OxenError> {
+pub fn delete_data_frame_column_changes(db: &DB, column_name: &str) -> Result<(), DataFrameError> {
     db.delete(column_name)?;
 
     log::debug!("delete_data_frame_column_changes() deleted change in: {column_name:?}");
@@ -41,7 +41,9 @@ pub fn delete_data_frame_column_changes(db: &DB, column_name: &str) -> Result<()
     Ok(())
 }
 
-pub fn get_all_data_frame_column_changes(db: &DB) -> Result<Vec<DataFrameColumnChange>, OxenError> {
+pub fn get_all_data_frame_column_changes(
+    db: &DB,
+) -> Result<Vec<DataFrameColumnChange>, DataFrameError> {
     let mut changes = Vec::new();
 
     // Iterate from the start
@@ -69,7 +71,7 @@ pub fn get_all_data_frame_column_changes(db: &DB) -> Result<Vec<DataFrameColumnC
 pub fn get_data_frame_column_change(
     db: &DB,
     name: &str,
-) -> Result<Option<DataFrameColumnChange>, OxenError> {
+) -> Result<Option<DataFrameColumnChange>, DataFrameError> {
     let val = db.get(name)?;
 
     match val {

--- a/crates/lib/src/core/db/data_frames/columns.rs
+++ b/crates/lib/src/core/db/data_frames/columns.rs
@@ -4,25 +4,27 @@ use duckdb::arrow::array::RecordBatch;
 use polars::frame::DataFrame;
 use rocksdb::DB;
 
+use crate::constants::TABLE_NAME;
 use crate::core::db;
-use crate::core::db::data_frames::column_changes_db;
 use crate::core::db::data_frames::workspace_df_db::schema_without_oxen_cols;
+use crate::core::db::data_frames::{DataFrameError, column_changes_db};
 use crate::model::Schema;
 use crate::model::data_frame::schema::DataType;
 use crate::view::data_frames::columns::{ColumnToDelete, ColumnToUpdate, NewColumn};
 use crate::view::data_frames::{ColumnChange, DataFrameColumnChange};
-use crate::{constants::TABLE_NAME, error::OxenError};
 
 use super::df_db;
 
 pub fn add_column(
     conn: &duckdb::Connection,
     new_column: &NewColumn,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, DataFrameError> {
     let table_schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
 
     if table_schema.has_column(&new_column.name) {
-        return Err(OxenError::column_name_already_exists(&new_column.name));
+        return Err(DataFrameError::ColumnNameAlreadyExists(
+            new_column.name.clone(),
+        ));
     }
 
     let inserted_df = polar_insert_column(conn, TABLE_NAME, new_column)?;
@@ -32,11 +34,13 @@ pub fn add_column(
 pub fn delete_column(
     conn: &duckdb::Connection,
     column_to_delete: &ColumnToDelete,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, DataFrameError> {
     let table_schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
 
     if !table_schema.has_column(&column_to_delete.name) {
-        return Err(OxenError::column_name_not_found(&column_to_delete.name));
+        return Err(DataFrameError::ColumnNameNotFound(
+            column_to_delete.name.clone(),
+        ));
     }
 
     let inserted_df = polar_delete_column(conn, TABLE_NAME, column_to_delete)?;
@@ -47,9 +51,11 @@ pub fn update_column(
     conn: &duckdb::Connection,
     column_to_update: &ColumnToUpdate,
     table_schema: &Schema,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, DataFrameError> {
     if !table_schema.has_column(&column_to_update.name) {
-        return Err(OxenError::column_name_not_found(&column_to_update.name));
+        return Err(DataFrameError::ColumnNameNotFound(
+            column_to_update.name.clone(),
+        ));
     }
 
     let inserted_df = polar_update_column(conn, TABLE_NAME, column_to_update)?;
@@ -61,7 +67,7 @@ pub fn record_column_change(
     operation: String,
     column_before: Option<ColumnChange>,
     column_after: Option<ColumnChange>,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     let opts = db::key_val::opts::default();
     let db = DB::open(&opts, dunce::simplified(column_changes_path))?;
 
@@ -87,7 +93,10 @@ pub fn record_column_change(
     column_changes_db::write_data_frame_column_change(&change, &db)
 }
 
-pub fn maybe_revert_column_changes(db: &DB, column: Option<ColumnChange>) -> Result<(), OxenError> {
+pub fn maybe_revert_column_changes(
+    db: &DB,
+    column: Option<ColumnChange>,
+) -> Result<(), DataFrameError> {
     if let Some(column) = column {
         column_changes_db::get_data_frame_column_change(db, &column.column_name).and_then(
             |change_opt| match change_opt {
@@ -100,16 +109,15 @@ pub fn maybe_revert_column_changes(db: &DB, column: Option<ColumnChange>) -> Res
     }
 }
 
-pub fn revert_column_changes(db: &DB, column_name: &str) -> Result<(), OxenError> {
+pub fn revert_column_changes(db: &DB, column_name: &str) -> Result<(), DataFrameError> {
     column_changes_db::delete_data_frame_column_changes(db, column_name)
 }
 
 pub fn polar_insert_column(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     new_column: &NewColumn,
-) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
+) -> Result<DataFrame, DataFrameError> {
     let data_type = DataType::from_string(&new_column.data_type).to_sql();
     let sql = format!(
         "ALTER TABLE {} ADD COLUMN {} {}",
@@ -125,11 +133,9 @@ pub fn polar_insert_column(
 
 pub fn polar_delete_column(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     column_to_delete: &ColumnToDelete,
-) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
-
+) -> Result<DataFrame, DataFrameError> {
     // Corrected to DROP COLUMN instead of ADD COLUMN
     let sql = format!(
         "ALTER TABLE {} DROP COLUMN {}",
@@ -145,29 +151,31 @@ pub fn polar_delete_column(
 
 pub fn polar_update_column(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     column_to_update: &ColumnToUpdate,
-) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
-    let mut sql_commands = Vec::new();
+) -> Result<DataFrame, DataFrameError> {
+    let sql_commands = {
+        let mut sql_commands = Vec::new();
 
-    if let Some(ref new_data_type) = column_to_update.new_data_type {
-        let data_type = DataType::from_string(new_data_type).to_sql();
+        if let Some(ref new_data_type) = column_to_update.new_data_type {
+            let data_type = DataType::from_string(new_data_type).to_sql();
 
-        let update_type_sql = format!(
-            "ALTER TABLE {} ALTER COLUMN {} TYPE {}",
-            table_name, column_to_update.name, data_type
-        );
-        sql_commands.push(update_type_sql);
-    }
+            let update_type_sql = format!(
+                "ALTER TABLE {} ALTER COLUMN {} TYPE {}",
+                table_name, column_to_update.name, data_type
+            );
+            sql_commands.push(update_type_sql);
+        }
 
-    if let Some(ref new_name) = column_to_update.new_name {
-        let rename_sql = format!(
-            "ALTER TABLE {} RENAME COLUMN {} TO {}",
-            table_name, column_to_update.name, new_name
-        );
-        sql_commands.push(rename_sql);
-    }
+        if let Some(ref new_name) = column_to_update.new_name {
+            let rename_sql = format!(
+                "ALTER TABLE {} RENAME COLUMN {} TO {}",
+                table_name, column_to_update.name, new_name
+            );
+            sql_commands.push(rename_sql);
+        }
+        sql_commands
+    };
 
     for sql in sql_commands {
         conn.execute(&sql, [])?;

--- a/crates/lib/src/core/db/data_frames/df_db.rs
+++ b/crates/lib/src/core/db/data_frames/df_db.rs
@@ -5,7 +5,7 @@ use crate::constants::{
     DEFAULT_PAGE_SIZE, DUCKDB_DF_TABLE_NAME, OXEN_COLS, OXEN_ID_COL, OXEN_ROW_ID_COL, TABLE_NAME,
 };
 
-use crate::core::db::data_frames::rows;
+use crate::core::db::data_frames::{DataFrameError, rows};
 use crate::core::df::tabular;
 use crate::core::v_latest::workspaces::data_frames::{
     is_valid_export_extension, wrap_sql_for_export,
@@ -75,7 +75,7 @@ pub fn remove_df_db_from_cache_with_children(
 /// process exit, so without this call the cached connections never run their
 /// drop-time `close()` and DuckDB's default end-of-session CHECKPOINT never
 /// fires — uncheckpointed work stays in WAL files until the next open, where
-/// it must go through the WAL-recovery path in `get_connection`.
+/// it must go through the WAL-recovery path in [`get_connection`].
 ///
 /// Skips (with a warning) any connection whose mutex is currently held. The
 /// caller is expected to have stopped its own use of the cache before
@@ -125,11 +125,11 @@ pub struct DfDBManager {
     df_db: Arc<Mutex<duckdb::Connection>>,
 }
 
-pub fn with_df_db_manager<F, T>(db_path: impl AsRef<Path>, operation: F) -> Result<T, OxenError>
+pub fn with_df_db_manager<F, T>(db_path: &Path, operation: F) -> Result<T, DataFrameError>
 where
-    F: FnOnce(&DfDBManager) -> Result<T, OxenError>,
+    F: FnOnce(&DfDBManager) -> Result<T, DataFrameError>,
 {
-    let db_path = db_path.as_ref().to_path_buf();
+    let db_path = db_path.to_path_buf();
 
     let df_db = {
         // 1. If df db exists in cache, return the existing connection
@@ -153,16 +153,16 @@ where
             {
                 std::fs::create_dir_all(parent).map_err(|e| {
                     log::error!("Failed to create df db directory: {e}");
-                    OxenError::basic_str(format!("Failed to create df db directory: {e}"))
+                    DataFrameError::FailCreateDfDbDir(e)
                 })?;
             }
 
             let conn = get_connection(&db_path).map_err(|e| {
                 log::error!("Failed to open df db: {e}");
-                OxenError::basic_str(format!("Failed to open df db: {e}"))
+                DataFrameError::FailOpenDfDb(Box::new(e))
             })?;
 
-            // Wrap the Connection in a Mutex and store it in the cache
+            // Wrap the connection in a Mutex and store it in the cache
             let db_lock = Arc::new(Mutex::new(conn));
             cache_w.put(db_path.clone(), db_lock.clone());
             db_lock
@@ -177,9 +177,9 @@ where
 
 impl DfDBManager {
     /// Execute an operation with the database connection
-    pub fn with_conn<F, T>(&self, operation: F) -> Result<T, OxenError>
+    pub fn with_conn<F, T>(&self, operation: F) -> Result<T, DataFrameError>
     where
-        F: FnOnce(&duckdb::Connection) -> Result<T, OxenError>,
+        F: FnOnce(&duckdb::Connection) -> Result<T, DataFrameError>,
     {
         let conn = self.df_db.lock();
         operation(&conn)
@@ -187,9 +187,9 @@ impl DfDBManager {
 
     /// Execute an operation with the database connection (mutable access)
     /// Note: This provides mutable access to the connection for functions that require it
-    pub fn with_conn_mut<F, T>(&self, operation: F) -> Result<T, OxenError>
+    pub fn with_conn_mut<F, T>(&self, operation: F) -> Result<T, DataFrameError>
     where
-        F: FnOnce(&mut duckdb::Connection) -> Result<T, OxenError>,
+        F: FnOnce(&mut duckdb::Connection) -> Result<T, DataFrameError>,
     {
         let mut conn = self.df_db.lock();
 
@@ -205,13 +205,12 @@ impl DfDBManager {
 /// touching the database file — open() can fail for reasons unrelated to the
 /// WAL (permissions, lock held by another process, etc.) and the caller is in
 /// a better position to decide whether re-indexing is appropriate.
-pub fn get_connection(path: impl AsRef<Path>) -> Result<duckdb::Connection, OxenError> {
-    let path = path.as_ref();
+pub fn get_connection(path: &Path) -> Result<duckdb::Connection, DataFrameError> {
     log::debug!("get_connection: Opening new DuckDB connection for path: {path:?}");
 
     if let Some(parent) = path.parent() {
         log::debug!("get_connection: Ensuring parent directory exists: {parent:?}");
-        util::fs::create_dir_all(parent)?;
+        util::fs::create_dir_all(parent).map_err(|e| DataFrameError::CreateParent(Box::new(e)))?;
     }
 
     let wal_path = wal_path_for(path);
@@ -232,7 +231,7 @@ pub fn get_connection(path: impl AsRef<Path>) -> Result<duckdb::Connection, Oxen
             "get_connection: Failed to open DuckDB at {path:?}: {initial_err}. \
              No WAL file present — skipping recovery."
         );
-        return Err(OxenError::from(initial_err));
+        return Err(initial_err.into());
     }
 
     // First recovery: remove only the WAL file and retry. A stale or corrupt
@@ -253,12 +252,15 @@ pub fn get_connection(path: impl AsRef<Path>) -> Result<duckdb::Connection, Oxen
     // another process, etc.), so leave it intact for the caller to decide.
     log::error!("get_connection: Retry after WAL removal still failed for {path:?}: {initial_err}");
 
-    Err(OxenError::from(initial_err))
+    Err(initial_err.into())
 }
 
 /// Flush any leftover WAL from a prior session so it cannot cause replay
 /// issues later (e.g. after a crash or LRU eviction).
-fn open_success(conn: duckdb::Connection, path: &Path) -> Result<duckdb::Connection, OxenError> {
+fn open_success(
+    conn: duckdb::Connection,
+    path: &Path,
+) -> Result<duckdb::Connection, DataFrameError> {
     if let Err(e) = conn.execute_batch("CHECKPOINT") {
         log::warn!("get_connection: CHECKPOINT after open failed for {path:?}: {e}");
     }
@@ -285,30 +287,27 @@ fn wal_path_for(db_path: &Path) -> PathBuf {
 /// Create a table in a duckdb database based on an oxen schema.
 pub fn create_table_if_not_exists(
     conn: &duckdb::Connection,
-    name: impl AsRef<str>,
+    name: &str,
     schema: &Schema,
-) -> Result<String, OxenError> {
+) -> Result<String, duckdb::Error> {
     p_create_table_if_not_exists(conn, name, &schema.fields)
 }
 
 /// Drop a table in a duckdb database.
-pub fn drop_table(conn: &duckdb::Connection, table_name: impl AsRef<str>) -> Result<(), OxenError> {
-    let table_name = table_name.as_ref();
+pub fn drop_table(conn: &duckdb::Connection, table_name: &str) -> Result<(), duckdb::Error> {
     let sql = format!("DROP TABLE IF EXISTS {table_name}");
     log::debug!("drop_table sql: {sql}");
-    conn.execute(&sql, []).map_err(OxenError::from)?;
+    conn.execute(&sql, [])?;
     Ok(())
 }
 
-pub fn table_exists(
-    conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-) -> Result<bool, OxenError> {
+pub fn table_exists(conn: &duckdb::Connection, table_name: &str) -> Result<bool, duckdb::Error> {
     log::debug!("checking exists in path {conn:?}");
-    let table_name = table_name.as_ref();
     let sql = "SELECT EXISTS (SELECT 1 FROM duckdb_tables WHERE table_name = ?) AS table_exists";
-    let mut stmt = conn.prepare(sql)?;
-    let exists: bool = stmt.query_row(params![table_name], |row| row.get(0))?;
+    let exists: bool = {
+        let mut stmt = conn.prepare(sql)?;
+        stmt.query_row(params![table_name], |row| row.get(0))?
+    };
     log::debug!("got exists: {exists}");
     Ok(exists)
 }
@@ -316,10 +315,9 @@ pub fn table_exists(
 /// Create a table from a set of oxen fields with data types.
 fn p_create_table_if_not_exists(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     fields: &[Field],
-) -> Result<String, OxenError> {
-    let table_name = table_name.as_ref();
+) -> Result<String, duckdb::Error> {
     let columns: Vec<String> = fields.iter().map(|f| f.to_sql()).collect();
     let columns = columns.join(" NOT NULL,\n");
     let sql = format!("CREATE TABLE IF NOT EXISTS {table_name} (\n{columns});");
@@ -329,17 +327,12 @@ fn p_create_table_if_not_exists(
 }
 
 /// Get the schema from the table.
-pub fn get_schema(
-    conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-) -> Result<Schema, OxenError> {
-    let table_name = table_name.as_ref();
+pub fn get_schema(conn: &duckdb::Connection, table_name: &str) -> Result<Schema, duckdb::Error> {
     let sql = format!(
         "SELECT column_name, data_type FROM information_schema.columns WHERE table_name == '{table_name}'"
     );
-    let mut stmt = conn.prepare(&sql)?;
 
-    let mut fields = vec![];
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map([], |row| {
         let column_name: String = row.get(0)?;
         let data_type: String = row.get(1)?;
@@ -347,13 +340,17 @@ pub fn get_schema(
         Ok((column_name, data_type))
     })?;
 
-    for row in rows {
-        let (column_name, data_type) = row?;
-        fields.push(Field::new(
-            &column_name,
-            &model::data_frame::schema::DataType::from_sql(data_type).as_str(),
-        ));
-    }
+    let fields = {
+        let mut fields = vec![];
+        for row in rows {
+            let (column_name, data_type) = row?;
+            fields.push(Field::new(
+                &column_name,
+                &model::data_frame::schema::DataType::from_sql(data_type).as_str(),
+            ));
+        }
+        fields
+    };
 
     Ok(Schema::new(fields))
 }
@@ -361,10 +358,9 @@ pub fn get_schema(
 // Get the schema from the table excluding specified columns - useful for virtual cols like .oxen.diff.status
 pub fn get_schema_excluding_cols(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     cols: &[&str],
-) -> Result<Schema, OxenError> {
-    let table_name = table_name.as_ref();
+) -> Result<Schema, duckdb::Error> {
     let sql = format!(
         "SELECT column_name, data_type FROM information_schema.columns WHERE table_name == '{}' AND column_name NOT IN ({})",
         table_name,
@@ -373,9 +369,8 @@ pub fn get_schema_excluding_cols(
             .collect::<Vec<String>>()
             .join(", ")
     );
-    let mut stmt = conn.prepare(&sql)?;
 
-    let mut fields = vec![];
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map([], |row| {
         let column_name: String = row.get(0)?;
         let data_type: String = row.get(1)?;
@@ -383,20 +378,23 @@ pub fn get_schema_excluding_cols(
         Ok((column_name, data_type))
     })?;
 
-    for row in rows {
-        let (column_name, data_type) = row?;
-        fields.push(Field::new(
-            &column_name,
-            &model::data_frame::schema::DataType::from_sql(data_type).as_str(),
-        ));
-    }
+    let fields = {
+        let mut fields = vec![];
+        for row in rows {
+            let (column_name, data_type) = row?;
+            fields.push(Field::new(
+                &column_name,
+                &model::data_frame::schema::DataType::from_sql(data_type).as_str(),
+            ));
+        }
+        fields
+    };
 
     Ok(Schema::new(fields))
 }
 
 /// Query number of rows in a table.
-pub fn count(conn: &duckdb::Connection, table_name: impl AsRef<str>) -> Result<usize, OxenError> {
-    let table_name = table_name.as_ref();
+pub fn count(conn: &duckdb::Connection, table_name: &str) -> Result<usize, DataFrameError> {
     let sql = format!("SELECT count(*) FROM {table_name}");
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query([])?;
@@ -404,20 +402,16 @@ pub fn count(conn: &duckdb::Connection, table_name: impl AsRef<str>) -> Result<u
         let size: usize = row.get(0)?;
         Ok(size)
     } else {
-        Err(OxenError::basic_str(format!(
-            "No rows in table {table_name}"
-        )))
+        Err(DataFrameError::NoRowsInTable(table_name.to_string()))
     }
 }
 
 /// Query number of rows in a table.
 pub fn count_where(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-    where_clause: impl AsRef<str>,
-) -> Result<usize, OxenError> {
-    let table_name = table_name.as_ref();
-    let where_clause = where_clause.as_ref();
+    table_name: &str,
+    where_clause: &str,
+) -> Result<usize, DataFrameError> {
     let sql = format!("SELECT count(*) FROM {table_name} WHERE {where_clause}");
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query([])?;
@@ -425,9 +419,7 @@ pub fn count_where(
         let size: usize = row.get(0)?;
         Ok(size)
     } else {
-        Err(OxenError::basic_str(format!(
-            "No rows in table {table_name}"
-        )))
+        Err(DataFrameError::NoRowsInTable(table_name.to_string()))
     }
 }
 
@@ -440,26 +432,21 @@ pub fn select(
     conn: &duckdb::Connection,
     stmt: &sql::Select,
     opts: Option<&DFOpts>,
-) -> Result<DataFrame, OxenError> {
-    let sql = stmt.as_string();
-    let df = select_str(conn, sql, opts)?;
+) -> Result<DataFrame, DataFrameError> {
+    let df = select_str(conn, &stmt.as_string(), opts)?;
     Ok(df)
 }
 
 pub fn export(
     conn: &duckdb::Connection,
-    sql: impl AsRef<str>,
+    sql: &str,
     _opts: Option<&DFOpts>,
-    tmp_path: impl AsRef<Path>,
-) -> Result<(), OxenError> {
-    let tmp_path = tmp_path.as_ref();
-    let sql = sql.as_ref();
+    tmp_path: &Path,
+) -> Result<(), DataFrameError> {
     // let sql = prepare_sql(sql, opts)?;
     // Get the file extension from the tmp_path
     if !is_valid_export_extension(tmp_path) {
-        return Err(OxenError::basic_str(
-            "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
-        ));
+        return Err(DataFrameError::InvalidFileType);
     }
     let export_sql = wrap_sql_for_export(sql, tmp_path);
     log::debug!("export_sql: {export_sql}");
@@ -469,14 +456,13 @@ pub fn export(
 
 pub fn prepare_sql(
     conn: &duckdb::Connection,
-    stmt: impl AsRef<str>,
+    stmt: &str,
     opts: Option<&DFOpts>,
-) -> Result<String, OxenError> {
-    let mut sql = stmt.as_ref().to_string();
+) -> Result<String, DataFrameError> {
     let empty_opts = DFOpts::empty();
     let opts = opts.unwrap_or(&empty_opts);
 
-    sql = add_special_columns(conn, &sql)?;
+    let mut sql = add_special_columns(conn, stmt)?;
 
     if opts.sort_by.is_some() {
         let sort_by: String = opts.sort_by.clone().unwrap_or_default();
@@ -495,18 +481,24 @@ pub fn prepare_sql(
     Ok(sql)
 }
 
-fn add_special_columns(conn: &duckdb::Connection, sql: &str) -> Result<String, OxenError> {
+/// Use this for DuckDB
+const DIALECT: PostgreSqlDialect = PostgreSqlDialect {};
+
+fn add_special_columns(conn: &duckdb::Connection, sql: &str) -> Result<String, DataFrameError> {
     let original_schema = get_schema(conn, TABLE_NAME)?;
-    let dialect = PostgreSqlDialect {}; // Use this for DuckDB
-    let mut ast = Parser::parse_sql(&dialect, sql).expect("Failed to parse SQL");
 
-    if let Some(Statement::Query(query)) = ast.get_mut(0) {
-        // Remove the existing LIMIT clause
-        query.limit = None;
+    let ast = {
+        let mut ast = Parser::parse_sql(&DIALECT, sql)?;
 
-        // Add a new LIMIT clause
-        query.limit = Some(SqlExpr::Value(SqlValue::Number("1".into(), false)));
-    }
+        if let Some(Statement::Query(query)) = ast.get_mut(0) {
+            // Remove the existing LIMIT clause
+            query.limit = None;
+
+            // Add a new LIMIT clause
+            query.limit = Some(SqlExpr::Value(SqlValue::Number("1".into(), false)));
+        }
+        ast
+    };
 
     // Convert the AST back to a SQL string
     let query_with_limit = ast
@@ -515,21 +507,25 @@ fn add_special_columns(conn: &duckdb::Connection, sql: &str) -> Result<String, O
         .collect::<Vec<_>>()
         .join(";");
 
-    let mut stmt = conn.prepare(&query_with_limit)?;
-    let records: Vec<RecordBatch> = stmt.query_arrow([])?.collect();
-
-    let mut result_fields = vec![];
+    let records: Vec<RecordBatch> = {
+        let mut stmt = conn.prepare(&query_with_limit)?;
+        stmt.query_arrow([])?.collect()
+    };
 
     // Retrieve and print the schema (column names)
-    if let Some(first_batch) = records.first() {
-        let schema = first_batch.schema();
-        for field in schema.fields() {
-            result_fields.push(Field::new(
-                field.name(),
-                field.data_type().to_string().as_str(),
-            ));
+    let result_fields = {
+        let mut result_fields = vec![];
+        if let Some(first_batch) = records.first() {
+            let schema = first_batch.schema();
+            for field in schema.fields() {
+                result_fields.push(Field::new(
+                    field.name(),
+                    field.data_type().to_string().as_str(),
+                ));
+            }
         }
-    }
+        result_fields
+    };
 
     let original_field_names: Vec<&str> = original_schema
         .fields
@@ -542,8 +538,6 @@ fn add_special_columns(conn: &duckdb::Connection, sql: &str) -> Result<String, O
         .iter()
         .all(|name| original_field_names.contains(name));
 
-    let mut modified_sql = sql.to_string();
-
     if is_subset {
         let special_columns: Vec<&str> = OXEN_COLS
             .iter()
@@ -552,54 +546,58 @@ fn add_special_columns(conn: &duckdb::Connection, sql: &str) -> Result<String, O
             .collect();
 
         if !special_columns.is_empty() {
-            let mut ast = Parser::parse_sql(&dialect, sql).expect("Failed to parse SQL");
+            let ast = {
+                let mut ast = Parser::parse_sql(&DIALECT, sql)?;
 
-            if let Some(Statement::Query(query)) = ast.get_mut(0)
-                && let ast::SetExpr::Select(select) = &mut *query.body
-            {
-                // Don't inject special columns into DISTINCT queries —
-                // adding per-row unique cols like _oxen_id defeats deduplication.
-                if select.distinct.is_some() {
-                    return Ok(sql.to_string());
-                }
+                if let Some(Statement::Query(query)) = ast.get_mut(0)
+                    && let ast::SetExpr::Select(select) = &mut *query.body
+                {
+                    // Don't inject special columns into DISTINCT queries —
+                    // adding per-row unique cols like _oxen_id defeats deduplication.
+                    if select.distinct.is_some() {
+                        return Ok(sql.to_string());
+                    }
 
-                // Add new columns to the SELECT clause
-                for special_column in special_columns {
-                    select
-                        .projection
-                        .push(SelectItem::UnnamedExpr(SqlExpr::Identifier(
-                            special_column.into(),
-                        )));
+                    // Add new columns to the SELECT clause
+                    for special_column in special_columns {
+                        select
+                            .projection
+                            .push(SelectItem::UnnamedExpr(SqlExpr::Identifier(
+                                special_column.into(),
+                            )));
+                    }
                 }
-            }
+                ast
+            };
 
             // Convert the AST back to a SQL string
-            modified_sql = ast
+            return Ok(ast
                 .iter()
                 .map(|stmt| stmt.to_string())
                 .collect::<Vec<_>>()
-                .join(";");
+                .join(";"));
         }
     }
-    Ok(modified_sql)
+
+    Ok(sql.to_string())
 }
 
 pub fn select_str(
     conn: &duckdb::Connection,
-    sql: impl AsRef<str>,
+    sql: &str,
     opts: Option<&DFOpts>,
-) -> Result<DataFrame, OxenError> {
-    let sql = sql.as_ref();
+) -> Result<DataFrame, DataFrameError> {
     let sql = prepare_sql(conn, sql, opts)?;
     let df = select_raw(conn, &sql)?;
     log::debug!("select_str() got raw df {df:?}");
     Ok(df)
 }
 
-pub fn select_raw(conn: &duckdb::Connection, stmt: &str) -> Result<DataFrame, OxenError> {
-    let mut stmt = conn.prepare(stmt)?;
-
-    let records: Vec<RecordBatch> = stmt.query_arrow([])?.collect();
+pub fn select_raw(conn: &duckdb::Connection, stmt: &str) -> Result<DataFrame, DataFrameError> {
+    let records: Vec<RecordBatch> = {
+        let mut stmt = conn.prepare(stmt)?;
+        stmt.query_arrow([])?.collect()
+    };
 
     if records.is_empty() {
         return Ok(DataFrame::default());
@@ -612,17 +610,13 @@ pub fn select_raw(conn: &duckdb::Connection, stmt: &str) -> Result<DataFrame, Ox
 
 pub fn modify_row_with_polars_df(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     id: &str,
     df: &DataFrame,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, DataFrameError> {
     if df.height() != 1 {
-        return Err(OxenError::basic_str(
-            "df must have exactly one row to be used for modification",
-        ));
+        Err(DataFrameError::ModifyOnly1Row)?;
     }
-
-    let table_name = table_name.as_ref();
 
     let schema = df.schema();
     let field_names: Vec<&str> = schema.iter_names().map(|s| s.as_str()).collect();
@@ -653,8 +647,10 @@ pub fn modify_row_with_polars_df(
         .map(|boxed_value| &**boxed_value as &dyn ToSql)
         .collect();
 
-    let mut stmt = conn.prepare(&sql)?;
-    let result_set: Vec<RecordBatch> = stmt.query_arrow(params.as_slice())?.collect();
+    let result_set: Vec<RecordBatch> = {
+        let mut stmt = conn.prepare(&sql)?;
+        stmt.query_arrow(params.as_slice())?.collect()
+    };
 
     let df = record_batches_to_polars_df(result_set)?;
 
@@ -663,15 +659,9 @@ pub fn modify_row_with_polars_df(
 
 pub fn modify_rows_with_polars_df(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     row_map: &HashMap<String, DataFrame>,
-) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
-    let mut all_result_batches = Vec::new();
-
-    let mut set_clauses = Vec::new();
-    let mut all_params: Vec<Box<dyn ToSql>> = Vec::new();
-
+) -> Result<DataFrame, DataFrameError> {
     // Construct the SQL query with combined CASE statements
     let column_names: Vec<String> = match row_map.iter().next() {
         Some((_, df)) => df.schema().iter_names().map(|s| s.to_string()).collect(),
@@ -680,32 +670,39 @@ pub fn modify_rows_with_polars_df(
 
     let column_sql_types = rows::column_sql_types_by_name(conn, table_name)?;
 
-    for col_name in &column_names {
-        let placeholder = rows::placeholder_for_column(&column_sql_types, col_name);
-        let mut case_clauses = Vec::new();
-        for (id, df) in row_map.iter() {
-            let series = df.column(col_name)?;
-            let value = series.get(0)?;
+    let (set_clauses, all_params) = {
+        let mut set_clauses = Vec::new();
+        let mut all_params: Vec<Box<dyn ToSql>> = Vec::new();
 
-            let boxed_value: Box<dyn ToSql> = Box::new(tabular::value_to_tosql(value));
+        for col_name in &column_names {
+            let placeholder = rows::placeholder_for_column(&column_sql_types, col_name);
+            let mut case_clauses = Vec::new();
+            for (id, df) in row_map.iter() {
+                let series = df.column(col_name)?;
+                let value = series.get(0)?;
 
-            case_clauses.push(format!(
-                "WHEN \"{OXEN_ID_COL}\" = '{id}' THEN {placeholder}"
+                let boxed_value: Box<dyn ToSql> = Box::new(tabular::value_to_tosql(value));
+
+                case_clauses.push(format!(
+                    "WHEN \"{OXEN_ID_COL}\" = '{id}' THEN {placeholder}"
+                ));
+
+                all_params.push(boxed_value);
+            }
+            set_clauses.push(format!(
+                "\"{}\" = CASE {} END",
+                col_name,
+                case_clauses.join(" ")
             ));
-
-            all_params.push(boxed_value);
         }
-        set_clauses.push(format!(
-            "\"{}\" = CASE {} END",
-            col_name,
-            case_clauses.join(" ")
-        ));
-    }
 
-    // Add all row IDs to the parameters for the WHERE clause
-    for id in row_map.keys() {
-        all_params.push(Box::new(id.clone()));
-    }
+        // Add all row IDs to the parameters for the WHERE clause
+        for id in row_map.keys() {
+            all_params.push(Box::new(id.clone()));
+        }
+
+        (set_clauses, all_params)
+    };
 
     let sql = format!(
         "UPDATE {} SET {} WHERE \"{}\" IN ({}) RETURNING *",
@@ -720,17 +717,17 @@ pub fn modify_rows_with_polars_df(
         .map(|boxed_value| &**boxed_value as &dyn ToSql)
         .collect();
 
-    let mut stmt = conn.prepare(&sql)?;
-    let result_set: Vec<RecordBatch> = stmt.query_arrow(params.as_slice())?.collect();
+    let result_set: Vec<RecordBatch> = {
+        let mut stmt = conn.prepare(&sql)?;
+        stmt.query_arrow(params.as_slice())?.collect()
+    };
 
-    all_result_batches.extend(result_set);
-
-    let df = record_batches_to_polars_df(all_result_batches)?;
+    let df = record_batches_to_polars_df(result_set)?;
 
     Ok(df)
 }
 
-pub fn index_file(path: &Path, conn: &duckdb::Connection) -> Result<(), OxenError> {
+pub fn index_file(path: &Path, conn: &duckdb::Connection) -> Result<(), DataFrameError> {
     log::debug!("df_db:index_file() at path {path:?}");
     let extension: &str = &util::fs::extension_from_path(path);
     let path_str = path.to_string_lossy().to_string();
@@ -760,9 +757,7 @@ pub fn index_file(path: &Path, conn: &duckdb::Connection) -> Result<(), OxenErro
             conn.execute(&query, [])?;
         }
         _ => {
-            return Err(OxenError::basic_str(
-                "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
-            ));
+            return Err(DataFrameError::InvalidFileType);
         }
     }
     Ok(())
@@ -774,7 +769,7 @@ pub fn index_file_with_id(
     path: &Path,
     conn: &duckdb::Connection,
     extension: &str,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     log::debug!("df_db:index_file() at path {path:?} into path {conn:?}");
     let path_str = path.to_string_lossy().to_string();
     let counter = "counter";
@@ -823,11 +818,12 @@ pub fn index_file_with_id(
             let alter_query = format!(
                 "SELECT column_name FROM information_schema.columns WHERE table_name = '{DUCKDB_DF_TABLE_NAME}' AND data_type LIKE 'STRUCT%'"
             );
-            let mut stmt = conn.prepare(&alter_query)?;
-            let struct_cols: Vec<String> = stmt
-                .query_map([], |row| row.get(0))?
-                .filter_map(|r| r.ok())
-                .collect();
+            let struct_cols: Vec<String> = {
+                let mut stmt = conn.prepare(&alter_query)?;
+                stmt.query_map([], |row| row.get(0))?
+                    .filter_map(|r| r.ok())
+                    .collect()
+            };
 
             for col in struct_cols {
                 let alter =
@@ -848,11 +844,12 @@ pub fn index_file_with_id(
             let alter_query = format!(
                 "SELECT column_name FROM information_schema.columns WHERE table_name = '{DUCKDB_DF_TABLE_NAME}' AND data_type = 'JSON[]'"
             );
-            let mut stmt = conn.prepare(&alter_query)?;
-            let json_list_cols: Vec<String> = stmt
-                .query_map([], |row| row.get(0))?
-                .filter_map(|r| r.ok())
-                .collect();
+            let json_list_cols: Vec<String> = {
+                let mut stmt = conn.prepare(&alter_query)?;
+                stmt.query_map([], |row| row.get(0))?
+                    .filter_map(|r| r.ok())
+                    .collect()
+            };
 
             for col in json_list_cols {
                 let alter = format!(
@@ -863,9 +860,7 @@ pub fn index_file_with_id(
             }
         }
         _ => {
-            return Err(OxenError::basic_str(
-                "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
-            ));
+            return Err(DataFrameError::InvalidFileType);
         }
     }
 
@@ -883,7 +878,7 @@ pub fn index_file_with_id(
     Ok(())
 }
 
-pub fn from_clause_from_disk_path(path: &Path) -> Result<String, OxenError> {
+pub fn from_clause_from_disk_path(path: &Path) -> Result<String, DataFrameError> {
     let extension: &str = &util::fs::extension_from_path(path);
     match extension {
         "csv" => {
@@ -902,34 +897,31 @@ pub fn from_clause_from_disk_path(path: &Path) -> Result<String, OxenError> {
             let str_path = path.to_string_lossy().to_string();
             Ok(format!("read_json('{str_path}')"))
         }
-        _ => Err(OxenError::basic_str(
-            "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
-        )),
+        _ => Err(DataFrameError::InvalidFileType),
     }
 }
 
-pub fn preview(
-    conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
+pub fn preview(conn: &duckdb::Connection, table_name: &str) -> Result<DataFrame, DataFrameError> {
     let query = format!("SELECT * FROM {table_name} LIMIT 10");
     let df = select_raw(conn, &query)?;
     Ok(df)
 }
 
-pub fn record_batches_to_polars_df(records: Vec<RecordBatch>) -> Result<DataFrame, OxenError> {
+pub fn record_batches_to_polars_df(records: Vec<RecordBatch>) -> Result<DataFrame, DataFrameError> {
     if records.is_empty() {
         return Ok(DataFrame::default());
     }
 
-    let mut buf = Vec::new();
-    let mut writer = arrow::ipc::writer::FileWriter::try_new(&mut buf, &records[0].schema())?;
+    let buf = {
+        let mut buf = Vec::new();
+        let mut writer = arrow::ipc::writer::FileWriter::try_new(&mut buf, &records[0].schema())?;
 
-    for batch in &records {
-        writer.write(batch)?;
-    }
-    writer.finish()?;
+        for batch in &records {
+            writer.write(batch)?;
+        }
+        writer.finish()?;
+        buf
+    };
 
     let content = Cursor::new(buf);
     let df = IpcReader::new(content).finish()?;
@@ -947,7 +939,7 @@ mod tests {
     fn test_df_db_create() -> Result<(), OxenError> {
         test::run_empty_dir_test(|data_dir| {
             let db_file = data_dir.join("data.db");
-            let conn = get_connection(db_file)?;
+            let conn = get_connection(&db_file)?;
             // bounding_box -> min_x, min_y, width, height
             let schema = test::schema_bounding_box();
             let table_name = "bounding_box";
@@ -997,7 +989,7 @@ mod tests {
     fn test_df_db_get_schema() -> Result<(), OxenError> {
         test::run_empty_dir_test(|data_dir| {
             let db_file = data_dir.join("data.db");
-            let conn = get_connection(db_file)?;
+            let conn = get_connection(&db_file)?;
             // bounding_box -> min_x, min_y, width, height
             let schema = test::schema_bounding_box();
             let table_name = "bounding_box";
@@ -1278,7 +1270,7 @@ mod tests {
             // with_df_db_manager should open a new connection (triggering
             // recovery in get_connection) and the operation should succeed.
             let exists = with_df_db_manager(&db_file, |manager| {
-                manager.with_conn(|conn| table_exists(conn, TABLE_NAME))
+                manager.with_conn(|conn| Ok(table_exists(conn, TABLE_NAME)?))
             })?;
 
             assert!(

--- a/crates/lib/src/core/db/data_frames/row_changes_db.rs
+++ b/crates/lib/src/core/db/data_frames/row_changes_db.rs
@@ -1,18 +1,18 @@
 use rocksdb::DB;
 
-use crate::{error::OxenError, view::data_frames::DataFrameRowChange};
+use crate::{core::db::data_frames::DataFrameError, view::data_frames::DataFrameRowChange};
 
 pub fn write_data_frame_row_change(
     data_frame_row_change: &DataFrameRowChange,
     db: &DB,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     save_data_frame_row_changes(db, data_frame_row_change)
 }
 
 pub fn save_data_frame_row_changes(
     db: &DB,
     data_frame_row_change: &DataFrameRowChange,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     let key = &data_frame_row_change.row_id;
     let val_json = serde_json::to_string(data_frame_row_change)?;
 
@@ -23,7 +23,7 @@ pub fn save_data_frame_row_changes(
     Ok(())
 }
 
-pub fn delete_data_frame_row_changes(db: &DB, row_id: &str) -> Result<(), OxenError> {
+pub fn delete_data_frame_row_changes(db: &DB, row_id: &str) -> Result<(), DataFrameError> {
     db.delete(row_id)?;
 
     log::debug!("delete_data_frame_row_changes() deleted change in: {row_id:?}");
@@ -31,7 +31,7 @@ pub fn delete_data_frame_row_changes(db: &DB, row_id: &str) -> Result<(), OxenEr
     Ok(())
 }
 
-pub fn get_all_data_frame_row_changes(db: &DB) -> Result<Vec<DataFrameRowChange>, OxenError> {
+pub fn get_all_data_frame_row_changes(db: &DB) -> Result<Vec<DataFrameRowChange>, DataFrameError> {
     let mut changes = Vec::new();
 
     // Iterate from the start
@@ -59,7 +59,7 @@ pub fn get_all_data_frame_row_changes(db: &DB) -> Result<Vec<DataFrameRowChange>
 pub fn get_data_frame_row_change(
     db: &DB,
     name: &str,
-) -> Result<Option<DataFrameRowChange>, OxenError> {
+) -> Result<Option<DataFrameRowChange>, DataFrameError> {
     let val = db.get(name)?;
 
     match val {

--- a/crates/lib/src/core/db/data_frames/rows.rs
+++ b/crates/lib/src/core/db/data_frames/rows.rs
@@ -12,25 +12,28 @@ use sql_query_builder as sql;
 
 use crate::constants::{DIFF_HASH_COL, DIFF_STATUS_COL, OXEN_COLS, OXEN_ID_COL};
 
+use crate::constants::TABLE_NAME;
 use crate::core::db;
-use crate::core::db::data_frames::row_changes_db;
 use crate::core::db::data_frames::workspace_df_db::schema_without_oxen_cols;
+use crate::core::db::data_frames::{DataFrameError, row_changes_db};
 use crate::core::df::tabular;
 use crate::model::data_frame::schema::DataType;
 use crate::model::staged_row_status::StagedRowStatus;
 use crate::view::data_frames::DataFrameRowChange;
-use crate::{constants::TABLE_NAME, error::OxenError};
 use polars::prelude::*; // or use polars::lazy::*; if you're working in a lazy context
 
 use super::df_db;
 
-pub fn append_row(conn: &duckdb::Connection, df: &DataFrame) -> Result<DataFrame, OxenError> {
+pub fn append_row(conn: &duckdb::Connection, df: &DataFrame) -> Result<DataFrame, DataFrameError> {
     let table_schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
     let df_schema = df.schema();
 
     let df_names: Vec<String> = df_schema.iter_names().map(|s| s.to_string()).collect();
     if !table_schema.has_field_names(&df_names) {
-        return Err(OxenError::incompatible_schemas(table_schema.clone()));
+        return Err(DataFrameError::IncompatibleSchemas {
+            table_schema,
+            df_cols: df_names,
+        });
     }
 
     let added_column = Column::Series(
@@ -67,9 +70,9 @@ pub fn modify_row(
     conn: &duckdb::Connection,
     df: &mut DataFrame,
     uuid: &str,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, DataFrameError> {
     if df.height() != 1 {
-        return Err(OxenError::basic_str("Modify row requires exactly one row"));
+        return Err(DataFrameError::ModifyOnly1Row);
     }
 
     let table_schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
@@ -85,7 +88,10 @@ pub fn modify_row(
     let df = df.select(&df_cols)?;
     if !table_schema.has_field_names(&df_cols) {
         log::error!("modify_row incompatible_schemas {table_schema:?}\n{df_cols:?}");
-        return Err(OxenError::incompatible_schemas(table_schema));
+        return Err(DataFrameError::IncompatibleSchemas {
+            table_schema,
+            df_cols,
+        });
     }
 
     // get existing hash and status from db
@@ -124,7 +130,7 @@ pub fn modify_row(
     ))?;
     let result = df_db::modify_row_with_polars_df(conn, TABLE_NAME, uuid, &new_row)?;
     if result.height() == 0 {
-        return Err(OxenError::resource_not_found(uuid));
+        return Err(DataFrameError::MissingDataFrame(uuid.to_string()));
     }
     Ok(result)
 }
@@ -132,7 +138,7 @@ pub fn modify_row(
 pub fn modify_rows(
     conn: &duckdb::Connection,
     row_map: HashMap<String, DataFrame>,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, DataFrameError> {
     let table_schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
 
     let mut update_map: HashMap<String, DataFrame> = HashMap::new();
@@ -140,9 +146,7 @@ pub fn modify_rows(
     // Filter it down to exclude any of the OXEN_COLS, we don't want to modify these but hub sends them over
     for (row_id, df) in row_map.iter() {
         if df.height() != 1 {
-            return Err(OxenError::basic_str(
-                "df must have exactly one row to be used for modification",
-            ));
+            return Err(DataFrameError::ModifyOnly1Row);
         }
         let schema = df.schema();
         let df_col_names: Vec<String> = schema.iter_names().map(|s| s.to_string()).collect();
@@ -154,7 +158,10 @@ pub fn modify_rows(
         let df = df.select(&df_cols)?;
         if !table_schema.has_field_names(&df_cols) {
             log::error!("modify_row incompatible_schemas {table_schema:?}\n{df_cols:?}");
-            return Err(OxenError::incompatible_schemas(table_schema));
+            return Err(DataFrameError::IncompatibleSchemas {
+                table_schema,
+                df_cols,
+            });
         }
 
         // get existing hash and status from db
@@ -194,30 +201,28 @@ pub fn modify_rows(
 
     let result = df_db::modify_rows_with_polars_df(conn, TABLE_NAME, &update_map)?;
     if result.height() == 0 {
-        return Err(OxenError::resource_not_found(""));
+        return Err(DataFrameError::MissingDataFrame("".to_string()));
     }
 
     if result.height() != update_map.len() {
-        return Err(OxenError::basic_str(format!(
-            "Expected {} rows to be modified, but got {}",
-            update_map.len(),
-            result.height()
-        )));
+        return Err(DataFrameError::UnexpectedModifications {
+            expected: update_map.len(),
+            actual: result.height(),
+        });
     }
 
     Ok(result)
 }
 
-pub fn delete_row(conn: &duckdb::Connection, uuid: &str) -> Result<DataFrame, OxenError> {
+pub fn delete_row(conn: &duckdb::Connection, uuid: &str) -> Result<DataFrame, DataFrameError> {
     let select_stmt = sql::Select::new()
         .select("*")
         .from(TABLE_NAME)
         .where_clause(&format!("{OXEN_ID_COL} = '{uuid}'"));
 
     let row_to_delete = df_db::select(conn, &select_stmt, None)?;
-
     if row_to_delete.height() == 0 {
-        return Err(OxenError::resource_not_found(uuid));
+        return Err(DataFrameError::MissingDataFrame(uuid.to_string()));
     }
 
     // If it's newly added, delete it. Otherwise, set it to removed
@@ -226,7 +231,7 @@ pub fn delete_row(conn: &duckdb::Connection, uuid: &str) -> Result<DataFrame, Ox
 
     let status = match status_str {
         Some(status) => status,
-        None => return Err(OxenError::basic_str("Diff status column is not a string")),
+        None => return Err(DataFrameError::DiffStatusColNotStr),
     };
     log::debug!("status is: {status}");
 
@@ -259,13 +264,13 @@ fn get_hash_and_status_for_modification(
     conn: &duckdb::Connection,
     old_row: &DataFrame,
     new_row: &DataFrame,
-) -> Result<(String, String), OxenError> {
+) -> Result<(String, String), DataFrameError> {
     let schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
     let col_names = schema.fields_names();
     let old_status = old_row.column(DIFF_STATUS_COL)?.get(0)?;
     let old_status = old_status
         .get_str()
-        .ok_or_else(|| OxenError::basic_str("Diff status column is not a string"))?;
+        .ok_or_else(|| DataFrameError::DiffStatusColNotStr)?;
 
     let old_hash = old_row.column(DIFF_HASH_COL)?.get(0)?;
 
@@ -273,7 +278,7 @@ fn get_hash_and_status_for_modification(
     let new_hash = new_hash_df.column("_temp_hash")?.get(0)?;
     let new_hash = new_hash
         .get_str()
-        .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string"))?;
+        .ok_or_else(|| DataFrameError::DiffHashColNotStr)?;
 
     // We need to calculate the original hash for the row
     // Use a temp hash column to avoid collision with the column that's already there.
@@ -283,19 +288,18 @@ fn get_hash_and_status_for_modification(
         let original_data_hash = original_data_hash.column("_temp_hash")?.get(0)?;
         original_data_hash
             .get_str()
-            .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string"))?
+            .ok_or_else(|| DataFrameError::DiffHashColNotStr)?
             .to_owned()
     } else {
         old_hash
             .get_str()
-            .ok_or_else(|| OxenError::basic_str("Diff hash column is not a string"))?
+            .ok_or_else(|| DataFrameError::DiffHashColNotStr)?
             .to_owned()
     };
 
     // Anything previously added must stay added regardless of any further modifications.
     // Modifying back to original state changes it to unchanged
     // If we have no prior hash info on the original hash state, it is now modified (this is the first modification)
-
     let new_status = if old_status == StagedRowStatus::Added.to_string() {
         StagedRowStatus::Added.to_string()
     } else if old_status == StagedRowStatus::Removed.to_string() {
@@ -318,11 +322,9 @@ fn get_hash_and_status_for_modification(
 /// Insert a row from a polars dataframe into a duckdb table.
 pub fn insert_polars_df(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
+    table_name: &str,
     df: &DataFrame,
-) -> Result<DataFrame, OxenError> {
-    let table_name = table_name.as_ref();
-
+) -> Result<DataFrame, DataFrameError> {
     let schema = df.schema();
     let field_names: Vec<&str> = schema.iter_names().map(|s| s.as_str()).collect();
     let column_names: Vec<String> = field_names
@@ -379,7 +381,7 @@ pub fn record_row_change(
     operation: String,
     value: Value,
     new_value: Option<Value>,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     let change = DataFrameRowChange {
         row_id: row_id.to_owned(),
         operation,
@@ -395,7 +397,7 @@ pub fn record_row_change(
     row_changes_db::write_data_frame_row_change(&change, &db)
 }
 
-pub fn maybe_revert_row_changes(db: &DB, row_id: String) -> Result<(), OxenError> {
+pub fn maybe_revert_row_changes(db: &DB, row_id: String) -> Result<(), DataFrameError> {
     match row_changes_db::get_data_frame_row_change(db, &row_id) {
         Ok(None) => revert_row_changes(db, row_id),
         Ok(Some(_)) => Ok(()),
@@ -403,7 +405,7 @@ pub fn maybe_revert_row_changes(db: &DB, row_id: String) -> Result<(), OxenError
     }
 }
 
-pub fn revert_row_changes(db: &DB, row_id: String) -> Result<(), OxenError> {
+pub fn revert_row_changes(db: &DB, row_id: String) -> Result<(), DataFrameError> {
     row_changes_db::delete_data_frame_row_changes(db, &row_id)
 }
 
@@ -414,7 +416,7 @@ pub fn revert_row_changes(db: &DB, row_id: String) -> Result<(), OxenError> {
 pub(crate) fn column_sql_types_by_name(
     conn: &duckdb::Connection,
     table_name: &str,
-) -> Result<HashMap<String, String>, OxenError> {
+) -> Result<HashMap<String, String>, DataFrameError> {
     let schema = df_db::get_schema(conn, table_name)?;
     let mut by_name = HashMap::with_capacity(schema.fields.len());
     for field in schema.fields {

--- a/crates/lib/src/core/db/data_frames/workspace_df_db.rs
+++ b/crates/lib/src/core/db/data_frames/workspace_df_db.rs
@@ -1,19 +1,18 @@
 use polars::frame::DataFrame;
 use sql_query_builder as sql;
 
-use crate::constants::{DIFF_STATUS_COL, OXEN_COLS, OXEN_ROW_ID_COL};
+use crate::constants::{DIFF_STATUS_COL, OXEN_COLS};
 
+use crate::constants::TABLE_NAME;
+use crate::core::db::data_frames::DataFrameError;
 use crate::model::Schema;
-use crate::model::data_frame::schema::Field;
 use crate::model::staged_row_status::StagedRowStatus;
-use crate::{constants::TABLE_NAME, error::OxenError};
-use polars::prelude::*; // or use polars::lazy::*; if you're working in a lazy context
 
 use super::df_db;
 
 /// Builds on df_db, but for specific use cases involving remote staging -
 /// i.e., handling additional virtual columns beyond the formal schema, table names, etc.
-pub fn select_cols_from_schema(schema: &Schema) -> Result<String, OxenError> {
+pub fn select_cols_from_schema(schema: &Schema) -> String {
     // Check if OXEN_COLS are already in the schema
     let missing_oxen_cols: Vec<&str> = OXEN_COLS
         .iter()
@@ -22,61 +21,24 @@ pub fn select_cols_from_schema(schema: &Schema) -> Result<String, OxenError> {
         .collect();
 
     // Add the missing oxen cols
-    let all_col_names = missing_oxen_cols
+
+    missing_oxen_cols
         .iter()
         .map(|col| format!("\"{col}\""))
         .chain(schema.fields.iter().map(|col| format!("\"{}\"", col.name)))
         .collect::<Vec<String>>()
-        .join(", ");
-
-    Ok(all_col_names)
-}
-
-// Returns the schema of the underlying table with the oxen cols prepended in a predictable
-// order expected by the UI / API
-pub fn full_staged_table_schema(conn: &duckdb::Connection) -> Result<Schema, OxenError> {
-    let schema = schema_without_oxen_cols(conn, TABLE_NAME)?;
-    enhance_schema_with_oxen_cols(&schema)
+        .join(", ")
 }
 
 pub fn schema_without_oxen_cols(
     conn: &duckdb::Connection,
-    table_name: impl AsRef<str>,
-) -> Result<Schema, OxenError> {
+    table_name: &str,
+) -> Result<Schema, DataFrameError> {
     let table_schema = df_db::get_schema_excluding_cols(conn, table_name, &OXEN_COLS)?;
     Ok(table_schema)
 }
 
-pub fn enhance_schema_with_oxen_cols(schema: &Schema) -> Result<Schema, OxenError> {
-    let mut schema = schema.clone();
-
-    // Check for missing oxen fields
-    let missing_oxen_fields: Vec<Field> = OXEN_COLS
-        .iter()
-        .filter(|col| !schema.fields.iter().any(|field| &field.name == *col))
-        .map(|col| Field {
-            name: col.to_string(),
-            dtype: if col == &OXEN_ROW_ID_COL {
-                DataType::Int32.to_string()
-            } else {
-                DataType::String.to_string()
-            },
-            metadata: None,
-            changes: None,
-        })
-        .collect();
-
-    // Add the missing oxen fields
-    schema.fields = missing_oxen_fields
-        .iter()
-        .chain(schema.fields.iter())
-        .cloned()
-        .collect();
-
-    Ok(schema)
-}
-
-pub fn df_diff(conn: &duckdb::Connection) -> Result<DataFrame, OxenError> {
+pub fn df_diff(conn: &duckdb::Connection) -> Result<DataFrame, DataFrameError> {
     let select = sql::Select::new()
         .select("*")
         .from(TABLE_NAME)

--- a/crates/lib/src/core/df/sql.rs
+++ b/crates/lib/src/core/df/sql.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::core::db::data_frames::DataFrameError;
 use crate::core::df::tabular;
 use crate::core::v_latest::workspaces;
 use crate::model::LocalRepository;
@@ -32,7 +33,7 @@ pub async fn query_df_from_repo(
         workspaces::data_frames::get_queryable_data_frame_workspace(repo, path, &commit)?;
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-    let df = with_df_db_manager(db_path, |manager| {
+    let df = with_df_db_manager(&db_path, |manager| {
         manager.with_conn_mut(|conn| query_df(conn, sql, Some(opts)))
     })?;
 
@@ -45,8 +46,8 @@ pub fn query_df(
     conn: &mut duckdb::Connection,
     sql: String,
     opts: Option<&DFOpts>,
-) -> Result<DataFrame, OxenError> {
-    let df = df_db::select_str(conn, sql, opts)?;
+) -> Result<DataFrame, DataFrameError> {
+    let df = df_db::select_str(conn, &sql, opts)?;
 
     Ok(df)
 }
@@ -55,7 +56,7 @@ pub fn export_df(
     conn: &duckdb::Connection,
     sql: String,
     opts: Option<&DFOpts>,
-    tmp_path: impl AsRef<Path>,
-) -> Result<(), OxenError> {
-    df_db::export(conn, sql, opts, tmp_path)
+    tmp_path: &Path,
+) -> Result<(), DataFrameError> {
+    df_db::export(conn, &sql, opts, tmp_path)
 }

--- a/crates/lib/src/core/df/tabular.rs
+++ b/crates/lib/src/core/df/tabular.rs
@@ -894,7 +894,7 @@ pub fn df_hash_rows_on_cols(
     df: DataFrame,
     hash_fields: &[String],
     out_col_name: &str,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, PolarsError> {
     let num_rows = df.height() as i64;
 
     log::debug!("df_hash_rows_on_cols df is {df:?}");
@@ -902,19 +902,23 @@ pub fn df_hash_rows_on_cols(
     log::debug!("df_hash_rows_on_cols out_col_name is {out_col_name:?}");
 
     // Create a vector to store columns to be hashed
-    let mut col_names = vec![];
-    let schema = df.schema();
-    for field in schema.iter_fields() {
-        let field_name = field.name().to_string();
-        if hash_fields.contains(&field_name) {
-            col_names.push(col(field.name().clone()));
-        }
-    }
+    let col_names = df
+        .schema()
+        .iter_fields()
+        .filter_map(|field| {
+            let field_name = field.name();
+            if hash_fields.contains(&field_name.to_string()) {
+                Some(col(field_name.clone()))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
 
     // This is to allow asymmetric target hashing for added / removed cols in default behavior
     if col_names.is_empty() {
         let null_string_col = lit(Null {}).alias(out_col_name);
-        return Ok(df.lazy().with_column(null_string_col).collect()?);
+        return df.lazy().with_column(null_string_col).collect();
     }
 
     // Continue as before
@@ -955,8 +959,7 @@ pub fn df_hash_rows_on_cols(
                 )
                 .alias(out_col_name),
         ])
-        .collect()
-        .unwrap();
+        .collect()?;
     log::debug!("Hashed rows: {df}");
     Ok(df)
 }

--- a/crates/lib/src/core/v_latest/data_frames.rs
+++ b/crates/lib/src/core/v_latest/data_frames.rs
@@ -153,7 +153,7 @@ async fn handle_sql_querying(
 
     if let (Some(sql), Some(workspace)) = (opts.sql.clone(), workspace) {
         let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-        let df = with_df_db_manager(db_path, |manager| {
+        let df = with_df_db_manager(&db_path, |manager| {
             manager.with_conn_mut(|conn| sql::query_df(conn, sql, None))
         })?;
         log::debug!("handle_sql_querying got df {df:?}");

--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -155,7 +155,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
         }
     };
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             if df_db::table_exists(conn, TABLE_NAME)? {
                 df_db::drop_table(conn, TABLE_NAME)?;
@@ -292,7 +292,7 @@ pub async fn rename(
     Ok(relative_path)
 }
 
-fn add_row_status_cols(conn: &Connection) -> Result<(), OxenError> {
+fn add_row_status_cols(conn: &Connection) -> Result<(), duckdb::Error> {
     let query_status = format!(
         "ALTER TABLE \"{}\" ADD COLUMN \"{}\" VARCHAR DEFAULT '{}'",
         TABLE_NAME,
@@ -309,10 +309,9 @@ fn add_row_status_cols(conn: &Connection) -> Result<(), OxenError> {
 
 pub fn extract_file_node_to_working_dir(
     workspace: &Workspace,
-    dir_path: impl AsRef<Path>,
+    dir_path: &Path,
     file_node: &FileNode,
 ) -> Result<PathBuf, OxenError> {
-    let dir_path = dir_path.as_ref();
     log::debug!("extract_file_node_to_working_dir dir_path: {dir_path:?} file_node: {file_node}");
     let workspace_repo = &workspace.workspace_repo;
     let path = PathBuf::from(file_node.name());
@@ -330,7 +329,7 @@ pub fn extract_file_node_to_working_dir(
         )?;
     }
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let delete = Delete::new().delete_from(TABLE_NAME).where_clause(&format!(
                 "\"{}\" = '{}'",
@@ -352,22 +351,18 @@ pub fn extract_file_node_to_working_dir(
     Ok(working_path)
 }
 
-pub fn valid_export_extensions() -> Vec<&'static str> {
-    vec!["csv", "tsv", "parquet", "jsonl", "json", "ndjson"]
-}
+pub const VALID_EXPORT_EXTENSIONS: [&str; 6] = ["csv", "tsv", "parquet", "jsonl", "json", "ndjson"];
 
-pub fn is_valid_export_extension(path: impl AsRef<Path>) -> bool {
-    let path = path.as_ref();
+pub fn is_valid_export_extension(path: &Path) -> bool {
     let extension = path
         .extension()
         .unwrap_or_default()
         .to_str()
         .unwrap_or_default();
-    valid_export_extensions().contains(&extension)
+    VALID_EXPORT_EXTENSIONS.contains(&extension)
 }
 
-pub fn wrap_sql_for_export(sql: &str, path: impl AsRef<Path>) -> String {
-    let path = path.as_ref();
+pub fn wrap_sql_for_export(sql: &str, path: &Path) -> String {
     let extension = path
         .extension()
         .unwrap_or_default()
@@ -403,17 +398,21 @@ pub fn wrap_sql_for_export(sql: &str, path: impl AsRef<Path>) -> String {
     }
 }
 
-fn get_existing_excluded_columns(conn: &Connection, table_name: &str) -> Result<String, OxenError> {
+fn get_existing_excluded_columns(
+    conn: &Connection,
+    table_name: &str,
+) -> Result<String, duckdb::Error> {
     // Query to get existing columns in the table
     let existing_cols_query = format!(
         "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}'"
     );
 
-    let mut stmt = conn.prepare(&existing_cols_query)?;
-    let existing_cols: Vec<String> = stmt
-        .query_map([], |row| row.get(0))?
-        .filter_map(Result::ok)
-        .collect();
+    let existing_cols: Vec<String> = {
+        let mut stmt = conn.prepare(&existing_cols_query)?;
+        stmt.query_map([], |row| row.get(0))?
+            .filter_map(Result::ok)
+            .collect()
+    };
 
     // Filter excluded columns to only those that exist in the table
     let filtered_excluded_cols: Vec<String> = EXCLUDE_OXEN_COLS

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -3,6 +3,7 @@ use rocksdb::DB;
 
 use crate::constants::TABLE_NAME;
 use crate::core::db;
+use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::workspace_df_db::schema_without_oxen_cols;
 use crate::core::db::data_frames::{column_changes_db, columns, df_db::with_df_db_manager};
 use crate::core::staged::staged_db_manager::get_staged_db_manager;
@@ -72,7 +73,7 @@ pub fn delete(
                 table_schema
                     .get_field(&column_to_delete.name)
                     .ok_or_else(|| {
-                        OxenError::Basic("A column with the given name does not exist".into())
+                        DataFrameError::ColumnNameNotFound(column_to_delete.name.to_string())
                     })?;
 
             let result = columns::delete_column(conn, column_to_delete)?;
@@ -359,9 +360,9 @@ pub async fn restore(
             )),
         }
     } else {
-        Err(OxenError::ColumnNameNotFound(
-            format!("Column to restore not found: {}", column_to_restore.name).into(),
-        ))
+        Err(DataFrameError::ColumnNameNotFound(
+            column_to_restore.name.to_string(),
+        ))?
     }
 }
 
@@ -446,7 +447,7 @@ pub fn add_column_metadata(
                     }
                 }
                 if !column_found {
-                    return Err(OxenError::ColumnNameNotFound(column.to_string().into()));
+                    Err(DataFrameError::ColumnNameNotFound(column.to_string()))?;
                 }
                 results.insert(path.clone(), m.tabular.schema.clone());
             }

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -40,7 +40,7 @@ pub fn add(
     let df = tabular::parse_json_to_df(data)?;
     log::debug!("add() df: {df:?}");
 
-    let mut result = with_df_db_manager(db_path, |manager| {
+    let mut result = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| rows::append_row(conn, &df))
     })?;
     let oxen_id_col = result
@@ -95,7 +95,7 @@ pub fn delete(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let row_changes_path = repositories::workspaces::data_frames::row_changes_path(workspace, path);
 
-    let mut deleted_row = with_df_db_manager(db_path, |manager| {
+    let mut deleted_row = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| rows::delete_row(conn, row_id))
     })?;
     log::debug!("delete() deleted_row: {deleted_row:?}");
@@ -149,7 +149,7 @@ pub fn update(
         return Err(OxenError::resource_not_found("row not found"));
     }
 
-    let mut result = with_df_db_manager(db_path, |manager| {
+    let mut result = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| rows::modify_row(conn, &mut df, row_id))
     })?;
 
@@ -215,7 +215,7 @@ pub fn batch_update(
         })
         .collect::<Result<_, OxenError>>()?;
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| rows::modify_rows(conn, row_map))
     })?;
 

--- a/crates/lib/src/core/v_latest/workspaces/diff.rs
+++ b/crates/lib/src/core/v_latest/workspaces/diff.rs
@@ -35,7 +35,7 @@ pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffResult,
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    let (diff_df, schema) = with_df_db_manager(db_path, |manager| {
+    let (diff_df, schema) = with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let diff_df = workspace_df_db::df_diff(conn)?;
             let schema = workspace_df_db::schema_without_oxen_cols(conn, TABLE_NAME)?;
@@ -79,8 +79,8 @@ pub fn is_indexed(workspace: &Workspace, path: &Path) -> Result<bool, OxenError>
     log::debug!("checking dataset is indexed for {path:?}");
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("getting conn at path {db_path:?}");
-    let table_exists = with_df_db_manager(db_path, |manager| {
-        manager.with_conn(|conn| df_db::table_exists(conn, TABLE_NAME))
+    let table_exists = with_df_db_manager(&db_path, |manager| {
+        manager.with_conn(|conn| Ok(df_db::table_exists(conn, TABLE_NAME)?))
     })?;
     log::debug!("dataset_is_indexed() got table_exists: {table_exists:?}");
     Ok(table_exists)

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -144,6 +144,13 @@ pub enum OxenError {
     MissingFileName(StringError),
 
     //
+    // Diff errors
+    //
+    /// The file type is unsupported for data frame operations.
+    #[error("{0}")]
+    InvalidFileType(StringError),
+
+    //
     // Workspaces
     //
     /// The workspace wasn't found (either locally or on a remote server).
@@ -170,6 +177,14 @@ pub enum OxenError {
         workspace_id: String,
         source: Box<OxenError>,
     },
+
+    /// Adding a file into a workspace
+    #[error("{0}")]
+    ImportFileError(StringError),
+
+    /// An error encountered during SQL parsing.
+    #[error("{0}")]
+    SQLParseError(StringError),
 
     #[error("{0}")]
     WorkspaceNameIndex(#[from] crate::core::workspaces::workspace_name_index::WsError),
@@ -284,7 +299,7 @@ pub enum OxenError {
     Lmdb(#[from] LmdbError),
 
     //
-    // Schema (dataframes)
+    // Schema
     //
     /// The schema is invalid or unsupported for dataframe operations.
     #[error("Invalid schema: {0}")]
@@ -293,18 +308,6 @@ pub enum OxenError {
     /// The schemas of the data frames are incompatible.
     #[error("Incompatible schemas: {0}")]
     IncompatibleSchemas(Box<Schema>),
-
-    /// The file type is unsupported for data frame operations.
-    #[error("{0}")]
-    InvalidFileType(StringError),
-
-    /// A column name already exists in the dataframe's schema and cannot be added again.
-    #[error("{0}")]
-    ColumnNameAlreadyExists(StringError),
-
-    /// A column name was requested in a dataframe, but no such column exists.
-    #[error("{0}")]
-    ColumnNameNotFound(StringError),
 
     /// An operation is not supported for the the dataframe.
     #[error("{0}")]
@@ -320,30 +323,14 @@ pub enum OxenError {
     ThumbnailingNotEnabled,
 
     //
-    // Dataframes
-    //
-    /// No rows were found for a given SQL query.
-    #[error("Query returned no rows")]
-    NoRowsFound,
-
-    /// An error encountered during dataframe operations.
-    /// Contains a human-readable description of the error.
-    #[error("{0}")]
-    DataFrameError(StringError),
-
-    /// Adding a file into a workspace
-    #[error("{0}")]
-    ImportFileError(StringError),
-
-    /// An error encountered during SQL parsing.
-    #[error("{0}")]
-    SQLParseError(StringError),
-
-    //
     //
     // Wrappers
     //
     //
+    /// An error encountered during dataframe operations.
+    #[error("{0}")]
+    DataFrameError(#[from] crate::core::db::data_frames::DataFrameError),
+
     /// An error encountered dealing with AWS
     #[error("AWS error: {0}")]
     AwsError(Box<dyn std::error::Error + Send + Sync>),
@@ -855,18 +842,6 @@ impl OxenError {
     pub fn invalid_file_type(file_type: impl AsRef<str>) -> OxenError {
         let err = format!("Invalid file type: {:?}", file_type.as_ref());
         OxenError::InvalidFileType(StringError::from(err))
-    }
-
-    /// Make a new OxenError::ColumnNameAlreadyExists error.
-    pub fn column_name_already_exists(column_name: &str) -> OxenError {
-        let err = format!("Column name already exists: {column_name:?}");
-        OxenError::ColumnNameAlreadyExists(StringError::from(err))
-    }
-
-    /// Make a new OxenError::ColumnNameNotFound error.
-    pub fn column_name_not_found(column_name: &str) -> OxenError {
-        let err = format!("Column name not found: {column_name:?}");
-        OxenError::ColumnNameNotFound(StringError::from(err))
     }
 
     /// Make a new OxenError::IncompatibleSchemas error.

--- a/crates/lib/src/model/diff/add_remove_modify_counts.rs
+++ b/crates/lib/src/model/diff/add_remove_modify_counts.rs
@@ -1,8 +1,8 @@
-use polars::frame::DataFrame;
+use polars::{error::PolarsError, frame::DataFrame};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::{constants::DIFF_STATUS_COL, error::OxenError};
+use crate::constants::DIFF_STATUS_COL;
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct AddRemoveModifyCounts {
@@ -12,7 +12,7 @@ pub struct AddRemoveModifyCounts {
 }
 
 impl AddRemoveModifyCounts {
-    pub fn from_diff_df(df: &DataFrame) -> Result<AddRemoveModifyCounts, OxenError> {
+    pub fn from_diff_df(df: &DataFrame) -> Result<AddRemoveModifyCounts, PolarsError> {
         let added_rows = df
             .column(DIFF_STATUS_COL)?
             .str()?

--- a/crates/lib/src/model/staged_row_status.rs
+++ b/crates/lib/src/model/staged_row_status.rs
@@ -1,33 +1,11 @@
-use std::fmt::Display;
+use strum::{Display, EnumString, VariantNames};
 
-use crate::error::OxenError;
-
+/// The status of rows that are being staged in a commit.
+#[derive(Debug, EnumString, VariantNames, Display)]
+#[strum(serialize_all = "lowercase")]
 pub enum StagedRowStatus {
     Added,
     Modified,
     Removed,
     Unchanged,
-}
-
-impl StagedRowStatus {
-    pub fn from_string(s: &str) -> Result<StagedRowStatus, OxenError> {
-        match s {
-            "added" => Ok(StagedRowStatus::Added),
-            "modified" => Ok(StagedRowStatus::Modified),
-            "removed" => Ok(StagedRowStatus::Removed),
-            "unchanged" => Ok(StagedRowStatus::Unchanged),
-            _ => Err(OxenError::basic_str("Invalid row status")),
-        }
-    }
-}
-
-impl Display for StagedRowStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StagedRowStatus::Added => write!(f, "added"),
-            StagedRowStatus::Modified => write!(f, "modified"),
-            StagedRowStatus::Removed => write!(f, "removed"),
-            StagedRowStatus::Unchanged => write!(f, "unchanged"),
-        }
-    }
 }

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -10,7 +10,7 @@ use crate::constants::{OXEN_COLS, TABLE_NAME};
 use crate::core;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
 use crate::core::db::data_frames::workspace_df_db::select_cols_from_schema;
-use crate::core::db::data_frames::{df_db, workspace_df_db};
+use crate::core::db::data_frames::{DataFrameError, df_db, workspace_df_db};
 use crate::core::df::sql;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
@@ -39,13 +39,12 @@ pub fn is_behind(workspace: &Workspace, path: impl AsRef<Path>) -> Result<bool, 
     Ok(commit_id != workspace.commit.id)
 }
 
-pub fn is_indexed(workspace: &Workspace, path: impl AsRef<Path>) -> Result<bool, OxenError> {
-    let path = path.as_ref();
+pub fn is_indexed(workspace: &Workspace, path: &Path) -> Result<bool, DataFrameError> {
     log::debug!("checking dataset is indexed for {path:?}");
     let db_path = duckdb_path(workspace, path);
     log::debug!("getting conn at path {db_path:?}");
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let table_exists = df_db::table_exists(conn, TABLE_NAME)?;
             log::debug!("dataset_is_indexed() got table_exists: {table_exists:?}");
@@ -106,11 +105,11 @@ pub async fn rename(
     }
 }
 
-pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), OxenError> {
+pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), DataFrameError> {
     let path = path.as_ref();
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             df_db::drop_table(conn, TABLE_NAME)?;
             Ok(())
@@ -132,10 +131,10 @@ pub async fn restore(
     Ok(())
 }
 
-pub fn count(workspace: &Workspace, path: impl AsRef<Path>) -> Result<usize, OxenError> {
+pub fn count(workspace: &Workspace, path: &Path) -> Result<usize, DataFrameError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let count = df_db::count(conn, TABLE_NAME)?;
             Ok(count)
@@ -145,20 +144,19 @@ pub fn count(workspace: &Workspace, path: impl AsRef<Path>) -> Result<usize, Oxe
 
 pub fn query(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     opts: &DFOpts,
-) -> Result<DataFrame, OxenError> {
-    let path = path.as_ref();
+) -> Result<DataFrame, DataFrameError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("query_staged_df() got db_path: {db_path:?}");
     log::debug!("query() opts: {opts:?}");
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn_mut(|conn| {
             // Get the schema of this commit entry
             let schema = df_db::get_schema(conn, TABLE_NAME)?;
 
-            let col_names = select_cols_from_schema(&schema)?;
+            let col_names = select_cols_from_schema(&schema);
 
             // Right now embeddings and sql are mutually exclusive
             let df = if let Some(embedding_opts) = opts.get_sort_by_embedding_query() {
@@ -184,15 +182,14 @@ pub fn query(
 
 pub fn export(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     opts: &DFOpts,
-    temp_file: impl AsRef<Path>,
-) -> Result<(), OxenError> {
-    let path = path.as_ref();
+    temp_file: &Path,
+) -> Result<(), DataFrameError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("export() got db_path: {db_path:?}");
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let sql = if let Some(embedding_opts) = opts.get_sort_by_embedding_query() {
                 let exclude_cols = true;
@@ -218,11 +215,10 @@ pub fn export(
     })
 }
 
-pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DataFrame, OxenError> {
-    let file_path = path.as_ref();
+pub fn diff(workspace: &Workspace, file_path: &Path) -> Result<DataFrame, DataFrameError> {
     let staged_db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
 
-    with_df_db_manager(staged_db_path, |manager| {
+    with_df_db_manager(&staged_db_path, |manager| {
         manager.with_conn(|conn| {
             let diff_df = workspace_df_db::df_diff(conn)?;
             Ok(diff_df)
@@ -230,19 +226,18 @@ pub fn diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DataFrame, 
     })
 }
 
-pub fn full_diff(workspace: &Workspace, path: impl AsRef<Path>) -> Result<DiffResult, OxenError> {
+pub fn full_diff(workspace: &Workspace, path: &Path) -> Result<DiffResult, DataFrameError> {
     let repo = &workspace.base_repo;
-    let path = path.as_ref();
     // Get commit for the branch head
     log::debug!("diff_workspace_df got repo at path {:?}", repo.path);
 
     if !is_indexed(workspace, path)? {
-        return Err(OxenError::basic_str("Dataset is not indexed"));
+        return Err(DataFrameError::NotIndexed);
     };
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    with_df_db_manager(db_path, |manager| {
+    with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             let diff_df = workspace_df_db::df_diff(conn)?;
             log::debug!("full_diff() diff_df: {diff_df:?}");
@@ -463,8 +458,8 @@ pub async fn set_media_render_metadata_if_applicable(
     Ok(())
 }
 
-pub fn duckdb_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {
-    let path = util::fs::linux_path(path.as_ref());
+pub fn duckdb_path(workspace: &Workspace, path: &Path) -> PathBuf {
+    let path = util::fs::linux_path(path);
     log::debug!(
         "duckdb_path path: {:?} workspace: {:?}",
         path,
@@ -514,7 +509,7 @@ pub fn row_changes_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBu
 }
 
 // Add this function after the existing imports
-fn add_exclude_to_sql(sql: &str) -> Result<String, OxenError> {
+fn add_exclude_to_sql(sql: &str) -> Result<String, DataFrameError> {
     // Create the EXCLUDE clause
     let excluded_cols = OXEN_COLS
         .iter()
@@ -526,13 +521,13 @@ fn add_exclude_to_sql(sql: &str) -> Result<String, OxenError> {
     let select_idx = sql
         .to_lowercase()
         .find("select")
-        .ok_or_else(|| OxenError::basic_str("No SELECT found in query"))?;
+        .ok_or_else(|| DataFrameError::NoSelectInQuery)?;
 
     // Find the first FROM after SELECT (case insensitive)
     let from_idx = sql[select_idx..]
         .to_lowercase()
         .find("from")
-        .ok_or_else(|| OxenError::basic_str("No FROM found in query"))?;
+        .ok_or_else(|| DataFrameError::NoFromInQuery)?;
 
     // Split into parts
     let before_from = &sql[..select_idx + from_idx];

--- a/crates/lib/src/repositories/workspaces/data_frames/columns.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/columns.rs
@@ -1,5 +1,6 @@
 use crate::core;
 use crate::core::db;
+use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::column_changes_db::get_all_data_frame_column_changes;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
@@ -110,7 +111,7 @@ pub async fn restore(
 pub fn get_column_diff(
     workspace: &Workspace,
     file_path: impl AsRef<Path>,
-) -> Result<Vec<DataFrameColumnChange>, OxenError> {
+) -> Result<Vec<DataFrameColumnChange>, DataFrameError> {
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
     let opts = db::key_val::opts::default();

--- a/crates/lib/src/repositories/workspaces/data_frames/embeddings.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/embeddings.rs
@@ -7,37 +7,35 @@ use crate::config::EMBEDDING_CONFIG_FILENAME;
 use crate::config::EmbeddingConfig;
 use crate::config::embedding_config::{EmbeddingColumn, EmbeddingStatus};
 use crate::constants::{EXCLUDE_OXEN_COLS, TABLE_NAME};
+use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::df_db::{self, with_df_db_manager};
-use crate::error::OxenError;
-use crate::model::Workspace;
 use crate::model::data_frame::schema::Field;
+use crate::model::{Schema, Workspace};
 use crate::opts::{EmbeddingQueryOpts, PaginateOpts};
 use crate::{repositories, util};
 
 use std::path::Path;
 use std::path::PathBuf;
 
-fn embedding_config_path(workspace: &Workspace, path: impl AsRef<Path>) -> PathBuf {
+fn embedding_config_path(workspace: &Workspace, path: &Path) -> PathBuf {
     let path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     let parent = path.parent().unwrap();
     parent.join(EMBEDDING_CONFIG_FILENAME)
 }
 
-fn embedding_config(
-    workspace: &Workspace,
-    path: impl AsRef<Path>,
-) -> Result<EmbeddingConfig, OxenError> {
+fn embedding_config(workspace: &Workspace, path: &Path) -> Result<EmbeddingConfig, DataFrameError> {
     let embedding_config = embedding_config_path(workspace, path);
-    let config_data = util::fs::read_from_path(&embedding_config)?;
+    let config_data = util::fs::read_from_path(&embedding_config)
+        .map_err(|e| DataFrameError::FailReadConfig(Box::new(e)))?;
     Ok(toml::from_str(&config_data)?)
 }
 
 fn write_embedding_size_to_config(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column_name: impl AsRef<str>,
+    path: &Path,
+    column_name: &str,
     vector_length: usize,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     let embedding_config = embedding_config_path(workspace, path);
 
     // Try to read existing config, create new one if it doesn't exist
@@ -49,39 +47,45 @@ fn write_embedding_size_to_config(
     };
 
     let column = EmbeddingColumn {
-        name: column_name.as_ref().to_string(),
+        name: column_name.to_string(),
         vector_length,
         status: EmbeddingStatus::InProgress,
     };
 
-    config
-        .columns
-        .insert(column_name.as_ref().to_string(), column);
+    config.columns.insert(column_name.to_string(), column);
 
     let config_str = toml::to_string(&config)?;
-    std::fs::write(embedding_config, config_str)?;
+    std::fs::write(embedding_config, config_str).map_err(DataFrameError::FailWriteConfig)?;
     Ok(())
 }
 
 fn update_embedding_status(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column_name: impl AsRef<str>,
+    path: &Path,
+    column_name: &str,
     status: EmbeddingStatus,
-) -> Result<(), OxenError> {
+) -> Result<(), DataFrameError> {
     let embedding_config = embedding_config_path(workspace, path);
-    let config_data = util::fs::read_from_path(&embedding_config)?;
-    let mut config: EmbeddingConfig = toml::from_str(&config_data)?;
-    config.columns.get_mut(column_name.as_ref()).unwrap().status = status;
+    let config_data = util::fs::read_from_path(&embedding_config)
+        .map_err(|e| DataFrameError::FailReadConfig(Box::new(e)))?;
+    let config = {
+        let mut config: EmbeddingConfig = toml::from_str(&config_data)?;
+        if let Some(existing) = config.columns.get_mut(column_name) {
+            existing.status = status;
+        } else {
+            return Err(DataFrameError::ColNotFoundInConfig(column_name.to_string()));
+        }
+        config
+    };
     let config_str = toml::to_string(&config)?;
-    std::fs::write(embedding_config, config_str)?;
+    std::fs::write(embedding_config, config_str).map_err(DataFrameError::FailWriteConfig)?;
     Ok(())
 }
 
 pub fn list_indexed_columns(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-) -> Result<Vec<EmbeddingColumn>, OxenError> {
+    path: &Path,
+) -> Result<Vec<EmbeddingColumn>, DataFrameError> {
     let Ok(config) = embedding_config(workspace, path) else {
         return Ok(vec![]);
     };
@@ -90,11 +94,11 @@ pub fn list_indexed_columns(
 
 fn perform_indexing(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column_name: String,
+    path: &Path,
+    column_name: &str,
     vector_length: usize,
-) -> Result<(), OxenError> {
-    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, &path);
+) -> Result<(), DataFrameError> {
+    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
             // Execute VSS commands separately
@@ -114,7 +118,7 @@ fn perform_indexing(
     log::debug!(
         "Completed indexing embeddings for column `{}` on {}",
         column_name,
-        path.as_ref().display()
+        path.display()
     );
     update_embedding_status(workspace, path, column_name, EmbeddingStatus::Complete)?;
 
@@ -123,34 +127,29 @@ fn perform_indexing(
 
 pub fn index(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column: impl AsRef<str>,
+    path: &Path,
+    column: &str,
     use_background_thread: bool,
-) -> Result<(), OxenError> {
-    let path = path.as_ref().to_path_buf();
-    let column = column.as_ref();
-
-    let column_name = column.to_string();
+) -> Result<(), DataFrameError> {
     log::debug!(
-        "Indexing embeddings for column: {column_name} using background thread: {use_background_thread}"
+        "Indexing embeddings for column: {column} using background thread: {use_background_thread}"
     );
 
-    let vector_length = get_embedding_length(workspace, &path, column)?;
+    let vector_length = get_embedding_length(workspace, path, column)?;
 
     if use_background_thread {
         // Clone necessary values for the background thread
         let workspace = workspace.clone();
-        let column_name = column_name.clone();
-        let path = path.clone();
-
+        let path = path.to_path_buf();
+        let column = column.to_string();
         // Spawn background thread for VSS setup
         std::thread::spawn(move || {
-            if let Err(e) = perform_indexing(&workspace, path, column_name, vector_length) {
+            if let Err(e) = perform_indexing(&workspace, &path, &column, vector_length) {
                 log::error!("Error in background indexing thread: {e}");
             }
         });
     } else {
-        perform_indexing(workspace, path, column_name, vector_length)?;
+        perform_indexing(workspace, path, column, vector_length)?;
     }
 
     Ok(())
@@ -158,11 +157,9 @@ pub fn index(
 
 fn get_embedding_length(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column: impl AsRef<str>,
-) -> Result<usize, OxenError> {
-    let path = path.as_ref();
-    let column = column.as_ref();
+    path: &Path,
+    column: &str,
+) -> Result<usize, DataFrameError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("Embedding index DB Path: {db_path:?}");
     let result_set = with_df_db_manager(&db_path, |manager| {
@@ -174,7 +171,7 @@ fn get_embedding_length(
         })
     })?;
     let Some(item) = result_set.first() else {
-        return Err(OxenError::basic_str("No items found"));
+        return Err(DataFrameError::NoRowsFound);
     };
     let first_column = item.column(0);
     log::debug!("First column: {first_column:?}");
@@ -186,43 +183,35 @@ fn get_embedding_length(
                 let array = first_column
                     .as_any()
                     .downcast_ref::<ListArray>()
-                    .ok_or_else(|| OxenError::basic_str("Failed to downcast to ListArray"))?;
+                    .ok_or_else(|| DataFrameError::FailListDowncast)?;
                 if let Some(first_value) = array.value(0).as_any().downcast_ref::<Float32Array>() {
                     first_value.len()
                 } else {
-                    return Err(OxenError::basic_str(
-                        "Expected Float32Array inside ListArray",
-                    ));
+                    return Err(DataFrameError::ExpectedF32ArrayInside);
                 }
             }
             arrow::datatypes::DataType::Float64 => {
                 let array = first_column
                     .as_any()
                     .downcast_ref::<ListArray>()
-                    .ok_or_else(|| OxenError::basic_str("Failed to downcast to ListArray"))?;
+                    .ok_or_else(|| DataFrameError::FailListDowncast)?;
                 if let Some(first_value) = array.value(0).as_any().downcast_ref::<Float64Array>() {
                     first_value.len()
                 } else {
-                    return Err(OxenError::basic_str(
-                        "Expected Float64Array inside ListArray",
-                    ));
+                    return Err(DataFrameError::ExpectF64ArrayInside);
                 }
             }
             _ => {
-                return Err(OxenError::basic_str(
-                    "Column must be a list of float32 or float64",
-                ));
+                return Err(DataFrameError::ExpectColFloats);
             }
         },
         arrow::datatypes::DataType::FixedSizeList(field, size) => match field.data_type() {
             arrow::datatypes::DataType::Float32 => *size as usize,
             _ => {
-                return Err(OxenError::basic_str(
-                    "Column FixedSizeList must be a float32 type",
-                ));
+                return Err(DataFrameError::ExpectF32FixedSizeList);
             }
         },
-        _ => return Err(OxenError::basic_str("Column must be a list type")),
+        _ => return Err(DataFrameError::ExpectList),
     };
 
     log::debug!("Vector length: {vector_length}");
@@ -234,10 +223,9 @@ fn get_embedding_length(
 pub fn embedding_from_query(
     conn: &duckdb::Connection,
     workspace: &Workspace,
-    path: impl AsRef<Path>,
+    path: &Path,
     query: &EmbeddingQueryOpts,
-) -> Result<(Vec<f32>, usize), OxenError> {
-    let path = path.as_ref();
+) -> Result<(Vec<f32>, usize), DataFrameError> {
     let column = query.column.clone();
     let query = query.query.clone();
     let sql = format!("SELECT {column} FROM df WHERE {query};");
@@ -247,11 +235,13 @@ pub fn embedding_from_query(
 
     // Read the vector length from the file we wrote in the index function
     let Ok(config) = embedding_config(workspace, path) else {
-        return Err(OxenError::basic_str(
-            "Must index embeddings before querying",
-        ));
+        return Err(DataFrameError::MustIndexEmbeddings);
     };
-    let vector_length = config.columns[&column].vector_length;
+    let vector_length = config
+        .columns
+        .get(&column)
+        .ok_or_else(|| DataFrameError::ColNotFoundInConfig(column.clone()))?
+        .vector_length;
     // log::debug!("Vector length: {}", vector_length);
     // Average the embeddings
     let avg_embedding = get_avg_embedding(result_set)?;
@@ -264,9 +254,9 @@ fn build_similarity_query_sql(
     similarity_column: &str,
     avg_embedding: &[f32],
     vector_length: usize,
-    schema: &crate::model::data_frame::schema::Schema,
+    schema: &Schema,
     exclude_cols: bool,
-) -> Result<String, OxenError> {
+) -> String {
     let embedding_str = format!(
         "[{}]",
         avg_embedding
@@ -284,17 +274,16 @@ fn build_similarity_query_sql(
         .collect::<Vec<&str>>();
 
     let columns_str = columns.join(", ");
-    let sql = format!(
+    format!(
         "SELECT {columns_str}, array_cosine_similarity({column}, {embedding_str}::FLOAT[{vector_length}]) as {similarity_column} FROM df ORDER BY {similarity_column} DESC"
-    );
-    Ok(sql)
+    )
 }
 
 pub fn similarity_query(
     workspace: &Workspace,
     opts: &EmbeddingQueryOpts,
     exclude_cols: bool,
-) -> Result<String, OxenError> {
+) -> Result<String, DataFrameError> {
     let column = opts.column.clone();
     let path = opts.path.clone();
     let similarity_column = opts.name.clone();
@@ -302,21 +291,21 @@ pub fn similarity_query(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, &path);
     log::debug!("Embedding query DB Path: {db_path:?}");
     let (avg_embedding, vector_length) = with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| embedding_from_query(conn, workspace, path.clone(), opts))
+        manager.with_conn(|conn| embedding_from_query(conn, workspace, &path, opts))
     })?;
 
     let schema = with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| df_db::get_schema(conn, TABLE_NAME))
+        manager.with_conn(|conn| Ok(df_db::get_schema(conn, TABLE_NAME)?))
     })?;
 
-    build_similarity_query_sql(
+    Ok(build_similarity_query_sql(
         &column,
         &similarity_column,
         &avg_embedding,
         vector_length,
         &schema,
         exclude_cols,
-    )
+    ))
 }
 
 /// Version of similarity_query that accepts a connection to avoid deadlock issues
@@ -325,37 +314,36 @@ pub fn similarity_query_with_conn(
     workspace: &Workspace,
     opts: &EmbeddingQueryOpts,
     exclude_cols: bool,
-) -> Result<String, OxenError> {
+) -> Result<String, DataFrameError> {
     let column = opts.column.clone();
     let path = opts.path.clone();
     let similarity_column = opts.name.clone();
 
-    let (avg_embedding, vector_length) = embedding_from_query(conn, workspace, path.clone(), opts)?;
+    let (avg_embedding, vector_length) = embedding_from_query(conn, workspace, &path, opts)?;
     let schema = df_db::get_schema(conn, TABLE_NAME)?;
 
-    build_similarity_query_sql(
+    Ok(build_similarity_query_sql(
         &column,
         &similarity_column,
         &avg_embedding,
         vector_length,
         &schema,
         exclude_cols,
-    )
+    ))
 }
 
 pub fn nearest_neighbors(
     workspace: &Workspace,
-    path: impl AsRef<Path>,
-    column: impl AsRef<str>,
+    path: &Path,
+    column: &str,
     embedding: Vec<f32>,
     pagination: &PaginateOpts,
     exclude_cols: bool,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, DataFrameError> {
     // Time the query
     let start = std::time::Instant::now();
-    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, &path);
+    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
 
-    let column = column.as_ref();
     let vector_length = embedding.len();
     let similarity_column = "similarity";
     let (result_set, mut schema) = with_df_db_manager(&db_path, |manager| {
@@ -370,7 +358,7 @@ pub fn nearest_neighbors(
                 vector_length,
                 &schema,
                 exclude_cols,
-            )?;
+            );
 
             // Add pagination
             let limit = pagination.page_size;
@@ -408,7 +396,7 @@ fn execute_similarity_query(
     conn: &duckdb::Connection,
     sql: &str,
     similarity_column: &str,
-) -> Result<(Vec<RecordBatch>, crate::model::data_frame::schema::Schema), OxenError> {
+) -> Result<(Vec<RecordBatch>, Schema), DataFrameError> {
     let result_set: Vec<RecordBatch> = conn.prepare(sql)?.query_arrow([])?.collect();
     let mut schema = df_db::get_schema(conn, TABLE_NAME)?;
     schema.fields.push(Field::new(similarity_column, "f32"));
@@ -420,7 +408,7 @@ pub fn query_with_conn(
     conn: &duckdb::Connection,
     workspace: &Workspace,
     opts: &EmbeddingQueryOpts,
-) -> Result<DataFrame, OxenError> {
+) -> Result<DataFrame, DataFrameError> {
     let similarity_column = opts.name.clone();
 
     // Get the base SQL using the connection
@@ -454,7 +442,10 @@ pub fn query_with_conn(
     Ok(df)
 }
 
-pub fn query(workspace: &Workspace, opts: &EmbeddingQueryOpts) -> Result<DataFrame, OxenError> {
+pub fn query(
+    workspace: &Workspace,
+    opts: &EmbeddingQueryOpts,
+) -> Result<DataFrame, DataFrameError> {
     let path = opts.path.clone();
     let similarity_column = opts.name.clone();
 
@@ -492,7 +483,7 @@ pub fn query(workspace: &Workspace, opts: &EmbeddingQueryOpts) -> Result<DataFra
     Ok(df)
 }
 
-fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError> {
+fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, DataFrameError> {
     let mut embeddings: Vec<Vec<f32>> = Vec::new();
     let mut vector_length = 0;
     for batch in result_set {
@@ -503,7 +494,7 @@ fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError
                     let array = first_column
                         .as_any()
                         .downcast_ref::<ListArray>()
-                        .ok_or_else(|| OxenError::basic_str("Failed to downcast to ListArray"))?;
+                        .ok_or_else(|| DataFrameError::FailListDowncast)?;
                     if let Some(first_value) =
                         array.value(0).as_any().downcast_ref::<Float32Array>()
                     {
@@ -511,20 +502,14 @@ fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError
                         if vector_length == 0 {
                             vector_length = first_value.len();
                         } else if first_value.len() != vector_length {
-                            return Err(OxenError::basic_str(
-                                "All embeddings must be the same length",
-                            ));
+                            return Err(DataFrameError::EmbeddingLengthMismatch);
                         }
                     } else {
-                        return Err(OxenError::basic_str(
-                            "Expected Float32Array inside ListArray",
-                        ));
+                        return Err(DataFrameError::ExpectedF32ArrayInside);
                     }
                 }
                 _ => {
-                    return Err(OxenError::basic_str(
-                        "Expected arrow::datatypes::DataType::Float32 inside List",
-                    ));
+                    return Err(DataFrameError::ExpectedF32);
                 }
             },
             arrow::datatypes::DataType::FixedSizeList(field, _) => match field.data_type() {
@@ -532,9 +517,7 @@ fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError
                     let array = first_column
                         .as_any()
                         .downcast_ref::<FixedSizeListArray>()
-                        .ok_or_else(|| {
-                            OxenError::basic_str("Failed to downcast to FixedSizeListArray")
-                        })?;
+                        .ok_or_else(|| DataFrameError::FailFixedSizeDowncast)?;
                     if let Some(first_value) =
                         array.value(0).as_any().downcast_ref::<Float32Array>()
                     {
@@ -542,34 +525,26 @@ fn get_avg_embedding(result_set: Vec<RecordBatch>) -> Result<Vec<f32>, OxenError
                         if vector_length == 0 {
                             vector_length = first_value.len();
                         } else if first_value.len() != vector_length {
-                            return Err(OxenError::basic_str(
-                                "All embeddings must be the same length",
-                            ));
+                            return Err(DataFrameError::EmbeddingLengthMismatch);
                         }
                     }
                 }
                 _ => {
-                    return Err(OxenError::basic_str(
-                        "Column FixedSizeList must be a float32 type",
-                    ));
+                    return Err(DataFrameError::ExpectF32FixedSizeList);
                 }
             },
             _ => {
-                return Err(OxenError::basic_str(
-                    "Expected arrow::datatypes::DataType::List inside as data type",
-                ));
+                return Err(DataFrameError::ExpectListInside);
             }
         }
     }
 
     if embeddings.is_empty() {
-        return Err(OxenError::NoRowsFound);
+        return Err(DataFrameError::NoRowsFound);
     }
 
     if vector_length == 0 {
-        return Err(OxenError::basic_str(
-            "Vector's must have a length greater than 0",
-        ));
+        return Err(DataFrameError::EmptyEmbedding);
     }
 
     // Average the embeddings along the columns

--- a/crates/lib/src/repositories/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/rows.rs
@@ -1,3 +1,4 @@
+use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::row_changes_db::get_all_data_frame_row_changes;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
@@ -22,6 +23,7 @@ use crate::model::LocalRepository;
 use crate::model::staged_row_status::StagedRowStatus;
 
 use std::path::Path;
+use std::str::FromStr;
 
 pub fn add(
     repo: &LocalRepository,
@@ -40,7 +42,7 @@ pub fn add(
 pub fn get_row_diff(
     workspace: &Workspace,
     file_path: impl AsRef<Path>,
-) -> Result<Vec<DataFrameRowChange>, OxenError> {
+) -> Result<Vec<DataFrameRowChange>, DataFrameError> {
     let row_changes_path =
         repositories::workspaces::data_frames::row_changes_path(workspace, file_path);
     let opts = db::key_val::opts::default();
@@ -147,14 +149,15 @@ pub fn get_row_id(row_df: &DataFrame) -> Result<Option<String>, OxenError> {
     }
 }
 
-pub fn get_row_status(row_df: &DataFrame) -> Result<Option<StagedRowStatus>, OxenError> {
+pub fn get_row_status(row_df: &DataFrame) -> Result<Option<StagedRowStatus>, DataFrameError> {
     let diff_status_col = PlSmallStr::from_str(DIFF_STATUS_COL);
     if row_df.height() == 1 && row_df.get_column_names().contains(&&diff_status_col) {
         let anyval_status = row_df.column(DIFF_STATUS_COL).unwrap().get(0)?;
         let str_status = anyval_status
             .get_str()
-            .ok_or_else(|| OxenError::basic_str("Row status not found"))?;
-        let status = StagedRowStatus::from_string(str_status)?;
+            .ok_or_else(|| DataFrameError::RowStatusNotFound)?;
+        let status = StagedRowStatus::from_str(str_status)
+            .map_err(|_| DataFrameError::InvalidRowStatus(str_status.to_string()))?;
         Ok(Some(status))
     } else {
         Ok(None)

--- a/crates/lib/src/repositories/workspaces/data_frames/schemas.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames/schemas.rs
@@ -11,7 +11,7 @@ pub fn get_by_path(workspace: &Workspace, path: impl AsRef<Path>) -> Result<Sche
     let file_path = path.as_ref();
     let staged_db_path = repositories::workspaces::data_frames::duckdb_path(workspace, file_path);
     let df_schema = with_df_db_manager(&staged_db_path, |manager| {
-        manager.with_conn(|conn| df_db::get_schema(conn, TABLE_NAME))
+        manager.with_conn(|conn| Ok(df_db::get_schema(conn, TABLE_NAME)?))
     })?;
     Ok(df_schema)
 }

--- a/crates/server/src/controllers/workspaces/data_frames/embeddings.rs
+++ b/crates/server/src/controllers/workspaces/data_frames/embeddings.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::errors::OxenHttpError;
 use crate::helpers::get_repo;
 use crate::params::{app_data, path_param};
@@ -22,7 +24,7 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
-    let file_path = path_param(&req, "path")?.to_string();
+    let file_path = Path::new(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -47,14 +49,14 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
-    let file_path = path_param(&req, "path")?.to_string();
+    let file_path = Path::new(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
     };
 
-    let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;
+    let is_indexed = repositories::workspaces::data_frames::is_indexed(&workspace, file_path)?;
     log::debug!("neighbors is_indexed: {is_indexed}");
     if !is_indexed {
         let response = WorkspaceJsonDataFrameViewResponse {
@@ -71,15 +73,18 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
 
     log::debug!("neighbors: Embedding query: {body:?}");
     let request: EmbeddingQuery = serde_json::from_str(&body)?;
-    let count = repositories::workspaces::data_frames::count(&workspace, &file_path)?;
+    let count = repositories::workspaces::data_frames::count(&workspace, file_path)?;
 
-    let mut opts = DFOpts::empty();
-    opts.page = Some(request.page_num);
-    opts.page_size = Some(request.page_size);
+    let opts = {
+        let mut opts = DFOpts::empty();
+        opts.page = Some(request.page_num);
+        opts.page_size = Some(request.page_size);
+        opts
+    };
 
     let df = repositories::workspaces::data_frames::embeddings::nearest_neighbors(
         &workspace,
-        &file_path,
+        file_path,
         &request.column,
         request.embedding,
         &PaginateOpts {
@@ -90,14 +95,14 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
     )?;
 
     let Some(mut df_schema) =
-        repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, &file_path)?
+        repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, file_path)?
     else {
         log::error!("Failed to get schema for data frame {file_path:?}");
         return Err(OxenHttpError::NotFound);
     };
 
     let resource = ResourceVersion {
-        path: file_path.clone(),
+        path: file_path.to_string_lossy().to_string(),
         version: workspace.commit.id.to_string(),
     };
 
@@ -116,13 +121,13 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
 
     repositories::workspaces::data_frames::columns::decorate_fields_with_column_diffs(
         &workspace,
-        &file_path,
+        file_path,
         &mut df_views,
     )?;
 
     let new_schema = repositories::data_frames::schemas::get_staged_schema_with_staged_db_manager(
         &workspace.workspace_repo,
-        &file_path,
+        file_path,
     )?;
     repositories::workspaces::data_frames::columns::update_column_schemas(
         new_schema,
@@ -150,7 +155,7 @@ pub async fn post(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, OxenHt
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
-    let file_path = path_param(&req, "path")?.to_string();
+    let file_path = Path::new(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -168,7 +173,7 @@ pub async fn post(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, OxenHt
 
     repositories::workspaces::data_frames::embeddings::index(
         &workspace,
-        &file_path,
+        file_path,
         &column,
         use_background_thread,
     )?;

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -2,6 +2,7 @@ use actix_multipart::MultipartError;
 use actix_web::{HttpResponse, error};
 use derive_more::{Display, Error};
 use liboxen::constants;
+use liboxen::core::db::data_frames::DataFrameError;
 use liboxen::error::{OxenError, PathBufError, StringError};
 use liboxen::model::{Branch, Workspace};
 use liboxen::view::http::{
@@ -57,12 +58,20 @@ pub enum OxenHttpError {
     SerdeError(serde_json::Error),
 }
 
+// Convert into its [`OxenError`] wrapper and treat it as an [`OxenHttpError::InternalOxenError`].
+impl From<DataFrameError> for OxenHttpError {
+    fn from(error: DataFrameError) -> Self {
+        Self::InternalOxenError(error.into())
+    }
+}
+
 impl From<OxenError> for OxenHttpError {
     fn from(error: OxenError) -> Self {
         OxenHttpError::InternalOxenError(error)
     }
 }
 
+// Convert into its [`OxenError`] wrapper and treat it as an [`OxenHttpError::InternalOxenError`].
 impl From<io::Error> for OxenHttpError {
     fn from(error: io::Error) -> Self {
         OxenHttpError::InternalOxenError(OxenError::IO(error))
@@ -207,9 +216,7 @@ impl error::ResponseError for OxenHttpError {
             OxenHttpError::ActixError(_) => {
                 HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
             }
-            OxenHttpError::SerdeError(_) => {
-                HttpResponse::BadRequest().json(StatusMessage::bad_request())
-            }
+            OxenHttpError::SerdeError(_) => handle_serde(),
             OxenHttpError::UpdateRequired(version) => {
                 let version_str = version.to_string();
                 let error_json = json!({
@@ -376,7 +383,6 @@ impl error::ResponseError for OxenHttpError {
                             format!("Schema is invalid: '{schema}'"),
                         ))
                     }
-
                     OxenError::IncompatibleSchemas(schema) => {
                         log::error!("Incompatible schemas: {schema}");
 
@@ -395,36 +401,6 @@ impl error::ResponseError for OxenHttpError {
                                     "Incompatible Schemas",
                                 "detail":
                                     format!("{}", error)
-                            },
-                            "status": STATUS_ERROR,
-                            "status_message": MSG_BAD_REQUEST,
-                        });
-                        HttpResponse::BadRequest().json(error_json)
-                    }
-                    OxenError::ColumnNameAlreadyExists(column_name) => {
-                        log::error!("Column Name Already Exists: {column_name}");
-                        let error_json = json!({
-                            "error": {
-                                "type": "column_error",
-                                "title":
-                                    "Column Name Already Exists",
-                                "detail":
-                                    format!("Column name '{}' already exists in schema", column_name)
-                            },
-                            "status": STATUS_ERROR,
-                            "status_message": MSG_BAD_REQUEST,
-                        });
-                        HttpResponse::BadRequest().json(error_json)
-                    }
-                    OxenError::ColumnNameNotFound(column_name) => {
-                        log::error!("Column Name Not Found: {column_name}");
-                        let error_json = json!({
-                            "error": {
-                                "type": "column_error",
-                                "title":
-                                    "Column Name Not Found",
-                                "detail":
-                                    format!("Column name '{}' not found in schema", column_name)
                             },
                             "status": STATUS_ERROR,
                             "status_message": MSG_BAD_REQUEST,
@@ -460,48 +436,69 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
-                    OxenError::DUCKDB(error) => {
-                        log::error!("DuckDB error: {error}");
-                        let error_json = json!({
-                            "error": {
-                                "type": "query_error",
-                                "title":
-                                    "Could not execute query on Data",
-                                "detail":
-                                    format!("{}", error)
-                            },
-                            "status": STATUS_ERROR,
-                            "status_message": MSG_BAD_REQUEST,
-                        });
-                        HttpResponse::BadRequest().json(error_json)
-                    }
-                    OxenError::PolarsError(error) => {
-                        log::error!("Polars error: {error:?}");
-                        let error_json = json!({
-                            "error": {
-                                "type": "data_frame_error",
-                                "title": "Error Reading DataFrame",
-                                "detail":
-                                    format!("{}", error),
-                            },
-                            "status": STATUS_ERROR,
-                            "status_message": MSG_BAD_REQUEST,
-                        });
-                        HttpResponse::InternalServerError().json(error_json)
-                    }
-                    OxenError::DataFrameError(error) => {
-                        log::error!("DataFrame error: {error}");
-                        let error_json = json!({
-                            "error": {
-                                "type": "data_frame_error",
-                                "title": "Error Reading DataFrame",
-                                "detail": format!("{}", error),
-                            },
-                            "status": STATUS_ERROR,
-                            "status_message": MSG_INTERNAL_SERVER_ERROR,
-                        });
-                        HttpResponse::InternalServerError().json(error_json)
-                    }
+                    OxenError::DUCKDB(error) => handle_duckdb(error),
+                    OxenError::PolarsError(error) => handle_polars(error),
+                    OxenError::DataFrameError(error) => match error {
+                        DataFrameError::DuckDb(error) => handle_duckdb(error),
+                        DataFrameError::Polars(error) => handle_polars(error),
+                        DataFrameError::SerdeJson(_) => handle_serde(),
+                        DataFrameError::ColumnNameAlreadyExists(column_name) => {
+                            log::error!("Column Name Already Exists: {column_name}");
+                            let error_json = json!({
+                                "error": {
+                                    "type": "column_error",
+                                    "title":
+                                        "Column Name Already Exists",
+                                    "detail":
+                                        format!("Column name '{}' already exists in schema", column_name)
+                                },
+                                "status": STATUS_ERROR,
+                                "status_message": MSG_BAD_REQUEST,
+                            });
+                            HttpResponse::BadRequest().json(error_json)
+                        }
+                        DataFrameError::ColumnNameNotFound(column_name) => {
+                            log::error!("Column Name Not Found: {column_name}");
+                            let error_json = json!({
+                                "error": {
+                                    "type": "column_error",
+                                    "title":
+                                        "Column Name Not Found",
+                                    "detail":
+                                        format!("Column name '{}' not found in schema", column_name)
+                                },
+                                "status": STATUS_ERROR,
+                                "status_message": MSG_BAD_REQUEST,
+                            });
+                            HttpResponse::BadRequest().json(error_json)
+                        }
+                        e @ DataFrameError::NoRowsFound => {
+                            log::error!("No rows found: {e}");
+                            let error_json = json!({
+                                "error": {
+                                    "type": "no_rows_found",
+                                    "title": "No rows found",
+                                    "detail": format!("{e}"),
+                                },
+                                "status": STATUS_ERROR,
+                                "status_message": MSG_INTERNAL_SERVER_ERROR,
+                            });
+                            HttpResponse::NotFound().json(error_json)
+                        }
+                        _ => {
+                            log::error!("DataFrame error: {error}");
+                            let error_json = json!({
+                                "error": {
+                                    "type": "data_frame_error",
+                                    "title": "Error Reading DataFrame",
+                                    "detail": format!("{}", error),
+                                },
+                                "status": STATUS_ERROR,
+                                "status_message": MSG_INTERNAL_SERVER_ERROR,
+                            });
+                            HttpResponse::InternalServerError().json(error_json)
+                        }
+                    },
                     thumbnail_error @ OxenError::ThumbnailingNotEnabled => {
                         log::error!("Thumbnailing not enabled: {thumbnail_error}");
                         let error_json = json!({
@@ -525,19 +522,6 @@ impl error::ResponseError for OxenHttpError {
                             "status_message": MSG_INTERNAL_SERVER_ERROR,
                         });
                         HttpResponse::InternalServerError().json(error_json)
-                    }
-                    e @ OxenError::NoRowsFound => {
-                        log::error!("No rows found: {e}");
-                        let error_json = json!({
-                            "error": {
-                                "type": "no_rows_found",
-                                "title": "No rows found",
-                                "detail": format!("{e}"),
-                            },
-                            "status": STATUS_ERROR,
-                            "status_message": MSG_INTERNAL_SERVER_ERROR,
-                        });
-                        HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::LocalRepoNotFound(path) => {
                         log::debug!("Local repo not found: {path}");
@@ -638,4 +622,39 @@ impl error::ResponseError for OxenHttpError {
             }
         }
     }
+}
+
+/// Convert a [`duckdb::Error`] into a HTTP bad request error.
+fn handle_duckdb(error: &impl std::error::Error) -> HttpResponse {
+    log::error!("DuckDB error: {error}");
+    let error_json = json!({
+        "error": {
+            "type": "query_error",
+            "title": "Could not execute query on Data",
+            "detail": format!("{}", error),
+        },
+        "status": STATUS_ERROR,
+        "status_message": MSG_BAD_REQUEST,
+    });
+    HttpResponse::BadRequest().json(error_json)
+}
+
+/// Convert a [`polars::error::PolarsError`] into a HTTP 500 error.
+fn handle_polars(error: &impl std::error::Error) -> HttpResponse {
+    log::error!("Polars error: {error:?}");
+    let error_json = json!({
+        "error": {
+            "type": "data_frame_error",
+            "title": "Error Reading DataFrame",
+            "detail": format!("{}", error),
+        },
+        "status": STATUS_ERROR,
+        "status_message": MSG_BAD_REQUEST,
+    });
+    HttpResponse::InternalServerError().json(error_json)
+}
+
+/// Convert a [`serde_json::Error`] into a HTTP bad request error.
+fn handle_serde() -> HttpResponse {
+    HttpResponse::BadRequest().json(StatusMessage::bad_request())
 }


### PR DESCRIPTION
All direct DataFrame operations now return this error as `-> Result<T, DataFrameError>`
instead of the more general `OxenError`. The entire `data_frames` module now uses
a unified error type.

Many isolated and many repeated uses of `OxenError:BasicStr` for DF ops have been fixed:
they now have distinct variants in `DataFrameError`. The narrowest error type that's
necessary is used: it's `DataFrameError` in most cases, but some functions now return
something narrower (e.g. `duckdb::Error` or `PolarsError`).

`oxen-server`'s `OxenHttpError` & associated `HttpResponse` types have been preserved
with this refactor. The existing DataFrame errors are routed correctly to the exact
same JSON error payloads and HTTP status codes. Notably, this includes: DuckDB errors,
Polars errors, serde_json errors, the no rows found error, column not found error, and
the column name already exists error.

Additionally, while implementing this refactor, several `AsRef<str|Path>` uses have been
cleaned up to use the borrow type directly. This is easier to read and understand and
speeds up compilation. Also, some unused functions have been removed.