### PR TITLE
Stop relying on files retrieved from production hub for tests

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -175,13 +175,13 @@ jobs:
       - name: Run oxen rust tests (Linux/macOS)
         if: matrix.platform != 'windows'
         run: |
-          ./target/debug/oxen-server start &
+          ./target/debug/oxen-server start --test &
           cargo nextest run --workspace --profile ci
 
       - name: Run oxen rust tests (Windows)
         if: matrix.platform == 'windows'
         run: |
-          Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
+          Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start","--test"
           cargo nextest run --workspace --profile ci
 
   python-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5522,6 +5522,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "mime",
+ "mockito",
  "os_path",
  "percent-encoding",
  "regex",

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -194,7 +194,7 @@ fi
 export OXEN_TEST_HOST="localhost:${OXEN_PORT}"
 
 echo "==> Starting oxen-server on port ${OXEN_PORT}..."
-./target/debug/oxen-server start -p "${OXEN_PORT}" &
+./target/debug/oxen-server start -p "${OXEN_PORT}" --test &
 SERVER_PID=$!
 
 wait_for_server() {

--- a/crates/lib/src/api/client/import.rs
+++ b/crates/lib/src/api/client/import.rs
@@ -230,8 +230,21 @@ mod tests {
     async fn test_import_url_with_update_timestamp() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
             let branch_name = DEFAULT_BRANCH_NAME;
-            let download_url =
-                "https://hub.oxen.ai/api/repos/ox/Oxen-AI-Assets/file/main/images/bloxy_white_background.png";
+
+            // Serve stable, identical bytes from a local mock server so the three imports below
+            // hash to the same version, exercising re-import dedup. The oxen-server process
+            // performs the fetch, so it must run in test mode to permit the loopback target. The
+            // mock and server stay in scope for the whole closure so every GET is served.
+            let mut server = mockito::Server::new_async().await;
+            let _mock = server
+                .mock("GET", "/images/bloxy_white_background.png")
+                .with_status(200)
+                .with_header("content-type", "image/png")
+                .with_body("fake png bytes for re-import dedup testing")
+                .create_async()
+                .await;
+            let download_url = format!("{}/images/bloxy_white_background.png", server.url());
+            let download_url = download_url.as_str();
 
             let commit_body = NewCommitBody {
                 message: "First import".to_string(),
@@ -285,14 +298,9 @@ mod tests {
             assert_ne!(first_commit.id, third_commit.id);
 
             // Verify latest_commit on the entry matches the update_timestamp commit
-            let entries = api::client::dir::list(
-                &remote_repo,
-                branch_name,
-                Path::new("imported"),
-                1,
-                100,
-            )
-            .await?;
+            let entries =
+                api::client::dir::list(&remote_repo, branch_name, Path::new("imported"), 1, 100)
+                    .await?;
             let file_entry = entries
                 .entries
                 .iter()

--- a/crates/lib/src/core/v_latest/workspaces/files.rs
+++ b/crates/lib/src/core/v_latest/workspaces/files.rs
@@ -311,7 +311,9 @@ enum InvalidUrlError {
 /// Resolves a URL's hostname via DNS and rejects it if any resolved address is
 /// private/reserved. This prevents SSRF attacks where a user-supplied URL could reach
 /// internal services (e.g. cloud metadata at 169.254.169.254, internal APIs, etc.).
-async fn validate_url_target(url: &Url) -> Result<(), InvalidUrlError> {
+///
+/// When `allow_loopback` is true, loopback targets (127.0.0.0/8 and ::1) are permitted (for tests).
+async fn validate_url_target(url: &Url, allow_loopback: bool) -> Result<(), InvalidUrlError> {
     let host = url.host_str().ok_or(InvalidUrlError::NoHost)?;
     let port = url.port_or_known_default().unwrap_or(443);
     let addr = format!("{host}:{port}");
@@ -325,8 +327,12 @@ async fn validate_url_target(url: &Url) -> Result<(), InvalidUrlError> {
             })?;
 
     for socket_addr in resolved {
-        if is_private_ip(&socket_addr.ip()) {
-            return Err(InvalidUrlError::PrivateIp(socket_addr.ip()));
+        let ip = socket_addr.ip();
+        if allow_loopback && ip.is_loopback() {
+            continue;
+        }
+        if is_private_ip(&ip) {
+            return Err(InvalidUrlError::PrivateIp(ip));
         }
     }
 
@@ -373,6 +379,8 @@ fn sanitize_filename(name: &str) -> String {
 
 /// Downloads a file from a user-supplied URL into a workspace directory.
 /// Validates the URL scheme and target IP before fetching to prevent SSRF.
+///
+/// `allow_loopback` relaxes the SSRF guard for loopback targets for tests.
 pub async fn import(
     url: &str,
     auth: &str,
@@ -380,6 +388,7 @@ pub async fn import(
     filename: Option<String>,
     workspace: &Workspace,
     update_timestamp: bool,
+    allow_loopback: bool,
 ) -> Result<(), OxenError> {
     let parsed_url =
         Url::parse(url).map_err(|_| OxenError::file_import_error(format!("Invalid URL: {url}")))?;
@@ -391,7 +400,7 @@ pub async fn import(
         ));
     }
 
-    validate_url_target(&parsed_url)
+    validate_url_target(&parsed_url, allow_loopback)
         .await
         .map_err(|e| OxenError::ImportFileError(format!("{e}").into()))?;
 
@@ -405,6 +414,7 @@ pub async fn import(
         filename,
         workspace,
         update_timestamp,
+        allow_loopback,
     )
     .await?;
 
@@ -476,6 +486,7 @@ async fn fetch_file(
     caller_filename: Option<String>,
     workspace: &Workspace,
     update_timestamp: bool,
+    allow_loopback: bool,
 ) -> Result<(), OxenError> {
     let client = Client::builder()
         .redirect(redirect::Policy::none())
@@ -521,7 +532,7 @@ async fn fetch_file(
                     "Redirect to non-HTTP(S) URL is not allowed",
                 ));
             }
-            validate_url_target(&next_url)
+            validate_url_target(&next_url, allow_loopback)
                 .await
                 .map_err(|e| OxenError::ImportFileError(format!("{e}").into()))?;
 

--- a/crates/lib/src/repositories/workspaces/files.rs
+++ b/crates/lib/src/repositories/workspaces/files.rs
@@ -61,6 +61,7 @@ pub async fn import(
     filename: Option<String>,
     workspace: &Workspace,
     update_timestamp: bool,
+    allow_loopback: bool,
 ) -> Result<(), OxenError> {
     match workspace.base_repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
@@ -72,6 +73,7 @@ pub async fn import(
                 filename,
                 workspace,
                 update_timestamp,
+                allow_loopback,
             )
             .await?;
             Ok(())
@@ -282,12 +284,14 @@ mod tests {
             ];
 
             for (url, label) in cases {
+                // allow_loopback is false, so loopback targets are rejected like other private IPs.
                 let result = workspaces::files::import(
                     url,
                     "",
                     std::path::PathBuf::from("data"),
                     None,
                     &workspace,
+                    false,
                     false,
                 )
                 .await;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -70,6 +70,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 actix-multipart-test = { workspace = true }
 liboxen = { workspace = true, features = ["test-utils"] }
+mockito = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/server/src/app_data.rs
+++ b/crates/server/src/app_data.rs
@@ -9,6 +9,8 @@ pub struct OxenAppData {
     pub path: PathBuf,
     pub config: Config,
     pub merkle_store_kind: MerkleStoreKind,
+    /// When true, relax some checks to facilitate testing. Never enable in normal operation.
+    pub test_mode: bool,
 }
 
 impl OxenAppData {
@@ -18,6 +20,7 @@ impl OxenAppData {
             path,
             config: Config::default(),
             merkle_store_kind: MerkleStoreKind::default(),
+            test_mode: false,
         }
     }
 }

--- a/crates/server/src/controllers/import.rs
+++ b/crates/server/src/controllers/import.rs
@@ -98,6 +98,8 @@ pub async fn import(
     body: web::Json<Value>,
 ) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
+    // In test mode the import SSRF guard allows loopback download targets; false otherwise.
+    let allow_loopback = app_data.test_mode;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, &repo_name)?;
@@ -195,6 +197,7 @@ pub async fn import(
         filename,
         &workspace,
         update_timestamp,
+        allow_loopback,
     )
     .await?;
 
@@ -501,18 +504,34 @@ mod tests {
         repositories::add(&repo, &hello_file).await?;
         let _commit = repositories::commit(&repo, "First commit")?;
 
+        // Serve a small tabular file from a local mock server. The URL's basename
+        // (cats_vs_dogs.tsv) becomes the committed filename.
+        let mut server = mockito::Server::new_async().await;
+        let tsv_body = "file\tlabel\ncat.1.jpg\tcat\ndog.1.jpg\tdog\n";
+        let _mock = server
+            .mock("GET", "/tables/cats_vs_dogs.tsv")
+            .with_status(200)
+            .with_header("content-type", "text/tab-separated-values")
+            .with_body(tsv_body)
+            .create_async()
+            .await;
+        let download_url = format!("{}/tables/cats_vs_dogs.tsv", server.url());
+
         let uri = format!("/oxen/{namespace}/{repo_name}/file/import/main/data");
 
-        // import a file from oxen for testing
+        // import a file from the local mock server for testing
         let body = serde_json::json!({
-            "download_url": "https://hub.oxen.ai/api/repos/datasets/GettingStarted/file/main/tables/cats_vs_dogs.tsv",
+            "download_url": download_url,
             "name": author,
             "email": email,
         });
 
         let req = actix_web::test::TestRequest::post()
             .uri(&uri)
-            .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+            .app_data(OxenAppData {
+                test_mode: true,
+                ..OxenAppData::new(sync_dir.to_path_buf())
+            })
             .param("namespace", namespace)
             .param("repo_name", repo_name)
             .set_json(&body)
@@ -520,7 +539,10 @@ mod tests {
 
         let app = actix_web::test::init_service(
             App::new()
-                .app_data(OxenAppData::new(sync_dir.clone()))
+                .app_data(OxenAppData {
+                    test_mode: true,
+                    ..OxenAppData::new(sync_dir.clone())
+                })
                 .route(
                     "/oxen/{namespace}/{repo_name}/file/import/{resource:.*}",
                     web::post().to(controllers::import::import),
@@ -564,18 +586,34 @@ mod tests {
         repositories::add(&repo, &hello_file).await?;
         let _commit = repositories::commit(&repo, "First commit")?;
 
+        // Serve a small text file from a local mock server. The URL's basename (chat.py)
+        // becomes the committed filename.
+        let mut server = mockito::Server::new_async().await;
+        let py_body = "import oxen\n\nprint(\"hello from a test notebook\")\n";
+        let _mock = server
+            .mock("GET", "/notebooks/chat.py")
+            .with_status(200)
+            .with_header("content-type", "text/x-python")
+            .with_body(py_body)
+            .create_async()
+            .await;
+        let download_url = format!("{}/notebooks/chat.py", server.url());
+
         let uri = format!("/oxen/{namespace}/{repo_name}/file/import/main/notebooks");
 
-        // import a file from oxen for testing
+        // import a file from the local mock server for testing
         let body = serde_json::json!({
-            "download_url": "https://hub.oxen.ai/api/repos/datasets/GettingStarted/file/main/notebooks/chat.py",
+            "download_url": download_url,
             "name": author,
             "email": email,
         });
 
         let req = actix_web::test::TestRequest::post()
             .uri(&uri)
-            .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+            .app_data(OxenAppData {
+                test_mode: true,
+                ..OxenAppData::new(sync_dir.to_path_buf())
+            })
             .param("namespace", namespace)
             .param("repo_name", repo_name)
             .set_json(&body)
@@ -583,7 +621,10 @@ mod tests {
 
         let app = actix_web::test::init_service(
             App::new()
-                .app_data(OxenAppData::new(sync_dir.clone()))
+                .app_data(OxenAppData {
+                    test_mode: true,
+                    ..OxenAppData::new(sync_dir.clone())
+                })
                 .route(
                     "/oxen/{namespace}/{repo_name}/file/import/{resource:.*}",
                     web::post().to(controllers::import::import),

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -361,6 +361,16 @@ enum ServerCommand {
             value_parser = clap::value_parser!(MerkleStoreKind),
         )]
         merkle_store_kind: MerkleStoreKind,
+
+        /// Run the server in test mode. Not for production use.
+        #[arg(
+            short = 't',
+            long = "test",
+            help = "Run the server in test mode. Currently this only relaxes the import SSRF \
+                    guard to allow loopback download targets so tests can serve fixtures from a \
+                    local mock HTTP server. Do not use in production."
+        )]
+        test: bool,
     },
 
     /// Create a new user in the server and output the config file for that user
@@ -475,6 +485,7 @@ async fn server() -> Result<(), ServerError> {
             auth,
             config,
             merkle_store_kind,
+            test,
         } => {
             let _metrics_guard = init_metrics()?;
             let server_config = load_server_config(config.as_deref())?;
@@ -491,6 +502,7 @@ async fn server() -> Result<(), ServerError> {
                     disable_merkle_cache: env::var("OXEN_DISABLE_MERKLE_CACHE").is_ok(),
                     enable_auth: auth,
                     merkle_store_kind,
+                    test_mode: test,
                 },
                 &sync_dir,
                 server_config,
@@ -576,6 +588,9 @@ struct ServerOpts {
     disable_merkle_cache: bool,
     enable_auth: bool,
     merkle_store_kind: MerkleStoreKind,
+    /// Test mode (`--test`): relaxes the import SSRF guard to allow loopback targets. Never
+    /// enabled in production.
+    test_mode: bool,
 }
 
 async fn start(
@@ -589,6 +604,7 @@ async fn start(
         disable_merkle_cache,
         enable_auth,
         merkle_store_kind,
+        test_mode,
     } = opts;
 
     // Configure merkle tree node caching
@@ -607,6 +623,7 @@ async fn start(
         path: PathBuf::from(sync_dir),
         config,
         merkle_store_kind,
+        test_mode,
     };
 
     {


### PR DESCRIPTION
CI was [failing because we weren't able to retrieve live files from oxen hub](https://github.com/Oxen-AI/Oxen/actions/runs/26765398718/job/78895751930?pr=583). Tests shouldn't rely on production being up and in a known state.

This PR fixes the tests to use local mocks instead of calling out to production. To accomplish this, I'm adding a new `--test` flag to `oxen-server start`. In a future PR I plan to go back and move other test-specific behavior under this flag instead of using external environment variable checks.