### PR TITLE
S3 (14c): Consolidate LocalRepository constructors (+ a bug fix)

### DIFF
--- a/crates/lib/src/config/repository_config.rs
+++ b/crates/lib/src/config/repository_config.rs
@@ -4,7 +4,7 @@ use strum::{Display, EnumIter, EnumString, IntoStaticStr, VariantArray, VariantN
 use thiserror::Error;
 use utoipa::ToSchema;
 
-use crate::constants::DEFAULT_VNODE_SIZE;
+use crate::constants::{DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
 use crate::error::OxenError;
 use crate::model::{LocalRepository, Remote};
 use crate::storage::StorageConfig;
@@ -94,13 +94,16 @@ pub struct RepositoryConfig {
 }
 
 impl Default for RepositoryConfig {
+    /// Default matches what `oxen init` writes to a fresh repo's `config.toml`: the current
+    /// `MIN_OXEN_VERSION`, the default vnode size, the default Merkle store backend, and `None`
+    /// for every per-repo override.
     fn default() -> Self {
         RepositoryConfig {
             remote_name: None,
             remotes: Vec::new(),
             subtree_paths: None,
             depth: None,
-            min_version: None,
+            min_version: Some(MIN_OXEN_VERSION.to_string()),
             vnode_size: Some(DEFAULT_VNODE_SIZE),
             storage: None,
             vfs: None,

--- a/crates/lib/src/core/v_latest/download.rs
+++ b/crates/lib/src/core/v_latest/download.rs
@@ -1,3 +1,4 @@
+use crate::config::RepositoryConfig;
 use crate::core::progress::pull_progress::PullProgress;
 use crate::error::OxenError;
 use crate::model::CommitEntry;
@@ -23,7 +24,7 @@ pub async fn download_dir(
     log::debug!("downloading dir {remote_path:?}");
     // Initialize temp repo to download node into
     // TODO: Where should this repo be?
-    let tmp_repo = LocalRepository::new(local_path, None)?;
+    let tmp_repo = LocalRepository::new(local_path, RepositoryConfig::default())?;
 
     // Find and download dir node and its children from remote repo
     let commit_id = &entry.latest_commit.as_ref().unwrap().id;

--- a/crates/lib/src/core/v_latest/init.rs
+++ b/crates/lib/src/core/v_latest/init.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::config::RepositoryConfig;
 use crate::config::repository_config::MerkleStoreKind;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
@@ -46,13 +47,13 @@ pub fn init_with_version_and_merkle_store(
         return Err(OxenError::RepoAlreadyExistsAtPath(path.to_path_buf()));
     }
 
-    let repo = LocalRepository::new_from_version_with_merkle_store_kind(
-        path,
-        version.to_string(),
-        None,
-        is_vfs,
+    let config = RepositoryConfig {
+        min_version: Some(version.to_string()),
+        vfs: if is_vfs { Some(true) } else { None },
         merkle_store_kind,
-    )?;
+        ..Default::default()
+    };
+    let repo = LocalRepository::new(path, config)?;
     repo.save()?;
 
     Ok(repo)
@@ -90,13 +91,14 @@ pub async fn init_with_version_storage_and_merkle_store(
         return Err(OxenError::RepoAlreadyExistsAtPath(path.to_path_buf()));
     }
 
-    let repo = LocalRepository::new_from_version_with_merkle_store_kind(
-        path,
-        version.to_string(),
-        storage_config,
-        is_vfs,
+    let config = RepositoryConfig {
+        min_version: Some(version.to_string()),
+        storage: storage_config,
+        vfs: if is_vfs { Some(true) } else { None },
         merkle_store_kind,
-    )?;
+        ..Default::default()
+    };
+    let repo = LocalRepository::new(path, config)?;
     repo.save()?;
 
     let version_store = repo.version_store();

--- a/crates/lib/src/core/v_latest/workspaces.rs
+++ b/crates/lib/src/core/v_latest/workspaces.rs
@@ -26,7 +26,8 @@ pub fn init_workspace_repo(
     let target_config_file = workspace_hidden_dir.join(constants::REPO_CONFIG_FILENAME);
     util::fs::copy(config_file, &target_config_file)?;
 
-    // Read the storage config from the config file
+    // Workspace inherits the parent repo's full config — min_version, merkle_store_kind, vfs,
+    // and storage — so a workspace built from an LMDB/VFS/S3 repo lands on the same backends.
     let config = RepositoryConfig::from_file(&target_config_file)?;
-    LocalRepository::new(workspace_dir, config.storage)
+    LocalRepository::new(workspace_dir, config)
 }

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -1,7 +1,7 @@
 use crate::config::RepositoryConfig;
 use crate::config::repository_config::MerkleStoreKind;
 use crate::constants::SHALLOW_FLAG;
-use crate::constants::{self, DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
+use crate::constants::{self, DEFAULT_VNODE_SIZE};
 use crate::core::db::merkle_node::file_backend::FileBackend;
 use crate::core::db::merkle_node::lmdb;
 use crate::core::versions::MinOxenVersion;
@@ -59,39 +59,12 @@ pub struct LocalRepositoryWithEntries {
 }
 
 impl LocalRepository {
-    /// Create a LocalRepository from a directory
+    /// Load a `LocalRepository` from a directory's `.oxen/config.toml`.
     pub fn from_dir(path: impl AsRef<Path>) -> Result<Self, OxenError> {
         let path = path.as_ref();
         let config_path = util::fs::config_filepath(path);
         let config = RepositoryConfig::from_file(&config_path)?;
-
-        let merkle_store_kind = config.merkle_store_kind;
-        let m_store = Self::load_merkle_store(
-            path.to_path_buf(),
-            merkle_store_kind,
-            config.vfs.unwrap_or(false),
-        )?;
-
-        let storage_config = config.storage.unwrap_or_default();
-        let version_store = create_version_store(path, &storage_config)?;
-
-        Ok(LocalRepository {
-            path: path.to_path_buf(),
-            remote_name: config.remote_name,
-            min_version: config.min_version,
-            remotes: config.remotes,
-            vnode_size: config.vnode_size,
-            subtree_paths: config.subtree_paths,
-            depth: config.depth,
-            vfs: config.vfs,
-            remote_mode: config.remote_mode,
-            workspace_name: config.workspace_name,
-            workspaces: config.workspaces,
-            storage_config,
-            version_store,
-            merkle_store: Some(m_store),
-            merkle_store_kind: config.merkle_store_kind,
-        })
+        Self::new(path, config)
     }
 
     /// Loads the Merkle store for the repository at the specified root path.
@@ -171,94 +144,42 @@ impl LocalRepository {
         LocalRepository::from_dir(&repo_dir)
     }
 
-    /// Instantiate a new repository at a given path
-    /// Note: Does not create the repository on disk, or read the config file, just instantiates the struct
-    /// To load the repository, use `LocalRepository::from_dir` or `LocalRepository::from_current_dir`
-    pub fn new(
-        path: impl AsRef<Path>,
-        storage_config: Option<StorageConfig>,
-    ) -> Result<LocalRepository, OxenError> {
-        Self::new_with_merkle_store_kind(path, storage_config, MerkleStoreKind::default())
-    }
-
-    /// [`Self::new`] but with an explicit [`MerkleStoreKind`] selection.
-    pub fn new_with_merkle_store_kind(
-        path: impl AsRef<Path>,
-        storage_config: Option<StorageConfig>,
-        merkle_store_kind: MerkleStoreKind,
-    ) -> Result<LocalRepository, OxenError> {
-        let path = path.as_ref().to_path_buf();
-        let storage_config = storage_config.unwrap_or_default();
-        let version_store = create_version_store(&path, &storage_config)?;
-        let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, false)?;
-        Ok(LocalRepository {
-            path,
-            remotes: vec![],
-            remote_name: None,
-            // New with a path should default to our current MIN_OXEN_VERSION
-            min_version: Some(MIN_OXEN_VERSION.to_string()),
-            vnode_size: None,
-            subtree_paths: None,
-            depth: None,
-            vfs: None,
-            remote_mode: None,
-            workspace_name: None,
-            workspaces: None,
-            storage_config,
-            version_store,
-            merkle_store: Some(m_store),
-            merkle_store_kind,
-        })
-    }
-
-    /// Load an older version of a repository with older oxen core logic
-    pub fn new_from_version(
-        path: impl AsRef<Path>,
-        min_version: impl AsRef<str>,
-        storage_config: Option<StorageConfig>,
-        is_vfs: bool,
-    ) -> Result<LocalRepository, OxenError> {
-        Self::new_from_version_with_merkle_store_kind(
-            path,
-            min_version,
-            storage_config,
-            is_vfs,
-            MerkleStoreKind::default(),
-        )
-    }
-
-    /// [`Self::new_from_version`] but with an explicit [`MerkleStoreKind`] selection.
+    /// Instantiate a new repository at a given path from a `RepositoryConfig`.
+    ///
+    /// Note: does NOT create the repo on disk or write the config file — just instantiates the
+    /// struct. To load an existing repo from disk, use [`Self::from_dir`].
     ///
     /// Errors with [`OxenError::MerkleStoreLmdbNotSupportedOnVfs`] when
-    /// `merkle_store_kind == MerkleStoreKind::Lmdb && is_vfs`, since the LMDB
-    /// backend uses memory-mapped IO that's incompatible with virtual file systems.
-    pub fn new_from_version_with_merkle_store_kind(
+    /// `config.merkle_store_kind == MerkleStoreKind::Lmdb && config.vfs == Some(true)`, since
+    /// LMDB's mmap is incompatible with virtual file systems.
+    pub fn new(
         path: impl AsRef<Path>,
-        min_version: impl AsRef<str>,
-        storage_config: Option<StorageConfig>,
-        is_vfs: bool,
-        merkle_store_kind: MerkleStoreKind,
+        config: RepositoryConfig,
     ) -> Result<LocalRepository, OxenError> {
         let path = path.as_ref().to_path_buf();
-        let storage_config = storage_config.unwrap_or_default();
+        let storage_config = config.storage.unwrap_or_default();
         let version_store = create_version_store(&path, &storage_config)?;
-        let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, is_vfs)?;
+        let m_store = Self::load_merkle_store(
+            path.clone(),
+            config.merkle_store_kind,
+            config.vfs.unwrap_or(false),
+        )?;
         Ok(LocalRepository {
             path,
-            remotes: vec![],
-            remote_name: None,
-            min_version: Some(min_version.as_ref().to_string()),
-            vnode_size: None,
-            subtree_paths: None,
-            depth: None,
-            vfs: if is_vfs { Some(true) } else { None },
-            remote_mode: None,
-            workspace_name: None,
-            workspaces: None,
+            remote_name: config.remote_name,
+            min_version: config.min_version,
+            remotes: config.remotes,
+            vnode_size: config.vnode_size,
+            subtree_paths: config.subtree_paths,
+            depth: config.depth,
+            vfs: config.vfs,
+            remote_mode: config.remote_mode,
+            workspace_name: config.workspace_name,
+            workspaces: config.workspaces,
             storage_config,
             version_store,
             merkle_store: Some(m_store),
-            merkle_store_kind,
+            merkle_store_kind: config.merkle_store_kind,
         })
     }
 
@@ -729,6 +650,7 @@ mod tests {
     use filetime::FileTime;
 
     use crate::api::requests::RepoNew;
+    use crate::config::RepositoryConfig;
     use crate::config::repository_config::MerkleStoreKind;
     use crate::error::OxenError;
     use crate::model::LocalRepository;
@@ -829,7 +751,7 @@ mod tests {
     fn test_add_workspace() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
         let repo_path = temp_dir.path().to_path_buf();
-        let mut repo = LocalRepository::new(repo_path, None)?;
+        let mut repo = LocalRepository::new(repo_path, RepositoryConfig::default())?;
 
         let sample_name = "sample";
         repo.add_workspace(sample_name);
@@ -847,7 +769,7 @@ mod tests {
     fn test_cannot_add_repeat_workspace() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
         let repo_path = temp_dir.path().to_path_buf();
-        let mut repo = LocalRepository::new(repo_path, None)?;
+        let mut repo = LocalRepository::new(repo_path, RepositoryConfig::default())?;
 
         let sample_name = "sample";
         repo.add_workspace(sample_name);
@@ -860,7 +782,7 @@ mod tests {
     fn test_delete_workspace() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
         let repo_path = temp_dir.path().to_path_buf();
-        let mut repo = LocalRepository::new(repo_path, None)?;
+        let mut repo = LocalRepository::new(repo_path, RepositoryConfig::default())?;
 
         let sample_name = "sample";
         repo.add_workspace(sample_name);
@@ -893,7 +815,13 @@ mod tests {
             kind: StorageKind::Local,
             versions_path: Some(PathBuf::from("/mnt/nfs/customer/.oxen/versions/files")),
         };
-        let repo = LocalRepository::new(&repo_path, Some(custom.clone()))?;
+        let repo = LocalRepository::new(
+            &repo_path,
+            RepositoryConfig {
+                storage: Some(custom.clone()),
+                ..Default::default()
+            },
+        )?;
         repo.save()?;
 
         let reloaded = LocalRepository::from_dir(&repo_path)?;
@@ -917,7 +845,7 @@ mod tests {
     #[test]
     fn test_new_defaults_to_file_merkle_store() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
-        let repo = LocalRepository::new(temp_dir.path(), None)?;
+        let repo = LocalRepository::new(temp_dir.path(), RepositoryConfig::default())?;
         assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::File);
         Ok(())
     }
@@ -927,10 +855,12 @@ mod tests {
     #[test]
     fn test_new_with_merkle_store_kind_picks_lmdb() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
-        let repo = LocalRepository::new_with_merkle_store_kind(
+        let repo = LocalRepository::new(
             temp_dir.path(),
-            None,
-            MerkleStoreKind::Lmdb,
+            RepositoryConfig {
+                merkle_store_kind: MerkleStoreKind::Lmdb,
+                ..Default::default()
+            },
         )?;
         assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::Lmdb);
         Ok(())
@@ -942,12 +872,14 @@ mod tests {
     #[test]
     fn test_new_with_merkle_store_kind_rejects_lmdb_on_vfs() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
-        let result = LocalRepository::new_from_version_with_merkle_store_kind(
+        let result = LocalRepository::new(
             temp_dir.path(),
-            "0.25.0",
-            None,
-            true, // is_vfs
-            MerkleStoreKind::Lmdb,
+            RepositoryConfig {
+                min_version: Some("0.25.0".to_string()),
+                vfs: Some(true),
+                merkle_store_kind: MerkleStoreKind::Lmdb,
+                ..Default::default()
+            },
         );
         assert!(
             matches!(result, Err(OxenError::MerkleStoreLmdbNotSupportedOnVfs)),
@@ -960,12 +892,14 @@ mod tests {
     #[test]
     fn test_new_with_file_kind_accepts_vfs() -> Result<(), OxenError> {
         let temp_dir = TempDir::new()?;
-        let repo = LocalRepository::new_from_version_with_merkle_store_kind(
+        let repo = LocalRepository::new(
             temp_dir.path(),
-            "0.25.0",
-            None,
-            true,
-            MerkleStoreKind::File,
+            RepositoryConfig {
+                min_version: Some("0.25.0".to_string()),
+                vfs: Some(true),
+                merkle_store_kind: MerkleStoreKind::File,
+                ..Default::default()
+            },
         )?;
         assert!(repo.is_vfs());
         assert_eq!(repo.merkle_store_kind(), MerkleStoreKind::File);

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -238,14 +238,17 @@ pub async fn create(
     util::fs::create_dir_all(&hidden_dir)?;
 
     // Create config file
-    let storage_config = new_repo
-        .storage_kind
-        .map(|kind| crate::storage::StorageConfig {
-            kind,
-            versions_path: None,
-        });
-    let local_repo =
-        LocalRepository::new_with_merkle_store_kind(&repo_dir, storage_config, merkle_store_kind)?;
+    let config = crate::config::RepositoryConfig {
+        storage: new_repo
+            .storage_kind
+            .map(|kind| crate::storage::StorageConfig {
+                kind,
+                versions_path: None,
+            }),
+        merkle_store_kind,
+        ..Default::default()
+    };
+    let local_repo = LocalRepository::new(&repo_dir, config)?;
     local_repo.save()?;
 
     // Initialize version store

--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -59,6 +59,7 @@ pub async fn pull_remote_branch(
 mod tests {
     use crate::api;
     use crate::command;
+    use crate::config::RepositoryConfig;
     use crate::constants;
     use crate::constants::OXEN_HIDDEN_DIR;
     use crate::core::df::tabular;
@@ -1995,7 +1996,7 @@ mod tests {
             let remote_repo_clone = remote_repo.clone();
             test::run_empty_dir_test_async(|dir| async move {
                 // Create an empty repo locally
-                let mut local_repo = LocalRepository::new(dir, None)?;
+                let mut local_repo = LocalRepository::new(dir, RepositoryConfig::default())?;
 
                 // Add and commit a new file
                 let hello_file = local_repo.path.join("dir").join("hello.txt");

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -94,7 +94,7 @@ pub fn get_by_dir(
         id: config.workspace_id.unwrap_or(workspace_id.to_owned()),
         name: config.workspace_name,
         base_repo: repo.clone(),
-        workspace_repo: LocalRepository::new(workspace_dir, repo_config.storage)?,
+        workspace_repo: LocalRepository::new(workspace_dir, repo_config)?,
         commit,
         is_editable: config.is_editable,
     }))


### PR DESCRIPTION
(Stacked on #585)

Collapse the four `LocalRepository::new*` constructors (`new`, `new_with_merkle_store_kind`, `new_from_version`, `new_from_version_with_merkle_store_kind`) into one `LocalRepository::new(path, RepositoryConfig)`.

- `from_dir` becomes a thin wrapper that loads the config from disk and delegates to `new`, so field-population logic lives in exactly one place.
- `RepositoryConfig::default()` now sets `min_version` to `MIN_OXEN_VERSION` so a fresh `RepositoryConfig` matches what `oxen init` writes to disk. Callers that need a specific version (init paths, the 0.25.0 LMDB/VFS tests) set `min_version` explicitly via struct update syntax.
- Bug fix: Workspace creation passes the parent's full `RepositoryConfig` instead of just `repo_config.storage`, so a workspace inherits the LMDB and VFS settings instead of changing to defaults.
- Delete `new_from_version`, since nothing calls it.