### PR TITLE
Don't reference private GitHub repositories

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -118,6 +118,7 @@ oxen push origin main               # Push to remote
 
 # Making Changes
 
+- This repository is **public**. Do not mention Oxen's private/internal repositories — by name or description — in code comments, doc-comments, error messages, commit messages, PR titles or descriptions, or any other code or documentation committed here. Keep references to private repos out of public artifacts entirely; if internal context is genuinely needed, point to the relevant Linear issue rather than inlining private-repo details.
 - When changing something that is documented in nearby code, or appears in any markdown files in the repository, update the affected documentation.
 - When prompted to always do something a certain way in general, add an entry to this section of the CLAUDE.md file.
 - When calling `get_staged_db_manager`, follow the doc comment on that function: drop the returned `StagedDBManager` as soon as possible (via a block scope or explicit `drop()`) to avoid holding the shared database handle longer than necessary.


### PR DESCRIPTION
Mentioning/linking to private repositories leads to confusion and broken links, so don't do it.