### PR TITLE
Raise oxen-server actix HTTP keep-alive to 75s to prevent push 502s

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -110,6 +110,7 @@ oxen push origin main               # Push to remote
 
 ## Code Organization
 - We define module exports in a `<module_name>.rs` file at the same level as the corresponding `module_name/` directory and *NOT* the older `mod.rs` pattern.
+- Prefer importing bare items (structs, enums, traits, functions, constants, macros) and referring to them unqualified, rather than importing a parent module and qualifying at each use site — e.g. `use std::time::Duration;` then `Duration::from_secs(5)`, not `std::time::Duration::from_secs(5)`. Exception: keep enough of the path to disambiguate when a bare import would be ambiguous or misleading, such as two same-named items from different modules, or where a module qualifier is the established idiom (the classic case is `use std::fmt;` then `fmt::Result` to avoid clashing with the prelude `Result`); reach for an `as` alias when that reads better than a module qualifier.
 
 ## Error Handling
 - Use the result type (`Result<T, Error>`) when an operation could fail.

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -81,6 +81,7 @@ use clap::{Parser, Subcommand};
 
 use std::env;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::config::Config;
 use crate::config::storage_policy::StoragePolicyError;
@@ -639,6 +640,12 @@ async fn start(
     // operations before a supervisor force-kills the process.
     const ACTIX_SHUTDOWN_TIMEOUT_SECS: u64 = 30;
 
+    // actix's default HTTP/1 keep-alive is 5s. Keep it comfortably above the OxenHub
+    // Finch client's idle-eviction window so the client always retires an idle pooled
+    // connection before the server reaps it — a reused server-closed socket surfaces
+    // to the client as a dropped connection (502 Bad Gateway).
+    const ACTIX_KEEP_ALIVE_SECS: u64 = 75;
+
     let server_result = HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
@@ -681,6 +688,7 @@ async fn start(
             .wrap(MetricsMiddleware)
             .wrap(TracingLogger::default())
     })
+    .keep_alive(Duration::from_secs(ACTIX_KEEP_ALIVE_SECS))
     .bind((host.to_owned(), port))?
     .shutdown_timeout(ACTIX_SHUTDOWN_TIMEOUT_SECS)
     .run()


### PR DESCRIPTION
Raise oxen-server actix HTTP keep-alive to 75s to prevent push `502` errors.

actix's default `HTTP/1` keep-alive is 5s, so oxen-server reaps an idle keep-alive connection ~5s after the previous request. OxenHub's Finch client pools backend connections and reuses them for longer, so under bursty push traffic it could send a request onto a socket the server had already closed before it noticed it had been closed. 

Since `oxen push` currently fans out to many simultaneous individual file pushes, the probability of hitting this condition with at least one file can be fairly high. Any errors for any individual file push will fail the entire `oxen push` operation, surfacing to the client as a dropped connection with a 502 Bad Gateway status.

This PR raises the server keep-alive to 75s so the server holds idle connections comfortably longer than the hub client's idle-eviction window (which we are setting to 60s in another PR).

I also threw in a Claude instruction to try to get it to stop using long absolute paths to everything, in favor of importing the item and using it directly.