### PR TITLE
Update error handling guidance

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -51,27 +51,21 @@ cargo build --workspace                           # Debug build
 ```
 
 ### Testing
-Many tests require the oxen server to be running. If it is not running on port 3000 and
-a test fails because it cannot connect to oxen-server, then start it:
+Use the `bin/test-rust` script to run the tests — do not invoke `cargo test` or `cargo nextest run` directly. The script builds the workspace, raises the file-handle limit, sets up a ramdisk for test data, starts `oxen-server` on a free port, runs the suite with `cargo nextest run`, and tears everything down on exit. Its full usage is documented in a comment at the top of the script.
 ```bash
-cargo run -p oxen-server start
+bin/test-rust                         # Build and run all Rust tests
+bin/test-rust test_function_name      # Run only Rust tests matching test_function_name
+bin/test-rust -p                      # Run the Python test suite (via pytest + maturin)
+bin/test-rust -p -k test_init         # Run Python tests matching test_init
 ```
-
-Run specific tests:
-```bash
-cargo test test_function_name         # Run specific matching tests
-cargo test --lib test_function_name   # Run specific library test
-```
-
-Run all tests
-```bash
-ulimit -n 10240                       # Increase file handles before running tests
-cargo nextest run                     # Run all tests
-```
+- The script starts `oxen-server` itself, so you do not need to start it separately.
+- It does not install prerequisites by default. If a dependency is missing, run `bin/install-prereqs` (or re-run with `bin/test-rust --install-deps`).
+- If the ramdisk cannot be mounted, pass `--no-ramdisk` to run against the regular filesystem.
+- Arguments after the script's own flags are forwarded to `cargo nextest run` (or `pytest` with `-p`).
 
 ### Testing with Debug Output
 ```bash
-env RUST_LOG=warn,liboxen=debug,integration_test=debug cargo test -- --nocapture test_name
+env RUST_LOG=warn,liboxen=debug,integration_test=debug bin/test-rust --no-capture test_name
 ```
 
 ### Code Quality
@@ -115,13 +109,11 @@ oxen push origin main               # Push to remote
 - Use the result type (`Result<T, Error>`) when an operation could fail.
 - Never use `.unwrap()` or `.expect()` on a `Result` or on an `Option`.
   + Exception: In test-only code, it is ok to use use `.expect(<descriptive explanation of invariant that was violated>)` since we want to fail fast and have good stack traces for failing test cases.
-  + This rule still applies when the panic feels "guaranteed unreachable" because of an upstream invariant. If the enclosing function returns a `Result`, surface the case as a structured `OxenError` variant and propagate with `?` — a panic in production code is never preferable to a clean error path, no matter how confident you are the case can't happen.
-- Use as specific of an error type as possible for a function. Don't use a wider type unless it's necessary. When making modules and related pieces of code, try to use a locally-defined error enum for them if they all have similar errors.
-- Make sure there's an `OxenError` variant for every error type. Be liberal in wrapping other modules error types, or other specific error types, in a new variant. Use a `Box<>` wrapper for it and have a `#[from]` to derive.
-- `OxenError` is the top-level type for everything. If you need to unify different error types into one, use `OxenError`. These kinds of functions should return `Result<T, OxenError>`
+  + This rule still applies when the panic feels "guaranteed unreachable" because of an upstream invariant. If the enclosing function returns a `Result`, propagate it with `?` — a panic in production code is never preferable to a clean error path, no matter how confident you are the case can't happen.
+- If an error type is acted upon in code, then use as specific of an error type as possible. Don't use a wider type unless it's necessary. When making modules and related pieces of code, try to use a locally-defined error enum for them if they all have similar errors.
+- liboxen uses `OxenError` as the top-level type for errors. Unify different error types under `OxenError`. Fallible functions should return `Result<T, OxenError>`. Do not create or use additional error types outside of `OxenError` if it can be avoided. If an error is never inspected internally and cannot be returned to a caller of the liboxen library through a public API, then use `OxenError::InternalError` with a formatted string. If an error is inspected or can be returned to a caller of the liboxen library through a public API, make a structured error variant on the `OxenError` `enum`.
+- oxen-server uses `OxenHttpError` as the top-level type for errors. All `OxenError` variants that we want to differentiate to the caller of the oxen-server API should be mapped to specific `OxenHttpError` variants. Otherwise they should be mapped to `OxenHttpError::InternalServerError`. Do not create or use additional error types outside of `OxenHttpError` if it can be avoided.
 - Implement proper error propagation through the `?` operator.
