### PR TITLE
Add merkle_store micro-benchmark and parameterize e2e benches over File/LMDB backends

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -178,3 +178,8 @@ required-features = ["test-utils"]
 name = "workspace_add"
 harness = false
 required-features = ["test-utils"]
+
+[[bench]]
+name = "merkle_store"
+harness = false
+required-features = ["test-utils"]

--- a/crates/lib/benches/add.rs
+++ b/crates/lib/benches/add.rs
@@ -1,5 +1,7 @@
 use criterion::{BenchmarkId, Criterion, black_box};
 use criterion::{criterion_group, criterion_main};
+use liboxen::config::repository_config::MerkleStoreKind;
+use liboxen::constants::MIN_OXEN_VERSION;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
@@ -8,6 +10,10 @@ use rand::distributions::Alphanumeric;
 use rand::{Rng, RngCore};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
+
+#[path = "bench_support.rs"]
+mod bench_support;
+use bench_support::backend_kinds_from_env;
 
 fn generate_random_string(len: usize) -> String {
     rand::thread_rng()
@@ -39,13 +45,18 @@ async fn setup_repo_for_add_benchmark(
     num_files_to_add_in_benchmark: usize,
     dir_size: usize,
     data_path: Option<String>,
+    kind: MerkleStoreKind,
+    backend_name: &str,
 ) -> Result<(LocalRepository, PathBuf), OxenError> {
-    let repo_dir = base_dir.join(format!("repo_{num_files_to_add_in_benchmark}"));
+    let repo_dir = base_dir.join(format!(
+        "repo_{backend_name}_{num_files_to_add_in_benchmark}"
+    ));
     if repo_dir.exists() {
         util::fs::remove_dir_all(&repo_dir)?;
     }
 
-    let repo = repositories::init(&repo_dir)?;
+    let repo =
+        repositories::init::init_with_version_and_merkle_store(&repo_dir, MIN_OXEN_VERSION, kind)?;
 
     let files_dir = if let Some(data_path) = data_path {
         PathBuf::from(data_path)
@@ -141,34 +152,39 @@ pub fn add_benchmark(c: &mut Criterion) {
         // (100000, 1000),
         // (1000000, 1000),
     ];
-    for &(repo_size, dir_size) in params.iter() {
-        let num_files_to_add = repo_size / 1000;
-        let (repo, file_dir) = rt
-            .block_on(setup_repo_for_add_benchmark(
-                &base_dir,
-                repo_size,
-                num_files_to_add,
-                dir_size,
-                data_path.clone(),
-            ))
-            .unwrap();
+    let backends = backend_kinds_from_env();
+    for &(kind, name) in &backends {
+        for &(repo_size, dir_size) in params.iter() {
+            let num_files_to_add = repo_size / 1000;
+            let (repo, file_dir) = rt
+                .block_on(setup_repo_for_add_benchmark(
+                    &base_dir,
+                    repo_size,
+                    num_files_to_add,
+                    dir_size,
+                    data_path.clone(),
+                    kind,
+                    name,
+                ))
+                .unwrap();
 
-        group.bench_with_input(
-            BenchmarkId::new(
-                format!("{num_files_to_add}k_files_in_{dir_size}dirs"),
-                format!("{:?}", (num_files_to_add, dir_size)),
-            ),
-            &(num_files_to_add, dir_size),
-            |b, _| {
-                b.to_async(&rt).iter(|| async {
-                    repositories::add(&repo, black_box(&file_dir))
-                        .await
-                        .unwrap();
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{name}_{num_files_to_add}k_files_in_{dir_size}dirs"),
+                    format!("{:?}", (name, num_files_to_add, dir_size)),
+                ),
+                &(num_files_to_add, dir_size),
+                |b, _| {
+                    b.to_async(&rt).iter(|| async {
+                        repositories::add(&repo, black_box(&file_dir))
+                            .await
+                            .unwrap();
 
-                    let _ = util::fs::remove_dir_all(repo.path.join(".oxen/staging"));
-                })
-            },
-        );
+                        let _ = util::fs::remove_dir_all(repo.path.join(".oxen/staging"));
+                    })
+                },
+            );
+        }
     }
     group.finish();
 

--- a/crates/lib/benches/bench_support.rs
+++ b/crates/lib/benches/bench_support.rs
@@ -1,0 +1,25 @@
+use liboxen::config::repository_config::MerkleStoreKind;
+
+pub const BACKEND_KINDS: &[(MerkleStoreKind, &str)] = &[
+    (MerkleStoreKind::File, "file"),
+    (MerkleStoreKind::Lmdb, "lmdb"),
+];
+
+/// Returns the backends to run based on the `BENCHMARK_BACKENDS` env var.
+///
+/// Set the variable to `"file"`, `"lmdb"`, or `"both"` (default when unset).
+/// Example:
+/// ```bash
+/// BENCHMARK_BACKENDS=lmdb cargo bench --features liboxen/test-utils --bench add
+/// ```
+pub fn backend_kinds_from_env() -> Vec<(MerkleStoreKind, &'static str)> {
+    let filter = std::env::var("BENCHMARK_BACKENDS").ok();
+    BACKEND_KINDS
+        .iter()
+        .filter(|(_, name)| match filter.as_deref() {
+            None | Some("both") => true,
+            Some(want) => *name == want,
+        })
+        .copied()
+        .collect()
+}

--- a/crates/lib/benches/download.rs
+++ b/crates/lib/benches/download.rs
@@ -1,5 +1,6 @@
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use liboxen::constants::DEFAULT_REMOTE_NAME;
+use liboxen::config::repository_config::MerkleStoreKind;
+use liboxen::constants::{DEFAULT_REMOTE_NAME, MIN_OXEN_VERSION};
 use liboxen::error::OxenError;
 use liboxen::model::{LocalRepository, RemoteRepository};
 use liboxen::repositories;
@@ -10,6 +11,10 @@ use rand::distributions::Alphanumeric;
 use rand::{Rng, RngCore};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+#[path = "bench_support.rs"]
+mod bench_support;
+use bench_support::backend_kinds_from_env;
 
 fn generate_random_string(len: usize) -> String {
     rand::thread_rng()
@@ -43,18 +48,21 @@ async fn setup_repo_for_download_benchmark(
     num_files_to_download_in_benchmark: usize,
     dir_size: usize,
     data_path: Option<String>,
+    kind: MerkleStoreKind,
+    backend_name: &str,
 ) -> Result<(LocalRepository, RemoteRepository, PathBuf), OxenError> {
     println!(
-        "setup_repo_for_download_benchmark got repo_size {repo_size}, num_files_to_download {num_files_to_download_in_benchmark}, and dir_size {dir_size}",
+        "setup_repo_for_download_benchmark got repo_size {repo_size}, num_files_to_download {num_files_to_download_in_benchmark}, dir_size {dir_size}, backend {backend_name}",
     );
     let repo_dir = base_dir.join(format!(
-        "repo_{num_files_to_download_in_benchmark}_{dir_size}"
+        "repo_{backend_name}_{num_files_to_download_in_benchmark}_{dir_size}"
     ));
     if repo_dir.exists() {
         util::fs::remove_dir_all(&repo_dir)?;
     }
 
-    let mut repo = repositories::init(&repo_dir)?;
+    let mut repo =
+        repositories::init::init_with_version_and_merkle_store(&repo_dir, MIN_OXEN_VERSION, kind)?;
     let remote_repo = create_or_clear_remote_repo(&repo).await?;
     command::config::set_remote(&mut repo, DEFAULT_REMOTE_NAME, &remote_repo.remote.url)?;
 
@@ -141,63 +149,73 @@ pub fn download_benchmark(c: &mut Criterion) {
         // (100000, 1000),
         // (1000000, 1000),
     ];
-    for &(repo_size, dir_size) in params.iter() {
-        let num_files_to_download = repo_size / 10;
-        let (repo, remote_repo, repo_dir) = rt
-            .block_on(setup_repo_for_download_benchmark(
-                &base_dir,
-                repo_size,
-                num_files_to_download,
-                dir_size,
-                data_path.clone(),
-            ))
-            .unwrap();
+    let backends = backend_kinds_from_env();
+    for &(kind, name) in &backends {
+        for &(repo_size, dir_size) in params.iter() {
+            let num_files_to_download = repo_size / 10;
+            let (repo, remote_repo, repo_dir) = rt
+                .block_on(setup_repo_for_download_benchmark(
+                    &base_dir,
+                    repo_size,
+                    num_files_to_download,
+                    dir_size,
+                    data_path.clone(),
+                    kind,
+                    name,
+                ))
+                .unwrap();
 
-        group.bench_with_input(
-            BenchmarkId::new(
-                format!("{num_files_to_download}k_files_in_{dir_size}dirs"),
-                format!("{:?}", (num_files_to_download, dir_size)),
-            ),
-            &(num_files_to_download, dir_size),
-            |b, _| {
-                b.to_async(&rt).iter_batched(
-                    || {
-                        let iter_dir =
-                            repo_dir.join(format!("run-{}", rand::thread_rng().r#gen::<u64>()));
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{name}_{num_files_to_download}_files_in_{dir_size}dirs"),
+                    format!("{:?}", (name, num_files_to_download, dir_size)),
+                ),
+                &(num_files_to_download, dir_size),
+                |b, _| {
+                    b.to_async(&rt).iter_batched(
+                        || {
+                            let iter_dir =
+                                repo_dir.join(format!("run-{}", rand::thread_rng().r#gen::<u64>()));
 
-                        // Create a clean local repo without the files
-                        let oxen_hidden_path = util::fs::oxen_hidden_dir(&iter_dir);
-                        util::fs::create_dir_all(&oxen_hidden_path).unwrap();
+                            // Create a clean local repo without the files
+                            let oxen_hidden_path = util::fs::oxen_hidden_dir(&iter_dir);
+                            util::fs::create_dir_all(&oxen_hidden_path).unwrap();
 
-                        // create a clean local repo ready for the fetch
-                        let mut local_repo =
-                            LocalRepository::from_remote(remote_repo.clone(), &iter_dir, false)
-                                .unwrap();
-                        iter_dir.clone_into(&mut local_repo.path);
-                        local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
-                        local_repo.set_min_version(repo.min_version());
-                        local_repo.set_subtree_paths(repo.subtree_paths());
-                        local_repo.set_depth(repo.depth());
+                            // create a clean local repo ready for the download
+                            let mut local_repo =
+                                LocalRepository::from_remote(remote_repo.clone(), &iter_dir, false)
+                                    .unwrap();
+                            iter_dir.clone_into(&mut local_repo.path);
+                            local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
+                            local_repo.set_min_version(repo.min_version());
+                            local_repo.set_subtree_paths(repo.subtree_paths());
+                            local_repo.set_depth(repo.depth());
 
-                        local_repo.save().unwrap();
-                        (&remote_repo, iter_dir)
-                    },
-                    |(remote_repo, iter_dir)| async move {
-                        repositories::download(remote_repo, Path::new("files"), &iter_dir, "main")
+                            local_repo.save().unwrap();
+                            (&remote_repo, iter_dir)
+                        },
+                        |(remote_repo, iter_dir)| async move {
+                            repositories::download(
+                                remote_repo,
+                                Path::new("files"),
+                                &iter_dir,
+                                "main",
+                            )
                             .await
                             .unwrap();
-                    },
-                    criterion::BatchSize::PerIteration,
-                );
-            },
-        );
+                        },
+                        criterion::BatchSize::PerIteration,
+                    );
+                },
+            );
 
-        std::thread::sleep(std::time::Duration::from_millis(1000));
+            std::thread::sleep(std::time::Duration::from_millis(1000));
 
-        let _ = rt
-            .block_on(api::client::repositories::delete(&remote_repo))
-            .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(500));
+            let _ = rt
+                .block_on(api::client::repositories::delete(&remote_repo))
+                .unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
     }
     group.finish();
 

--- a/crates/lib/benches/fetch.rs
+++ b/crates/lib/benches/fetch.rs
@@ -1,5 +1,6 @@
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use liboxen::constants::DEFAULT_REMOTE_NAME;
+use liboxen::config::{RepositoryConfig, repository_config::MerkleStoreKind};
+use liboxen::constants::{DEFAULT_REMOTE_NAME, MIN_OXEN_VERSION};
 use liboxen::error::OxenError;
 use liboxen::model::{LocalRepository, RemoteRepository};
 use liboxen::opts::FetchOpts;
@@ -11,6 +12,10 @@ use rand::distributions::Alphanumeric;
 use rand::{Rng, RngCore};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+#[path = "bench_support.rs"]
+mod bench_support;
+use bench_support::backend_kinds_from_env;
 
 fn generate_random_string(len: usize) -> String {
     rand::thread_rng()
@@ -44,16 +49,21 @@ async fn setup_repo_for_fetch_benchmark(
     num_files_to_fetch_in_benchmark: usize,
     dir_size: usize,
     data_path: Option<String>,
+    kind: MerkleStoreKind,
+    backend_name: &str,
 ) -> Result<(LocalRepository, RemoteRepository, PathBuf), OxenError> {
     println!(
-        "setup_repo_for_fetch_benchmark got repo_size {repo_size}, num_files_to_fetch {num_files_to_fetch_in_benchmark}, and dir_size {dir_size}",
+        "setup_repo_for_fetch_benchmark got repo_size {repo_size}, num_files_to_fetch {num_files_to_fetch_in_benchmark}, dir_size {dir_size}, backend {backend_name}",
     );
-    let repo_dir = base_dir.join(format!("repo_{num_files_to_fetch_in_benchmark}_{dir_size}"));
+    let repo_dir = base_dir.join(format!(
+        "repo_{backend_name}_{num_files_to_fetch_in_benchmark}_{dir_size}"
+    ));
     if repo_dir.exists() {
         util::fs::remove_dir_all(&repo_dir)?;
     }
 
-    let mut repo = repositories::init(&repo_dir)?;
+    let mut repo =
+        repositories::init::init_with_version_and_merkle_store(&repo_dir, MIN_OXEN_VERSION, kind)?;
     let remote_repo = create_or_clear_remote_repo(&repo).await?;
     command::config::set_remote(&mut repo, DEFAULT_REMOTE_NAME, &remote_repo.remote.url)?;
 
@@ -140,68 +150,80 @@ pub fn fetch_benchmark(c: &mut Criterion) {
         // (100000, 1000),
         // (1000000, 1000),
     ];
-    for &(repo_size, dir_size) in params.iter() {
-        let num_files_to_fetch = repo_size / 10;
-        let (repo, remote_repo, repo_dir) = rt
-            .block_on(setup_repo_for_fetch_benchmark(
-                &base_dir,
-                repo_size,
-                num_files_to_fetch,
-                dir_size,
-                data_path.clone(),
-            ))
-            .unwrap();
+    let backends = backend_kinds_from_env();
+    for &(kind, name) in &backends {
+        for &(repo_size, dir_size) in params.iter() {
+            let num_files_to_fetch = repo_size / 10;
+            let (repo, remote_repo, repo_dir) = rt
+                .block_on(setup_repo_for_fetch_benchmark(
+                    &base_dir,
+                    repo_size,
+                    num_files_to_fetch,
+                    dir_size,
+                    data_path.clone(),
+                    kind,
+                    name,
+                ))
+                .unwrap();
 
-        group.bench_with_input(
-            BenchmarkId::new(
-                format!("{num_files_to_fetch}_files_in_{dir_size}dirs"),
-                format!("{:?}", (num_files_to_fetch, dir_size)),
-            ),
-            &(num_files_to_fetch, dir_size),
-            |b, _| {
-                b.to_async(&rt).iter_batched(
-                    || {
-                        let iter_dir =
-                            repo_dir.join(format!("run-{}", rand::thread_rng().r#gen::<u64>()));
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{name}_{num_files_to_fetch}_files_in_{dir_size}dirs"),
+                    format!("{:?}", (name, num_files_to_fetch, dir_size)),
+                ),
+                &(num_files_to_fetch, dir_size),
+                |b, _| {
+                    b.to_async(&rt).iter_batched(
+                        || {
+                            let iter_dir =
+                                repo_dir.join(format!("run-{}", rand::thread_rng().r#gen::<u64>()));
 
-                        // Create a clean local repo without the files
-                        let oxen_hidden_path = util::fs::oxen_hidden_dir(&iter_dir);
-                        util::fs::create_dir_all(&oxen_hidden_path).unwrap();
+                            // Create a clean local repo without the files
+                            let oxen_hidden_path = util::fs::oxen_hidden_dir(&iter_dir);
+                            util::fs::create_dir_all(&oxen_hidden_path).unwrap();
 
-                        // create a clean local repo ready for the fetch
-                        let mut local_repo =
-                            LocalRepository::from_remote(remote_repo.clone(), &iter_dir, false)
+                            // Create a clean local repo ready for the fetch
+                            let mut local_repo =
+                                LocalRepository::from_remote(remote_repo.clone(), &iter_dir, false)
+                                    .unwrap();
+                            iter_dir.clone_into(&mut local_repo.path);
+                            local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
+                            local_repo.set_min_version(repo.min_version());
+                            local_repo.set_subtree_paths(repo.subtree_paths());
+                            local_repo.set_depth(repo.depth());
+                            local_repo.save().unwrap();
+
+                            // Patch the saved config to ensure the desired backend is used.
+                            // from_remote defaults to the File backend; re-writing and
+                            // reloading gives us a repo with the correct MerkleStore.
+                            let config_path = util::fs::config_filepath(&iter_dir);
+                            let mut config = RepositoryConfig::from_file(&config_path).unwrap();
+                            config.merkle_store_kind = kind;
+                            config.save(&config_path).unwrap();
+                            let local_repo = LocalRepository::from_dir(&iter_dir).unwrap();
+
+                            let mut fetch_opts = FetchOpts::new();
+                            fetch_opts.subtree_paths = local_repo.subtree_paths();
+
+                            (local_repo, fetch_opts, iter_dir)
+                        },
+                        |(local_repo, fetch_opts, _iter_dir)| async move {
+                            repositories::fetch_all(&local_repo, &fetch_opts)
+                                .await
                                 .unwrap();
-                        iter_dir.clone_into(&mut local_repo.path);
-                        local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
-                        local_repo.set_min_version(repo.min_version());
-                        local_repo.set_subtree_paths(repo.subtree_paths());
-                        local_repo.set_depth(repo.depth());
+                        },
+                        criterion::BatchSize::PerIteration,
+                    );
+                },
+            );
 
-                        local_repo.save().unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(1000));
 
-                        let mut fetch_opts = FetchOpts::new();
-                        let subtrees = local_repo.subtree_paths();
-                        fetch_opts.subtree_paths = subtrees;
-
-                        (local_repo.clone(), fetch_opts, iter_dir.clone())
-                    },
-                    |(local_repo, fetch_opts, _iter_dir)| async move {
-                        repositories::fetch_all(&local_repo, &fetch_opts)
-                            .await
-                            .unwrap();
-                    },
-                    criterion::BatchSize::PerIteration,
-                );
-            },
-        );
-
-        std::thread::sleep(std::time::Duration::from_millis(1000));
-
-        let _ = rt
-            .block_on(api::client::repositories::delete(&remote_repo))
-            .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(500));
+            let _ = rt
+                .block_on(api::client::repositories::delete(&remote_repo))
+                .unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
     }
     group.finish();
 

--- a/crates/lib/benches/merkle_store.rs
+++ b/crates/lib/benches/merkle_store.rs
@@ -1,0 +1,374 @@
+//! Micro-benchmarks for the [`FileBackend`] and [`LmdbBackend`] Merkle tree stores.
+//!
+//! Three benchmark groups:
+//! - `merkle_store_writes`  — populate N commit→dir→vnode subtrees from scratch
+//! - `merkle_store_reads`   — `exists` / `get_node` / `get_children` on a pre-populated store
+//! - `merkle_store_tree_walk` — top-down walk of all subtrees in a pre-populated store
+//!
+//! # Running
+//! ```bash
+//! # Quick smoke run (both backends):
+//! BENCHMARK_ITERS=3 BENCHMARK_BACKENDS=both \
+//!   cargo bench --features liboxen/test-utils --bench merkle_store -- --quick
+//!
+//! # Full run (results under target/criterion/):
+//! cargo bench --features liboxen/test-utils --bench merkle_store
+//!
+//! # Single backend:
+//! BENCHMARK_BACKENDS=lmdb cargo bench --features liboxen/test-utils --bench merkle_store
+//! ```
+//!
+//! # Cold-cache reads
+//! To measure cold-cache performance (OS page-cache bypassed), run these commands
+//! manually between criterion samples:
+//! - Linux: `sync && echo 3 | sudo tee /proc/sys/vm/drop_caches`
+//! - macOS: `sync && sudo purge`
+
+use std::collections::HashMap;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use tempfile::TempDir;
+use time::OffsetDateTime;
+
+#[path = "bench_support.rs"]
+mod bench_support;
+use bench_support::backend_kinds_from_env;
+
+use liboxen::config::repository_config::MerkleStoreKind;
+use liboxen::constants::MIN_OXEN_VERSION;
+use liboxen::model::merkle_tree::MerkleStore;
+use liboxen::model::merkle_tree::node::{
+    CommitNode, DirNode, FileNode, VNode, commit_node::CommitNodeOpts, dir_node::DirNodeOpts,
+    file_node::FileNodeOpts, vnode::VNodeOpts,
+};
+use liboxen::model::{EntryDataType, LocalRepository, MerkleHash};
+use liboxen::repositories;
+
+// ─── repo setup ──────────────────────────────────────────────────────────────
+
+fn build_bench_repo(kind: MerkleStoreKind) -> (TempDir, LocalRepository) {
+    let tmp = TempDir::new().expect("create temp dir");
+    let repo =
+        repositories::init::init_with_version_and_merkle_store(tmp.path(), MIN_OXEN_VERSION, kind)
+            .expect("init repo");
+    (tmp, repo)
+}
+
+// ─── deterministic hash helpers ──────────────────────────────────────────────
+//
+// Each "type" occupies a distinct region of the 128-bit hash space so hashes
+// can never collide across node kinds or subtree indices.
+
+fn commit_hash(idx: u64) -> MerkleHash {
+    MerkleHash::new((1u128 << 96) | idx as u128)
+}
+fn dir_hash(idx: u64) -> MerkleHash {
+    MerkleHash::new((2u128 << 96) | idx as u128)
+}
+fn vnode_hash(idx: u64) -> MerkleHash {
+    MerkleHash::new((3u128 << 96) | idx as u128)
+}
+fn file_hash(subtree: u64, file_idx: u64) -> MerkleHash {
+    // Up to 2^16 files per subtree and 2^48 subtrees before collision.
+    MerkleHash::new((4u128 << 96) | ((subtree as u128) << 16) | file_idx as u128)
+}
+
+// ─── node fixture helpers ─────────────────────────────────────────────────────
+
+fn make_commit(repo: &LocalRepository, idx: u64) -> CommitNode {
+    CommitNode::new(
+        repo,
+        CommitNodeOpts {
+            hash: commit_hash(idx),
+            parent_ids: vec![],
+            email: String::new(),
+            author: String::new(),
+            message: String::new(),
+            timestamp: OffsetDateTime::UNIX_EPOCH,
+        },
+    )
+    .expect("CommitNode::new")
+}
+
+fn make_dir(repo: &LocalRepository, idx: u64) -> DirNode {
+    DirNode::new(
+        repo,
+        DirNodeOpts {
+            name: String::new(),
+            hash: dir_hash(idx),
+            num_entries: 0,
+            num_bytes: 0,
+            last_commit_id: MerkleHash::new(0),
+            last_modified_seconds: 0,
+            last_modified_nanoseconds: 0,
+            data_type_counts: HashMap::new(),
+            data_type_sizes: HashMap::new(),
+        },
+    )
+    .expect("DirNode::new")
+}
+
+fn make_vnode(repo: &LocalRepository, idx: u64) -> VNode {
+    VNode::new(
+        repo,
+        VNodeOpts {
+            hash: vnode_hash(idx),
+            num_entries: 0,
+        },
+    )
+    .expect("VNode::new")
+}
+
+fn make_files(repo: &LocalRepository, subtree_idx: u64, fan_out: usize) -> Vec<FileNode> {
+    (0..fan_out as u64)
+        .map(|j| {
+            FileNode::new(
+                repo,
+                FileNodeOpts {
+                    name: format!("f{j}"),
+                    hash: file_hash(subtree_idx, j),
+                    combined_hash: MerkleHash::new(0),
+                    metadata_hash: None,
+                    num_bytes: 0,
+                    last_modified_seconds: 0,
+                    last_modified_nanoseconds: 0,
+                    data_type: EntryDataType::Binary,
+                    metadata: None,
+                    mime_type: String::new(),
+                    extension: String::new(),
+                },
+            )
+            .expect("FileNode::new")
+        })
+        .collect()
+}
+
+// ─── populate helper ─────────────────────────────────────────────────────────
+
+/// Write `n` commit→dir→vnode subtrees into `repo`'s Merkle store.
+/// Each vnode has `fan_out` file children.
+fn populate(repo: &LocalRepository, n: usize, fan_out: usize) {
+    let store = repo.merkle_store().expect("merkle_store");
+    let session = store.begin().expect("begin write session");
+    for i in 0..n as u64 {
+        let commit = make_commit(repo, i);
+        let dir = make_dir(repo, i);
+        let vnode = make_vnode(repo, i);
+        let files = make_files(repo, i, fan_out);
+
+        {
+            let mut ns = session
+                .create_node(&commit, None)
+                .expect("create commit node");
+            ns.add_child(&dir).expect("add dir child");
+            ns.finish().expect("finish commit node");
+        }
+        {
+            let mut ns = session
+                .create_node(&dir, Some(commit_hash(i)))
+                .expect("create dir node");
+            ns.add_child(&vnode).expect("add vnode child");
+            ns.finish().expect("finish dir node");
+        }
+        {
+            let mut ns = session
+                .create_node(&vnode, Some(dir_hash(i)))
+                .expect("create vnode node");
+            for f in &files {
+                ns.add_child(f).expect("add file child");
+            }
+            ns.finish().expect("finish vnode node");
+        }
+    }
+    session.finish().expect("finish write session");
+}
+
+/// Collect all commit / dir / vnode hashes for `n` subtrees.
+fn collect_hashes(n: usize) -> Vec<MerkleHash> {
+    let mut hashes = Vec::with_capacity(n * 3);
+    for i in 0..n as u64 {
+        hashes.push(commit_hash(i));
+        hashes.push(dir_hash(i));
+        hashes.push(vnode_hash(i));
+    }
+    hashes
+}
+
+// ─── walk helper ─────────────────────────────────────────────────────────────
+
+fn walk_subtree(store: &dyn MerkleStore, hash: &MerkleHash) {
+    let _ = store.get_node(hash).expect("get_node");
+    for (child_hash, _) in store.get_children(hash).expect("get_children") {
+        walk_subtree(store, &child_hash);
+    }
+}
+
+// ─── benchmarks ──────────────────────────────────────────────────────────────
+
+/// Measures the time to write N subtrees from scratch into an empty store.
+///
+/// `measurement_time` is sized per-N to keep `--quick` mode's loop above
+/// criterion's early-exit branch. That branch (codspeed-criterion-compat-walltime
+/// ≤ 2.10.1 `routine.rs:104`; upstream criterion.rs PR #685) tries to perturb
+/// the second sample with `t_prev + 0.000001` to avoid identical-sample KDE
+/// crashes, but the perturbation rounds away in f64 above ~1 s, so the samples
+/// collapse to equality and downstream KDE produces NaN — panicking
+/// `Sample::new`. Keeping a single iteration under `measurement_time` routes
+/// us through the loop's normal-exit path instead, where OS jitter naturally
+/// separates `t_prev` and `t_now`.
+fn bench_writes(c: &mut Criterion) {
+    let fan_out = 10;
+    let mut group = c.benchmark_group("merkle_store_writes");
+    let backends = backend_kinds_from_env();
+    for &n in &[100usize, 1_000, 10_000] {
+        // FileBackend is the slow path at ~30 ms/subtree (fan_out=10, 13 nodes
+        // per subtree). Budget 4× the expected single-iteration cost so the
+        // loop can take its second sample before the timeout, plus a 5 s floor.
+        let budget_secs = ((n as u64 * 30 * 4) / 1_000).max(5);
+        group.measurement_time(std::time::Duration::from_secs(budget_secs));
+        for &(kind, name) in &backends {
+            group.bench_with_input(
+                BenchmarkId::new(format!("{name}_subtrees"), n),
+                &n,
+                |b, &n| {
+                    b.iter_batched(
+                        || build_bench_repo(kind),
+                        |(_tmp, repo)| {
+                            populate(&repo, black_box(n), fan_out);
+                        },
+                        BatchSize::PerIteration,
+                    )
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+/// Measures `exists`, `get_node`, and `get_children` on a pre-populated store.
+/// Hashes are sampled in random order to model realistic read access patterns.
+fn bench_reads(c: &mut Criterion) {
+    let fan_out = 10;
+    let sample_size = 1_000;
+    let mut group = c.benchmark_group("merkle_store_reads");
+    let backends = backend_kinds_from_env();
+    for &n in &[1_000usize, 10_000] {
+        for &(kind, name) in &backends {
+            let (_tmp, repo) = build_bench_repo(kind);
+            populate(&repo, n, fan_out);
+            let all_hashes = collect_hashes(n);
+            let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+            let mut shuffled = all_hashes.clone();
+            shuffled.shuffle(&mut rng);
+            let sampled: Vec<MerkleHash> = shuffled
+                .into_iter()
+                .take(sample_size.min(all_hashes.len()))
+                .collect();
+
+            let store = repo.merkle_store().expect("merkle_store");
+
+            group.bench_function(BenchmarkId::new(format!("{name}_exists"), n), |b| {
+                b.iter(|| {
+                    for h in &sampled {
+                        black_box(store.exists(h).expect("exists"));
+                    }
+                })
+            });
+
+            group.bench_function(BenchmarkId::new(format!("{name}_get_node"), n), |b| {
+                b.iter(|| {
+                    for h in &sampled {
+                        black_box(store.get_node(h).expect("get_node"));
+                    }
+                })
+            });
+
+            group.bench_function(BenchmarkId::new(format!("{name}_get_children"), n), |b| {
+                b.iter(|| {
+                    for h in &sampled {
+                        black_box(store.get_children(h).expect("get_children"));
+                    }
+                })
+            });
+
+            // `store` borrows from `repo`; both are dropped at end of loop body.
+            // Rust's reverse-declaration order (store → repo → tmp) is the safe order.
+        }
+    }
+    group.finish();
+}
+
+/// Measures a full top-down tree walk across all subtrees in the store.
+/// Models the read pattern used during migration / verification passes.
+fn bench_tree_walk(c: &mut Criterion) {
+    let fan_out = 10;
+    let mut group = c.benchmark_group("merkle_store_tree_walk");
+    let backends = backend_kinds_from_env();
+    for &n in &[100usize, 1_000] {
+        for &(kind, name) in &backends {
+            let (_tmp, repo) = build_bench_repo(kind);
+            populate(&repo, n, fan_out);
+            let commit_hashes: Vec<MerkleHash> = (0..n as u64).map(commit_hash).collect();
+            let store = repo.merkle_store().expect("merkle_store");
+
+            group.bench_function(BenchmarkId::new(name, n), |b| {
+                b.iter(|| {
+                    for h in &commit_hashes {
+                        walk_subtree(store, h);
+                    }
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_writes, bench_reads, bench_tree_walk);
+criterion_main!(benches);
+
+// ─── correctness check ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+
+    /// Confirm that both backends produce identical round-trip results for a
+    /// fixed N=10 subtree fixture. Catches future divergence between backends.
+    #[test]
+    fn both_backends_round_trip_identically() {
+        let n = 10;
+        let fan_out = 3;
+
+        let mut results: Vec<Vec<(MerkleHash, String)>> = Vec::new();
+        for kind in [MerkleStoreKind::File, MerkleStoreKind::Lmdb] {
+            let (_tmp, repo) = build_bench_repo(kind);
+            populate(&repo, n, fan_out);
+            let store = repo.merkle_store().expect("merkle_store");
+
+            let mut tuples: Vec<(MerkleHash, String)> = Vec::new();
+            for i in 0..n as u64 {
+                for h in [commit_hash(i), dir_hash(i), vnode_hash(i)] {
+                    assert!(
+                        store.exists(&h).expect("exists"),
+                        "hash {h} missing for {kind:?}"
+                    );
+                    let entry = store.get_node(&h).expect("get_node");
+                    let kind_name = entry
+                        .map(|e| format!("{:?}", e.node.node_type()))
+                        .unwrap_or_else(|| "None".to_string());
+                    tuples.push((h, kind_name));
+                }
+            }
+            tuples.sort_by_key(|(h, _)| h.to_u128());
+            results.push(tuples);
+            // store → repo → tmp drop in correct order (reverse declaration) at end of body.
+        }
+
+        assert_eq!(
+            results[0], results[1],
+            "File and LMDB backends returned different results for the same fixture"
+        );
+    }
+}

--- a/crates/lib/benches/push.rs
+++ b/crates/lib/benches/push.rs
@@ -1,6 +1,7 @@
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use liboxen::api::requests::RepoNew;
-use liboxen::constants::{DEFAULT_NAMESPACE, DEFAULT_REMOTE_NAME};
+use liboxen::config::repository_config::MerkleStoreKind;
+use liboxen::constants::{DEFAULT_NAMESPACE, DEFAULT_REMOTE_NAME, MIN_OXEN_VERSION};
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
@@ -11,6 +12,10 @@ use rand::distributions::Alphanumeric;
 use rand::{Rng, RngCore};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+#[path = "bench_support.rs"]
+mod bench_support;
+use bench_support::backend_kinds_from_env;
 
 fn generate_random_string(len: usize) -> String {
     rand::thread_rng()
@@ -46,16 +51,21 @@ async fn setup_repo_for_push_benchmark(
     num_files_to_push_in_benchmark: usize,
     dir_size: usize,
     data_path: Option<String>,
+    kind: MerkleStoreKind,
+    backend_name: &str,
 ) -> Result<LocalRepository, OxenError> {
     println!(
-        "setup_repo_for_push_benchmark got repo_size {repo_size}, num_files_to_push {num_files_to_push_in_benchmark}, and dir_size {dir_size}",
+        "setup_repo_for_push_benchmark got repo_size {repo_size}, num_files_to_push {num_files_to_push_in_benchmark}, dir_size {dir_size}, backend {backend_name}",
     );
-    let repo_dir = base_dir.join(format!("repo_{num_files_to_push_in_benchmark}_{dir_size}"));
+    let repo_dir = base_dir.join(format!(
+        "repo_{backend_name}_{num_files_to_push_in_benchmark}_{dir_size}"
+    ));
     if repo_dir.exists() {
         util::fs::remove_dir_all(&repo_dir)?;
     }
 
-    let repo = repositories::init(&repo_dir)?;
+    let repo =
+        repositories::init::init_with_version_and_merkle_store(&repo_dir, MIN_OXEN_VERSION, kind)?;
 
     let mut rng = rand::thread_rng();
     let files_dir = if let Some(data_path) = data_path {
@@ -158,76 +168,81 @@ pub fn push_benchmark(c: &mut Criterion) {
         // (100000, 1000),
         // (1000000, 1000),
     ];
-    for &(repo_size, dir_size) in params.iter() {
-        let num_files_to_push = repo_size / 1000;
-        let mut repo = rt
-            .block_on(setup_repo_for_push_benchmark(
-                &base_dir,
-                repo_size,
-                num_files_to_push,
-                dir_size,
-                data_path.clone(),
-            ))
-            .unwrap();
+    let backends = backend_kinds_from_env();
+    for &(kind, name) in &backends {
+        for &(repo_size, dir_size) in params.iter() {
+            let num_files_to_push = repo_size / 1000;
+            let mut repo = rt
+                .block_on(setup_repo_for_push_benchmark(
+                    &base_dir,
+                    repo_size,
+                    num_files_to_push,
+                    dir_size,
+                    data_path.clone(),
+                    kind,
+                    name,
+                ))
+                .unwrap();
 
-        group.bench_with_input(
-            BenchmarkId::new(
-                format!("{num_files_to_push}k_files_in_{dir_size}dirs"),
-                format!("{:?}", (num_files_to_push, dir_size)),
-            ),
-            &(num_files_to_push, dir_size),
-            |b, _| {
-                b.to_async(&rt).iter_batched(
-                    || {
-                        // Create a new remote for each iteration
-                        let iter_dirname =
-                            format!("push-run-{}", rand::thread_rng().r#gen::<u64>());
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{name}_{num_files_to_push}k_files_in_{dir_size}dirs"),
+                    format!("{:?}", (name, num_files_to_push, dir_size)),
+                ),
+                &(num_files_to_push, dir_size),
+                |b, _| {
+                    b.to_async(&rt).iter_batched(
+                        || {
+                            // Create a new remote for each iteration
+                            let iter_dirname =
+                                format!("push-run-{}", rand::thread_rng().r#gen::<u64>());
 
-                        let repo_new = RepoNew::from_namespace_name_host(
-                            DEFAULT_NAMESPACE,
-                            iter_dirname,
-                            test_host(),
-                            None,
-                        );
+                            let repo_new = RepoNew::from_namespace_name_host(
+                                DEFAULT_NAMESPACE,
+                                iter_dirname,
+                                test_host(),
+                                None,
+                            );
 
-                        // Spawn a new thread to escape the tokio runtime
-                        // context — the setup closure runs on a runtime
-                        // thread, so block_on would panic with a nested
-                        // runtime error.
-                        let repo_ref = &repo;
-                        let remote_repo = std::thread::scope(|s| {
-                            s.spawn(|| {
-                                let setup_rt = tokio::runtime::Runtime::new().unwrap();
-                                setup_rt
-                                    .block_on(api::client::repositories::create_from_local(
-                                        repo_ref, repo_new,
-                                    ))
-                                    .unwrap()
-                            })
-                            .join()
-                            .unwrap()
-                        });
-                        std::thread::sleep(std::time::Duration::from_millis(500));
-                        let _ = command::config::set_remote(
-                            &mut repo,
-                            DEFAULT_REMOTE_NAME,
-                            &remote_repo.remote.url,
-                        );
+                            // Spawn a new thread to escape the tokio runtime
+                            // context — the setup closure runs on a runtime
+                            // thread, so block_on would panic with a nested
+                            // runtime error.
+                            let repo_ref = &repo;
+                            let remote_repo = std::thread::scope(|s| {
+                                s.spawn(|| {
+                                    let setup_rt = tokio::runtime::Runtime::new().unwrap();
+                                    setup_rt
+                                        .block_on(api::client::repositories::create_from_local(
+                                            repo_ref, repo_new,
+                                        ))
+                                        .unwrap()
+                                })
+                                .join()
+                                .unwrap()
+                            });
+                            std::thread::sleep(std::time::Duration::from_millis(500));
+                            let _ = command::config::set_remote(
+                                &mut repo,
+                                DEFAULT_REMOTE_NAME,
+                                &remote_repo.remote.url,
+                            );
 
-                        (repo.clone(), remote_repo)
-                    },
-                    |(repo, remote_repo)| async move {
-                        repositories::push(&repo).await.unwrap();
-                        // cleanup the remote repo for push
-                        api::client::repositories::delete(&remote_repo)
-                            .await
-                            .unwrap();
-                    },
-                    criterion::BatchSize::PerIteration,
-                );
-            },
-        );
-    }
+                            (repo.clone(), remote_repo)
+                        },
+                        |(repo, remote_repo)| async move {
+                            repositories::push(&repo).await.unwrap();
+                            // cleanup the remote repo for push
+                            api::client::repositories::delete(&remote_repo)
+                                .await
+                                .unwrap();
+                        },
+                        criterion::BatchSize::PerIteration,
+                    );
+                },
+            );
+        } // end params loop
+    } // end backends loop
     group.finish();
 
     util::fs::remove_dir_all(base_dir).unwrap();

--- a/crates/lib/benches/workspace_add.rs
+++ b/crates/lib/benches/workspace_add.rs
@@ -2,7 +2,8 @@ use criterion::{BenchmarkId, Criterion, black_box};
 use criterion::{criterion_group, criterion_main};
 use liboxen::api;
 use liboxen::command;
-use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_REMOTE_NAME};
+use liboxen::config::repository_config::MerkleStoreKind;
+use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_REMOTE_NAME, MIN_OXEN_VERSION};
 use liboxen::error::OxenError;
 use liboxen::model::{LocalRepository, RemoteRepository};
 use liboxen::repositories;
@@ -13,6 +14,10 @@ use rand::{Rng, RngCore};
 use std::fs;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
+
+#[path = "bench_support.rs"]
+mod bench_support;
+use bench_support::backend_kinds_from_env;
 
 fn generate_random_string(len: usize) -> String {
     rand::thread_rng()
@@ -46,21 +51,24 @@ async fn setup_repo_for_workspace_add_benchmark(
     num_files_to_add_in_benchmark: usize,
     dir_size: usize,
     data_path: Option<String>,
+    kind: MerkleStoreKind,
+    backend_name: &str,
 ) -> Result<(LocalRepository, RemoteRepository, Vec<PathBuf>), OxenError> {
     println!(
-        "setup_repo_for_workspace_add_benchmark got repo_size {repo_size}, num_files_to_add {num_files_to_add_in_benchmark}, and dir_size {dir_size}",
+        "setup_repo_for_workspace_add_benchmark got repo_size {repo_size}, num_files_to_add {num_files_to_add_in_benchmark}, dir_size {dir_size}, backend {backend_name}",
     );
     // Generate Uuid to ensure the data is pushed to a new remote
     let remote_id = Uuid::new_v4().to_string();
     let repo_dir = base_dir.join(format!(
-        "repo_{num_files_to_add_in_benchmark}_{dir_size}_{remote_id}"
+        "repo_{backend_name}_{num_files_to_add_in_benchmark}_{dir_size}_{remote_id}"
     ));
 
     if repo_dir.exists() {
         util::fs::remove_dir_all(&repo_dir)?;
     }
 
-    let mut repo = repositories::init(&repo_dir)?;
+    let mut repo =
+        repositories::init::init_with_version_and_merkle_store(&repo_dir, MIN_OXEN_VERSION, kind)?;
 
     let remote_repo = create_or_clear_remote_repo(&repo).await?;
     command::config::set_remote(&mut repo, DEFAULT_REMOTE_NAME, &remote_repo.remote.url)?;
@@ -175,55 +183,60 @@ pub fn workspace_add_benchmark(c: &mut Criterion) {
         // (100000, 1000),
         // (1000000, 1000),
     ];
-    for &(repo_size, dir_size) in params.iter() {
-        let num_files_to_add = repo_size / 1000;
-        let (_, remote_repo, files) = rt
-            .block_on(setup_repo_for_workspace_add_benchmark(
-                &base_dir,
-                repo_size,
-                num_files_to_add,
-                dir_size,
-                data_path.clone(),
-            ))
-            .unwrap();
+    let backends = backend_kinds_from_env();
+    for &(kind, name) in &backends {
+        for &(repo_size, dir_size) in params.iter() {
+            let num_files_to_add = repo_size / 1000;
+            let (_, remote_repo, files) = rt
+                .block_on(setup_repo_for_workspace_add_benchmark(
+                    &base_dir,
+                    repo_size,
+                    num_files_to_add,
+                    dir_size,
+                    data_path.clone(),
+                    kind,
+                    name,
+                ))
+                .unwrap();
 
-        group.bench_with_input(
-            BenchmarkId::new(
-                format!("{num_files_to_add}k_files_in_{dir_size}dirs"),
-                format!("{:?}", (num_files_to_add, dir_size)),
-            ),
-            &(num_files_to_add, dir_size),
-            |b, _| {
-                let branch_name = DEFAULT_BRANCH_NAME;
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{name}_{num_files_to_add}k_files_in_{dir_size}dirs"),
+                    format!("{:?}", (name, num_files_to_add, dir_size)),
+                ),
+                &(num_files_to_add, dir_size),
+                |b, _| {
+                    let branch_name = DEFAULT_BRANCH_NAME;
 
-                // Generate a random workspace id
-                let workspace_id = Uuid::new_v4().to_string();
+                    // Generate a random workspace id
+                    let workspace_id = Uuid::new_v4().to_string();
 
-                let workspace = rt
-                    .block_on(api::client::workspaces::create(
-                        &remote_repo,
-                        &branch_name,
-                        &workspace_id,
-                    ))
-                    .unwrap();
+                    let workspace = rt
+                        .block_on(api::client::workspaces::create(
+                            &remote_repo,
+                            &branch_name,
+                            &workspace_id,
+                        ))
+                        .unwrap();
 
-                b.to_async(&rt).iter(|| async {
-                    api::client::workspaces::files::add(
-                        &remote_repo,
-                        &workspace.id.as_str(),
-                        "",
-                        files.clone(),
-                        &None,
-                    )
-                    .await
-                    .unwrap();
-                });
+                    b.to_async(&rt).iter(|| async {
+                        api::client::workspaces::files::add(
+                            &remote_repo,
+                            &workspace.id.as_str(),
+                            "",
+                            files.clone(),
+                            &None,
+                        )
+                        .await
+                        .unwrap();
+                    });
 
-                let _ = rt
-                    .block_on(api::client::workspaces::delete(&remote_repo, &workspace.id))
-                    .unwrap();
-            },
-        );
+                    let _ = rt
+                        .block_on(api::client::workspaces::delete(&remote_repo, &workspace.id))
+                        .unwrap();
+                },
+            );
+        }
     }
     group.finish();
 


### PR DESCRIPTION
Introduces a new `merkle_store` benchmark (writes, reads, tree-walk groups) that exercises
the FileBackend and LmdbBackend MerkleStore implementations in isolation, and wires a shared
`bench_support` helper into the existing add/download/fetch/push/workspace_add benchmarks so
all of them iterate over both backends controlled by the `BENCHMARK_BACKENDS` env var.