### PR TITLE
S3 (14b): helpers::get_repo takes &OxenAppData

### DIFF
--- a/crates/server/src/controllers/branches.rs
+++ b/crates/server/src/controllers/branches.rs
@@ -70,7 +70,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(app_data, namespace, name)?;
 
     let branches = repositories::branches::list(&repo)?;
 
@@ -103,7 +103,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let branch_name = path_param(&req, "branch_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     log::debug!("show branch {branch_name:?}");
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?;
@@ -146,7 +146,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     log::debug!("Create branch: {body}");
 
@@ -227,7 +227,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let branch_name = path_param(&req, "branch_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?;
 
@@ -270,7 +270,7 @@ pub async fn update(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let branch_name = path_param(&req, "branch_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     let data: Result<BranchUpdate, serde_json::Error> = serde_json::from_str(&body);
     let data = data.map_err(|err| OxenHttpError::BadRequest(format!("{err:?}").into()))?;
@@ -315,7 +315,7 @@ pub async fn maybe_create_merge(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
     let branch_name = path_param(&req, "branch_name")?.to_string();
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?;
 
@@ -386,7 +386,7 @@ pub async fn list_entry_versions(
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let branch_name = path_param(&req, "branch_name")?.to_string();
 
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
     let branch = repositories::branches::get_by_name(&repo, &branch_name)?;
 
     let path = PathBuf::from(path_param(&req, "path")?);

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -89,7 +89,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let commits = repositories::commits::list(&repo).unwrap_or_default();
     Ok(HttpResponse::Ok().json(ListCommitResponse::success(commits)))
@@ -122,7 +122,7 @@ pub async fn history(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let resource_param = path_param(&req, "resource")?.to_string();
 
     let pagination = PaginateOpts {
@@ -208,7 +208,7 @@ pub async fn list_all(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let pagination = PaginateOpts {
         page_num: query.page.unwrap_or(constants::DEFAULT_PAGE_NUM),
@@ -249,7 +249,7 @@ pub async fn list_missing(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let data: Result<MerkleHashes, serde_json::Error> = serde_json::from_str(&body);
     let Ok(merkle_hashes) = data else {
@@ -311,7 +311,7 @@ pub async fn list_missing_files(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let base_commit = match &query.base {
         Some(base) => repositories::commits::get_by_id(&repo, base)?,
@@ -405,7 +405,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let commit_id = path_param(&req, "commit_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let commit = repositories::commits::get_by_id(&repo, &commit_id)?
         .ok_or_else(|| OxenError::RevisionNotFound(commit_id.into()))?;
 
@@ -436,7 +436,7 @@ pub async fn parents(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHt
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let commit_or_branch = path_param(&req, "commit_or_branch")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
     let commit = repositories::revisions::get(&repository, &commit_or_branch)?
         .ok_or_else(|| OxenError::RevisionNotFound(commit_or_branch.into()))?;
     let parents = repositories::commits::list_from(&repository, &commit.id)?;
@@ -468,7 +468,7 @@ pub async fn download_commits_db(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     let buffer = compress_commits_db(&repository)?;
     Ok(HttpResponse::Ok().body(buffer))
@@ -522,7 +522,7 @@ pub async fn download_dir_hashes_db(
     let name = path_param(&req, "repo_name")?.to_string();
     // base_head is the base and head commit id separated by ..
     let base_head = path_param(&req, "base_head")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     // Let user pass in base..head to download a range of commits
     // or we just get all the commits from the base commit to the first commit
@@ -570,7 +570,7 @@ pub async fn download_commit_entries_db(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let commit_or_branch = path_param(&req, "commit_or_branch")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     let commit = repositories::revisions::get(&repository, &commit_or_branch)?
         .ok_or_else(|| OxenError::RevisionNotFound(commit_or_branch.into()))?;
@@ -694,7 +694,7 @@ pub async fn create(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
 
     let new_commit: Commit = match serde_json::from_str(&body) {
         Ok(commit) => commit,
@@ -756,7 +756,7 @@ pub async fn upload_chunk(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(app_data, namespace, name)?;
 
     let hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
     let id = query.hash.clone();
@@ -996,7 +996,7 @@ pub async fn upload(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &name)?;
+    let repo = get_repo(app_data, &namespace, &name)?;
 
     // Read bytes from body
     let mut bytes = Vec::new();
@@ -1108,7 +1108,7 @@ pub async fn upload_tree(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let client_head_id = path_param(&req, "commit_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(app_data, namespace, name)?;
     // Get head commit on sever repo
     let server_head_commit = repositories::commits::head_commit(&repo)?;
 
@@ -1157,7 +1157,7 @@ pub async fn root_commit(req: HttpRequest) -> Result<HttpResponse, OxenHttpError
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(app_data, namespace, name)?;
 
     let root = repositories::commits::root_commit_maybe(&repo)?;
 

--- a/crates/server/src/controllers/data_frames.rs
+++ b/crates/server/src/controllers/data_frames.rs
@@ -45,7 +45,7 @@ pub async fn get(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let resource = parse_resource(&req, &repo)?;
 
     let commit = match &resource.workspace {
@@ -143,7 +143,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
 
@@ -211,7 +211,7 @@ pub async fn from_directory(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
     let branch = resource.clone().branch.ok_or(OxenHttpError::NotFound)?;

--- a/crates/server/src/controllers/diff.rs
+++ b/crates/server/src/controllers/diff.rs
@@ -63,7 +63,7 @@ pub async fn commits(
     let base_head = path_param(&req, "base_head")?.to_string();
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     // Page size and number
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
@@ -122,7 +122,7 @@ pub async fn entries(
     let base_head = path_param(&req, "base_head")?.to_string();
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     // Page size and number
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
@@ -201,7 +201,7 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
     let base_head = path_param(&req, "base_head")?.to_string();
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
@@ -254,7 +254,7 @@ pub async fn dir_entries(
     let dir = path_param(&req, "dir")?.to_string();
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     // Page size and number
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
@@ -338,7 +338,7 @@ pub async fn file(
     let base_head = path_param(&req, "base_head")?.to_string();
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     // Parse the base and head from the base..head/resource string
     // For Example)
@@ -408,7 +408,7 @@ pub async fn create_df_diff(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
 
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     let data: Result<TabularCompareBody, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
@@ -515,7 +515,7 @@ pub async fn update_df_diff(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let compare_id = path_param(&req, "compare_id")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     let data: Result<TabularCompareBody, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
@@ -624,7 +624,7 @@ pub async fn get_df_diff(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let compare_id = path_param(&req, "compare_id")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
     let base_head = path_param(&req, "base_head")?.to_string();
 
     let data: TabularCompareBody = serde_json::from_str(&body)?;
@@ -705,7 +705,7 @@ pub async fn delete_df_diff(req: HttpRequest) -> Result<HttpResponse, OxenHttpEr
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let compare_id = path_param(&req, "compare_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     repositories::diffs::delete_df_diff(&repo, &compare_id)?;
 
@@ -737,7 +737,7 @@ pub async fn get_derived_df(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let compare_id = path_param(&req, "compare_id")?.to_string();
     // let base_head = path_param(&req, "base_head")?.to_string();
 

--- a/crates/server/src/controllers/dir.rs
+++ b/crates/server/src/controllers/dir.rs
@@ -38,7 +38,7 @@ pub async fn get(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
 
     let page: usize = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);

--- a/crates/server/src/controllers/entries.rs
+++ b/crates/server/src/controllers/entries.rs
@@ -33,7 +33,7 @@ pub async fn download_data_from_version_paths(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -103,7 +103,7 @@ pub async fn download_chunk(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
     let path = resource.path.clone();
@@ -141,7 +141,7 @@ pub async fn list_tabular(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let commit_or_branch = path_param(&req, "commit_or_branch")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let commit = repositories::revisions::get(&repo, &commit_or_branch)?
         .ok_or_else(|| OxenError::RevisionNotFound(commit_or_branch.into()))?;
 

--- a/crates/server/src/controllers/export.rs
+++ b/crates/server/src/controllers/export.rs
@@ -30,7 +30,7 @@ pub async fn download_zip(req: HttpRequest) -> Result<HttpResponse, OxenHttpErro
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     let resource = parse_resource(&req, &repo)?;
     let directory = resource.path.clone();

--- a/crates/server/src/controllers/file.rs
+++ b/crates/server/src/controllers/file.rs
@@ -137,7 +137,7 @@ pub async fn get(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
     let version_store = repo.version_store();
     let resource = parse_resource(&req, &repo)?;
     let workspace = resource.workspace.as_ref();
@@ -259,7 +259,7 @@ pub async fn put(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     // If there's no head commit, handle initial upload
     if repositories::commits::head_commit_maybe(&repo)?.is_none() {
@@ -372,7 +372,7 @@ pub async fn delete(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     // Parse the resource (branch/commit/path)
     let resource = parse_resource(&req, &repo)?;
@@ -463,7 +463,7 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     // Parse the resource (branch/commit/path)
     let resource = parse_resource(&req, &repo)?;

--- a/crates/server/src/controllers/fork.rs
+++ b/crates/server/src/controllers/fork.rs
@@ -36,7 +36,7 @@ pub async fn fork(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
 
-    let original_repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let original_repo = get_repo(app_data, &namespace, &repo_name)?;
 
     // Update storage path in config.toml to relative path
     original_repo.save()?;

--- a/crates/server/src/controllers/fsck.rs
+++ b/crates/server/src/controllers/fsck.rs
@@ -40,7 +40,7 @@ pub async fn rebuild_dir_hashes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     let commit = if let Some(commit_id) = &query.commit_id {
         repositories::commits::get_by_id(&repo, commit_id)?
@@ -99,7 +99,7 @@ pub async fn clean(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     let dry_run = query.dry_run;
     log::info!("fsck clean: {namespace}/{repo_name} dry_run={dry_run}");

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -100,7 +100,7 @@ pub async fn import(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
 
     // Resource must specify branch for committing the workspace
@@ -244,7 +244,7 @@ pub async fn upload_zip(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     // If there's no head commit, handle initial upload
     if repositories::commits::head_commit_maybe(&repo)?.is_none() {

--- a/crates/server/src/controllers/merger.rs
+++ b/crates/server/src/controllers/merger.rs
@@ -34,7 +34,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let base_head = path_param(&req, "base_head")?.to_string();
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
@@ -93,7 +93,7 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let base_head = path_param(&req, "base_head")?.to_string();
 
     // Get the repository or return error
-    let repo = get_repo(&app_data.path, namespace, name)?;
+    let repo = get_repo(app_data, namespace, name)?;
 
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;

--- a/crates/server/src/controllers/metadata.rs
+++ b/crates/server/src/controllers/metadata.rs
@@ -33,7 +33,7 @@ pub async fn file(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
     let workspace_ref = resource.workspace.as_ref();
 
@@ -120,7 +120,7 @@ pub async fn update_metadata(req: HttpRequest) -> actix_web::Result<HttpResponse
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
     let resource = parse_resource(&req, &repo)?;
 
     let version_str = resource

--- a/crates/server/src/controllers/migrations.rs
+++ b/crates/server/src/controllers/migrations.rs
@@ -79,7 +79,7 @@ pub async fn run(req: HttpRequest, body: web::Bytes) -> Result<HttpResponse, Oxe
         OxenHttpError::BadRequest(format!("Unknown migration: {migration_name}").into())
     })?;
 
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     try_apply_migration(migration, direction, run_optional, repo)?;
 

--- a/crates/server/src/controllers/prune.rs
+++ b/crates/server/src/controllers/prune.rs
@@ -44,7 +44,7 @@ pub async fn prune(
     let repo_name = path_param(&req, "repo_name")?.to_string();
 
     // Get the repository
-    let repository = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repository = get_repo(app_data, &namespace, &repo_name)?;
 
     let dry_run = body.dry_run;
 

--- a/crates/server/src/controllers/repositories.rs
+++ b/crates/server/src/controllers/repositories.rs
@@ -86,7 +86,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let name = path_param(&req, "repo_name")?.to_string();
 
     // Get the repository or return error
-    let repository = get_repo(&app_data.path, &namespace, &name)?;
+    let repository = get_repo(app_data, &namespace, &name)?;
     let mut size: u64 = 0;
     let mut data_types: Vec<DataTypeCount> = vec![];
     let mut default_resource: Option<ParsedResourceView> = None;
@@ -216,7 +216,7 @@ pub async fn update_size(req: HttpRequest) -> actix_web::Result<HttpResponse, Ox
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
 
-    let repository = get_repo(&app_data.path, &namespace, &name)?;
+    let repository = get_repo(app_data, &namespace, &name)?;
     repositories::size::update_size(&repository)?;
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))
@@ -242,7 +242,7 @@ pub async fn get_size(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
 
-    let repository = get_repo(&app_data.path, &namespace, &name)?;
+    let repository = get_repo(app_data, &namespace, &name)?;
     let size = repositories::size::get_size(&repository)?;
     Ok(HttpResponse::Ok().json(size))
 }
@@ -547,7 +547,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
 
-    let Ok(repository) = get_repo(&app_data.path, &namespace, &name) else {
+    let Ok(repository) = get_repo(app_data, &namespace, &name) else {
         return Ok(HttpResponse::NotFound().json(StatusMessage::resource_not_found()));
     };
 

--- a/crates/server/src/controllers/revisions.rs
+++ b/crates/server/src/controllers/revisions.rs
@@ -30,7 +30,7 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
 
     let resource = parse_resource(&req, &repository)?;
     let response = ParseResourceResponse {

--- a/crates/server/src/controllers/schemas.rs
+++ b/crates/server/src/controllers/schemas.rs
@@ -17,7 +17,7 @@ pub async fn list_or_get(req: HttpRequest) -> actix_web::Result<HttpResponse, Ox
 
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     // Try to see if they are asking for a specific file
     if let Ok(resource) = parse_resource(&req, &repo)

--- a/crates/server/src/controllers/tree.rs
+++ b/crates/server/src/controllers/tree.rs
@@ -31,7 +31,7 @@ pub async fn get_node_by_id(req: HttpRequest) -> actix_web::Result<HttpResponse,
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
     let hash_str = path_param(&req, "hash")?.to_string();
 
     let node = repositories::tree::get_node_by_id(&repository, &hash_str.parse()?)?
@@ -48,7 +48,7 @@ pub async fn list_missing_node_hashes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -80,7 +80,7 @@ pub async fn list_missing_file_hashes_from_commits(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -117,7 +117,7 @@ pub async fn list_missing_file_hashes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
     let hash_str = path_param(&req, "hash")?.to_string();
     let hash = hash_str.parse()?;
 
@@ -141,7 +141,7 @@ pub async fn mark_nodes_as_synced(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -171,7 +171,7 @@ pub async fn create_nodes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -193,7 +193,7 @@ pub async fn download_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, 
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     // Download the entire tree
     let buffer = repositories::tree::compress_tree(&repository)?;
@@ -208,7 +208,7 @@ pub async fn get_node_hash_by_path(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, repo_name)?;
+    let repository = get_repo(app_data, namespace, repo_name)?;
     let resource = parse_resource(&req, &repository)?;
     let commit = resource.commit.ok_or(OxenHttpError::NotFound)?;
 
@@ -229,7 +229,7 @@ pub async fn download_tree_nodes(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
     let base_head_str = path_param(&req, "base_head")?.to_string();
     let is_download = query.is_download.unwrap_or(false);
 
@@ -326,7 +326,7 @@ pub async fn download_node(req: HttpRequest) -> actix_web::Result<HttpResponse, 
     let name = path_param(&req, "repo_name")?.to_string();
     let hash_str = path_param(&req, "hash")?.to_string();
     let hash = hash_str.parse()?;
-    let repository = get_repo(&app_data.path, namespace, name)?;
+    let repository = get_repo(app_data, namespace, name)?;
 
     let buffer = {
         let mut buffer = Vec::new();

--- a/crates/server/src/controllers/versions.rs
+++ b/crates/server/src/controllers/versions.rs
@@ -55,7 +55,7 @@ pub async fn metadata(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let version_id = path_param(&req, "version_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let exists = repo.version_store().version_exists(&version_id).await?;
     if !exists {
@@ -77,7 +77,7 @@ pub async fn clean(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
     let version_store = repo.version_store();
     let result = version_store.clean_corrupted_versions(false).await?;
 
@@ -118,7 +118,7 @@ pub async fn download(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
     let version_store = repo.version_store();
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
@@ -185,7 +185,7 @@ pub async fn batch_download(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -529,7 +529,7 @@ pub async fn batch_upload(
 
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
     let err_files = save_multiparts(payload, &repo).await?;
     log::debug!("batch upload complete with err_files: {}", err_files.len());
 

--- a/crates/server/src/controllers/versions/chunks.rs
+++ b/crates/server/src/controllers/versions/chunks.rs
@@ -31,7 +31,7 @@ pub async fn upload(
 
     let offset = query.offset.unwrap_or(0);
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     log::debug!(
         "/upload version {} chunk offset{} to repo: {:?}",
@@ -61,7 +61,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let version_id = path_param(&req, "version_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     log::debug!("/complete version chunk upload to repo: {:?}", repo.path);
 
@@ -145,7 +145,7 @@ pub async fn download(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let version_id = path_param(&req, "version_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let offset = query.offset.unwrap_or(0);
     let size = query.size.unwrap_or_else(stream_segment_size);

--- a/crates/server/src/controllers/workspaces.rs
+++ b/crates/server/src/controllers/workspaces.rs
@@ -51,7 +51,7 @@ pub async fn get_or_create(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let data: Result<NewWorkspace, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
@@ -164,7 +164,7 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -217,7 +217,7 @@ pub async fn list(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     log::debug!("workspaces::list got repo: {:?}", repo.path);
 
     // When filtering by name, use the indexed O(1) lookup instead of loading all workspaces
@@ -266,7 +266,7 @@ pub async fn clear(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     repositories::workspaces::clear(&repo)?;
     Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))
 }
@@ -293,7 +293,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -333,7 +333,7 @@ pub async fn mergeability(req: HttpRequest) -> Result<HttpResponse, OxenHttpErro
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
     let branch_name = path_param(&req, "branch")?.to_string();
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -383,7 +383,7 @@ pub async fn commit(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
     let branch_name = path_param(&req, "branch")?.to_string();
 
     log::debug!(

--- a/crates/server/src/controllers/workspaces/changes.rs
+++ b/crates/server/src/controllers/workspaces/changes.rs
@@ -27,7 +27,7 @@ pub async fn list_root(
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     log::debug!("/changes looking up repo: {namespace}/{repo_name}");
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let page_num = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
 
@@ -64,7 +64,7 @@ pub async fn list(
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     log::debug!("/changes looking up repo: {namespace}/{repo_name}");
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
     let page_num = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
@@ -113,7 +113,7 @@ pub async fn unstage(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -154,7 +154,7 @@ pub async fn unstage_many(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
     log::debug!("unstage_many found repo {repo_name}, workspace_id {workspace_id}");
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {

--- a/crates/server/src/controllers/workspaces/data_frames.rs
+++ b/crates/server/src/controllers/workspaces/data_frames.rs
@@ -96,7 +96,7 @@ pub async fn get(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -222,7 +222,7 @@ pub async fn get_schema(req: HttpRequest) -> Result<HttpResponse, OxenHttpError>
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -277,7 +277,7 @@ pub async fn download(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -406,7 +406,7 @@ pub async fn download_streaming(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -477,7 +477,7 @@ pub async fn get_by_branch(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let branch_name: &str = query_param(&req, "branch");
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -524,7 +524,7 @@ pub async fn diff(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -589,7 +589,7 @@ pub async fn put(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHtt
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     log::debug!("workspace {workspace_id} data frame put {file_path:?}");
@@ -618,7 +618,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -635,7 +635,7 @@ pub async fn rename(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
     // Attempt to parse the body
     let body: RenameRequest = serde_json::from_str(&body)?; // Use the Json wrapper to get the inner value

--- a/crates/server/src/controllers/workspaces/data_frames/columns.rs
+++ b/crates/server/src/controllers/workspaces/data_frames/columns.rs
@@ -25,7 +25,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace.clone(), repo_name.clone())?;
+    let repo = get_repo(app_data, namespace.clone(), repo_name.clone())?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     let mut body_json: Value = serde_json::from_str(&body).map_err(|_err| {
@@ -106,7 +106,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace.clone(), repo_name.clone())?;
+    let repo = get_repo(app_data, namespace.clone(), repo_name.clone())?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let column_name = path_param(&req, "column_name")
         .map_err(|_| OxenHttpError::BadRequest("Column name missing in path parameters".into()))?;
@@ -183,7 +183,7 @@ pub async fn update(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace.clone(), repo_name.clone())?;
+    let repo = get_repo(app_data, namespace.clone(), repo_name.clone())?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let column_name = path_param(&req, "column_name")
         .map_err(|_| OxenHttpError::BadRequest("Column name missing in path parameters".into()))?;
@@ -305,7 +305,7 @@ pub async fn add_column_metadata(
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let path = path_param(&req, "path")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -346,7 +346,7 @@ pub async fn restore(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
         name: column_name.to_string(),
     };
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()

--- a/crates/server/src/controllers/workspaces/data_frames/embeddings.rs
+++ b/crates/server/src/controllers/workspaces/data_frames/embeddings.rs
@@ -23,7 +23,7 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let file_path = Path::new(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -48,7 +48,7 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let file_path = Path::new(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -154,7 +154,7 @@ pub async fn post(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, OxenHt
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let file_path = Path::new(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {

--- a/crates/server/src/controllers/workspaces/data_frames/rows.rs
+++ b/crates/server/src/controllers/workspaces/data_frames/rows.rs
@@ -23,7 +23,7 @@ pub async fn create(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace.clone(), repo_name.clone())?;
+    let repo = get_repo(app_data, namespace.clone(), repo_name.clone())?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     let data = String::from_utf8(bytes.to_vec()).expect("Could not parse bytes as utf8");
@@ -92,7 +92,7 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let file_path = path_param(&req, "path")?.to_string();
     let row_id = path_param(&req, "row_id")?.to_string();
 
@@ -136,7 +136,7 @@ pub async fn update(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let row_id = path_param(&req, "row_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Ok(data) = String::from_utf8(bytes.to_vec()) else {
@@ -197,7 +197,7 @@ pub async fn delete(req: HttpRequest, _bytes: Bytes) -> Result<HttpResponse, Oxe
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let row_id = path_param(&req, "row_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -234,7 +234,7 @@ pub async fn restore(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let row_id = path_param(&req, "row_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -276,7 +276,7 @@ pub async fn batch_update(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
-    let repo = get_repo(&app_data.path, &namespace, &repo_name)?;
+    let repo = get_repo(app_data, &namespace, &repo_name)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Ok(data) = String::from_utf8(bytes.to_vec()) else {

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -86,7 +86,7 @@ pub async fn get(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let version_store = repo.version_store();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -205,7 +205,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, &repo_name)?;
+    let repo = get_repo(app_data, namespace, &repo_name)?;
     let directory = path_param(&req, "path")?.to_string();
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -296,7 +296,7 @@ pub async fn add_version_files(
     let directory = path_param(&req, "directory")?.to_string();
     let update_timestamp = query.update_timestamp.unwrap_or(false);
 
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -355,7 +355,7 @@ pub async fn rm_files(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -399,7 +399,7 @@ pub async fn validate(req: HttpRequest, _body: String) -> Result<HttpResponse, O
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
 
     let Some(_workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -437,7 +437,7 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let repo = get_repo(app_data, namespace, repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
 
     // Parse request body

--- a/crates/server/src/helpers.rs
+++ b/crates/server/src/helpers.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 // use liboxen::constants::DEFAULT_REDIS_URL;
 use actix_web::http::header;
 use actix_web::{HttpResponse, HttpResponseBuilder};
@@ -8,14 +6,16 @@ use liboxen::error::OxenError;
 use liboxen::model::{LocalRepository, User};
 use liboxen::repositories;
 
+use crate::app_data::OxenAppData;
 use crate::errors::OxenHttpError;
 
+/// Look up a repo by `<namespace>/<name>` under the server's sync dir.
 pub fn get_repo(
-    path: &Path,
+    app_data: &OxenAppData,
     namespace: impl AsRef<str>,
     name: impl AsRef<str>,
 ) -> Result<LocalRepository, OxenHttpError> {
-    let repo = repositories::get_by_namespace_and_name(path, &namespace, &name)?;
+    let repo = repositories::get_by_namespace_and_name(&app_data.path, &namespace, &name)?;
     let Some(repo) = repo else {
         return Err(
             OxenError::RepoNotFound(Box::new(RepoNew::from_namespace_name(


### PR DESCRIPTION
(Stacked on #584) 

Refactor `get_repo` to take a reference to an `OxenAppData`. This makes it so we only need to change all these call sites once, instead of every time that we add a new field to `OxenAppData`...which I'll be doing in a subsequent PR anyway.

No behavior changes.