### PR TITLE
S3 (14d): Wire S3 backend in create_version_store

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -115,6 +115,7 @@ oxen push origin main               # Push to remote
 - Use the result type (`Result<T, Error>`) when an operation could fail.
 - Never use `.unwrap()` or `.expect()` on a `Result` or on an `Option`.
   + Exception: In test-only code, it is ok to use use `.expect(<descriptive explanation of invariant that was violated>)` since we want to fail fast and have good stack traces for failing test cases.
+  + This rule still applies when the panic feels "guaranteed unreachable" because of an upstream invariant. If the enclosing function returns a `Result`, surface the case as a structured `OxenError` variant and propagate with `?` — a panic in production code is never preferable to a clean error path, no matter how confident you are the case can't happen.
 - Use as specific of an error type as possible for a function. Don't use a wider type unless it's necessary. When making modules and related pieces of code, try to use a locally-defined error enum for them if they all have similar errors.
 - Make sure there's an `OxenError` variant for every error type. Be liberal in wrapping other modules error types, or other specific error types, in a new variant. Use a `Box<>` wrapper for it and have a `#[from]` to derive.
 - `OxenError` is the top-level type for everything. If you need to unify different error types into one, use `OxenError`. These kinds of functions should return `Result<T, OxenError>`

--- a/crates/lib/src/core/v_latest/workspaces.rs
+++ b/crates/lib/src/core/v_latest/workspaces.rs
@@ -27,7 +27,8 @@ pub fn init_workspace_repo(
     util::fs::copy(config_file, &target_config_file)?;
 
     // Workspace inherits the parent repo's full config — min_version, merkle_store_kind, vfs,
-    // and storage — so a workspace built from an LMDB/VFS/S3 repo lands on the same backends.
+    // and storage — plus its server S3 opts so a workspace built from an LMDB/VFS/S3 repo lands
+    // on the same backends.
     let config = RepositoryConfig::from_file(&target_config_file)?;
-    LocalRepository::new(workspace_dir, config)
+    LocalRepository::new_with_server_opts(workspace_dir, config, repo.server_s3_opts())
 }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -281,10 +281,16 @@ pub enum OxenError {
     #[error("Unsupported storage kind: {0}")]
     UnsupportedStorageKind(String),
 
-    /// The S3 version store backend is not yet implemented; admin/server wiring lands in a later
-    /// step of the storage-policy work.
-    #[error("S3 storage backend not yet implemented")]
-    S3BackendNotImplemented,
+    /// An S3-backed repo was requested but the server has no S3 opts configured (the
+    /// `s3_bucket` is unset in the server's TOML). On the repo-create path this normally surfaces
+    /// as a 400 from `StoragePolicy::resolve()` before construction; this variant catches the
+    /// repo-load path or any other caller that built a `StorageConfig { kind: S3, .. }` without
+    /// going through the policy.
+    #[error(
+        "S3 storage requested but the server has no S3 opts configured \
+         (see `s3_bucket` under [storage] in the server config)"
+    )]
+    S3BackendMissingServerOpts,
 
     /// `oxen restore` finished with one or more file-restore failures. Aggregated rather than
     /// fail-fast so the rest of the files can still be restored. The vector should be non-empty.
@@ -732,6 +738,9 @@ impl OxenError {
             }
             DownloadBatchExhausted { .. } | VersionsMissingOnServer { .. } => {
                 "If a content blob is missing on the server, run `oxen push --missing-files` from a clone with the full local history to repair it."
+            }
+            S3BackendMissingServerOpts => {
+                "Set `[storage] s3_bucket = \"<your-bucket>\"` in the server's config TOML and restart oxen-server."
             }
             _ => return None,
         }

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -292,6 +292,15 @@ pub enum OxenError {
     )]
     S3BackendMissingServerOpts,
 
