### PR TITLE
Min Version (2): Drop `MinOxenVersion::V0_25_0`

### DIFF
--- a/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -68,7 +68,7 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
 
     // Iterate over the nodes, find the VNode and DirNode, and add the child counts
     let mut new_repo = repository.clone();
-    new_repo.set_min_version(MinOxenVersion::from_string("0.25.0")?);
+    new_repo.set_min_version(MinOxenVersion::LATEST);
 
     // *******************************************************************
     // We need to load all the children of all the VNodes for each DirNode
@@ -118,9 +118,9 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
     // println!("new tree for commit {}", commit);
     // repositories::tree::print_tree(&new_repo, commit)?;
 
-    // Set the oxen version to 0.25.0
+    // Stamp the migrated repo with the current LATEST version string.
     let mut config = RepositoryConfig::from_repo(&new_repo)?;
-    config.min_version = Some("0.25.0".to_string());
+    config.min_version = Some(MinOxenVersion::LATEST.as_str().to_string());
     let path = util::fs::config_filepath(&new_repo.path);
     config.save(&path)?;
 
@@ -369,7 +369,7 @@ mod tests {
             // Make sure that the repo version is updated
             let repo = LocalRepository::from_dir(&repo.path)?;
             let version_str = repo.min_version().to_string();
-            assert_eq!(version_str, "0.25.0");
+            assert_eq!(version_str, "0.36.0");
 
             Ok(())
         })
@@ -495,7 +495,7 @@ mod tests {
             // Make sure that the repo version is updated
             let repo = LocalRepository::from_dir(&repo.path)?;
             let version_str = repo.min_version().to_string();
-            assert_eq!(version_str, "0.25.0");
+            assert_eq!(version_str, "0.36.0");
 
             Ok(())
         })

--- a/crates/lib/src/core/v_latest.rs
+++ b/crates/lib/src/core/v_latest.rs
@@ -1,4 +1,4 @@
-//! Core logic for oxen v0.25.0 and above
+//! Core logic for the latest oxen on-disk format.
 //!
 
 pub mod add;

--- a/crates/lib/src/core/versions.rs
+++ b/crates/lib/src/core/versions.rs
@@ -9,7 +9,6 @@ use crate::{error::OxenError, util::oxen_version::OxenVersion};
 #[derive(Debug, Clone)]
 pub enum MinOxenVersion {
     V0_19_0,
-    V0_25_0,
     LATEST,
 }
 
@@ -36,7 +35,9 @@ impl MinOxenVersion {
         match s.as_ref() {
             "0.10.0" => Err(OxenError::UnsupportedRepoVersion(s.as_ref().into())),
             "0.19.0" => Ok(MinOxenVersion::V0_19_0),
-            "0.25.0" => Ok(MinOxenVersion::V0_25_0),
+            // Repos written by the v0.25.0 add_child_counts_to_nodes migration carry
+            // "0.25.0" in their .oxen/config.toml; the on-disk format is identical to LATEST.
+            "0.25.0" => Ok(MinOxenVersion::LATEST),
             "0.36.0" => Ok(MinOxenVersion::LATEST),
             _ => Err(OxenError::invalid_version(s.as_ref())),
         }
@@ -45,7 +46,6 @@ impl MinOxenVersion {
     pub fn as_str(&self) -> &'static str {
         match self {
             MinOxenVersion::V0_19_0 => "0.19.0",
-            MinOxenVersion::V0_25_0 => "0.25.0",
             MinOxenVersion::LATEST => "0.36.0",
         }
     }

--- a/crates/lib/src/model/merkle_tree/node/commit_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/commit_node.rs
@@ -57,7 +57,7 @@ impl CommitNode {
                     node_type: MerkleTreeNodeType::Commit,
                 }),
             }),
