### PR TITLE
S3 (14a): Promote S3Opts to liboxen

### DIFF
--- a/crates/lib/src/storage.rs
+++ b/crates/lib/src/storage.rs
@@ -3,7 +3,7 @@ pub mod s3;
 pub mod version_store;
 
 pub use local::LocalVersionStore;
-pub use s3::S3VersionStore;
+pub use s3::{S3Opts, S3VersionStore};
 pub use version_store::{
     LocalFilePath, StorageConfig, StorageKind, VersionStore, create_version_store,
 };

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -26,6 +26,15 @@ use xxhash_rust::xxh3::Xxh3;
 /// AWS recommends uploading to S3 in a single PUT if filesize is <= 100 MB.
 const DEFAULT_ONESHOT_SIZE: u64 = 100 * 1024 * 1024;
 
+/// Server-supplied S3 configuration carried separately from per-repo `StorageConfig`. The bucket is
+/// a server-wide setting (the server can rotate it without rewriting every repo's config), so it
+/// never appears in `.oxen/config.toml` — only in the server's TOML, then threaded through repo
+/// construction. Clients of liboxen pass `None` for this when no S3 backend is server-enabled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S3Opts {
+    pub bucket: String,
+}
+
 /// S3 implementation of version storage
 #[derive(Debug)]
 pub struct S3VersionStore {

--- a/crates/server/src/config/storage_policy.rs
+++ b/crates/server/src/config/storage_policy.rs
@@ -13,17 +13,10 @@
 
 use std::collections::HashSet;
 
-use liboxen::storage::StorageKind;
+use liboxen::storage::{S3Opts, StorageKind};
 use serde::Deserialize;
 
 use crate::errors::OxenHttpError;
-
-/// Admin-only S3 configuration. The bucket is server-wide; per-repo prefixes are derived from
-/// `{namespace}/{name}` when the version store is constructed (not yet wired up).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct S3Opts {
-    pub bucket: String,
-}
 
 /// Server-side storage policy.
 ///


### PR DESCRIPTION
Move the server-side `S3Opts` struct that contains the S3 bucket name from oxen-server to liboxen so liboxen functions can name the type without a circular dependency. This is to prep for wiring up S3 storage for reals.

No behavior changes.