-- Never write code that uses `OxenError::Basic` or `OxenError::InternalError`. Do not use their constructor methods either (`OxenError::basic_str` and `OxenError::internal_error`, respectively). These variants are deprecated and will be removed. As a general principle, never encode an error as a string: it throws away valuable structured information about the error, which makes it impossible for a caller to handle the error programmatically. Instead, make a structured error variant of an appropriate error `enum` that describes the error. Include a `#[error("...")]` on the variant to provide a helpful user-facing error message describing the problem and, if applicable, a possible command or procedure the user can perform to fix the error.
-- If making logically related code that all share the same kind of errors, then strongly consider making a unique error `enum` _for that code only_. If that code is called by other code that has a different error enum, then define an explicit `impl From<SourceError> for TargetError` conversion to convert. If that makes the code messy, then make a conversion into `OxenError` and upgrade the calling function to return `OxenError` instead.
 
 # Making Changes
 
@@ -134,7 +126,7 @@ oxen push origin main               # Push to remote
 - The `bin/test-rust` script does not install prerequisites by default. If any dependencies turn out to be missing, prompt the user to run `bin/install-prereqs` (or re-run `bin/test-rust --install-deps`).
 - Prefer using inline code over creating a new function when the function would only be called once and the function body would be less than 15 lines.
 - Do not use "out parameters" (functions that take an `&mut Vec` / `&mut HashMap` / etc. for the callee to fill). Return the value directly instead. Exceptions: the user explicitly asks for an out parameter, or the caller genuinely needs to reuse a pre-allocated buffer across many calls to avoid allocation churn in a measured hot path.
-- Preserve comments whenever possible. Comments that were written by someone other than Claude should always be preserved or updated if possible.
+- Preserve code comments whenever possible. Comments that were written by someone other than Claude should always be preserved or updated if possible.
 - The Python project calls into the Rust project. Whenever changing the Rust code, check to see if the Python code needs to be updated.
 - After changing any Rust or Python code, verify that Rust tests pass with `bin/test-rust` and Python tests pass with `bin/test-rust -p`
 - When updating a dependency, prefer updating to the latest stable version.

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -610,11 +610,13 @@ pub enum OxenError {
     //
     // Fallback
     //
-    // TODO: remove all uses of `Basic` and replace with specific errors.
+    // Legacy generic string error. Prefer InternalError for internal errors that no caller acts on,
+    // or a structured variant when the error is inspected or can reach the public liboxen API.
     #[error("{0}")]
     Basic(StringError),
 
-    // TODO: remove all uses of `Basic` and replace with specific errors.
+    // String fallback for internal errors that are never inspected and never reach the public
+    // liboxen API.
     #[error("{0}")]
     InternalError(StringError),
 }

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -13,38 +13,42 @@ this consistent design pattern on a best-effort approach
    generally disallowed in the code as they cause the calling code to panic. Only tests that are
    asserting properties may use `.unwrap()` and `.expect()` on `Result` and `Option` typed values.
 