-            MinOxenVersion::LATEST | MinOxenVersion::V0_25_0 => Ok(CommitNode {
+            MinOxenVersion::LATEST => Ok(CommitNode {
                 node: ECommitNode::V0_25_0(CommitNodeDataV0_25_0 {
                     hash: opts.hash,
                     parent_ids: opts.parent_ids,

--- a/crates/lib/src/model/merkle_tree/node/dir_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/dir_node.rs
@@ -57,7 +57,7 @@ pub struct DirNode {
 impl DirNode {
     pub fn new(repo: &LocalRepository, opts: DirNodeOpts) -> Result<Self, OxenError> {
         match repo.min_version() {
-            MinOxenVersion::LATEST | MinOxenVersion::V0_25_0 => Ok(Self {
+            MinOxenVersion::LATEST => Ok(Self {
                 node: EDirNode::V0_25_0(DirNodeDataV0_25_0 {
                     node_type: MerkleTreeNodeType::Dir,
                     name: opts.name,

--- a/crates/lib/src/model/merkle_tree/node/file_node.rs
+++ b/crates/lib/src/model/merkle_tree/node/file_node.rs
@@ -66,28 +66,26 @@ pub struct FileNode {
 impl FileNode {
     pub fn new(repo: &LocalRepository, opts: FileNodeOpts) -> Result<Self, OxenError> {
         match repo.min_version() {
-            MinOxenVersion::LATEST | MinOxenVersion::V0_25_0 | MinOxenVersion::V0_19_0 => {
-                Ok(Self {
-                    node: EFileNode::V0_25_0(FileNodeDataV0_25_0 {
-                        node_type: MerkleTreeNodeType::File,
-                        name: opts.name,
-                        hash: opts.hash,
-                        combined_hash: opts.combined_hash,
-                        metadata_hash: opts.metadata_hash,
-                        num_bytes: opts.num_bytes,
-                        last_commit_id: MerkleHash::new(0),
-                        last_modified_seconds: opts.last_modified_seconds,
-                        last_modified_nanoseconds: opts.last_modified_nanoseconds,
-                        data_type: opts.data_type,
-                        metadata: opts.metadata,
-                        mime_type: opts.mime_type,
-                        extension: opts.extension,
-                        chunk_hashes: vec![],
-                        chunk_type: FileChunkType::SingleFile,
-                        storage_backend: FileStorageType::Disk,
-                    }),
-                })
-            }
+            MinOxenVersion::LATEST | MinOxenVersion::V0_19_0 => Ok(Self {
+                node: EFileNode::V0_25_0(FileNodeDataV0_25_0 {
+                    node_type: MerkleTreeNodeType::File,
+                    name: opts.name,
+                    hash: opts.hash,
+                    combined_hash: opts.combined_hash,
+                    metadata_hash: opts.metadata_hash,
+                    num_bytes: opts.num_bytes,
+                    last_commit_id: MerkleHash::new(0),
+                    last_modified_seconds: opts.last_modified_seconds,
+                    last_modified_nanoseconds: opts.last_modified_nanoseconds,
+                    data_type: opts.data_type,
+                    metadata: opts.metadata,
+                    mime_type: opts.mime_type,
+                    extension: opts.extension,
+                    chunk_hashes: vec![],
+                    chunk_type: FileChunkType::SingleFile,
+                    storage_backend: FileStorageType::Disk,
+                }),
+            }),
         }
     }
 

--- a/crates/lib/src/model/merkle_tree/node/vnode.rs
+++ b/crates/lib/src/model/merkle_tree/node/vnode.rs
@@ -44,7 +44,7 @@ impl VNode {
                     node_type: MerkleTreeNodeType::VNode,
                 }),
             }),
-            MinOxenVersion::LATEST | MinOxenVersion::V0_25_0 => Ok(Self {
+            MinOxenVersion::LATEST => Ok(Self {
                 node: EVNode::V0_25_0(VNodeImplV0_25_0 {
                     hash: vnode_opts.hash,
                     node_type: MerkleTreeNodeType::VNode,

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -914,7 +914,7 @@ mod tests {
         let result = LocalRepository::new(
             temp_dir.path(),
             RepositoryConfig {
-                min_version: Some("0.25.0".to_string()),
+                min_version: Some("0.36.0".to_string()),
                 vfs: Some(true),
                 merkle_store_kind: MerkleStoreKind::Lmdb,
                 ..Default::default()
@@ -934,7 +934,7 @@ mod tests {
         let repo = LocalRepository::new(
             temp_dir.path(),
             RepositoryConfig {
-                min_version: Some("0.25.0".to_string()),
+                min_version: Some("0.36.0".to_string()),
                 vfs: Some(true),
                 merkle_store_kind: MerkleStoreKind::File,
                 ..Default::default()


### PR DESCRIPTION
We can drop `MinOxenVersion::V0_25_0`, since it behaves identically to `MinOxenVersion::LATEST` everywhere it's referenced. There's not even a `core/v_old/v0_25_0/` directory.

The `add_child_counts_to_nodes` migration now stamps the new repo with `MinOxenVersion::LATEST` instead of a hardcoded "0.25.0" string. Its two assertions that the migration produces "0.25.0" on disk are updated to "0.36.0".