### PR TITLE
Disable coderabbit's docstring check, since it isn't working

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,3 +28,8 @@ reviews:
     # Review PRs against any base branch
     base_branches:
       - ".*"
+
+  # Disable the docstring-coverage pre-merge check — it reports a misleading 0% for this repo.
+  pre_merge_checks:
+    docstrings:
+      mode: "off"


### PR DESCRIPTION
Disable coderabbit's docstring check, since it isn't working. It just does this:

<img width="807" height="183" alt="image" src="https://github.com/user-attachments/assets/60e8e8ea-c5ec-4914-b8b5-038826da2d96" />