-2. In library code, errors must be as structured and informative as possible. All of the information
-   about the source of the error must be included so that a caller has a reasonable opportunity to
-   understand the error and handle it programmatically. Idiomatic Rust encourages the use of an `enum`
-   defined error type to encapsulate different conditions as variants of the `enum`.
+2. In `liboxen`, make an error a structured `OxenError` variant when — and only when — a caller will
+   act on it: either the error is inspected (`match`ed) somewhere in the code, or it can be returned to
+   a caller of the public liboxen API. A structured variant carries the information needed to understand
+   and handle the condition programmatically; its `#[error("...")]` message documents the condition.
+   Idiomatic Rust encourages the use of an `enum`-defined error type with one variant per meaningful
+   condition.
 
-3. Errors that obfuscate the source or transform an error into a simple string message must be avoided.
-   In Rust, errors must either be defined as a `struct` or an `enum` that provides descriptive variants
-   that each describe a specific error condition. For `enum`-defined errors, callers of code that uses
-   these errors must be able to reasonably `match` on the `Err` variant. An error that is a string
-   makes such programmatic introspection and handling of errors impossible.
+3. An error that is never inspected and never crosses the public liboxen API does not need a structured
+   variant. Encode it as `OxenError::InternalError` with a formatted string. (`OxenError::Basic` is the
+   older, less specific form of the same idea; prefer `InternalError` for these internal cases.)
+   Inventing a structured variant that no caller ever matches on adds ceremony without changing
+   behavior, so reserve structured variants for the cases described in Goal 2.
 
 4. End-user facing code (the CLI and server) must have descriptive error messages that explain the
    problem clearly. When it's possible to correct the error, the user-facing error message must
    provide guidance or instructions the user can follow that will rectify the issue.
 
-5. Errors should be defined as close to the using code as possible. Strongly prefer making error `enum`s
-   that are specific to a module, package, or crate. For example, wrappers and helpers on networking
-   code should use a streamlined locally defined error `enum` that is specific to _networking_ errors.
-   Calling code should rely on `From` implementations to convert from one logically related set of code's
-   error type into an appropriate unifying container error type.
+5. Do not introduce new error types when a crate's top-level error type fits. `liboxen` uses
+   `OxenError` and `oxen-server` uses `OxenHttpError`. Prefer extending the top-level type — or
+   wrapping a third-party error into it with a `#[from]` conversion — over defining a new module- or
+   crate-local error `enum`.
 
-6. For `liboxen`, the top-level unifying error type is `OxenError`. All library code must have some
-   conversion(s) that allow a more specific error type to be wrapped as an `OxenError`.
+6. `liboxen` library code returns `Result<T, OxenError>`; wrap more specific error types into
+   `OxenError` with `#[from]` conversions. `oxen-server` translates those failures into HTTP responses
+   through `OxenHttpError`: map each `OxenError` variant you want to differentiate to the API caller to a
+   specific `OxenHttpError` variant (e.g. `RepoNotFound` → 404) and map everything else to
+   `OxenHttpError::InternalServerError`.
 
 
 ## Specific Guidance for Modernization of Existing Oxen Code
 
-The `OxenError::Basic` and `OxenError::InternalError` variants are deprecated. No new code must use these
-string error representations. These throw away all useful error information and encode it as a string,
-making it impossible to `match` on specific error conditions and handle them programmatically. Library users
-are unable to meaningfully handle these variants.
+When you touch existing code that uses `OxenError::Basic` or `OxenError::InternalError`, decide based on
+how the error is used:
 
-Any refactoring that touches these uses of string-defined OxenError variants should convert them into well-defined
-variants of an error `enum`. At a bare minimum, they should be translated to a new structured _variant_
-on `OxenError`. The existing string message can be used as the `#[error("...")]` on the new variant.
+- If the error is inspected somewhere, or can be returned to a caller of the public liboxen API, convert
+  it to a structured `OxenError` variant. The existing string message can be reused as the
+  `#[error("...")]` on the new variant.
+- Otherwise it is an internal error that no caller acts on; leave it as a string error, preferring
+  `OxenError::InternalError` over the older `OxenError::Basic`.


### PR DESCRIPTION
- Update the error handling guidance to focus more on utility.
- Also updated the testing section directions to use `bin/test-rust`