### PR TITLE
Remove CLI-only errors from OxenError, have CLI use anyhow::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,6 +5453,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 name = "oxen-cli"
 version = "0.50.1"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytesize",
  "chrono",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ otel = ["liboxen/otel"]
 production = ["metrics", "otel", "default"]
 
 [dependencies]
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytesize = { workspace = true }
 chrono = { workspace = true }

--- a/crates/cli/src/cli_error.rs
+++ b/crates/cli/src/cli_error.rs
@@ -1,11 +1,8 @@
-use colored::Colorize;
-use liboxen::error::OxenError;
+use thiserror::Error;
 
-/// Print an OxenError to stderr with colored prefix and optional hints.
-pub fn print_error(err: &OxenError) {
-    eprintln!("{} {}", "Error:".red().bold(), err);
-
-    if let Some(hint) = err.hint() {
-        eprintln!("  {} {}", "hint:".cyan().bold(), hint);
-    }
+#[derive(Debug, Error)]
+#[error("Unknown {parent} subcommand '{name}'")]
+pub struct UnknownSubcommand {
+    pub parent: &'static str,
+    pub name: String,
 }

--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -1,5 +1,4 @@
-use clap;
-use liboxen::error::OxenError;
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 
@@ -117,11 +116,21 @@ pub use prune::PruneCmd;
 pub mod fsck;
 pub use fsck::FsckCmd;
 
+/// Maps the name of a [`RunCmd`] to its implementation.
+pub type Runners = HashMap<String, Box<dyn RunCmd>>;
+
 /// Trait for that any oxen CLI comand must implement.
+///
+/// Oxen CLI programs have a human-readable name, CLI arguments, and a method to trigger the program's
+/// main logic given parsed CLI arguments.
+///
 /// NOTE: Must keep this trait dyn-compatible.
 #[async_trait]
 pub trait RunCmd {
+    /// The name of the CLI program. Used to identify it and display in user-facing messages.
     fn name(&self) -> &str;
+    /// The CLI arguments for this program.
     fn args(&self) -> clap::Command;
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError>;
+    /// Execute the CLI program's logic.
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error>;
 }

--- a/crates/cli/src/cmd/add.rs
+++ b/crates/cli/src/cmd/add.rs
@@ -38,7 +38,7 @@ impl RunCmd for AddCmd {
         add_args()
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let paths: Vec<PathBuf> = args
             .get_many::<String>("files")

--- a/crates/cli/src/cmd/branch.rs
+++ b/crates/cli/src/cmd/branch.rs
@@ -7,6 +7,7 @@ use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
+use crate::cli_error::UnknownSubcommand;
 use crate::cmd::RunCmd;
 use crate::helpers::{
     check_remote_version, check_remote_version_blocking, get_scheme_and_host_from_repo,
@@ -85,47 +86,51 @@ impl RunCmd for BranchCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Find the repository
         let repo = LocalRepository::from_current_dir()?;
 
         // Parse Args
         if let Some((cmd, _)) = args.subcommand() {
-            Err(OxenError::unknown_subcommand("branch", cmd))
+            return Err(UnknownSubcommand {
+                parent: "branch",
+                name: cmd.to_string(),
+            })?;
         } else if args.get_flag("all") {
-            self.list_all_branches(&repo).await
+            self.list_all_branches(&repo).await?;
         } else if let Some(remote_name) = args.get_one::<String>("remote") {
             if let Some(branch_name) = args.get_one::<String>("delete") {
                 self.delete_remote_branch(&repo, remote_name, branch_name)
-                    .await
+                    .await?;
             } else {
-                self.list_remote_branches(&repo, remote_name).await
+                self.list_remote_branches(&repo, remote_name).await?;
             }
         } else if let Some(name) = args.get_one::<String>("name") {
             if args.get_flag("force") {
                 let commit_id = args
                     .get_one::<String>("commit_id")
-                    .ok_or_else(|| OxenError::basic_str("Must supply a commit ID with --force"))?;
-                self.force_update_branch(&repo, name, commit_id)
+                    .ok_or_else(|| anyhow::anyhow!("Must supply a commit ID with --force"))?;
+                self.force_update_branch(&repo, name, commit_id)?;
             } else {
-                self.create_branch(&repo, name)
+                self.create_branch(&repo, name)?;
             }
         } else if let Some(name) = args.get_one::<String>("delete") {
-            self.delete_branch(&repo, name)
+            self.delete_branch(&repo, name)?;
         } else if let Some(name) = args.get_one::<String>("force-delete") {
-            self.force_delete_branch(&repo, name)
+            self.force_delete_branch(&repo, name)?;
         } else if let Some(name) = args.get_one::<String>("move") {
-            self.rename_current_branch(&repo, name)
+            self.rename_current_branch(&repo, name)?;
         } else if args.get_flag("show-current") {
-            self.show_current_branch(&repo)
+            self.show_current_branch(&repo)?;
         } else {
             // If in remote mode, include the head commit id for each branch
             if repo.is_remote_mode() {
-                self.list_branches_with_commits(&repo)
+                self.list_branches_with_commits(&repo)?;
             } else {
-                self.list_branches(&repo)
+                self.list_branches(&repo)?;
             }
         }
+        Ok(())
     }
 }
 

--- a/crates/cli/src/cmd/checkout.rs
+++ b/crates/cli/src/cmd/checkout.rs
@@ -41,7 +41,7 @@ impl RunCmd for CheckoutCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Find the repository
         let repo = LocalRepository::from_current_dir()?;
 
@@ -50,15 +50,13 @@ impl RunCmd for CheckoutCmd {
             self.create_checkout_branch(&repo, name)?
         } else if args.get_flag("ours") {
             let Some(name) = args.get_one::<String>("name") else {
-                return Err(OxenError::basic_str(
-                    "Err: Usage `oxen checkout --ours <name>`",
-                ));
+                return Err(anyhow::anyhow!("Err: Usage `oxen checkout --ours <name>`",));
             };
 
             self.checkout_ours(&repo, name).await?
         } else if args.get_flag("theirs") {
             let Some(name) = args.get_one::<String>("name") else {
-                return Err(OxenError::basic_str(
+                return Err(anyhow::anyhow!(
                     "Err: Usage `oxen checkout --theirs <name>`",
                 ));
             };

--- a/crates/cli/src/cmd/clean.rs
+++ b/crates/cli/src/cmd/clean.rs
@@ -43,7 +43,7 @@ impl RunCmd for CleanCmd {
             )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repository = LocalRepository::from_current_dir()?;
         check_repo_migration_needed(&repository)?;
 

--- a/crates/cli/src/cmd/clone.rs
+++ b/crates/cli/src/cmd/clone.rs
@@ -85,7 +85,7 @@ impl RunCmd for CloneCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let url = args.get_one::<String>("URL").expect("required");
         let all = args.get_flag("all");
@@ -118,14 +118,14 @@ impl RunCmd for CloneCmd {
                 if path.is_absolute()
                     || path.components().any(|c| matches!(c, Component::ParentDir))
                 {
-                    return Err(OxenError::basic_str(
+                    return Err(anyhow::anyhow!(
                         "Invalid destination: absolute paths or '..' not allowed",
                     ));
                 }
 
                 let joined = current_dir.join(path);
                 if !joined.starts_with(&current_dir) {
-                    return Err(OxenError::basic_str(
+                    return Err(anyhow::anyhow!(
                         "Invalid destination: path escapes base directory",
                     ));
                 }

--- a/crates/cli/src/cmd/commit.rs
+++ b/crates/cli/src/cmd/commit.rs
@@ -4,7 +4,6 @@ use std::io::Write;
 use tempfile::TempDir;
 
 use liboxen::config::UserConfig;
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
@@ -40,7 +39,7 @@ impl RunCmd for CommitCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let message = match args.get_one::<String>("message") {
             Some(msg) => msg.clone(),
             None => get_message_from_editor(UserConfig::get().ok().as_ref())?,
@@ -89,9 +88,9 @@ fn resolve_editor(maybe_config: Option<&UserConfig>) -> Option<String> {
     None
 }
 
-fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, OxenError> {
+fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, anyhow::Error> {
     let editor = resolve_editor(maybe_config).ok_or_else(|| {
-        OxenError::basic_str(
+        anyhow::anyhow!(
             "No editor is configured and no commit message was provided via -m.\n\n\
              To set your preferred editor, run:\n    \
              oxen config --editor <EDITOR>\n\n\
@@ -124,7 +123,7 @@ fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, 
     // Split the editor string to support commands like "code --wait"
     let parts: Vec<&str> = editor.split_whitespace().collect();
     if parts.is_empty() {
-        return Err(OxenError::basic_str(
+        return Err(anyhow::anyhow!(
             "Must supply valid editor path, not an empty/whitespace-only string.",
         ));
     }
@@ -134,9 +133,9 @@ fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, 
         .status()?;
 
     if !status.success() {
-        return Err(OxenError::basic_str(format!(
+        return Err(anyhow::anyhow!(
             "Editor '{editor}' exited with non-zero status."
-        )));
+        ));
     }
 
     // Read the file and strip comments
@@ -151,7 +150,7 @@ fn get_message_from_editor(maybe_config: Option<&UserConfig>) -> Result<String, 
     let message = message.trim().to_string();
 
     if message.is_empty() {
-        return Err(OxenError::basic_str(
+        return Err(anyhow::anyhow!(
             "Aborting commit due to empty commit message.",
         ));
     }

--- a/crates/cli/src/cmd/config.rs
+++ b/crates/cli/src/cmd/config.rs
@@ -75,7 +75,7 @@ impl RunCmd for ConfigCmd {
             .arg_required_else_help(true)
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Non-Repo Dependent
         if let Some(name) = args.get_one::<String>("name") {
             self.set_user_name(name)?;
@@ -117,11 +117,11 @@ impl RunCmd for ConfigCmd {
 }
 
 impl ConfigCmd {
-    fn strip_host(host: &str) -> Result<String, OxenError> {
+    fn strip_host(host: &str) -> Result<String, anyhow::Error> {
         if host.contains("://") {
             Ok(url::Url::parse(host)?
                 .host_str()
-                .ok_or_else(|| OxenError::basic_str("Unable to parse host."))?
+                .ok_or_else(|| anyhow::anyhow!("Unable to parse host."))?
                 .to_string())
         } else {
             Ok(host.to_string())
@@ -145,7 +145,7 @@ impl ConfigCmd {
         Ok(())
     }
 
-    pub fn set_auth_token(&self, host: &str, token: &str) -> Result<(), OxenError> {
+    pub fn set_auth_token(&self, host: &str, token: &str) -> Result<(), anyhow::Error> {
         let host = Self::strip_host(host)?;
         let mut config = AuthConfig::get_or_create()?;
         config.add_host_auth_token(host.as_ref(), token);
@@ -154,7 +154,7 @@ impl ConfigCmd {
         Ok(())
     }
 
-    pub fn set_default_host(&self, host: &str) -> Result<(), OxenError> {
+    pub fn set_default_host(&self, host: &str) -> Result<(), anyhow::Error> {
         let host = Self::strip_host(host)?;
         let mut config = AuthConfig::get_or_create()?;
         if host.is_empty() {

--- a/crates/cli/src/cmd/create_remote.rs
+++ b/crates/cli/src/cmd/create_remote.rs
@@ -9,13 +9,14 @@ use liboxen::api;
 use liboxen::api::requests::RepoNew;
 use liboxen::config::UserConfig;
 use liboxen::constants::{DEFAULT_HOST, DEFAULT_SCHEME};
-use liboxen::error::OxenError;
 use liboxen::model::file::{FileContents, FileNew};
 use liboxen::storage::StorageKind;
 
 use crate::cmd::RunCmd;
-pub const NAME: &str = "create-remote";
+
 pub struct CreateRemoteCmd;
+
+const NAME: &str = "create-remote";
 
 #[async_trait]
 impl RunCmd for CreateRemoteCmd {
@@ -69,10 +70,10 @@ impl RunCmd for CreateRemoteCmd {
         )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let Some(namespace_name) = args.get_one::<String>("name") else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Must supply a namespace/name for the remote repository.",
             ));
         };
@@ -96,13 +97,19 @@ impl RunCmd for CreateRemoteCmd {
         // The format is namespace/name
         let parts: Vec<&str> = namespace_name.split('/').collect();
         if parts.len() != 2 {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Invalid name format. Must be namespace/name",
             ));
         }
 
         let namespace = parts[0];
         let name = parts[1];
+        if namespace.is_empty() || name.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Invalid name format. Neither namespace ({namespace}) nor name ({name}) can be empty.",
+            ));
+        }
+
         let empty = !args.get_flag("add_readme");
         let is_public = args.get_flag("is_public");
 

--- a/crates/cli/src/cmd/db.rs
+++ b/crates/cli/src/cmd/db.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use clap::Command;
-use liboxen::error::OxenError;
 
-use crate::cmd::RunCmd;
+use crate::{
+    cli_error::UnknownSubcommand,
+    cmd::{RunCmd, Runners},
+};
 
 pub const NAME: &str = "db";
 
@@ -38,12 +40,15 @@ impl RunCmd for DbCmd {
         command
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let sub_commands = self.get_subcommands();
         if let Some((name, sub_matches)) = args.subcommand() {
             let Some(cmd) = sub_commands.get(name) else {
-                return Err(OxenError::unknown_subcommand("db", name));
+                return Err(UnknownSubcommand {
+                    parent: "db",
+                    name: name.to_string(),
+                })?;
             };
 
             // Calling await within an await is making it complain?
@@ -51,7 +56,7 @@ impl RunCmd for DbCmd {
                 tokio::runtime::Handle::current().block_on(cmd.run(sub_matches))
             })?;
         } else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "No db subcommand provided. Run `oxen db --help` for usage.",
             ));
         }
@@ -61,13 +66,13 @@ impl RunCmd for DbCmd {
 }
 
 impl DbCmd {
-    fn get_subcommands(&self) -> HashMap<String, Box<dyn RunCmd>> {
-        let commands: Vec<Box<dyn RunCmd>> = vec![
+    fn get_subcommands(&self) -> Runners {
+        let commands: [Box<dyn RunCmd>; 3] = [
             Box::new(DbListCmd),
             Box::new(DbGetCmd),
             Box::new(DbCountCmd),
         ];
-        let mut runners: HashMap<String, Box<dyn RunCmd>> = HashMap::new();
+        let mut runners = HashMap::new();
         for cmd in commands {
             runners.insert(cmd.name().to_string(), cmd);
         }

--- a/crates/cli/src/cmd/db/count.rs
+++ b/crates/cli/src/cmd/db/count.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use clap::{Arg, Command};
 
 use liboxen::command;
-use liboxen::error::OxenError;
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "count";
@@ -24,10 +23,10 @@ impl RunCmd for DbCountCmd {
             .arg(Arg::new("PATH").help("The path of the database."))
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str("Must supply path"));
+            return Err(anyhow::anyhow!("Must supply path"));
         };
 
         let count = command::db::count(PathBuf::from(path))?;

--- a/crates/cli/src/cmd/db/get.rs
+++ b/crates/cli/src/cmd/db/get.rs
@@ -1,10 +1,14 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::{command, error::OxenError};
+use liboxen::command;
 
 use crate::cmd::RunCmd;
-pub const NAME: &str = "get";
+
 pub struct DbGetCmd;
+
+const NAME: &str = "get";
+
+const ERROR_USE: &str = "Usage: oxen db get <PATH> <KEY>";
 
 #[async_trait]
 impl RunCmd for DbGetCmd {
@@ -27,14 +31,14 @@ impl RunCmd for DbGetCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
-        let error = "Usage: oxen db get <PATH> <KEY>";
+
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str(error));
+            return Err(anyhow::anyhow!(ERROR_USE));
         };
         let Some(key) = args.get_one::<String>("KEY") else {
-            return Err(OxenError::basic_str(error));
+            return Err(anyhow::anyhow!(ERROR_USE));
         };
 
         let dtype = args.get_one::<String>("dtype").map(|x| x.as_str());

--- a/crates/cli/src/cmd/db/list.rs
+++ b/crates/cli/src/cmd/db/list.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use clap::{Arg, Command};
 
 use liboxen::command;
-use liboxen::error::OxenError;
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "list";
@@ -30,10 +29,10 @@ impl RunCmd for DbListCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str("Must supply path"));
+            return Err(anyhow::anyhow!("Must supply path"));
         };
 
         let limit = args

--- a/crates/cli/src/cmd/delete_remote.rs
+++ b/crates/cli/src/cmd/delete_remote.rs
@@ -1,14 +1,15 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use clap::{Arg, Command};
-
 use dialoguer::Confirm;
 use liboxen::api;
 use liboxen::constants::DEFAULT_HOST;
-use liboxen::error::OxenError;
 
 use crate::cmd::RunCmd;
-pub const NAME: &str = "delete-remote";
+
 pub struct DeleteRemoteCmd;
+
+const NAME: &str = "delete-remote";
 
 #[async_trait]
 impl RunCmd for DeleteRemoteCmd {
@@ -49,10 +50,10 @@ impl RunCmd for DeleteRemoteCmd {
         )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let Some(namespace_name) = args.get_one::<String>("name") else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Must supply a namespace/name for the remote repository.",
             ));
         };
@@ -87,10 +88,8 @@ impl RunCmd for DeleteRemoteCmd {
                 Ok(false) => {
                     return Ok(());
                 }
-                Err(e) => {
-                    return Err(OxenError::basic_str(format!(
-                        "Error confirming deletion: {e}"
-                    )));
+                error => {
+                    error.context("Error confirming deletion.")?;
                 }
             }
         } else {

--- a/crates/cli/src/cmd/df.rs
+++ b/crates/cli/src/cmd/df.rs
@@ -245,11 +245,11 @@ impl RunCmd for DFCmd {
         )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let mut opts = DFCmd::parse_df_args(args)?;
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str("Must supply a DataFrame to process."));
+            return Err(anyhow::anyhow!("Must supply a DataFrame to process."));
         };
         opts.path = Some(PathBuf::from(path));
 

--- a/crates/cli/src/cmd/diff.rs
+++ b/crates/cli/src/cmd/diff.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use clap::{Arg, Command};
 use colored::ColoredString;
@@ -15,18 +16,18 @@ use liboxen::opts::DiffOpts;
 use liboxen::repositories;
 
 use crate::cmd::RunCmd;
-pub const NAME: &str = "diff";
-pub const DIFFSEP: &str = "..";
+
 pub struct DiffCmd;
 
-fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
-    write!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
+const NAME: &str = "diff";
+const DIFFSEP: &str = "..";
+
+fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), anyhow::Error> {
+    write!(output, "{text}").context("Could not write to pager.")
 }
 
-fn writeln_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
-    writeln!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
+fn writeln_to_pager(output: &mut Pager, text: &str) -> Result<(), anyhow::Error> {
+    writeln!(output, "{text}").context("Could not write to pager.")
 }
 
 #[async_trait]
@@ -80,7 +81,7 @@ impl RunCmd for DiffCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let opts = DiffCmd::parse_args(args);
         let output = opts.output.clone();
@@ -217,7 +218,7 @@ impl DiffCmd {
         }
     }
 
-    pub fn print_diff_result(results: &Vec<DiffResult>) -> Result<(), OxenError> {
+    pub fn print_diff_result(results: &Vec<DiffResult>) -> Result<(), anyhow::Error> {
         let mut p = Pager::new();
 
         for result in results {
@@ -252,7 +253,7 @@ impl DiffCmd {
         Ok(())
     }
 
-    fn print_row_changes(p: &mut Pager, mods: &TabularDiffMods) -> Result<(), OxenError> {
+    fn print_row_changes(p: &mut Pager, mods: &TabularDiffMods) -> Result<(), anyhow::Error> {
         let mut outputs: Vec<ColoredString> = vec![];
 
         if mods.row_counts.modified + mods.row_counts.added + mods.row_counts.removed == 0 {
@@ -283,7 +284,7 @@ impl DiffCmd {
     }
 
     // TODO: Truncate to "and x more"
-    fn print_column_changes(p: &mut Pager, mods: &TabularDiffMods) -> Result<(), OxenError> {
+    fn print_column_changes(p: &mut Pager, mods: &TabularDiffMods) -> Result<(), anyhow::Error> {
         let mut outputs: Vec<ColoredString> = vec![];
 
         if !mods.col_changes.added.is_empty() || !mods.col_changes.added.is_empty() {
@@ -305,7 +306,7 @@ impl DiffCmd {
         Ok(())
     }
 
-    fn print_text_diff(p: &mut Pager, diff: &TextDiff) -> Result<(), OxenError> {
+    fn print_text_diff(p: &mut Pager, diff: &TextDiff) -> Result<(), anyhow::Error> {
         let filename1 = diff.filename1.clone();
         let filename2 = diff.filename2.clone();
 

--- a/crates/cli/src/cmd/download.rs
+++ b/crates/cli/src/cmd/download.rs
@@ -5,7 +5,6 @@ use clap::{Arg, Command};
 
 use liboxen::api;
 use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_HOST, DEFAULT_SCHEME};
-use liboxen::error::OxenError;
 use std::path::PathBuf;
 
 use liboxen::repositories;
@@ -59,14 +58,14 @@ impl RunCmd for DownloadCmd {
         )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse args
         let id = args
             .get_one::<String>("ID")
             .expect("Must supply a repository id");
         // Check that the id format is namespace/repo-name
         if id.chars().filter(|&c| c == '/').count() != 1 {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Invalid repository ID format. Must be namespace/repo-name",
             ));
         }
@@ -76,7 +75,7 @@ impl RunCmd for DownloadCmd {
             .map(PathBuf::from)
             .collect();
         if paths.is_empty() {
-            return Err(OxenError::basic_str("Must supply a path to download."));
+            return Err(anyhow::anyhow!("Must supply a path to download."));
         }
         let dst = args
             .get_one::<String>("output")

--- a/crates/cli/src/cmd/embeddings.rs
+++ b/crates/cli/src/cmd/embeddings.rs
@@ -2,9 +2,10 @@ use async_trait::async_trait;
 use clap::Command;
 use std::collections::HashMap;
 
-use liboxen::error::OxenError;
-
-use crate::cmd::RunCmd;
+use crate::{
+    cli_error::UnknownSubcommand,
+    cmd::{RunCmd, Runners},
+};
 pub const NAME: &str = "embeddings";
 
 pub mod index;
@@ -34,11 +35,14 @@ impl RunCmd for EmbeddingsCmd {
         command
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let sub_commands = self.get_subcommands();
         if let Some((name, sub_matches)) = args.subcommand() {
             let Some(cmd) = sub_commands.get(name) else {
-                return Err(OxenError::unknown_subcommand("embeddings", name));
+                return Err(UnknownSubcommand {
+                    parent: "embeddings",
+                    name: name.to_string(),
+                })?;
             };
 
             // Calling await within an await is making it complain?
@@ -51,10 +55,10 @@ impl RunCmd for EmbeddingsCmd {
 }
 
 impl EmbeddingsCmd {
-    fn get_subcommands(&self) -> HashMap<String, Box<dyn RunCmd>> {
-        let commands: Vec<Box<dyn RunCmd>> =
-            vec![Box::new(EmbeddingsIndexCmd), Box::new(EmbeddingsQueryCmd)];
-        let mut runners: HashMap<String, Box<dyn RunCmd>> = HashMap::new();
+    fn get_subcommands(&self) -> Runners {
+        let commands: [Box<dyn RunCmd>; 2] =
+            [Box::new(EmbeddingsIndexCmd), Box::new(EmbeddingsQueryCmd)];
+        let mut runners = HashMap::new();
         for cmd in commands {
             runners.insert(cmd.name().to_string(), cmd);
         }

--- a/crates/cli/src/cmd/embeddings/index.rs
+++ b/crates/cli/src/cmd/embeddings/index.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
@@ -37,19 +36,19 @@ impl RunCmd for EmbeddingsIndexCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let path = args.get_one::<String>("PATH");
         let column = args.get_one::<String>("column");
 
         let err_msg = "Must supply a path to the data frame.";
         let Some(path) = path else {
-            return Err(OxenError::basic_str(err_msg));
+            return Err(anyhow::anyhow!(err_msg));
         };
 
         let err_msg = "Must supply a column name.";
         let Some(column) = column else {
-            return Err(OxenError::basic_str(err_msg));
+            return Err(anyhow::anyhow!(err_msg));
         };
 
         let use_background_thread = args.get_flag("use-background-thread");
@@ -75,7 +74,7 @@ impl RunCmd for EmbeddingsIndexCmd {
             )?;
             Ok(())
         } else {
-            Err(OxenError::basic_str("Data frame is already indexed."))
+            Err(anyhow::anyhow!("Data frame is already indexed."))
         }
     }
 }

--- a/crates/cli/src/cmd/embeddings/query.rs
+++ b/crates/cli/src/cmd/embeddings/query.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 use liboxen::constants::{DEFAULT_PAGE_NUM, DEFAULT_PAGE_SIZE};
 use liboxen::core::df::tabular;
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::opts::{EmbeddingQueryOpts, PaginateOpts};
 use liboxen::repositories;
@@ -61,23 +60,21 @@ impl RunCmd for EmbeddingsQueryCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let path = args.get_one::<String>("PATH");
         let column = args.get_one::<String>("column");
 
         let Some(path) = path else {
-            return Err(OxenError::basic_str(
-                "Must supply a path to the data frame.",
-            ));
+            return Err(anyhow::anyhow!("Must supply a path to the data frame."));
         };
 
         let Some(column) = column else {
-            return Err(OxenError::basic_str("Must supply a column name."));
+            return Err(anyhow::anyhow!("Must supply a column name."));
         };
 
         let Some(query) = args.get_one::<String>("query") else {
-            return Err(OxenError::basic_str("Must supply a query."));
+            return Err(anyhow::anyhow!("Must supply a query."));
         };
 
         let page_size = args
@@ -101,18 +98,14 @@ impl RunCmd for EmbeddingsQueryCmd {
         };
 
         if opts.parse_query().is_err() {
-            return Err(OxenError::basic_str(
-                "Query must be in the format key=value",
-            ));
+            return Err(anyhow::anyhow!("Query must be in the format key=value"));
         }
 
         let repository = LocalRepository::from_current_dir()?;
         let commit = repositories::commits::head_commit(&repository)?;
         let workspace_id = format!("{}-{}", path, commit.id);
         let Some(workspace) = repositories::workspaces::get(&repository, &workspace_id)? else {
-            return Err(OxenError::basic_str(format!(
-                "Workspace not found: {workspace_id}"
-            )));
+            return Err(anyhow::anyhow!("Workspace not found: {workspace_id}"));
         };
 
         let start = std::time::Instant::now();

--- a/crates/cli/src/cmd/fetch.rs
+++ b/crates/cli/src/cmd/fetch.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::opts::fetch_opts::FetchOpts;
 use liboxen::repositories;
@@ -43,7 +42,7 @@ impl RunCmd for FetchCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let repository = LocalRepository::from_current_dir()?;
         let (scheme, host) = get_scheme_and_host_from_repo(&repository)?;
 

--- a/crates/cli/src/cmd/fsck.rs
+++ b/crates/cli/src/cmd/fsck.rs
@@ -59,15 +59,18 @@ impl RunCmd for FsckCmd {
         fsck_args()
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repository = LocalRepository::from_current_dir()?;
         check_repo_migration_needed(&repository)?;
 
         match args.subcommand() {
-            Some(("clean", sub_args)) => run_clean(&repository, sub_args).await,
-            Some(("rebuild-dir-hashes", sub_args)) => run_rebuild_dir_hashes(&repository, sub_args),
+            Some(("clean", sub_args)) => run_clean(&repository, sub_args).await?,
+            Some(("rebuild-dir-hashes", sub_args)) => {
+                run_rebuild_dir_hashes(&repository, sub_args)?
+            }
             _ => unreachable!("clap enforces subcommand_required(true)"),
         }
+        Ok(())
     }
 }
 

--- a/crates/cli/src/cmd/info.rs
+++ b/crates/cli/src/cmd/info.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use std::path::PathBuf;
 
@@ -37,13 +36,13 @@ impl RunCmd for InfoCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse args
         let path = args.get_one::<String>("path").map(PathBuf::from);
         let revision = args.get_one::<String>("revision").map(String::from);
 
         if path.is_none() {
-            return Err(OxenError::basic_str("Must supply path."));
+            return Err(anyhow::anyhow!("Must supply path."));
         }
 
         let path = path.unwrap();

--- a/crates/cli/src/cmd/init.rs
+++ b/crates/cli/src/cmd/init.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 use liboxen::config::repository_config::{MerkleStoreKind, RepoConfigError};
 use liboxen::core::versions::MinOxenVersion;
-use liboxen::error::OxenError;
 use strum::VariantNames;
 
 use crate::cmd::RunCmd;
@@ -59,7 +58,7 @@ impl RunCmd for InitCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         //
         // parse args
         //

--- a/crates/cli/src/cmd/load.rs
+++ b/crates/cli/src/cmd/load.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::error::OxenError;
 use std::path::Path;
 
 use liboxen::repositories;
@@ -34,7 +33,7 @@ impl RunCmd for LoadCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Match on both SRC_PATH and DEST_PATH
         let src_path_str = args.get_one::<String>("SRC_PATH").expect("required");
         let dest_path_str = args.get_one::<String>("DEST_PATH").expect("required");

--- a/crates/cli/src/cmd/log.rs
+++ b/crates/cli/src/cmd/log.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 use colored::Colorize;
@@ -5,17 +6,17 @@ use minus::Pager;
 use std::fmt::Write;
 use time::format_description;
 
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
 use crate::cmd::RunCmd;
-pub const NAME: &str = "log";
+
 pub struct LogCmd;
 
-fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
-    writeln!(output, "{text}")
-        .map_err(|e| OxenError::basic_str(format!("Could not write to pager: {e}")))
+const NAME: &str = "log";
+
+fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), anyhow::Error> {
+    writeln!(output, "{text}").context("Could not write to pager.")
 }
 
 #[async_trait]
@@ -42,7 +43,7 @@ impl RunCmd for LogCmd {
             )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         // Look up from the current dir for .oxen directory
         let repo = LocalRepository::from_current_dir()?;
 
@@ -64,7 +65,7 @@ impl LogCmd {
         repo: &LocalRepository,
         revision: Option<String>,
         num_commits: usize,
-    ) -> Result<(), OxenError> {
+    ) -> Result<(), anyhow::Error> {
         let revision = match revision {
             Some(revision) => revision,
             None => repositories::commits::head_commit(repo)?.id,

--- a/crates/cli/src/cmd/ls.rs
+++ b/crates/cli/src/cmd/ls.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::error::OxenError;
 use liboxen::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
 use liboxen::model::staged_data::StagedDataOpts;
 use liboxen::model::{LocalRepository, StagedData, StagedEntry, StagedEntryStatus};
@@ -43,7 +42,7 @@ impl RunCmd for LsCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let repo = LocalRepository::from_current_dir()?;
 
         // Early exit for non-remote-mode repositories
@@ -62,9 +61,7 @@ impl RunCmd for LsCmd {
             repositories::commits::head_commit(&repo)?
         } else {
             let Some(commit) = repositories::commits::get_by_id(&repo, commit_id)? else {
-                return Err(OxenError::basic_str(format!(
-                    "Commit {commit_id} not found"
-                )));
+                return Err(anyhow::anyhow!("Commit {commit_id} not found"));
             };
             commit
         };

--- a/crates/cli/src/cmd/merge.rs
+++ b/crates/cli/src/cmd/merge.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 
 use liboxen::repositories;
@@ -33,12 +32,12 @@ impl RunCmd for MergeCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let repository = LocalRepository::from_current_dir()?;
 
         // Don't allow in remote mode
         if repository.is_remote_mode() {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Error: Command 'oxen merge' not implemented for remote mode repositories",
             ));
         }
@@ -56,15 +55,13 @@ impl RunCmd for MergeCmd {
         let current = if let Some(current) = repositories::branches::current_branch(&repository)? {
             current
         } else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Error: Cannot use 'oxen merge' in an empty repository",
             ));
         };
 
         if current.name == *branch {
-            return Err(OxenError::basic_str(
-                "Error: Cannot merge into current branch",
-            ));
+            return Err(anyhow::anyhow!("Error: Cannot merge into current branch",));
         }
 
         repositories::merge::merge(&repository, branch).await?;

--- a/crates/cli/src/cmd/migrate.rs
+++ b/crates/cli/src/cmd/migrate.rs
@@ -74,13 +74,13 @@ impl RunCmd for MigrateCmd {
             .subcommand(subcommands("down", "Apply a named migration backward."))
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         if let Some((direction, sub_matches)) = args.subcommand()
             && let Some((migration, sub_matches)) = sub_matches.subcommand()
         {
             let Some(migration) = all_migrations(migration) else {
-                return Err(OxenError::UnknownMigration(migration.to_string()));
+                return Err(OxenError::UnknownMigration(migration.to_string()))?;
             };
 
             let direction = Direction::from_str(direction)?;
@@ -109,7 +109,7 @@ impl RunCmd for MigrateCmd {
                     for (repo_path, error) in errored {
                         println!("\t[FAIL] \"{}\" due to: {error}", repo_path.display());
                     }
-                    return Err(OxenError::MigrationFailed);
+                    return Err(OxenError::MigrationFailed)?;
                 }
             } else {
                 let mr = try_apply_migration(

--- a/crates/cli/src/cmd/moo.rs
+++ b/crates/cli/src/cmd/moo.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::error::OxenError;
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "moo";
@@ -33,7 +32,7 @@ impl RunCmd for MooCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let n = args
             .get_one::<String>("number")

--- a/crates/cli/src/cmd/node.rs
+++ b/crates/cli/src/cmd/node.rs
@@ -55,7 +55,7 @@ impl RunCmd for NodeCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Find the repository
         let repository = LocalRepository::from_current_dir()?;
 
@@ -70,7 +70,7 @@ impl RunCmd for NodeCmd {
             let path = Path::new(path);
             let Some(node) = repositories::tree::get_node_by_path(&repository, &commit, path)?
             else {
-                return Err(OxenError::entry_does_not_exist_in_commit(path, &commit.id));
+                return Err(OxenError::entry_does_not_exist_in_commit(path, &commit.id))?;
             };
 
             println!("{node:?}");
@@ -88,7 +88,7 @@ impl RunCmd for NodeCmd {
             let Some(node) = repositories::tree::get_node_by_id(&repository, &node_hash)? else {
                 return Err(OxenError::resource_not_found(format!(
                     "Node {node_hash} not found in repo"
-                )));
+                )))?;
             };
 
             println!("{node:?}");
@@ -99,7 +99,7 @@ impl RunCmd for NodeCmd {
                 }
             }
         } else {
-            return Err(OxenError::basic_str("Must supply file path or node hash"));
+            return Err(anyhow::anyhow!("Must supply file path or node hash"));
         }
 
         Ok(())

--- a/crates/cli/src/cmd/prune.rs
+++ b/crates/cli/src/cmd/prune.rs
@@ -44,7 +44,7 @@ impl RunCmd for PruneCmd {
         prune_args()
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repository = LocalRepository::from_current_dir()?;
         check_repo_migration_needed(&repository)?;
 

--- a/crates/cli/src/cmd/pull.rs
+++ b/crates/cli/src/cmd/pull.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
 use liboxen::model::LocalRepository;
-use liboxen::{error::OxenError, opts::FetchOpts};
+use liboxen::opts::FetchOpts;
 
 use liboxen::repositories;
 
@@ -48,7 +48,7 @@ impl RunCmd for PullCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let repo = LocalRepository::from_current_dir()?;
         let current_branch = repositories::branches::current_branch(&repo)?;
 

--- a/crates/cli/src/cmd/push.rs
+++ b/crates/cli/src/cmd/push.rs
@@ -63,7 +63,7 @@ impl RunCmd for PushCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse args
         let remote = args
             .get_one::<String>("REMOTE")
@@ -91,7 +91,7 @@ impl RunCmd for PushCmd {
         } else if let Some(branch) = current_branch {
             branch.name
         } else {
-            return Err(OxenError::must_be_on_valid_branch());
+            return Err(OxenError::must_be_on_valid_branch())?;
         };
 
         let opts = PushOpts {

--- a/crates/cli/src/cmd/remote.rs
+++ b/crates/cli/src/cmd/remote.rs
@@ -24,7 +24,7 @@ impl RunCmd for RemoteCmd {
         )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let verbose = args.get_flag("verbose");
         if verbose {
             self.list_remotes_verbose()?;

--- a/crates/cli/src/cmd/remote_mode.rs
+++ b/crates/cli/src/cmd/remote_mode.rs
@@ -13,10 +13,9 @@ pub use status::RemoteModeStatusCmd;
 use async_trait::async_trait;
 use clap::Command;
 
-use liboxen::error::OxenError;
 use std::collections::HashMap;
 
-use crate::cmd::RunCmd;
+use crate::{Runners, cli_error::UnknownSubcommand, cmd::RunCmd};
 pub const NAME: &str = "remote_mode";
 pub struct RemoteModeCmd;
 
@@ -42,11 +41,14 @@ impl RunCmd for RemoteModeCmd {
 
     // Note: Currently, you can't run `oxen remote-mode status` or other subcommand from the command line
     // They're only accessible via their aliases in remote-mode repos
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let sub_commands = Self::get_subcommands();
         if let Some((name, sub_matches)) = args.subcommand() {
             let Some(cmd) = sub_commands.get(name) else {
-                return Err(OxenError::unknown_subcommand("remote mode", name));
+                return Err(UnknownSubcommand {
+                    parent: "remote mode",
+                    name: name.to_string(),
+                })?;
             };
 
             // Calling await within an await is making it complain?
@@ -59,14 +61,14 @@ impl RunCmd for RemoteModeCmd {
 }
 
 impl RemoteModeCmd {
-    fn get_subcommands() -> HashMap<String, Box<dyn RunCmd>> {
-        let commands: Vec<Box<dyn RunCmd>> = vec![
+    fn get_subcommands() -> Runners {
+        let commands: [Box<dyn RunCmd>; 4] = [
             Box::new(RemoteModeCheckoutCmd),
             Box::new(RemoteModeCommitCmd),
             Box::new(RemoteModeRestoreCmd),
             Box::new(RemoteModeStatusCmd),
         ];
-        let mut runners: HashMap<String, Box<dyn RunCmd>> = HashMap::new();
+        let mut runners = HashMap::new();
         for cmd in commands {
             runners.insert(cmd.name().to_string(), cmd);
         }
@@ -76,10 +78,13 @@ impl RemoteModeCmd {
     pub async fn run_subcommands(
         name: &str,
         sub_matches: &clap::ArgMatches,
-    ) -> Result<(), OxenError> {
+    ) -> Result<(), anyhow::Error> {
         let sub_commands = Self::get_subcommands();
         let Some(cmd) = sub_commands.get(name) else {
-            return Err(OxenError::unknown_subcommand("remote mode", name));
+            return Err(UnknownSubcommand {
+                parent: "remote mode",
+                name: name.to_string(),
+            })?;
         };
 
         tokio::task::block_in_place(|| {

--- a/crates/cli/src/cmd/remote_mode/checkout.rs
+++ b/crates/cli/src/cmd/remote_mode/checkout.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
 
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
@@ -34,7 +33,7 @@ impl RunCmd for RemoteModeCheckoutCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let mut repo = LocalRepository::from_current_dir()?;
 
         // Parse Args

--- a/crates/cli/src/cmd/remote_mode/commit.rs
+++ b/crates/cli/src/cmd/remote_mode/commit.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use clap::{Arg, Command};
 
 use liboxen::config::UserConfig;
-use liboxen::error::OxenError;
 use liboxen::model::{LocalRepository, NewCommitBody};
 use liboxen::repositories;
 
@@ -32,10 +31,10 @@ impl RunCmd for RemoteModeCommitCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let Some(message) = args.get_one::<String>("message") else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Err: Usage `oxen workspace commit -w <workspace_id> -m <message>`",
             ));
         };

--- a/crates/cli/src/cmd/remote_mode/restore.rs
+++ b/crates/cli/src/cmd/remote_mode/restore.rs
@@ -23,7 +23,7 @@ impl RunCmd for RemoteModeRestoreCmd {
     }
 
     // TODO: Support multiple paths
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let paths: Vec<PathBuf> = args
             .get_many::<String>("paths")
             .expect("Must supply paths")

--- a/crates/cli/src/cmd/remote_mode/status.rs
+++ b/crates/cli/src/cmd/remote_mode/status.rs
@@ -60,7 +60,7 @@ impl RunCmd for RemoteModeStatusCmd {
             )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let current_dir = std::env::current_dir().map_err(OxenError::from)?;
         let repo_dir = util::fs::get_repo_root_from_current_dir()
             .ok_or_else(|| OxenError::local_repo_not_found(&current_dir))?;
@@ -70,7 +70,7 @@ impl RunCmd for RemoteModeStatusCmd {
             repository.workspace_name.clone().unwrap()
         } else {
             // TODO: New error type
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "New err type, can't do rmeote mode command outside remote mode repo",
             ));
         };

--- a/crates/cli/src/cmd/restore.rs
+++ b/crates/cli/src/cmd/restore.rs
@@ -50,7 +50,7 @@ impl RunCmd for RestoreCmd {
         restore_args()
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repository = LocalRepository::from_current_dir()?;
         check_repo_migration_needed(&repository)?;
         let paths: Vec<PathBuf> = args

--- a/crates/cli/src/cmd/rm.rs
+++ b/crates/cli/src/cmd/rm.rs
@@ -47,7 +47,7 @@ impl RunCmd for RmCmd {
         rm_args()
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let paths: Vec<PathBuf> = args
             .get_many::<String>("files")
             .expect("Must supply files")

--- a/crates/cli/src/cmd/save.rs
+++ b/crates/cli/src/cmd/save.rs
@@ -34,7 +34,7 @@ impl RunCmd for SaveCmd {
             )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repo_str = args.get_one::<String>("PATH").expect("Required");
         let output_str = args.get_one::<String>("output").expect("Required");
 

--- a/crates/cli/src/cmd/schemas.rs
+++ b/crates/cli/src/cmd/schemas.rs
@@ -2,11 +2,11 @@ use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 use std::collections::HashMap;
 
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
-use crate::cmd::RunCmd;
+use crate::cli_error::UnknownSubcommand;
+use crate::cmd::{RunCmd, Runners};
 pub const NAME: &str = "schemas";
 
 pub mod add;
@@ -57,11 +57,14 @@ impl RunCmd for SchemasCmd {
         command
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let sub_commands = self.get_subcommands();
         if let Some((name, sub_matches)) = args.subcommand() {
             let Some(cmd) = sub_commands.get(name) else {
-                return Err(OxenError::unknown_subcommand("schemas", name));
+                return Err(UnknownSubcommand {
+                    parent: "schemas",
+                    name: name.to_string(),
+                })?;
             };
 
             // Calling await within an await is making it complain?
@@ -78,7 +81,10 @@ impl RunCmd for SchemasCmd {
         } else {
             // Fall back to list schemas
             let Some(cmd) = sub_commands.get("list") else {
-                return Err(OxenError::unknown_subcommand("schemas", "list"));
+                return Err(UnknownSubcommand {
+                    parent: "schemas",
+                    name: "list".to_string(),
+                })?;
             };
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(cmd.run(args))
@@ -89,14 +95,14 @@ impl RunCmd for SchemasCmd {
 }
 
 impl SchemasCmd {
-    fn get_subcommands(&self) -> HashMap<String, Box<dyn RunCmd>> {
-        let commands: Vec<Box<dyn RunCmd>> = vec![
+    fn get_subcommands(&self) -> Runners {
+        let commands: [Box<dyn RunCmd>; 4] = [
             Box::new(SchemasAddCmd),
             Box::new(SchemasListCmd),
             Box::new(SchemasRmCmd),
             Box::new(SchemasShowCmd),
         ];
-        let mut runners: HashMap<String, Box<dyn RunCmd>> = HashMap::new();
+        let mut runners = HashMap::new();
         for cmd in commands {
             runners.insert(cmd.name().to_string(), cmd);
         }

--- a/crates/cli/src/cmd/schemas/add.rs
+++ b/crates/cli/src/cmd/schemas/add.rs
@@ -9,6 +9,7 @@ use liboxen::repositories;
 
 use crate::cmd::RunCmd;
 use crate::util;
+use anyhow::Context;
 pub const NAME: &str = "add";
 
 pub struct SchemasAddCmd;
@@ -43,7 +44,7 @@ impl RunCmd for SchemasAddCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         // Path
         let path = args
@@ -63,12 +64,12 @@ impl RunCmd for SchemasAddCmd {
         let err_msg = "Must supply a file path, column name and either -m for metadata or -t for data type\n\n  oxen schemas add file.csv -c 'col1' -t 'str'\n";
 
         let Some(path) = &path else {
-            return Err(OxenError::basic_str(err_msg));
+            return Err(anyhow::anyhow!(err_msg));
         };
 
         // If there is a render flag without a column, return an error
         if render.is_some() && column.is_none() {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Must supply a column name with the -c flag when using --render.",
             ));
         }
@@ -80,7 +81,7 @@ impl RunCmd for SchemasAddCmd {
         if let Some(column) = column {
             if let Some(render) = render {
                 let render_json = self.generate_render_json(render)?;
-                match self.schema_add_column_metadata(&repository, path, column, render_json) {
+                match self.schema_add_column_metadata(&repository, path, column, &render_json) {
                     Ok(_) => {}
                     Err(err) => {
                         eprintln!("{err}")
@@ -116,18 +117,13 @@ impl SchemasAddCmd {
     fn schema_add_column_metadata(
         &self,
         repository: &LocalRepository,
-        path: impl AsRef<Path>,
-        column: impl AsRef<str>,
-        metadata: impl AsRef<str>,
-    ) -> Result<(), OxenError> {
+        path: &Path,
+        column: &str,
+        metadata: &str,
+    ) -> Result<(), anyhow::Error> {
         // make sure metadata is valid json, return oxen error if not
-        let metadata: serde_json::Value = serde_json::from_str(metadata.as_ref()).map_err(|e| {
-            OxenError::basic_str(format!(
-                "Metadata must be valid JSON: '{}'\n{}",
-                metadata.as_ref(),
-                e
-            ))
-        })?;
+        let metadata: serde_json::Value = serde_json::from_str(metadata)
+            .with_context(|| format!("Metadata must be valid JSON: '{}'", metadata))?;
 
         for (path, schema) in repositories::data_frames::schemas::add_column_metadata(
             repository, path, column, &metadata,
@@ -141,16 +137,11 @@ impl SchemasAddCmd {
     fn schema_add_metadata(
         &self,
         repository: &LocalRepository,
-        path: impl AsRef<Path>,
-        metadata: impl AsRef<str>,
-    ) -> Result<(), OxenError> {
-        let metadata: serde_json::Value = serde_json::from_str(metadata.as_ref()).map_err(|e| {
-            OxenError::basic_str(format!(
-                "Metadata must be valid JSON: '{}'\n{}",
-                metadata.as_ref(),
-                e
-            ))
-        })?;
+        path: &Path,
+        metadata: &str,
+    ) -> Result<(), anyhow::Error> {
+        let metadata: serde_json::Value = serde_json::from_str(metadata)
+            .with_context(|| format!("Metadata must be valid JSON: '{}'", metadata))?;
 
         for (path, schema) in
             repositories::data_frames::schemas::add_schema_metadata(repository, path, &metadata)?
@@ -161,8 +152,7 @@ impl SchemasAddCmd {
         Ok(())
     }
 
-    fn generate_render_json(&self, render_type: impl AsRef<str>) -> Result<String, OxenError> {
-        let render_type = render_type.as_ref();
+    fn generate_render_json(&self, render_type: &str) -> Result<String, anyhow::Error> {
         let valid_render_types: HashSet<&str> = ["image", "link", "video"].into_iter().collect();
         if valid_render_types.contains(render_type) {
             let json = serde_json::json!({
@@ -175,9 +165,9 @@ impl SchemasAddCmd {
 
             Ok(serde_json::to_string(&json)?)
         } else {
-            Err(OxenError::basic_str(format!(
-                "Invalid render type: {render_type}"
-            )))
+            Err(anyhow::anyhow!(
+                "Invalid render type: \"{render_type}\" - Only accepts \"image\", \"link\", or \"video\"."
+            ))
         }
     }
 }

--- a/crates/cli/src/cmd/schemas/list.rs
+++ b/crates/cli/src/cmd/schemas/list.rs
@@ -29,7 +29,7 @@ impl RunCmd for SchemasListCmd {
         )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let staged = args.get_flag("staged");
 

--- a/crates/cli/src/cmd/schemas/rm.rs
+++ b/crates/cli/src/cmd/schemas/rm.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
@@ -29,12 +28,12 @@ impl RunCmd for SchemasRmCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let repository = LocalRepository::from_current_dir()?;
 
         let Some(schema_ref) = args.get_one::<String>("NAME_OR_HASH") else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Must supply a name, hash, or path of the schema you want to remove.",
             ));
         };

--- a/crates/cli/src/cmd/schemas/show.rs
+++ b/crates/cli/src/cmd/schemas/show.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
@@ -36,12 +35,12 @@ impl RunCmd for SchemasShowCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let repository = LocalRepository::from_current_dir()?;
 
         let Some(path) = args.get_one::<String>("PATH") else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Must supply a path of the schema you want to show.",
             ));
         };

--- a/crates/cli/src/cmd/status.rs
+++ b/crates/cli/src/cmd/status.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
 use glob::glob;
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::model::staged_data::StagedDataOpts;
 use liboxen::repositories;
@@ -62,7 +61,7 @@ impl RunCmd for StatusCmd {
             )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let skip = args
             .get_one::<String>("skip")
             .expect("Must supply skip")

--- a/crates/cli/src/cmd/tree.rs
+++ b/crates/cli/src/cmd/tree.rs
@@ -58,7 +58,7 @@ impl RunCmd for TreeCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let depth = args
             .get_one::<String>("depth")
@@ -74,7 +74,7 @@ impl RunCmd for TreeCmd {
             repositories::commits::head_commit(&repo)?
         } else {
             let Some(commit) = repositories::commits::get_by_id(&repo, commit_id)? else {
-                return Err(OxenError::commit_id_does_not_exist(commit_id));
+                return Err(OxenError::commit_id_does_not_exist(commit_id))?;
             };
             commit
         };
@@ -107,7 +107,7 @@ impl TreeCmd {
         commit: &Commit,
         path: Option<&String>,
         depth: i32,
-    ) -> Result<(), OxenError> {
+    ) -> Result<(), anyhow::Error> {
         let load_start = Instant::now(); // Start timing
         match (repo.subtree_paths(), repo.depth()) {
             (Some(subtrees), Some(depth)) => {
@@ -116,7 +116,7 @@ impl TreeCmd {
                 println!("Loading first tree...");
                 let first = subtrees
                     .first()
-                    .ok_or_else(|| OxenError::basic_str("No subtree paths configured"))?;
+                    .ok_or_else(|| anyhow::anyhow!("No subtree paths configured"))?;
                 repositories::tree::print_tree_depth_subtree(repo, commit, depth, first)?;
             }
             (_, _) => {

--- a/crates/cli/src/cmd/upload.rs
+++ b/crates/cli/src/cmd/upload.rs
@@ -5,7 +5,6 @@ use liboxen::api;
 use liboxen::constants::DEFAULT_HOST;
 use liboxen::constants::DEFAULT_REMOTE_NAME;
 use liboxen::constants::DEFAULT_SCHEME;
-use liboxen::error::OxenError;
 use liboxen::opts::UploadOpts;
 use liboxen::repositories;
 
@@ -72,7 +71,7 @@ impl RunCmd for UploadCmd {
         )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let opts = UploadOpts {
             paths: args
                 .get_many::<String>("paths")
@@ -104,8 +103,8 @@ impl RunCmd for UploadCmd {
 
         // `oxen upload $namespace/$repo_name $path`
         let paths = &opts.paths;
-        if paths.is_empty() {
-            return Err(OxenError::basic_str(
+        if paths.len() < 2 {
+            return Err(anyhow::anyhow!(
                 "Must supply repository and a file to upload.",
             ));
         }

--- a/crates/cli/src/cmd/workspace.rs
+++ b/crates/cli/src/cmd/workspace.rs
@@ -37,10 +37,12 @@ pub use status::WorkspaceStatusCmd;
 use async_trait::async_trait;
 use clap::Command;
 
-use liboxen::error::OxenError;
 use std::collections::HashMap;
 
-use crate::cmd::RunCmd;
+use crate::{
+    cli_error::UnknownSubcommand,
+    cmd::{RunCmd, Runners},
+};
 pub const NAME: &str = "workspace";
 pub struct WorkspaceCmd;
 
@@ -66,11 +68,14 @@ impl RunCmd for WorkspaceCmd {
         command
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         let sub_commands = Self::get_subcommands();
         if let Some((name, sub_matches)) = args.subcommand() {
             let Some(cmd) = sub_commands.get(name) else {
-                return Err(OxenError::unknown_subcommand("workspace", name));
+                return Err(UnknownSubcommand {
+                    parent: "workspace",
+                    name: name.to_string(),
+                })?;
             };
 
             // Calling await within an await is making it complain?
@@ -83,8 +88,8 @@ impl RunCmd for WorkspaceCmd {
 }
 
 impl WorkspaceCmd {
-    fn get_subcommands() -> HashMap<String, Box<dyn RunCmd>> {
-        let commands: Vec<Box<dyn RunCmd>> = vec![
+    fn get_subcommands() -> Runners {
+        let commands: [Box<dyn RunCmd>; 12] = [
             Box::new(WorkspaceAddCmd),
             Box::new(WorkspaceClearCmd),
             Box::new(WorkspaceCommitCmd),
@@ -98,7 +103,7 @@ impl WorkspaceCmd {
             Box::new(WorkspaceStatusCmd),
             Box::new(WorkspaceDownloadCmd),
         ];
-        let mut runners: HashMap<String, Box<dyn RunCmd>> = HashMap::new();
+        let mut runners = HashMap::new();
         for cmd in commands {
             runners.insert(cmd.name().to_string(), cmd);
         }
@@ -108,10 +113,13 @@ impl WorkspaceCmd {
     pub async fn run_subcommands(
         name: &str,
         sub_matches: &clap::ArgMatches,
-    ) -> Result<(), OxenError> {
+    ) -> Result<(), anyhow::Error> {
         let sub_commands = Self::get_subcommands();
         let Some(cmd) = sub_commands.get(name) else {
-            return Err(OxenError::unknown_subcommand("workspace", name));
+            return Err(UnknownSubcommand {
+                parent: "workspace",
+                name: name.to_string(),
+            })?;
         };
 
         tokio::task::block_in_place(|| {

--- a/crates/cli/src/cmd/workspace/add.rs
+++ b/crates/cli/src/cmd/workspace/add.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use clap::{Arg, ArgGroup, ArgMatches, Command};
 
-use liboxen::{api, core::oxenignore, error::OxenError, model::LocalRepository};
+use liboxen::{api, core::oxenignore, model::LocalRepository};
 
 use crate::cmd::{RunCmd, add::add_args};
 pub const NAME: &str = "add";
@@ -52,7 +52,7 @@ impl RunCmd for WorkspaceAddCmd {
             .arg_required_else_help(true)
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let mut paths: Vec<PathBuf> = args
             .get_many::<String>("files")
@@ -76,7 +76,7 @@ impl RunCmd for WorkspaceAddCmd {
                     if let Some(name) = workspace_name {
                         (name, directory.as_str())
                     } else {
-                        return Err(OxenError::basic_str(
+                        return Err(anyhow::anyhow!(
                             "Either workspace-id or workspace-name must be provided.",
                         ));
                     }
@@ -94,7 +94,7 @@ impl RunCmd for WorkspaceAddCmd {
 
         // If no paths left after filtering, return early
         if paths.is_empty() {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "No files to add after filtering with .oxenignore.",
             ));
         }

--- a/crates/cli/src/cmd/workspace/clear.rs
+++ b/crates/cli/src/cmd/workspace/clear.rs
@@ -1,13 +1,15 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use clap::{ArgMatches, Command};
-
 use dialoguer::Confirm;
 use liboxen::api;
 use liboxen::{error::OxenError, model::LocalRepository};
 
 use crate::cmd::RunCmd;
-pub const NAME: &str = "clear";
+
 pub struct WorkspaceClearCmd;
+
+const NAME: &str = "clear";
 
 #[async_trait]
 impl RunCmd for WorkspaceClearCmd {
@@ -25,7 +27,7 @@ impl RunCmd for WorkspaceClearCmd {
         )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repository = LocalRepository::from_current_dir()?;
         let remote_name = args.get_one::<String>("remote");
         let remote_repo = match remote_name {
@@ -53,10 +55,8 @@ impl RunCmd for WorkspaceClearCmd {
             Ok(false) => {
                 return Ok(());
             }
-            Err(e) => {
-                return Err(OxenError::basic_str(format!(
-                    "Error confirming deletion: {e}"
-                )));
+            error => {
+                error.context("Error confirming deletion.")?;
             }
         }
 

--- a/crates/cli/src/cmd/workspace/commit.rs
+++ b/crates/cli/src/cmd/workspace/commit.rs
@@ -3,7 +3,6 @@ use clap::{Arg, Command};
 
 use liboxen::api;
 use liboxen::config::UserConfig;
-use liboxen::error::OxenError;
 use liboxen::model::{LocalRepository, NewCommitBody};
 use liboxen::repositories;
 
@@ -53,10 +52,10 @@ impl RunCmd for WorkspaceCommitCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let Some(message) = args.get_one::<String>("message") else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Err: Usage `oxen workspace commit -w <workspace_id> -m <message>`",
             ));
         };
@@ -75,7 +74,7 @@ impl RunCmd for WorkspaceCommitCmd {
                     if let Some(name) = workspace_name {
                         name
                     } else {
-                        return Err(OxenError::basic_str(
+                        return Err(anyhow::anyhow!(
                             "Either workspace-id or workspace-name must be provided.",
                         ));
                     }
@@ -92,7 +91,7 @@ impl RunCmd for WorkspaceCommitCmd {
                 match repositories::branches::current_branch(&repo)? {
                     Some(branch) => branch.name,
                     None => {
-                        return Err(OxenError::basic_str(
+                        return Err(anyhow::anyhow!(
                             "No current branch. Use --branch to specify a target branch to commit the workspace to.",
                         ));
                     }

--- a/crates/cli/src/cmd/workspace/create.rs
+++ b/crates/cli/src/cmd/workspace/create.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
 use colored::Colorize;
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::{api, repositories};
 use uuid::Uuid;
@@ -36,7 +35,7 @@ impl RunCmd for WorkspaceCreateCmd {
             )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repo = LocalRepository::from_current_dir()?;
 
         let branch_name = match args.get_one::<String>("branch") {
@@ -46,7 +45,7 @@ impl RunCmd for WorkspaceCreateCmd {
                 match repositories::branches::current_branch(&repo)? {
                     Some(branch) => branch.name,
                     None => {
-                        return Err(OxenError::basic_str(
+                        return Err(anyhow::anyhow!(
                             "No current branch. Use --branch to specify a branch name.",
                         ));
                     }

--- a/crates/cli/src/cmd/workspace/delete.rs
+++ b/crates/cli/src/cmd/workspace/delete.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
 use liboxen::api;
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 
 use crate::cmd::RunCmd;
@@ -37,7 +36,7 @@ impl RunCmd for WorkspaceDeleteCmd {
             .arg_required_else_help(true)
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repo = LocalRepository::from_current_dir()?;
         let remote_repo = api::client::repositories::get_default_remote(&repo).await?;
         let workspace_name = args.get_one::<String>("workspace-name");
@@ -50,7 +49,7 @@ impl RunCmd for WorkspaceDeleteCmd {
                 if let Some(name) = workspace_name {
                     name
                 } else {
-                    return Err(OxenError::basic_str(
+                    return Err(anyhow::anyhow!(
                         "Either workspace-id or workspace-name must be provided.",
                     ));
                 }

--- a/crates/cli/src/cmd/workspace/df.rs
+++ b/crates/cli/src/cmd/workspace/df.rs
@@ -3,8 +3,6 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use clap::Command;
 
-use liboxen::error::OxenError;
-
 // subcommands
 pub mod get;
 use get::WorkspaceDFGetCmd;
@@ -12,7 +10,10 @@ use get::WorkspaceDFGetCmd;
 pub mod index;
 use index::WorkspaceDFIndexCmd;
 
-use crate::cmd::RunCmd;
+use crate::{
+    cli_error::UnknownSubcommand,
+    cmd::{RunCmd, Runners},
+};
 
 pub const NAME: &str = "df";
 pub struct WorkspaceDfCmd;
@@ -36,12 +37,15 @@ impl RunCmd for WorkspaceDfCmd {
         command
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let sub_commands = self.get_subcommands();
         if let Some((name, sub_matches)) = args.subcommand() {
             let Some(cmd) = sub_commands.get(name) else {
-                return Err(OxenError::unknown_subcommand("df", name));
+                return Err(UnknownSubcommand {
+                    parent: "df",
+                    name: name.to_string(),
+                })?;
             };
 
             // Calling await within an await is making it complain?
@@ -54,10 +58,10 @@ impl RunCmd for WorkspaceDfCmd {
 }
 
 impl WorkspaceDfCmd {
-    fn get_subcommands(&self) -> HashMap<String, Box<dyn RunCmd>> {
-        let commands: Vec<Box<dyn RunCmd>> =
-            vec![Box::new(WorkspaceDFIndexCmd), Box::new(WorkspaceDFGetCmd)];
-        let mut runners: HashMap<String, Box<dyn RunCmd>> = HashMap::new();
+    fn get_subcommands(&self) -> Runners {
+        let commands: [Box<dyn RunCmd>; 2] =
+            [Box::new(WorkspaceDFIndexCmd), Box::new(WorkspaceDFGetCmd)];
+        let mut runners = HashMap::new();
         for cmd in commands {
             runners.insert(cmd.name().to_string(), cmd);
         }

--- a/crates/cli/src/cmd/workspace/df/get.rs
+++ b/crates/cli/src/cmd/workspace/df/get.rs
@@ -80,15 +80,15 @@ impl RunCmd for WorkspaceDFGetCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let Some(path) = args.get_one::<String>("path") else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Must supply a path to the data frame you want to get.",
             ));
         };
         let Some(workspace_id) = args.get_one::<String>("workspace-id") else {
-            return Err(OxenError::basic_str("Must supply a workspace id."));
+            return Err(anyhow::anyhow!("Must supply a workspace id."));
         };
 
         let repository = LocalRepository::from_current_dir()?;
@@ -120,13 +120,13 @@ impl RunCmd for WorkspaceDFGetCmd {
                     println!("{df:?}");
                     println!("Query took: {:?}", start.elapsed());
                 } else {
-                    return Err(OxenError::basic_str(format!(
+                    return Err(anyhow::anyhow!(
                         "No data frame found. Index the data frame before querying.\n\n  oxen workspace df index {path} -w {workspace_id}\n"
-                    )));
+                    ));
                 }
             }
             Err(e) => {
-                return Err(e);
+                return Err(e)?;
             }
         }
 

--- a/crates/cli/src/cmd/workspace/df/index.rs
+++ b/crates/cli/src/cmd/workspace/df/index.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use clap::{Arg, Command};
 
 use liboxen::api;
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::opts::DFOpts;
 
@@ -53,14 +52,14 @@ impl RunCmd for WorkspaceDFIndexCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let Some(workspace_id) = args.get_one::<String>("workspace-id") else {
-            return Err(OxenError::basic_str("Must supply a workspace id."));
+            return Err(anyhow::anyhow!("Must supply a workspace id."));
         };
 
         let Some(path) = args.get_one::<String>("path") else {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "Must supply a path to the data frame you want to index.",
             ));
         };
@@ -88,7 +87,7 @@ impl RunCmd for WorkspaceDFIndexCmd {
 
         if args.get_flag("embeddings") {
             let Some(column) = args.get_one::<String>("column") else {
-                return Err(OxenError::basic_str(
+                return Err(anyhow::anyhow!(
                     "Must supply a column to index for embeddings.",
                 ));
             };

--- a/crates/cli/src/cmd/workspace/diff.rs
+++ b/crates/cli/src/cmd/workspace/diff.rs
@@ -5,7 +5,6 @@ use clap::Command;
 use liboxen::api;
 use liboxen::constants::DEFAULT_PAGE_NUM;
 use liboxen::constants::DEFAULT_PAGE_SIZE;
-use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 
 use crate::cmd::DiffCmd;
@@ -32,7 +31,7 @@ impl RunCmd for WorkspaceDiffCmd {
         )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let opts = DiffCmd::parse_args(args);
         let repo = LocalRepository::from_current_dir()?;
@@ -42,7 +41,7 @@ impl RunCmd for WorkspaceDiffCmd {
         } else if let Some(id) = args.get_one::<String>("workspace-id") {
             Some(id.to_string())
         } else {
-            return Err(OxenError::basic_str("Must supply a workspace id."));
+            return Err(anyhow::anyhow!("Must supply a workspace id."));
         }
         .unwrap();
 

--- a/crates/cli/src/cmd/workspace/download.rs
+++ b/crates/cli/src/cmd/workspace/download.rs
@@ -53,11 +53,11 @@ impl RunCmd for WorkspaceDownloadCmd {
             .arg_required_else_help(true)
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let file_path = args
             .get_one::<String>("file")
-            .map_or_else(|| Err(OxenError::basic_str("Must supply --file (-f)")), Ok)?;
+            .map_or_else(|| Err(anyhow::anyhow!("Must supply --file (-f)")), Ok)?;
 
         let workspace_name = args.get_one::<String>("workspace-name");
         let workspace_id = args.get_one::<String>("workspace-id");
@@ -70,24 +70,32 @@ impl RunCmd for WorkspaceDownloadCmd {
         let remote_repo = api::client::repositories::get_default_remote(&repository).await?;
 
         let workspace: WorkspaceResponse = match (workspace_id, workspace_name) {
-            (Some(workspace_id), None) => api::client::workspaces::get(&remote_repo, workspace_id)
-                .await
-                .and_then(|w| match w {
-                    Some(workspace) => Ok(workspace),
-                    None => Err(workspace_not_found(&format!("ID={workspace_id}"))),
-                })?,
+            (Some(workspace_id), None) => {
+                let Some(workspace) =
+                    api::client::workspaces::get(&remote_repo, workspace_id).await?
+                else {
+                    return Err(anyhow::anyhow!(
+                        "Workspace ID={workspace_id} does not exist"
+                    ));
+                };
+                workspace
+            }
             (None, Some(workspace_name)) => {
-                api::client::workspaces::get_by_name(&remote_repo, workspace_name)
-                    .await
-                    .and_then(|w| match w {
-                        Some(workspace) => Ok(workspace),
-                        None => Err(workspace_not_found(&format!("name={workspace_name}"))),
-                    })?
+                let Some(workspace) =
+                    api::client::workspaces::get_by_name(&remote_repo, workspace_name).await?
+                else {
+                    return Err(anyhow::anyhow!(
+                        "Workspace name={workspace_name} does not exist"
+                    ));
+                };
+                workspace
             }
             // This should never be reached due to clap's required_unless_present
-            _ => Err(OxenError::basic_str(
-                "Either --workspace-id or --workspace-name must be provided.",
-            ))?,
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Either --workspace-id or --workspace-name must be provided.",
+                ));
+            }
         };
 
         match api::client::workspaces::files::download(
@@ -101,19 +109,8 @@ impl RunCmd for WorkspaceDownloadCmd {
             Ok(_) => Ok(()),
             Err(OxenError::PathDoesNotExist(_)) => Err(OxenError::resource_not_found(
                 "File not found in workspace staged DB or base repo",
-            )),
-            unexpected_error => unexpected_error,
+            ))?,
+            unexpected_error => Ok(unexpected_error?),
         }
     }
-}
-
-/// CLI-facing error message for when a workspace is not found.
-fn workspace_not_found(message: &str) -> OxenError {
-    // TODO: should be a `OxenError::WorkspaceNotFound` but this is debug-rendered in the CLI at the moment.
-    //       To control formatting exactly, it's an `OxenError::Basic`.
-    //
-    //       CLI error rendering needs to be updated so we can use error variants properly & have precise
-    //       error message formatting control.
-    // OxenError::WorkspaceNotFound(Box::new(StringError::new(format!("Workspace {message} does not exist"))))
-    OxenError::basic_str(format!("Workspace {message} does not exist"))
 }

--- a/crates/cli/src/cmd/workspace/list.rs
+++ b/crates/cli/src/cmd/workspace/list.rs
@@ -24,7 +24,7 @@ impl RunCmd for WorkspaceListCmd {
         )
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let repository = LocalRepository::from_current_dir()?;
         let remote_name = args.get_one::<String>("remote");
         let remote_repo = match remote_name {

--- a/crates/cli/src/cmd/workspace/restore.rs
+++ b/crates/cli/src/cmd/workspace/restore.rs
@@ -25,7 +25,7 @@ impl RunCmd for WorkspaceRestoreCmd {
         restore_args()
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let paths: Vec<PathBuf> = args
             .get_many::<String>("paths")
             .expect("Must supply paths")

--- a/crates/cli/src/cmd/workspace/rm.rs
+++ b/crates/cli/src/cmd/workspace/rm.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use clap::{Arg, ArgGroup, ArgMatches, Command};
 
-use liboxen::{api, core::oxenignore, error::OxenError, model::LocalRepository};
+use liboxen::{api, core::oxenignore, model::LocalRepository};
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "rm";
@@ -57,7 +57,7 @@ impl RunCmd for WorkspaceRmCmd {
             .arg_required_else_help(true)
     }
 
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let mut paths: Vec<PathBuf> = args
             .get_many::<String>("files")
@@ -79,7 +79,7 @@ impl RunCmd for WorkspaceRmCmd {
                     if let Some(name) = workspace_name {
                         name
                     } else {
-                        return Err(OxenError::basic_str(
+                        return Err(anyhow::anyhow!(
                             "Either workspace-id or workspace-name must be provided.",
                         ));
                     }
@@ -97,7 +97,7 @@ impl RunCmd for WorkspaceRmCmd {
 
         // If no paths left after filtering, return early
         if paths.is_empty() {
-            return Err(OxenError::basic_str(
+            return Err(anyhow::anyhow!(
                 "No files to remove after filtering with .oxenignore.",
             ));
         }

--- a/crates/cli/src/cmd/workspace/status.rs
+++ b/crates/cli/src/cmd/workspace/status.rs
@@ -88,7 +88,7 @@ impl RunCmd for WorkspaceStatusCmd {
     }
 
     /// Parse CLI arguments and execute the workspace status command.
-    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &ArgMatches) -> Result<(), anyhow::Error> {
         let directory = args.get_one::<String>("path").map(PathBuf::from);
 
         // let workspace_id = args.get_one::<String>("workspace-id");
@@ -116,7 +116,7 @@ impl RunCmd for WorkspaceStatusCmd {
                 if let Some(name) = workspace_name {
                     name
                 } else {
-                    return Err(OxenError::basic_str(
+                    return Err(anyhow::anyhow!(
                         "Either workspace-id or workspace-name must be provided.",
                     ));
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,16 +4,20 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use crate::cmd::RemoteModeCmd;
+use crate::cmd::Runners;
 use crate::cmd::WorkspaceCmd;
 use clap::{Arg, Command};
+use colored::Colorize;
+use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::util;
 use tracing::level_filters::LevelFilter;
-// use env_logger::Env;
 
-pub mod cli_error;
-pub mod cmd;
-pub mod helpers;
+// NOTE: ALL INTERNAL MODULES OF oxen-cli MUST BE EXTERNALLY PRIVATE
+mod cli_error;
+mod cmd;
+mod helpers;
+// THE **ONLY** PUBLIC THING IN oxen-cli IS THE BINARY !!!
 
 const SHORT_ABOUT: &str = "🐂 is the AI and machine learning data management toolchain";
 
@@ -27,24 +31,25 @@ const LONG_ABOUT: &str = "
             https://discord.gg/s3tBEn7Ptg
 ";
 
-fn oxen_stack_size() -> usize {
-    env::var("OXEN_STACK_SIZE")
+/// Runs [`async_main`] with the [`OXEN_STACK_SIZE`].
+fn main() -> ExitCode {
+    let oxen_stack_size = env::var("OXEN_STACK_SIZE")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(liboxen::constants::OXEN_STACK_SIZE)
-}
+        .unwrap_or(liboxen::constants::OXEN_STACK_SIZE);
+    log::debug!("Using stack size in async runtime: {oxen_stack_size} bytes");
 
-fn main() -> ExitCode {
     let runtime = tokio::runtime::Builder::new_multi_thread()
-        .thread_stack_size(oxen_stack_size())
+        .thread_stack_size(oxen_stack_size)
         .enable_io()
         .enable_time()
         .build()
-        .unwrap();
+        .expect("Failed to create multi-threaded Tokio runtime.");
 
     runtime.block_on(async_main())
 }
 
+/// Actual oxen CLI logic.
 async fn async_main() -> ExitCode {
     // NOTE: if we fail to initialze logging, we do not crash here
     let _tracing_guard = match util::telemetry::init_tracing("oxen", LevelFilter::OFF) {
@@ -55,7 +60,112 @@ async fn async_main() -> ExitCode {
         }
     };
 
-    let cmds: Vec<Box<dyn cmd::RunCmd>> = vec![
+    let (command, runners) = main_oxen_command();
+
+    // Parse the command line args and run the appropriate command
+    let matches = command.get_matches();
+
+    handle_args(&matches);
+
+    let is_remote_repo = match LocalRepository::from_current_dir() {
+        Ok(repo) => repo.is_remote_mode(),
+        Err(_) => false,
+    };
+
+    match matches.subcommand() {
+        // TODO: Get these in the help command instead of just falling back
+        Some((command, args)) => {
+            // Lookup command in runners and run on args
+            if let Some(runner) = runners.get(command) {
+                // If in a remote-mode repo, re-route to correct command
+                if is_remote_repo {
+                    match command {
+                        // Workspace commands
+                        "add" | "df" | "diff" | "rm" => {
+                            match WorkspaceCmd::run_subcommands(command, args).await {
+                                Ok(_) => {}
+                                Err(err) => {
+                                    print_error(&err);
+                                    return ExitCode::FAILURE;
+                                }
+                            }
+
+                            return ExitCode::SUCCESS;
+                        }
+                        // Remote-mode specific commands
+                        "commit" | "checkout" | "pull" | "restore" | "status" => {
+                            match RemoteModeCmd::run_subcommands(command, args).await {
+                                Ok(_) => {}
+                                Err(err) => {
+                                    print_error(&err);
+                                    return ExitCode::FAILURE;
+                                }
+                            }
+                            return ExitCode::SUCCESS;
+                        }
+                        // Disallowed commands
+                        "embeddings" | "merge" | "push" | "workspace" => {
+                            eprintln!(
+                                "Command `oxen {command}` not implemented for remote-mode repositories"
+                            );
+                            return ExitCode::FAILURE;
+                        }
+                        _ => {} // All other commands behave as normal
+                    }
+                }
+
+                match runner.run(args).await {
+                    Ok(_) => {}
+                    Err(err) => {
+                        print_error(&err);
+                        return ExitCode::FAILURE;
+                    }
+                }
+            } else {
+                eprintln!("Unknown command `oxen {command}`");
+                return ExitCode::FAILURE;
+            }
+        }
+        _ => unreachable!(
+            "[ERROR] Failed to parse command. CLI arguments:\n{:?}",
+            matches
+        ), // If all subcommands are defined above, anything else is unreachable!()
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn main_oxen_command() -> (Command, Runners) {
+    let mut command = Command::new("oxen")
+        .version(liboxen::constants::OXEN_VERSION)
+        .about(SHORT_ABOUT)
+        .long_about(LONG_ABOUT)
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .allow_external_subcommands(true)
+        .arg(
+            Arg::new("config-dir")
+                .long("config-dir")
+                .value_parser(clap::value_parser!(PathBuf))
+                .global(true)
+                .help(
+                    "Directory for oxen's user and auth config files \
+                     (overrides $OXEN_CONFIG_DIR; defaults to ~/.config/oxen/)",
+                ),
+        );
+
+    // Add all the commands to the command line
+    let mut runners = HashMap::new();
+    for cmd in all_commands() {
+        command = command.subcommand(cmd.args());
+        runners.insert(cmd.name().to_string(), cmd);
+    }
+    (command, runners)
+}
+
+/// Every command that is used by the `oxen` CLI **MUST** be listed here!
+fn all_commands() -> [Box<dyn cmd::RunCmd>; 37] {
+    [
         Box::new(cmd::AddCmd),
         Box::new(cmd::BranchCmd),
         Box::new(cmd::CheckoutCmd),
@@ -93,36 +203,10 @@ async fn async_main() -> ExitCode {
         Box::new(cmd::TreeCmd),
         Box::new(cmd::UploadCmd),
         Box::new(cmd::WorkspaceCmd),
-    ];
+    ]
+}
 
-    let mut command = Command::new("oxen")
-        .version(liboxen::constants::OXEN_VERSION)
-        .about(SHORT_ABOUT)
-        .long_about(LONG_ABOUT)
-        .subcommand_required(true)
-        .arg_required_else_help(true)
-        .allow_external_subcommands(true)
-        .arg(
-            Arg::new("config-dir")
-                .long("config-dir")
-                .value_parser(clap::value_parser!(PathBuf))
-                .global(true)
-                .help(
-                    "Directory for oxen's user and auth config files \
-                     (overrides $OXEN_CONFIG_DIR; defaults to ~/.config/oxen/)",
-                ),
-        );
-
-    // Add all the commands to the command line
-    let mut runners: HashMap<String, Box<dyn cmd::RunCmd>> = HashMap::new();
-    for cmd in cmds {
-        command = command.subcommand(cmd.args());
-        runners.insert(cmd.name().to_string(), cmd);
-    }
-
-    // Parse the command line args and run the appropriate command
-    let matches = command.get_matches();
-
+fn handle_args(matches: &clap::ArgMatches) {
     // Install the --config-dir override before any work that might consult user/auth
     // config via util::fs::oxen_config_dir(). `from_current_dir()` below currently reads
     // only the per-repo .oxen/config.toml, but keeping this first preserves the invariant
@@ -130,67 +214,15 @@ async fn async_main() -> ExitCode {
     if let Some(dir) = matches.get_one::<PathBuf>("config-dir") {
         util::fs::set_oxen_config_dir(dir.clone());
     }
+}
 
-    let is_remote_repo = match LocalRepository::from_current_dir() {
-        Ok(repo) => repo.is_remote_mode(),
-        Err(_) => false,
-    };
-    match matches.subcommand() {
-        // TODO: Get these in the help command instead of just falling back
-        Some((command, args)) => {
-            // Lookup command in runners and run on args
-            if let Some(runner) = runners.get(command) {
-                // If in a remote-mode repo, re-route to correct command
-                if is_remote_repo {
-                    match command {
-                        // Workspace commands
-                        "add" | "df" | "diff" | "rm" => {
-                            match WorkspaceCmd::run_subcommands(command, args).await {
-                                Ok(_) => {}
-                                Err(err) => {
-                                    cli_error::print_error(&err);
-                                    return ExitCode::FAILURE;
-                                }
-                            }
+/// Print an error to STDERR with colored prefix. If it's an [`OxenError`], then also optionally print its hint.
+fn print_error(err: &anyhow::Error) {
+    eprintln!("{} {}", "Error:".red().bold(), err);
 
-                            return ExitCode::SUCCESS;
-                        }
-                        // Remote-mode specific commands
-                        "commit" | "checkout" | "pull" | "restore" | "status" => {
-                            match RemoteModeCmd::run_subcommands(command, args).await {
-                                Ok(_) => {}
-                                Err(err) => {
-                                    cli_error::print_error(&err);
-                                    return ExitCode::FAILURE;
-                                }
-                            }
-                            return ExitCode::SUCCESS;
-                        }
-                        // Disallowed commands
-                        "embeddings" | "merge" | "push" | "workspace" => {
-                            eprintln!(
-                                "Command `oxen {command}` not implemented for remote-mode repositories"
-                            );
-                            return ExitCode::FAILURE;
-                        }
-                        _ => {} // All other commands behave as normal
-                    }
-                }
-
-                match runner.run(args).await {
-                    Ok(_) => {}
-                    Err(err) => {
-                        cli_error::print_error(&err);
-                        return ExitCode::FAILURE;
-                    }
-                }
-            } else {
-                eprintln!("Unknown command `oxen {command}`");
-                return ExitCode::FAILURE;
-            }
-        }
-        _ => unreachable!(), // If all subcommands are defined above, anything else is unreachable!()
+    if let Some(oxen_error) = err.downcast_ref::<OxenError>()
+        && let Some(hint) = oxen_error.hint()
+    {
+        eprintln!("  {} {}", "hint:".cyan().bold(), hint);
     }
-
-    ExitCode::SUCCESS
 }

--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -183,14 +183,11 @@ pub async fn add_files(
     let base_dir = std::path::absolute(base_dir)?;
 
     if !base_dir.is_dir() {
-        return Err(OxenError::basic_str(format!(
-            "base_dir is not a directory: {}",
-            base_dir.display()
-        )));
+        return Err(OxenError::NotADirectory(base_dir.to_path_buf()));
     }
 
     if paths.is_empty() {
-        return Err(OxenError::basic_str("No paths to add!"));
+        return Err(OxenError::NoPathsToAdd);
     }
 
     let workspace_id = workspace_id.as_ref();

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -211,6 +211,12 @@ pub enum OxenError {
     #[error("{0}")]
     WorkspaceNameIndex(#[from] crate::core::workspaces::workspace_name_index::WsError),
 
+    #[error("Not a real directory: {0}")]
+    NotADirectory(PathBuf),
+
+    #[error("No paths to add!")]
+    NoPathsToAdd,
+
     //
     // Resources (paths, uris, etc.)
     //
@@ -1056,14 +1062,6 @@ impl OxenError {
 
     pub fn parse_error(value: impl AsRef<str>) -> OxenError {
         OxenError::basic_str(format!("Parse error: {:?}", value.as_ref()))
-    }
-
-    pub fn unknown_subcommand(parent: impl AsRef<str>, name: impl AsRef<str>) -> OxenError {
-        OxenError::basic_str(format!(
-            "Unknown {} subcommand '{}'",
-            parent.as_ref(),
-            name.as_ref()
-        ))
     }
 }
 

--- a/experiments/block-level-dedup/src/cmd/pack.rs
+++ b/experiments/block-level-dedup/src/cmd/pack.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::error::OxenError;
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "pack";
@@ -43,7 +42,7 @@ impl RunCmd for PackCmd {
             )
     }
 
-    async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         // Parse Args
         let _paths: Vec<PathBuf> = args
             .get_many::<String>("files")
@@ -64,7 +63,7 @@ impl RunCmd for PackCmd {
             .expect("Chunk size must be a valid integer.");
 
         if _paths.len() != 1 {
-            return Err(OxenError::basic_str("Must supply exactly one file"));
+            return Err(anyhow::anyhow!("Must supply exactly one file"));
         }
         Ok(())
     }

--- a/experiments/block-level-dedup/src/cmd/unpack.rs
+++ b/experiments/block-level-dedup/src/cmd/unpack.rs
@@ -70,7 +70,7 @@ impl RunCmd for UnpackCmd {
             .expect("Must supply output path");
 
         if paths.len() != 1 {
-            return Err(OxenError::basic_str("Must supply exactly one file"));
+            return Err(anyhow::anyhow!("Must supply exactly one file"));
         }
 
         let path = &paths[0];
@@ -93,7 +93,7 @@ impl RunCmd for UnpackCmd {
         // Get the entry to reconstruct
         let commit_entry_reader = CommitEntryReader::new(&repo, commit)?;
         let Some(entry) = commit_entry_reader.get_entry(path)? else {
-            return Err(OxenError::basic_str("File not found in commit"));
+            return Err(anyhow::anyhow!("File not found in commit"));
         };
         let file_hash = entry.hash;
         println!("Reconstructing file hash: {:?}", file_hash);
@@ -118,7 +118,7 @@ impl RunCmd for UnpackCmd {
                     let v = usize::from_be_bytes((*v).try_into().unwrap());
                     indices.push((v, k));
                 }
-                Err(_) => return Err(OxenError::basic_str("Error iterating over indices")),
+                Err(_) => return Err(anyhow::anyhow!("Error iterating over indices")),
             }
         }
 


### PR DESCRIPTION
Removes all CLI-only error variants from `OxenError`. `OxenError` is the `liboxen` unifying
error type. It should never have any coupling with either `oxen-cli` nor `oxen-server.
All CLI-specific variants have been deleted.

Instead, all `oxen` programs -- via the `RunCmd` trait -- now use `anyhow::Error` as the
error return type. `anyhow` is intended for use in applications, so it fits the CLI.
`anyhow` has been added to `oxen-cli`'s dependencies.

Most of the CLI errors are only needed for their string formatting: there is never another
caller that uses most of the errors (they're mostly `OxenError::Basic` variants anyways).
These isolated string errors have been changed to use `anyhow::Error` directly.