### PR TITLE
Tolerate invalid JSON in JSON-typed columns on data frame export

### DIFF
--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -339,8 +339,8 @@ pub fn extract_file_node_to_working_dir(
             let res = conn.execute(&delete.to_string(), [])?;
             log::debug!("delete query result is: {res:?}");
 
-            let excluded_cols = get_existing_excluded_columns(conn, TABLE_NAME)?;
-            let sql = format!("SELECT * EXCLUDE ({excluded_cols}) FROM '{TABLE_NAME}'");
+            let projection = build_export_projection(conn, TABLE_NAME)?;
+            let sql = format!("SELECT {projection} FROM '{TABLE_NAME}'");
             let query = wrap_sql_for_export(&sql, &working_path);
             log::debug!("extracting file node to working dir query: {query:?}");
             conn.execute(&query, [])?;
@@ -398,28 +398,181 @@ pub fn wrap_sql_for_export(sql: &str, path: &Path) -> String {
     }
 }
 
-fn get_existing_excluded_columns(
-    conn: &Connection,
-    table_name: &str,
-) -> Result<String, duckdb::Error> {
-    // Query to get existing columns in the table
-    let existing_cols_query = format!(
-        "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}'"
+/// Build the explicit `SELECT` projection used when exporting the staged DuckDB
+/// table to the working tree, omitting the oxen-internal columns
+/// ([`EXCLUDE_OXEN_COLS`]).
+///
+/// Columns whose DuckDB `data_type` is `JSON` or `JSON[]` are wrapped so that a
+/// stored value which isn't valid JSON is preserved as a JSON string rather than
+/// aborting the export:
+///
+/// ```sql
+/// CASE WHEN "col" IS NULL OR json_valid(CAST("col" AS VARCHAR))
+///      THEN "col"
+///      ELSE to_json(CAST("col" AS VARCHAR)) END AS "col"
+/// ```
+///
+/// Rows written before insert-time JSON validation was added can hold raw
+/// non-JSON text in JSON-typed columns. `COPY ... (FORMAT JSON)` re-parses each
+/// value and throws a "Malformed JSON" error on those, failing the whole
+/// data-frame export. `json_valid` returns false (it does not throw) on invalid
+/// input, so the wrap is a no-op for valid data and only rewrites
+/// genuinely-corrupt values. Only the JSON writer (jsonl/ndjson/json) re-parses
+/// these values; the csv/tsv/parquet export paths are unaffected, and this
+/// projection is a safe identity for them.
+///
+/// Columns are emitted in `ordinal_position` order so the exported schema matches
+/// the table.
+fn build_export_projection(conn: &Connection, table_name: &str) -> Result<String, duckdb::Error> {
+    let cols_query = format!(
+        "SELECT column_name, data_type FROM information_schema.columns \
+         WHERE table_name = '{table_name}' ORDER BY ordinal_position"
     );
 
-    let existing_cols: Vec<String> = {
-        let mut stmt = conn.prepare(&existing_cols_query)?;
-        stmt.query_map([], |row| row.get(0))?
-            .filter_map(Result::ok)
-            .collect()
+    let cols: Vec<(String, String)> = {
+        let mut stmt = conn.prepare(&cols_query)?;
+        stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .filter_map(Result::ok)
+        .collect()
     };
 
-    // Filter excluded columns to only those that exist in the table
-    let filtered_excluded_cols: Vec<String> = EXCLUDE_OXEN_COLS
-        .iter()
-        .filter(|col| existing_cols.contains(&col.to_string()))
-        .map(|col| format!("\"{col}\""))
+    let projection: Vec<String> = cols
+        .into_iter()
+        .filter(|(name, _)| !EXCLUDE_OXEN_COLS.contains(&name.as_str()))
+        .map(|(name, data_type)| {
+            if data_type == "JSON" || data_type == "JSON[]" {
+                json_tolerant_export_expr(&name)
+            } else {
+                format!("\"{name}\"")
+            }
+        })
         .collect();
 
-    Ok(filtered_excluded_cols.join(", "))
+    Ok(projection.join(", "))
+}
+
+/// Projection expression for a single `JSON`/`JSON[]` column that tolerates a
+/// stored value which isn't valid JSON. `json_valid` returns false (never throws)
+/// on invalid input, so valid values pass through unchanged (the `THEN` branch)
+/// and only genuinely-corrupt values are rewritten into a valid JSON string (the
+/// `ELSE` branch). See [`build_export_projection`] for why corrupt values exist.
+fn json_tolerant_export_expr(name: &str) -> String {
+    format!(
+        "CASE WHEN \"{name}\" IS NULL OR json_valid(CAST(\"{name}\" AS VARCHAR)) \
+         THEN \"{name}\" ELSE to_json(CAST(\"{name}\" AS VARCHAR)) END AS \"{name}\""
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::db::data_frames::df_db;
+    use crate::test;
+
+    /// The export projection must wrap `JSON` and `JSON[]` columns in the
+    /// invalid-JSON-tolerant `CASE` expression, project everything else as-is,
+    /// drop the oxen-internal columns, and preserve `ordinal_position` order.
+    #[test]
+    fn test_build_export_projection_wraps_json_columns() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_empty_dir_test(|dir| {
+            let conn = df_db::get_connection(&dir.join("db"))?;
+            // Column order here is the order information_schema reports.
+            conn.execute(
+                &format!(
+                    "CREATE TABLE {TABLE_NAME} (\
+                       \"name\" VARCHAR, \
+                       \"meta\" JSON, \
+                       \"count\" BIGINT, \
+                       \"tags\" JSON[], \
+                       \"{oxen_id}\" VARCHAR, \
+                       \"{DIFF_STATUS_COL}\" VARCHAR, \
+                       \"{DIFF_HASH_COL}\" VARCHAR)",
+                    oxen_id = crate::constants::OXEN_ID_COL,
+                ),
+                [],
+            )?;
+
+            let projection = build_export_projection(&conn, TABLE_NAME)?;
+
+            let expected = format!(
+                "\"name\", {}, \"count\", {}",
+                json_tolerant_export_expr("meta"),
+                json_tolerant_export_expr("tags"),
+            );
+            assert_eq!(projection, expected);
+
+            // The wrap must reference json_valid / to_json so a corrupt value
+            // can't abort the COPY ... (FORMAT JSON) re-serialization.
+            assert!(projection.contains("json_valid"));
+            assert!(projection.contains("to_json"));
+            // Oxen-internal columns are dropped, never emitted.
+            assert!(!projection.contains(crate::constants::OXEN_ID_COL));
+            assert!(!projection.contains(DIFF_STATUS_COL));
+            assert!(!projection.contains(DIFF_HASH_COL));
+            Ok(())
+        })
+    }
+
+    /// The tolerant `CASE` wrap must turn a value that isn't valid JSON into a
+    /// JSON string that survives `COPY ... (FORMAT JSON)`, while valid values
+    /// pass through untouched. DuckDB 1.5.2 validates JSON on every ingestion
+    /// path (insert, cast, `read_json`, `read_parquet`), so the corrupt
+    /// JSON-column state this guards against can only originate from data
+    /// written by older engines and can't be synthesized here. We instead
+    /// exercise the exact projection SQL: `CAST(json_col AS VARCHAR)` yields the
+    /// raw stored bytes, so feeding the wrap a `VARCHAR` reproduces the runtime
+    /// behavior on those bytes.
+    #[test]
+    fn test_json_tolerant_export_neutralizes_invalid_json() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_empty_dir_test(|dir| {
+            let conn = df_db::get_connection(&dir.join("db"))?;
+            // 'Insufficient credits' mimics a legacy value: a plain string
+            // stored in a JSON-typed column; '{"a":1}' is genuinely valid
+            // JSON; NULL takes the IS NULL guard.
+            conn.execute("CREATE TABLE t (v VARCHAR, ord INTEGER)", [])?;
+            conn.execute(
+                "INSERT INTO t VALUES ('Insufficient credits', 1), ('{\"a\":1}', 2), (NULL, 3)",
+                [],
+            )?;
+
+            let expr = json_tolerant_export_expr("v");
+            let out = dir.join("out.jsonl");
+            let query = wrap_sql_for_export(&format!("SELECT {expr} FROM t ORDER BY ord"), &out);
+
+            // Must NOT raise "Malformed JSON" the way a bare `SELECT v` would on
+            // a corrupt JSON column.
+            conn.execute(&query, [])?;
+
+            // Bad value is emitted as a valid JSON string, not raw text.
+            let content = std::fs::read_to_string(&out)?;
+            assert!(
+                content.contains("{\"v\":\"Insufficient credits\"}"),
+                "expected the invalid value to be wrapped as a JSON string, got:\n{content}"
+            );
+            assert!(
+                content.contains("{\"v\":{\"a\":1}}"),
+                "expected valid JSON to pass through unchanged, got:\n{content}"
+            );
+
+            // Output round-trips: read_json re-parses it without error.
+            let count: i64 = conn.query_row(
+                &format!(
+                    "SELECT count(*) FROM read_json('{}')",
+                    out.to_string_lossy()
+                ),
+                [],
+                |row| row.get(0),
+            )?;
+            assert_eq!(count, 3);
+            Ok(())
+        })
+    }
 }

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -1349,6 +1349,67 @@ mod tests {
         }).await
     }
 
