### PR TITLE
S3 (16a): Add VersionStore::version_location and VersionLocation enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5292,6 +5292,7 @@ dependencies = [
  "humantime",
  "hyper 1.8.1",
  "itertools 0.14.0",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.4",
@@ -6131,6 +6132,7 @@ dependencies = [
  "bitflags 2.11.0",
  "chrono",
  "either",
+ "futures",
  "memchr",
  "polars-arrow",
  "polars-compute",
@@ -6145,6 +6147,7 @@ dependencies = [
  "polars-time",
  "polars-utils",
  "rayon",
+ "tokio",
  "version_check",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ par-stream = { version = "0.10.2", features = ["runtime-tokio"] }
 parking_lot = "0.12.1"
 pathdiff = "0.2.3"
 percent-encoding = "2.1"
-polars = { version = "0.49.0", features = ["lazy", "parquet", "json", "ipc", "ipc_streaming", "dtype-full", "timezones", "random"] }
+polars = { version = "0.49.0", features = ["lazy", "parquet", "json", "ipc", "ipc_streaming", "dtype-full", "timezones", "random", "cloud", "aws"] }
 pyo3 = { version = "0.25", features = ["abi3-py311"] }
 pyo3-async-runtimes = { version = "0.25", features = ["attributes", "tokio-runtime"] }
 pyo3-polars = { version = "0.22", features = ["dtype-full"] }

--- a/crates/lib/src/storage/local.rs
+++ b/crates/lib/src/storage/local.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::constants::{VERSION_CHUNK_FILE_NAME, VERSION_CHUNKS_DIR, VERSION_FILE_NAME};
 use crate::error::OxenError;
 use crate::model::MerkleHash;
-use crate::storage::version_store::{LocalFilePath, VersionStore};
+use crate::storage::version_store::{LocalFilePath, VersionLocation, VersionStore};
 use crate::util::{self, concurrency, hasher};
 use crate::view::versions::CleanCorruptedVersionsResult;
 
@@ -196,6 +196,10 @@ impl VersionStore for LocalVersionStore {
 
     async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError> {
         Ok(LocalFilePath::Stable(self.version_path(hash)))
+    }
+
+    async fn version_location(&self, hash: &str) -> Result<VersionLocation, OxenError> {
+        Ok(VersionLocation::Local(self.version_path(hash)))
     }
 
     // TODO: (CleanCut) Do we need to make sure the destination path is outside the version store?
@@ -617,6 +621,20 @@ mod tests {
         // Get and verify the data
         let retrieved = store.get_version(&hash).await.unwrap();
         assert_eq!(retrieved, data);
+    }
+
+    #[tokio::test]
+    async fn test_version_location_returns_local_path() {
+        let (_temp_dir, store) = setup().await;
+        let hash = "abcdef1234567890";
+
+        let location = store.version_location(hash).await.unwrap();
+        match location {
+            VersionLocation::Local(path) => {
+                assert_eq!(path, store.version_path(hash));
+            }
+            other => panic!("expected Local variant, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -17,7 +17,7 @@ use tokio::sync::OnceCell;
 use tokio_stream::Stream;
 use tokio_util::io::StreamReader;
 
-use super::version_store::{LocalFilePath, VersionStore};
+use super::version_store::{LocalFilePath, VersionLocation, VersionStore};
 use crate::constants::{STREAMING_BUF_SIZE, VERSION_FILE_NAME};
 use crate::util::hasher;
 use crate::view::versions::CleanCorruptedVersionsResult;
@@ -43,6 +43,11 @@ pub struct S3VersionStore {
     prefix: String,
     /// Threshold (bytes) below which we upload with a single PUT rather than a multipart upload.
     oneshot_size: u64,
+    /// Optional endpoint override (S3-compatible stores, the in-process s3s test fixture, MinIO,
+    /// etc.). `None` selects the default AWS endpoint. Surfaced through `VersionLocation::S3` so
+    /// cloud-aware readers (Polars `CloudOptions`, DuckDB `SET s3_endpoint=...`) hit the same
+    /// host as the version store itself.
+    endpoint_url: Option<String>,
 }
 
 impl S3VersionStore {
@@ -57,6 +62,7 @@ impl S3VersionStore {
             bucket: bucket.into(),
             prefix: prefix.into(),
             oneshot_size: DEFAULT_ONESHOT_SIZE,
+            endpoint_url: None,
         }
     }
 
@@ -102,7 +108,12 @@ impl S3VersionStore {
     }
 
     #[cfg(test)]
-    pub fn new_with_client(client: Arc<Client>, bucket: String, prefix: String) -> Self {
+    pub fn new_with_client(
+        client: Arc<Client>,
+        bucket: String,
+        prefix: String,
+        endpoint_url: Option<String>,
+    ) -> Self {
         let cell = OnceCell::new();
         cell.set(Ok(client)).expect("cell was just created");
         Self {
@@ -110,6 +121,7 @@ impl S3VersionStore {
             bucket,
             prefix,
             oneshot_size: DEFAULT_ONESHOT_SIZE,
+            endpoint_url,
         }
     }
 
@@ -611,6 +623,21 @@ impl VersionStore for S3VersionStore {
         Ok(LocalFilePath::Temp(tmp))
     }
 
+    async fn version_location(&self, hash: &str) -> Result<VersionLocation, OxenError> {
+        let client = self.client().await?;
+        let region = client
+            .config()
+            .region()
+            .map(|r| r.to_string())
+            .unwrap_or_else(|| "us-east-1".to_string());
+        Ok(VersionLocation::S3 {
+            url: format!("s3://{}/{}", self.bucket, self.generate_key(hash)),
+            bucket: self.bucket.clone(),
+            region,
+            endpoint_url: self.endpoint_url.clone(),
+        })
+    }
+
     /// Copy a version file to a destination path on the local filesystem, creating any necessary
     /// parent directories and overwriting any existing file at the destination path.
     // TODO: We should probably only allow writing to a specific set of path prefixes
@@ -1055,6 +1082,7 @@ mod tests {
             Arc::new(client),
             "test-bucket".to_string(),
             "test-namespace/test-repo".to_string(),
+            Some(format!("http://{addr}")),
         );
 
         (store, tmp, server_handle)
@@ -1071,6 +1099,35 @@ mod tests {
             .force_path_style(true)
             .build();
         Client::from_conf(config)
+    }
+
+    #[tokio::test]
+    async fn test_version_location_returns_s3_variant_with_endpoint() {
+        let (store, _tmp, _server) = setup().await;
+        let hash = "abcdef1234567890";
+
+        let location = store.version_location(hash).await.unwrap();
+        match location {
+            VersionLocation::S3 {
+                url,
+                bucket,
+                region,
+                endpoint_url,
+            } => {
+                assert_eq!(
+                    url,
+                    format!("s3://test-bucket/test-namespace/test-repo/{hash}/data")
+                );
+                assert_eq!(bucket, "test-bucket");
+                assert_eq!(region, "us-east-1");
+                let endpoint = endpoint_url.expect("test setup configures a loopback endpoint");
+                assert!(
+                    endpoint.starts_with("http://127.0.0.1:"),
+                    "expected loopback endpoint url, got {endpoint:?}"
+                );
+            }
+            other => panic!("expected S3 variant, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -75,6 +75,30 @@ impl LocalFilePath {
     }
 }
 
+/// Where a version file's data lives, in a form a cloud-aware reader can consume directly.
+///
+/// Unlike [`LocalFilePath`], this never materializes a remote version file to a temp file on
+/// local disk. Callers that need bytes-on-disk should use `copy_version_to_path` instead.
+/// Callers that already use a cloud-aware reader (Polars `scan_*` with `CloudOptions`, DuckDB
+/// `read_parquet` via the `httpfs` extension, …) consume `S3` variants directly.
+#[derive(Debug, Clone)]
+pub enum VersionLocation {
+    /// Local-backed store: the version file lives on disk at this path.
+    Local(PathBuf),
+    /// S3-backed store: enough config for a cloud-aware reader to fetch the version file
+    /// directly without round-tripping through local disk.
+    S3 {
+        /// Fully-qualified S3 URL of the combined version file:
+        /// `s3://{bucket}/{prefix}/{hash}/data`.
+        url: String,
+        bucket: String,
+        region: String,
+        /// `Some(host:port)` for non-AWS S3-compatible endpoints (s3s test fixture, MinIO,
+        /// etc.). `None` selects the default AWS endpoint.
+        endpoint_url: Option<String>,
+    },
+}
+
 /// Storage backend kind. Serializes as `"local"` / `"s3"` on the wire and on disk.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
@@ -317,6 +341,22 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// # Arguments
     /// * `hash` - The content hash of the version file to retrieve
     async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError>;
+
+    /// Return a [`VersionLocation`] describing where the version file lives, in a form a
+    /// cloud-aware reader can consume without materializing it to a temp file on local disk.
+    ///
+    /// Local-backed stores return [`VersionLocation::Local`] with the on-disk path; S3-backed
+    /// stores return [`VersionLocation::S3`] carrying the s3:// URL plus the bucket, region, and
+    /// endpoint override the caller needs to configure Polars `CloudOptions` or DuckDB `httpfs`.
+    ///
+    /// Prefer this over [`Self::get_version_path`] whenever the consumer has a cloud-aware
+    /// reader available (Polars `scan_*`, DuckDB `read_parquet`, …): `get_version_path`
+    /// materializes the entire version file to a temp file on S3, which is fine for small
+    /// files but OOMs at the multi-GB scale customers care about.
+    ///
+    /// # Arguments
+    /// * `hash` - The content hash of the version file
+    async fn version_location(&self, hash: &str) -> Result<VersionLocation, OxenError>;
 
     /// Copy a versioned file from the version store to a destination path on the local filesystem
     ///


### PR DESCRIPTION
(Stacked on #587)

Polars should be able to manipulate files directly in cloud storage in most cases. This PR adds a trait method `version_location()` that returns the `VersionLocation` enum that wraps either a local file location or the cloud information needed to access a file directly.

The existing `get_version_path` on `S3VersionStore` reads the entire object into RAM before writing it to a temp file. Even if we fix the OOM and get huge disks, the performance won't be satisfactory, so that's not going to work for our terabyte-scale customers using S3 storage.

Polars gains `cloud, aws` features in the workspace `Cargo.toml`. They're unused in this PR but we'll use them in an upcoming PR that consumes `version_location()`