+    /// `create_version_store` could not derive the S3 object prefix from the repo path because the
+    /// path lacks the expected `<namespace>/<name>` tail. Server repo paths are always built as
+    /// `<sync_dir>/<namespace>/<name>`, so this only surfaces for malformed callers — but we
+    /// surface it as a structured error rather than panicking.
+    #[error(
+        "Cannot derive S3 object prefix from repo path {0}: expected `<namespace>/<name>` tail"
+    )]
+    S3PrefixUnresolvable(PathBufError),
+
     /// `oxen restore` finished with one or more file-restore failures. Aggregated rather than
     /// fail-fast so the rest of the files can still be restored. The vector should be non-empty.
     #[error("{}", format_restore_failures(failures))]

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -9,7 +9,7 @@ use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::merkle_tree::{MerkleStore, MerkleTransport, TransportableMerkleStore};
 use crate::model::{MetadataEntry, Remote, RemoteRepository};
-use crate::storage::{StorageConfig, VersionStore, create_version_store};
+use crate::storage::{S3Opts, StorageConfig, VersionStore, create_version_store};
 use crate::util;
 use crate::view::RepositoryView;
 
@@ -45,7 +45,11 @@ pub struct LocalRepository {
     /// Storage backend configuration. Set once at construction and never mutated for the life
     /// of this `LocalRepository` — the source of truth for which backend `version_store` is.
     storage_config: StorageConfig,
-    /// Built from `storage_config` at construction. Never replaced.
+    /// Server-wide S3 opts, carried so that operations that derive a new `LocalRepository`
+    /// from an existing one (e.g. workspace creation) can rebuild a matching S3 version store
+    /// without re-threading the server opts through every function. CLI paths leave this `None`.
+    server_s3_opts: Option<S3Opts>,
+    /// Built from `storage_config` + `server_s3_opts` at construction. Never replaced.
     version_store: Arc<dyn VersionStore>,
 
     merkle_store: Option<Arc<dyn TransportableMerkleStore>>,
@@ -59,12 +63,24 @@ pub struct LocalRepositoryWithEntries {
 }
 
 impl LocalRepository {
-    /// Load a `LocalRepository` from a directory's `.oxen/config.toml`.
+    /// Load a repo from disk without any server-side S3 opts. Use this from the CLI and any code
+    /// path that doesn't talk to the server's storage config — an on-disk `[storage] kind = "s3"`
+    /// will surface as [`OxenError::S3BackendMissingServerOpts`]. Server code should call
+    /// [`Self::from_dir_with_server_opts`] instead.
     pub fn from_dir(path: impl AsRef<Path>) -> Result<Self, OxenError> {
+        Self::from_dir_with_server_opts(path, None)
+    }
+
+    /// Server-side variant of [`Self::from_dir`]: threads the server's S3 opts so that
+    /// `[storage] kind = "s3"` repos build a real `S3VersionStore`.
+    pub fn from_dir_with_server_opts(
+        path: impl AsRef<Path>,
+        server_s3_opts: Option<&S3Opts>,
+    ) -> Result<Self, OxenError> {
         let path = path.as_ref();
         let config_path = util::fs::config_filepath(path);
         let config = RepositoryConfig::from_file(&config_path)?;
-        Self::new(path, config)
+        Self::new_with_server_opts(path, config, server_s3_opts)
     }
 
     /// Loads the Merkle store for the repository at the specified root path.
@@ -129,6 +145,14 @@ impl LocalRepository {
         &self.storage_config
     }
 
+    /// Server-wide S3 opts the repo was constructed with (always `None` on CLI builds).
+    /// Operations that derive a new `LocalRepository` from this one — workspace creation, for
+    /// example — should pass this back into the constructor so the derived repo's S3 version
+    /// store can be rebuilt.
+    pub fn server_s3_opts(&self) -> Option<&S3Opts> {
+        self.server_s3_opts.as_ref()
+    }
+
     /// Get a reference to the version store.
     pub fn version_store(&self) -> Arc<dyn VersionStore> {
         Arc::clone(&self.version_store)
@@ -144,7 +168,9 @@ impl LocalRepository {
         LocalRepository::from_dir(&repo_dir)
     }
 
-    /// Instantiate a new repository at a given path from a `RepositoryConfig`.
+    /// Instantiate a new repository at a given path from a `RepositoryConfig`. CLI/test helper;
+    /// server code that may build S3-backed repos should call [`Self::new_with_server_opts`]
+    /// instead.
     ///
     /// Note: does NOT create the repo on disk or write the config file — just instantiates the
     /// struct. To load an existing repo from disk, use [`Self::from_dir`].
@@ -156,9 +182,19 @@ impl LocalRepository {
         path: impl AsRef<Path>,
         config: RepositoryConfig,
     ) -> Result<LocalRepository, OxenError> {
+        Self::new_with_server_opts(path, config, None)
+    }
+
+    /// Server-side variant of [`Self::new`]: threads server S3 opts so an
+    /// `[storage] kind = "s3"` config builds a real `S3VersionStore`.
+    pub fn new_with_server_opts(
+        path: impl AsRef<Path>,
+        config: RepositoryConfig,
+        server_s3_opts: Option<&S3Opts>,
+    ) -> Result<LocalRepository, OxenError> {
         let path = path.as_ref().to_path_buf();
         let storage_config = config.storage.unwrap_or_default();
-        let version_store = create_version_store(&path, &storage_config)?;
+        let version_store = create_version_store(&path, &storage_config, server_s3_opts)?;
         let m_store = Self::load_merkle_store(
             path.clone(),
             config.merkle_store_kind,
@@ -177,6 +213,7 @@ impl LocalRepository {
             workspace_name: config.workspace_name,
             workspaces: config.workspaces,
             storage_config,
+            server_s3_opts: server_s3_opts.cloned(),
             version_store,
             merkle_store: Some(m_store),
             merkle_store_kind: config.merkle_store_kind,
@@ -186,7 +223,7 @@ impl LocalRepository {
     pub fn from_view(view: RepositoryView) -> Result<LocalRepository, OxenError> {
         let path = std::env::current_dir()?.join(view.name);
         let storage_config = StorageConfig::default();
-        let version_store = create_version_store(&path, &storage_config)?;
+        let version_store = create_version_store(&path, &storage_config, None)?;
         let merkle_store_kind = MerkleStoreKind::default();
         let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, false)?;
         Ok(LocalRepository {
@@ -202,6 +239,7 @@ impl LocalRepository {
             workspace_name: None,
             workspaces: None,
             storage_config,
+            server_s3_opts: None,
             version_store,
             merkle_store: Some(m_store),
             merkle_store_kind,
@@ -229,7 +267,7 @@ impl LocalRepository {
     ) -> Result<LocalRepository, OxenError> {
         let path = path.to_owned();
         let storage_config = StorageConfig::default();
-        let version_store = create_version_store(&path, &storage_config)?;
+        let version_store = create_version_store(&path, &storage_config, None)?;
         let m_store = Self::load_merkle_store(path.clone(), merkle_store_kind, is_vfs)?;
         Ok(LocalRepository {
             path,
@@ -244,6 +282,7 @@ impl LocalRepository {
             workspace_name: None,
             workspaces: None,
             storage_config,
+            server_s3_opts: None,
             version_store,
             merkle_store: Some(m_store),
             merkle_store_kind,

--- a/crates/lib/src/repositories.rs
+++ b/crates/lib/src/repositories.rs
@@ -18,6 +18,7 @@ use crate::model::merkle_tree;
 use crate::model::repository::local_repository::LocalRepositoryWithEntries;
 use crate::repositories;
 use crate::repositories::fork::FORK_STATUS_FILENAME;
+use crate::storage::S3Opts;
 use crate::util;
 use jwalk::WalkDir;
 use regex::Regex;
@@ -75,6 +76,7 @@ pub fn get_by_namespace_and_name(
     sync_dir: &Path,
     namespace: impl AsRef<str>,
     name: impl AsRef<str>,
+    server_s3_opts: Option<&S3Opts>,
 ) -> Result<Option<LocalRepository>, OxenError> {
     let namespace = namespace.as_ref();
     let name = name.as_ref();
@@ -85,10 +87,10 @@ pub fn get_by_namespace_and_name(
         return Ok(None);
     }
 
-    let repo = LocalRepository::from_dir(&repo_dir);
+    let repo = LocalRepository::from_dir_with_server_opts(&repo_dir, server_s3_opts);
     match repo {
         Ok(repo) => Ok(Some(repo)),
-        Err(OxenError::LocalRepoNotFound(_)) => is_repo_forked(&repo_dir),
+        Err(OxenError::LocalRepoNotFound(_)) => is_repo_forked(&repo_dir, server_s3_opts),
         Err(err) => {
             log::error!("Error getting repo from dir: {err:?}");
             Err(err)
@@ -96,11 +98,17 @@ pub fn get_by_namespace_and_name(
     }
 }
 
-fn is_repo_forked(repo_dir: &Path) -> Result<Option<LocalRepository>, OxenError> {
+fn is_repo_forked(
+    repo_dir: &Path,
+    server_s3_opts: Option<&S3Opts>,
+) -> Result<Option<LocalRepository>, OxenError> {
     let status_path = repo_dir.join(OXEN_HIDDEN_DIR).join(FORK_STATUS_FILENAME);
 
     if status_path.exists() {
-        Ok(Some(LocalRepository::from_dir(repo_dir)?))
+        Ok(Some(LocalRepository::from_dir_with_server_opts(
+            repo_dir,
+            server_s3_opts,
+        )?))
     } else {
         Err(OxenError::local_repo_not_found(repo_dir))
     }
@@ -163,6 +171,7 @@ pub fn transfer_namespace(
     repo_name: &str,
     from_namespace: &str,
     to_namespace: &str,
+    server_s3_opts: Option<&S3Opts>,
 ) -> Result<LocalRepository, OxenError> {
     log::debug!("transfer_namespace from: {from_namespace} to: {to_namespace}");
 
@@ -186,12 +195,13 @@ pub fn transfer_namespace(
 
     // Update path in config
     {
-        let repo = LocalRepository::from_dir(&new_repo_dir)?;
+        let repo = LocalRepository::from_dir_with_server_opts(&new_repo_dir, server_s3_opts)?;
         repo.save()?;
         // ensure drop(repo)
     }
 
-    let updated_repo = get_by_namespace_and_name(sync_dir, to_namespace, repo_name)?;
+    let updated_repo =
+        get_by_namespace_and_name(sync_dir, to_namespace, repo_name, server_s3_opts)?;
     match updated_repo {
         Some(new_repo) => Ok(new_repo),
         None => Err(OxenError::FailedTransfer),
@@ -209,6 +219,7 @@ pub async fn create(
     root_dir: &Path,
     new_repo: RepoNew,
     merkle_store_kind: MerkleStoreKind,
+    server_s3_opts: Option<&S3Opts>,
 ) -> Result<LocalRepositoryWithEntries, OxenError> {
     // Validate repo name
     if !is_valid_repo_name(&new_repo.name) {
@@ -248,7 +259,7 @@ pub async fn create(
         merkle_store_kind,
         ..Default::default()
     };
-    let local_repo = LocalRepository::new(&repo_dir, config)?;
+    let local_repo = LocalRepository::new_with_server_opts(&repo_dir, config, server_s3_opts)?;
     local_repo.save()?;
 
     // Initialize version store
@@ -380,7 +391,7 @@ mod tests {
             };
             let repo_new = RepoNew::from_root_commit(namespace, name, root_commit);
             let _repo =
-                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default(), None).await?;
 
             let repo_path = Path::new(&sync_dir)
                 .join(Path::new(namespace))
@@ -409,7 +420,7 @@ mod tests {
             }];
             let repo_new = RepoNew::from_files(namespace, name, files, None);
             let _repo =
-                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default(), None).await?;
 
             let repo_path = Path::new(&sync_dir)
                 .join(Path::new(namespace))
@@ -431,7 +442,7 @@ mod tests {
             let name: &str = "test-repo-name";
             let repo_new = RepoNew::from_namespace_name(namespace, name, None);
             let _repo =
-                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default(), None).await?;
 
             let repo_path = Path::new(&sync_dir)
                 .join(Path::new(namespace))
@@ -455,7 +466,7 @@ mod tests {
             let name = "default-merkle-repo";
             let repo_new = RepoNew::from_namespace_name(namespace, name, None);
             let created =
-                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default(), None).await?;
             assert_eq!(
                 created.local_repo.merkle_store_kind(),
                 MerkleStoreKind::File,
@@ -485,7 +496,7 @@ mod tests {
             let repo_new: RepoNew = serde_json::from_str(json).expect("parse RepoNew");
 
             let created =
-                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default(), None).await?;
             assert_eq!(
                 created.local_repo.merkle_store_kind(),
                 MerkleStoreKind::File,
@@ -533,7 +544,7 @@ mod tests {
             let name = "repo with spaces";
             let repo_new = RepoNew::from_namespace_name(namespace, name, None);
             let result =
-                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await;
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default(), None).await;
 
             assert!(result.is_err(), "Expected error but got: {result:?}");
             match result.unwrap_err() {
@@ -555,7 +566,7 @@ mod tests {
             let name = "valid-repo";
             let repo_new = RepoNew::from_namespace_name(namespace, name, None);
             let result =
-                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await;
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default(), None).await;
 
             assert!(result.is_err(), "Expected error but got: {result:?}");
             match result.unwrap_err() {
@@ -640,7 +651,7 @@ mod tests {
 
             let _ = repositories::init(&repo_dir)?;
             let _repo =
-                repositories::get_by_namespace_and_name(sync_dir, namespace, name)?.unwrap();
+                repositories::get_by_namespace_and_name(sync_dir, namespace, name, None)?.unwrap();
             Ok(())
         })
     }
@@ -671,7 +682,7 @@ mod tests {
             };
             let repo_new = RepoNew::from_root_commit(old_namespace, name, root_commit);
             let _repo =
-                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default()).await?;
+                repositories::create(&sync_dir, repo_new, MerkleStoreKind::default(), None).await?;
 
             let old_namespace_repos = repositories::list_repos_in_namespace(&old_namespace_dir);
             let new_namespace_repos = repositories::list_repos_in_namespace(&new_namespace_dir);
@@ -680,8 +691,13 @@ mod tests {
             assert_eq!(new_namespace_repos.count(), 0);
 
             // Transfer to new namespace
-            let updated_repo =
-                repositories::transfer_namespace(&sync_dir, name, old_namespace, new_namespace)?;
+            let updated_repo = repositories::transfer_namespace(
+                &sync_dir,
+                name,
+                old_namespace,
+                new_namespace,
+                None,
+            )?;
 
             // Log out updated_repo
             log::debug!("updated_repo: {updated_repo:?}");

--- a/crates/lib/src/repositories/workspaces.rs
+++ b/crates/lib/src/repositories/workspaces.rs
@@ -94,7 +94,11 @@ pub fn get_by_dir(
         id: config.workspace_id.unwrap_or(workspace_id.to_owned()),
         name: config.workspace_name,
         base_repo: repo.clone(),
-        workspace_repo: LocalRepository::new(workspace_dir, repo_config)?,
+        workspace_repo: LocalRepository::new_with_server_opts(
+            workspace_dir,
+            repo_config,
+            repo.server_s3_opts(),
+        )?,
         commit,
         is_editable: config.is_editable,
     }))

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -422,16 +422,17 @@ pub fn create_version_store(
         StorageKind::S3 => {
             let opts = server_s3_opts.ok_or(OxenError::S3BackendMissingServerOpts)?;
             // Server repo paths are always `<sync_dir>/<namespace>/<name>` (the only path that
-            // reaches the S3 branch), so the tail components are guaranteed present.
+            // reaches the S3 branch), so the tail components should always be present. We still
+            // surface a structured error instead of panicking on a malformed caller.
             let name = repo_dir
                 .file_name()
                 .and_then(|s| s.to_str())
-                .expect("server-built repo path must have a name component");
+                .ok_or_else(|| OxenError::S3PrefixUnresolvable(repo_dir.into()))?;
             let namespace = repo_dir
                 .parent()
                 .and_then(|p| p.file_name())
                 .and_then(|s| s.to_str())
-                .expect("server-built repo path must have a namespace component");
+                .ok_or_else(|| OxenError::S3PrefixUnresolvable(repo_dir.into()))?;
             let prefix = format!("{namespace}/{name}");
             let store = S3VersionStore::new(opts.bucket.clone(), prefix);
             Ok(Arc::new(store))

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -14,7 +14,7 @@ use utoipa::ToSchema;
 use crate::constants;
 use crate::constants::MAX_CONCURRENT_VERSION_PROBES;
 use crate::error::OxenError;
-use crate::storage::LocalVersionStore;
+use crate::storage::{LocalVersionStore, S3Opts, S3VersionStore};
 use crate::util;
 use crate::view::versions::CleanCorruptedVersionsResult;
 
@@ -389,10 +389,17 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     fn storage_kind(&self) -> StorageKind;
 }
 
-/// This only creates a version store struct, it does not initialize it
+/// Build a `VersionStore` for the given repo according to its persisted `StorageConfig`.
+///
+/// `server_s3_opts` is the server-wide S3 configuration (bucket name). It must be `Some`
+/// whenever `config.kind == StorageKind::S3`; CLI and test paths pass `None` because they never
+/// run with the S3 backend enabled. The S3 prefix is derived from the repo path's
+/// `<namespace>/<name>` tail at construction time and never written to per-repo config, so the
+/// server can rotate buckets without rewriting every repo.
 pub fn create_version_store(
     repo_dir: &Path,
     config: &StorageConfig,
+    server_s3_opts: Option<&S3Opts>,
 ) -> Result<Arc<dyn VersionStore>, OxenError> {
     match config.kind {
         StorageKind::Local => {
@@ -412,6 +419,59 @@ pub fn create_version_store(
             let store = LocalVersionStore::new(versions_dir);
             Ok(Arc::new(store))
         }
-        StorageKind::S3 => Err(OxenError::S3BackendNotImplemented),
+        StorageKind::S3 => {
+            let opts = server_s3_opts.ok_or(OxenError::S3BackendMissingServerOpts)?;
+            // Server repo paths are always `<sync_dir>/<namespace>/<name>` (the only path that
+            // reaches the S3 branch), so the tail components are guaranteed present.
+            let name = repo_dir
+                .file_name()
+                .and_then(|s| s.to_str())
+                .expect("server-built repo path must have a name component");
+            let namespace = repo_dir
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|s| s.to_str())
+                .expect("server-built repo path must have a namespace component");
+            let prefix = format!("{namespace}/{name}");
+            let store = S3VersionStore::new(opts.bucket.clone(), prefix);
+            Ok(Arc::new(store))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn s3_config() -> StorageConfig {
+        StorageConfig {
+            kind: StorageKind::S3,
+            versions_path: None,
+        }
+    }
+
+    /// The S3 branch requires server opts. `None` is the runtime tripwire for callers that
+    /// somehow built an S3-shaped `StorageConfig` without going through `StoragePolicy::resolve()`.
+    #[test]
+    fn create_version_store_s3_without_server_opts_errors() {
+        let repo_dir = PathBuf::from("/srv/oxen/test-ns/test-repo");
+        let result = create_version_store(&repo_dir, &s3_config(), None);
+        assert!(
+            matches!(result, Err(OxenError::S3BackendMissingServerOpts)),
+            "expected S3BackendMissingServerOpts, got {result:?}",
+        );
+    }
+
+    /// With server opts, the S3 branch returns an S3-kind store.
+    #[test]
+    fn create_version_store_s3_with_server_opts_builds_s3_store() {
+        let repo_dir = PathBuf::from("/srv/oxen/test-ns/test-repo");
+        let opts = S3Opts {
+            bucket: "my-bucket".to_string(),
+        };
+        let store = create_version_store(&repo_dir, &s3_config(), Some(&opts))
+            .expect("S3 store should construct when server opts are present");
+        assert_eq!(store.storage_kind(), StorageKind::S3);
     }
 }

--- a/crates/server/src/config/storage_policy.rs
+++ b/crates/server/src/config/storage_policy.rs
@@ -107,6 +107,12 @@ impl StoragePolicy {
         }
     }
 
+    /// Server S3 opts to thread into liboxen constructors (e.g. `LocalRepository::from_dir`).
+    /// `None` when the S3 backend is not configured on this server.
+    pub fn s3(&self) -> Option<&S3Opts> {
+        self.s3.as_ref()
+    }
+
     /// Resolve the storage backend kind to use for a new repo.
     ///
     /// - `requested = None`: returns the server's default.

--- a/crates/server/src/controllers/commits.rs
+++ b/crates/server/src/controllers/commits.rs
@@ -1048,7 +1048,12 @@ pub async fn complete(req: HttpRequest) -> Result<HttpResponse, Error> {
     let repo_name: &str = path_param(&req, "repo_name").unwrap();
     let commit_id: &str = path_param(&req, "commit_id").unwrap();
 
-    match repositories::get_by_namespace_and_name(&app_data.path, namespace, repo_name) {
+    match repositories::get_by_namespace_and_name(
+        &app_data.path,
+        namespace,
+        repo_name,
+        app_data.config.storage.s3(),
+    ) {
         Ok(Some(repo)) => {
             match repositories::commits::get_by_id(&repo, commit_id) {
                 Ok(Some(commit)) => {

--- a/crates/server/src/controllers/oxen_version.rs
+++ b/crates/server/src/controllers/oxen_version.rs
@@ -42,7 +42,12 @@ pub async fn resolve(req: HttpRequest) -> HttpResponse {
     let namespace: Option<&str> = path_param(&req, "namespace").ok();
     let name: Option<&str> = path_param(&req, "repo_name").ok();
     if let (Some(name), Some(namespace)) = (name, namespace) {
-        match repositories::get_by_namespace_and_name(&app_data.path, namespace, name) {
+        match repositories::get_by_namespace_and_name(
+            &app_data.path,
+            namespace,
+            name,
+            app_data.config.storage.s3(),
+        ) {
             Ok(Some(_)) => match req.url_for("repo_root", [namespace, name]) {
                 Ok(url) => {
                     log::debug!("resolved repo URL: {url}");

--- a/crates/server/src/controllers/repositories.rs
+++ b/crates/server/src/controllers/repositories.rs
@@ -158,7 +158,12 @@ pub async fn stats(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let namespace: Option<&str> = path_param(&req, "namespace").ok();
     let name: Option<&str> = path_param(&req, "repo_name").ok();
     if let (Some(name), Some(namespace)) = (name, namespace) {
-        match repositories::get_by_namespace_and_name(&app_data.path, namespace, name) {
+        match repositories::get_by_namespace_and_name(
+            &app_data.path,
+            namespace,
+            name,
+            app_data.config.storage.s3(),
+        ) {
             Ok(Some(repo)) => {
                 let stats = repositories::stats::get_stats(&repo)?;
                 let data_types: Vec<DataTypeView> = stats
@@ -319,7 +324,14 @@ async fn handle_json_creation(
     };
 
     let repo_new_clone = data.clone();
-    match repositories::create(&app_data.path, data, app_data.merkle_store_kind).await {
+    match repositories::create(
+        &app_data.path,
+        data,
+        app_data.merkle_store_kind,
+        app_data.config.storage.s3(),
+    )
+    .await
+    {
         Ok(repo) => match repositories::commits::latest_commit(&repo.local_repo) {
             Ok(latest_commit) => Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                 status: STATUS_SUCCESS.to_string(),
@@ -457,7 +469,14 @@ async fn handle_multipart_creation(
     let repo_data_clone = repo_data.clone();
 
     // Create repository
-    match repositories::create(&app_data.path, repo_data, app_data.merkle_store_kind).await {
+    match repositories::create(
+        &app_data.path,
+        repo_data,
+        app_data.merkle_store_kind,
+        app_data.config.storage.s3(),
+    )
+    .await
+    {
         Ok(repo) => match repositories::commits::latest_commit(&repo.local_repo) {
             Ok(latest_commit) => Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                 status: STATUS_SUCCESS.to_string(),
@@ -596,8 +615,13 @@ pub async fn transfer_namespace(
 
     log::debug!("transfer_namespace from: {from_namespace} to: {to_namespace}");
 
-    let repo =
-        repositories::transfer_namespace(&app_data.path, &name, &from_namespace, &to_namespace)?;
+    let repo = repositories::transfer_namespace(
+        &app_data.path,
+        &name,
+        &from_namespace,
+        &to_namespace,
+        app_data.config.storage.s3(),
+    )?;
 
     // Return repository view under new namespace
     Ok(HttpResponse::Ok().json(RepositoryResponse {

--- a/crates/server/src/helpers.rs
+++ b/crates/server/src/helpers.rs
@@ -15,7 +15,12 @@ pub fn get_repo(
     namespace: impl AsRef<str>,
     name: impl AsRef<str>,
 ) -> Result<LocalRepository, OxenHttpError> {
-    let repo = repositories::get_by_namespace_and_name(&app_data.path, &namespace, &name)?;
+    let repo = repositories::get_by_namespace_and_name(
+        &app_data.path,
+        &namespace,
+        &name,
+        app_data.config.storage.s3(),
+    )?;
     let Some(repo) = repo else {
         return Err(
             OxenError::RepoNotFound(Box::new(RepoNew::from_namespace_name(


### PR DESCRIPTION
Wire up the S3 config through to repos so it can actually work on oxen-server. The S3 branch of `create_version_store` now builds a real `S3VersionStore` from the server's bucket plus a prefix derived from the repo path's `<namespace>/<name>` tail.

@gschoeni @jcelliott NOTE the implicit design decision above. Shared content is partitioned _per repository_. We can always switch to per-namespace, global, or custom content sharing in the future.

- Replace `OxenError::S3BackendNotImplemented` with `S3BackendMissingServerOpts`, including a hint pointing at `[storage] s3_bucket` in the server's TOML.
- `create_version_store` grows `server_s3_opts: Option<&S3Opts>`. The Local branch ignores it; the S3 branch errors when it's `None`.
- Add `LocalRepository::from_dir_with_server_opts` and `LocalRepository::new_with_server_opts` server-side constructor twins.
- Carry `server_s3_opts: Option<S3Opts>` on `LocalRepository` so workspace creation can inherit it via `repo.server_s3_opts()` without re-threading the param through every function.
- Thread `server_s3_opts` through `repositories::{get_by_namespace_and_name, is_repo_forked, transfer_namespace, create}`.
- Add `StoragePolicy::s3()` accessor; `helpers::get_repo` reads it once and threads through.
- Workspace inheritance: `core/v_latest/workspaces::init_workspace_repo` and `repositories/workspaces::get_by_dir` use `LocalRepository::new_with_server_opts(.., repo.server_s3_opts())`.