+    /// Regression guard for the workspace-commit export on JSON-typed columns.
+    /// Exercises the real index → add-row → commit path on a column DuckDB
+    /// infers as `JSON`, so the export projection (`build_export_projection`)
+    /// round-trips a JSON column through the export's `COPY ... (FORMAT JSON)`.
+    ///
+    /// DuckDB 1.5.2 validates JSON on every ingestion path, so a genuinely
+    /// corrupt JSON-column value can't be synthesized through the public API;
+    /// that tolerance branch is covered by the focused tests in
+    /// `core::v_latest::workspaces::data_frames`. This test guards the happy
+    /// path so the export projection can't regress normal JSON-column exports.
+    #[tokio::test]
+    async fn test_commit_workspace_with_json_column_round_trips() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Object values make read_json (and the workspace index) type
+            // `error_details` as a JSON column.
+            let path = Path::new("media.jsonl");
+            let full_path = repo.path.join(path);
+            std::fs::write(
+                &full_path,
+                "{\"id\":1,\"error_details\":{\"code\":402,\"msg\":\"x\"}}\n\
+                 {\"id\":2,\"error_details\":{\"code\":200,\"msg\":\"ok\"}}\n",
+            )?;
+            repositories::add(&repo, &full_path).await?;
+            let commit = repositories::commit(&repo, "add media jsonl")?;
+
+            let user = UserConfig::get()?.to_user();
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            workspaces::data_frames::index(&repo, &workspace, path).await?;
+
+            // Append a row whose JSON column holds a valid object.
+            let json_data = json!({"id": 3, "error_details": {"code": 500, "msg": "err"}});
+            workspaces::data_frames::rows::add(&repo, &workspace, path, &json_data)?;
+
+            let new_commit = NewCommitBody {
+                author: user.name.to_owned(),
+                email: user.email,
+                message: "Commit workspace with JSON column".to_string(),
+            };
+            // The export driven by this commit is where a corrupt legacy value
+            // would abort; it must succeed for a valid JSON column.
+            let commit = workspaces::commit(&workspace, &new_commit, DEFAULT_BRANCH_NAME).await?;
+
+            // The committed file round-trips: re-read it and confirm every row survived.
+            let entry = repositories::entries::get_commit_entry(&repo, &commit, path)?.unwrap();
+            let version_store = repo.version_store();
+            let version_file = version_store.get_version_path(&entry.hash).await?;
+            let extension = entry.path.extension().unwrap().to_str().unwrap();
+            let data_frame =
+                df::tabular::read_df_with_extension(version_file, extension, &DFOpts::empty())
+                    .await?;
+            assert_eq!(data_frame.height(), 3);
+            assert!(data_frame.column("error_details").is_ok());
+            Ok(())
+        })
+        .await
+    }
+
     #[test]
     fn test_add_exclude_to_simple_select() -> Result<(), OxenError> {
         let sql = "SELECT * FROM table";


### PR DESCRIPTION
Workspace data-frame export built `SELECT * EXCLUDE (<oxen cols>)` and wrapped it in `COPY ... (FORMAT JSON)`. Legacy rows can hold raw non-JSON text in columns DuckDB typed as JSON, so the re-serialize re-parses them and aborts the whole commit with "Malformed JSON".

Replace the `SELECT *` with an explicit projection (`build_export_projection`) that wraps JSON/JSON[] columns in a `json_valid`-guarded CASE, preserving a corrupt value as a JSON string instead of failing. Valid data is unchanged; csv/tsv/parquet paths are unaffected.