### PR TITLE
S3 (16b.2): Update polars logic to operate with S3

### DIFF
--- a/crates/lib/src/core/df/tabular.rs
+++ b/crates/lib/src/core/df/tabular.rs
@@ -1,4 +1,5 @@
 use duckdb::ToSql;
+use polars::io::cloud::CloudOptions;
 use polars::prelude::*;
 use serde_json::json;
 use std::collections::HashSet;
@@ -13,15 +14,16 @@ use crate::core::df::pretty_print;
 use crate::core::df::sql;
 use crate::error::OxenError;
 use crate::io::chunk_reader::ChunkReader;
-use crate::model::Commit;
 use crate::model::DataFrameSize;
 use crate::model::LocalRepository;
 use crate::model::data_frame::schema::DataType;
 use crate::model::merkle_tree::node::MerkleTreeNode;
 use crate::opts::{CountLinesOpts, DFOpts, PaginateOpts};
 use crate::repositories;
+use crate::storage::{VersionLocation, VersionStore};
 use crate::util::fs;
 use crate::util::hasher;
+use std::sync::Arc;
 
 use comfy_table::Table;
 use indicatif::ProgressBar;
@@ -433,15 +435,6 @@ fn unique_count_df(df: LazyFrame, columns: Vec<String>) -> Result<LazyFrame, Oxe
 pub async fn transform(df: DataFrame, opts: DFOpts) -> Result<DataFrame, OxenError> {
     let df = transform_lazy(df.lazy(), opts.clone()).await?;
     Ok(transform_slice_lazy(df, &opts)?.collect()?)
-}
-
-pub async fn transform_new(df: LazyFrame, opts: &DFOpts) -> Result<LazyFrame, OxenError> {
-    //    let height = df.height();
-    let df = transform_lazy(df, opts.clone()).await?;
-    // `transform_slice_lazy` collects in its `column_at` branch; run it off the async runtime so a
-    // cloud-backed frame's collect doesn't `block_in_place`-panic on a current-thread runtime.
-    let opts = opts.clone();
-    task::spawn_blocking(move || transform_slice_lazy(df, &opts)).await?
 }
 
 pub async fn transform_lazy(mut df: LazyFrame, opts: DFOpts) -> Result<LazyFrame, OxenError> {
@@ -985,11 +978,13 @@ struct CsvDialect {
     quote_char: Option<u8>,
 }
 
-fn sniff_csv_dialect(path: impl AsRef<Path>, opts: &DFOpts) -> Result<CsvDialect, OxenError> {
+/// Parse the user-specified CSV delimiter/quote overrides from `DFOpts`. Either may be `None`, in
+/// which case that value is sniffed from the data instead.
+fn parse_user_csv_opts(opts: &DFOpts) -> Result<(Option<u8>, Option<u8>), OxenError> {
     let user_delimiter = match &opts.delimiter {
         Some(delimiter) => {
             if delimiter.len() != 1 {
-                return Err(OxenError::basic_str("Delimiter must be a single character"));
+                return Err(OxenError::InvalidDelimiter);
             }
             Some(delimiter.as_bytes()[0])
         }
@@ -1002,37 +997,53 @@ fn sniff_csv_dialect(path: impl AsRef<Path>, opts: &DFOpts) -> Result<CsvDialect
             if !b.is_empty() {
                 Some(b[0])
             } else {
-                return Err(OxenError::basic_str(
-                    "If provided, quote character must be non empty!",
-                ));
+                return Err(OxenError::InvalidQuoteChar);
             }
         }
         None => None,
     };
 
+    Ok((user_delimiter, user_quote))
+}
+
+/// Combine sniffer output with the user overrides into a final dialect, falling back to RFC 4180
+/// defaults when sniffing failed.
+fn build_csv_dialect<E: std::fmt::Debug>(
+    sniffed: Result<qsv_sniffer::metadata::Metadata, E>,
+    user_delimiter: Option<u8>,
+    user_quote: Option<u8>,
+) -> CsvDialect {
+    match sniffed {
+        Ok(metadata) => {
+            log::debug!("Sniffed csv dialect: {:?}", metadata.dialect);
+            CsvDialect {
+                delimiter: user_delimiter.unwrap_or(metadata.dialect.delimiter),
+                quote_char: user_quote.or_else(|| Some(sniffed_quote(&metadata))),
+            }
+        }
+        Err(err) => {
+            log::warn!("Error sniffing csv -> {err:?}");
+            CsvDialect {
+                delimiter: user_delimiter.unwrap_or(DEFAULT_DELIMITER),
+                quote_char: user_quote.or(Some(DEFAULT_QUOTE_CHAR)),
+            }
+        }
+    }
+}
+
+fn sniff_csv_dialect(path: impl AsRef<Path>, opts: &DFOpts) -> Result<CsvDialect, OxenError> {
+    let (user_delimiter, user_quote) = parse_user_csv_opts(opts)?;
     if let (Some(delimiter), Some(_)) = (user_delimiter, user_quote) {
         return Ok(CsvDialect {
             delimiter,
             quote_char: user_quote,
         });
     }
-
-    match qsv_sniffer::Sniffer::new().sniff_path(&path) {
-        Ok(metadata) => {
-            log::debug!("Sniffed csv dialect: {:?}", metadata.dialect);
-            Ok(CsvDialect {
-                delimiter: user_delimiter.unwrap_or(metadata.dialect.delimiter),
-                quote_char: user_quote.or_else(|| Some(sniffed_quote(&metadata))),
-            })
-        }
-        Err(err) => {
-            log::warn!("Error sniffing csv {:?} -> {:?}", path.as_ref(), err);
-            Ok(CsvDialect {
-                delimiter: user_delimiter.unwrap_or(DEFAULT_DELIMITER),
-                quote_char: user_quote.or(Some(DEFAULT_QUOTE_CHAR)),
-            })
-        }
-    }
+    Ok(build_csv_dialect(
+        qsv_sniffer::Sniffer::new().sniff_path(&path),
+        user_delimiter,
+        user_quote,
+    ))
 }
 
 const DEFAULT_QUOTE_CHAR: u8 = b'"';
@@ -1065,15 +1076,15 @@ pub async fn read_df(path: impl AsRef<Path>, opts: DFOpts) -> Result<DataFrame, 
     }
 }
 
+/// Read a tabular file from a local filesystem path. For version files held by a `VersionStore`,
+/// use [`read_version_df`] instead so access goes through the store's byte interface.
 pub async fn read_df_with_extension(
     path: impl AsRef<Path>,
     extension: impl AsRef<str>,
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
     let path = path.as_ref().to_path_buf();
-    let extension_str = extension.as_ref();
-
-    p_read_df_with_extension(path, extension_str, opts.clone()).await
+    p_read_df_with_extension(path, extension.as_ref(), opts.clone()).await
 }
 
 async fn _read_lazy_df_with_extension(
@@ -1130,59 +1141,230 @@ pub async fn p_read_df_with_extension(
     opts: DFOpts,
 ) -> Result<DataFrame, OxenError> {
     let df_lazy = _read_lazy_df_with_extension(path, extension.as_ref(), &opts).await?;
-
-    let result_df_lazy = if opts.has_transform() {
-        transform_new(df_lazy, &opts).await?
-    } else {
-        df_lazy
-    };
-
-    task::spawn_blocking(move || result_df_lazy.collect().map_err(OxenError::from))
-        .await
-        .map_err(|e| OxenError::basic_str(format!("Collect task panicked: {e}")))?
+    collect_with_opts(df_lazy, opts).await
 }
 
-pub async fn maybe_read_df_with_extension(
-    repo: &LocalRepository,
-    version_path: impl AsRef<Path>,
-    path: impl AsRef<Path>,
-    commit_id: &str,
+/// Apply any `DFOpts` transform to a lazy frame and collect it into a `DataFrame` off the async
+/// runtime. Shared by the local and S3 read paths. The IO-bearing transform pipeline
+/// (`transform_lazy`) runs on the caller's runtime; the eager slice and the final collect then
+/// share one `spawn_blocking` so a cloud-backed frame's collect never drives `block_in_place` on
+/// the server's current-thread runtime.
+pub(crate) async fn collect_with_opts(
+    df_lazy: LazyFrame,
+    opts: DFOpts,
+) -> Result<DataFrame, OxenError> {
+    if opts.has_transform() {
+        let transformed = transform_lazy(df_lazy, opts.clone()).await?;
+        task::spawn_blocking(move || {
+            transform_slice_lazy(transformed, &opts)?
+                .collect()
+                .map_err(OxenError::from)
+        })
+        .await?
+    } else {
+        task::spawn_blocking(move || df_lazy.collect().map_err(OxenError::from)).await?
+    }
+}
+
+/// Head bytes fetched as the CSV/TSV dialect sniff sample. qsv_sniffer reads whole lines and stops
+/// once the cumulative size passes its 16 KiB default sample, so it normally inspects ~16 KiB; the
+/// extra headroom here covers wide rows. If we have trouble sniffing wide rows, we can try
+/// increasing this value.
+const CSV_SNIFF_SAMPLE_BYTES: u64 = 64 * 1024;
+
+/// Read a tabular version file by hash through the `VersionStore` byte interface.
+///
+/// The store is immutable, content-addressed byte storage, so this never asks it for a writable
+/// handle. Local backends read the version file from disk. For S3, JSON content and the CSV/TSV
+/// dialect sniff sample are pulled through the store's own `get_version`/`get_version_chunk`; the
+/// columnar formats (Parquet/CSV/TSV/JSONL/IPC) additionally use a cloud-aware Polars scan as a
+/// read-only optimization so Polars can prune via range requests instead of reading the whole
+/// object.
+pub async fn read_version_df(
+    version_store: &Arc<dyn VersionStore>,
+    hash: &str,
+    extension: impl AsRef<str>,
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
-    let version_path = version_path.as_ref();
-    if !version_path.exists() {
-        return Err(OxenError::entry_does_not_exist(path));
-    }
-
-    let extension = version_path.extension().and_then(OsStr::to_str);
-
-    if let Some(extension) = extension {
-        read_df_with_extension(path, extension, opts).await
-    } else {
-        let commit = repositories::commits::get_by_id(repo, commit_id)?;
-        if let Some(commit) = commit {
-            try_to_read_extension_from_node(repo, version_path, path, &commit, opts).await
-        } else {
-            let err = format!("Could not find commit: {commit_id}");
-            Err(OxenError::basic_str(err))
+    let extension = extension.as_ref();
+    match version_store.version_location(hash).await? {
+        VersionLocation::Local(path) => {
+            p_read_df_with_extension(path, extension, opts.clone()).await
+        }
+        VersionLocation::S3 {
+            url,
+            region,
+            endpoint_url,
+            ..
+        } => {
+            read_s3_version_df(
+                version_store,
+                hash,
+                &url,
+                &region,
+                endpoint_url,
+                extension,
+                opts,
+            )
+            .await
         }
     }
 }
 
-async fn try_to_read_extension_from_node(
-    repo: &LocalRepository,
-    version_path: impl AsRef<Path>,
-    path: impl AsRef<Path>,
-    commit: &Commit,
+/// S3 branch of [`read_version_df`]. Columnar formats use a cloud-aware Polars scan; JSON and the
+/// CSV/TSV sniff sample are read through the store's byte interface.
+async fn read_s3_version_df(
+    version_store: &Arc<dyn VersionStore>,
+    hash: &str,
+    url: &str,
+    region: &str,
+    endpoint_url: Option<String>,
+    extension: &str,
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
-    let node = repositories::tree::get_file_by_path(repo, commit, &path)?;
-    if let Some(file_node) = node {
-        read_df_with_extension(&version_path, file_node.extension(), opts).await
-    } else {
-        let err = format!("Could not find file node {:?}", path.as_ref());
-        Err(OxenError::basic_str(err))
+    log::debug!("Reading S3 version df {url} with extension {extension}");
+    let cloud_opts = {
+        let region: &str = region;
+        let endpoint_url = endpoint_url.as_deref();
+        let mut config = vec![("aws_region", region.to_string())];
+        if let Some(endpoint) = endpoint_url {
+            config.push(("aws_endpoint_url", endpoint.to_string()));
+            config.push(("aws_allow_http", "true".to_string()));
+            config.push(("aws_virtual_hosted_style_request", "false".to_string()));
+        }
+        CloudOptions::from_untyped_config(url, config.iter().map(|(k, v)| (*k, v.as_str())))
+    }?;
+    let url = url.to_string();
+
+    let df_lazy = match extension {
+        "ndjson" | "jsonl" => {
+            task::spawn_blocking(move || read_s3_jsonl(&url, cloud_opts)).await??
+        }
+        "json" => {
+            // `JsonReader` is byte-stream only (no cloud reader), so pull the bytes through the
+            // store and parse them in memory.
+            let bytes = version_store.get_version(hash).await?;
+            task::spawn_blocking(move || read_json_bytes(bytes)).await??
+        }
+        "csv" | "data" | "tsv" => {
+            // `.tsv` pins the tab delimiter; only the quote character is sniffed.
+            let force_delim = (extension == "tsv").then_some(b'\t');
+            let dialect = resolve_s3_csv_dialect(version_store, hash, opts, force_delim).await?;
+            task::spawn_blocking(move || {
+                read_s3_csv(&url, cloud_opts, dialect.delimiter, dialect.quote_char)
+            })
+            .await??
+        }
+        "parquet" => task::spawn_blocking(move || read_s3_parquet(&url, cloud_opts)).await??,
+        "arrow" => {
+            if opts.sql.is_some() {
+                return Err(OxenError::internal_error(
+                    "SQL queries are not supported for .arrow files",
+                ));
+            }
+            task::spawn_blocking(move || read_s3_ipc(&url, cloud_opts)).await??
+        }
+        _ => {
+            return Err(OxenError::internal_error(format!(
+                "Could not load data frame from S3 with unsupported extension: {extension}"
+            )));
+        }
+    };
+
+    collect_with_opts(df_lazy, opts.clone()).await
+}
+
+/// Resolve the CSV/TSV dialect for an S3 version file: honor explicit `DFOpts` overrides, otherwise
+/// sniff a head sample fetched through the store's `get_version_chunk` (full parity with the local
+/// path, which also samples only the head). `force_delim` pins the delimiter for `.tsv` while still
+/// sniffing the quote character.
+async fn resolve_s3_csv_dialect(
+    version_store: &Arc<dyn VersionStore>,
+    hash: &str,
+    opts: &DFOpts,
+    force_delim: Option<u8>,
+) -> Result<CsvDialect, OxenError> {
+    let (user_delimiter, user_quote) = parse_user_csv_opts(opts)?;
+    let delimiter = force_delim.or(user_delimiter);
+    if let (Some(delimiter), Some(_)) = (delimiter, user_quote) {
+        return Ok(CsvDialect {
+            delimiter,
+            quote_char: user_quote,
+        });
     }
+    // Fixed-size head sample. `sniff_reader` needs Read+Seek and rewinds per pass, so it can't
+    // consume the forward-only `get_version_stream` directly; a buffer (hence a byte cap) is
+    // required. If huge first lines sniff wrong, raise this cap. Streaming whole lines would match
+    // local exactly but reintroduces local's unbounded single-line memory cost.
+    let sample = version_store
+        .get_version_chunk(hash, 0, CSV_SNIFF_SAMPLE_BYTES)
+        .await?;
+    // Sniffing parses the sample (CPU-bound); keep it off the async runtime.
+    let sniffed =
+        task::spawn_blocking(move || qsv_sniffer::Sniffer::new().sniff_reader(Cursor::new(sample)))
+            .await?;
+    Ok(build_csv_dialect(sniffed, delimiter, user_quote))
+}
+
+fn read_s3_parquet(url: &str, cloud_opts: CloudOptions) -> Result<LazyFrame, OxenError> {
+    let args = ScanArgsParquet {
+        cloud_options: Some(cloud_opts),
+        ..Default::default()
+    };
+    LazyFrame::scan_parquet(url, args).map_err(OxenError::from)
+}
+
+fn read_s3_ipc(url: &str, cloud_opts: CloudOptions) -> Result<LazyFrame, OxenError> {
+    let args = ScanArgsIpc {
+        cloud_options: Some(cloud_opts),
+        ..Default::default()
+    };
+    LazyFrame::scan_ipc(url, args).map_err(OxenError::from)
+}
+
+fn read_s3_jsonl(url: &str, cloud_opts: CloudOptions) -> Result<LazyFrame, OxenError> {
+    LazyJsonLineReader::new(url)
+        .with_infer_schema_length(Some(NonZeroUsize::new(10000).unwrap()))
+        .with_cloud_options(Some(cloud_opts))
+        .finish()
+        .map_err(OxenError::from)
+}
+
+fn read_s3_csv(
+    url: &str,
+    cloud_opts: CloudOptions,
+    delimiter: u8,
+    quote_char: Option<u8>,
+) -> Result<LazyFrame, OxenError> {
+    base_lazy_csv_reader(url, delimiter, quote_char)
+        .with_cloud_options(Some(cloud_opts))
+        .finish()
+        .map_err(OxenError::from)
+}
+
+fn read_json_bytes(bytes: Vec<u8>) -> Result<LazyFrame, OxenError> {
+    let df = JsonReader::new(Cursor::new(bytes))
+        .infer_schema_len(Some(NonZeroUsize::new(10000).unwrap()))
+        .finish()?;
+    Ok(df.lazy())
+}
+
+/// Read a version file by hash whose extension isn't known to the caller, resolving it from the
+/// committed file node. Version files are content-addressed (stored as `.../data`), so the
+/// extension never comes from the stored object itself.
+pub async fn maybe_read_version_df(
+    repo: &LocalRepository,
+    version_store: &Arc<dyn VersionStore>,
+    hash: &str,
+    path: impl AsRef<Path>,
+    commit_id: &str,
+    opts: &DFOpts,
+) -> Result<DataFrame, OxenError> {
+    let commit = repositories::commits::get_by_id(repo, commit_id)?
+        .ok_or_else(|| OxenError::commit_id_does_not_exist(commit_id))?;
+    let node = repositories::tree::get_file_by_path(repo, &commit, &path)?
+        .ok_or_else(|| OxenError::entry_does_not_exist(&path))?;
+    read_version_df(version_store, hash, node.extension(), opts).await
 }
 
 pub fn scan_df(
@@ -1985,7 +2167,7 @@ mod tests {
                 opts
             },
         );
-        assert!(matches!(r, Err(OxenError::Basic(_))));
+        assert!(matches!(r, Err(OxenError::InvalidQuoteChar)));
         Ok(())
     }
 

--- a/crates/lib/src/core/v_latest/data_frames.rs
+++ b/crates/lib/src/core/v_latest/data_frames.rs
@@ -1,5 +1,4 @@
 use crate::core::db::data_frames::df_db::with_df_db_manager;
-use crate::core::df::tabular::transform_new;
 use crate::core::df::{sql, tabular};
 use crate::core::staged::get_staged_db_manager;
 use crate::error::OxenError;
@@ -93,10 +92,13 @@ pub async fn get_slice(
     }
     // Read the data frame from the version path
     let version_store = repo.version_store();
-    let version_path = version_store
-        .get_version_path(&file_node.hash().to_string())
-        .await?;
-    let df = tabular::read_df_with_extension(version_path, file_node.extension(), opts).await?;
+    let df = tabular::read_version_df(
+        &version_store,
+        &file_node.hash().to_string(),
+        file_node.extension(),
+        opts,
+    )
+    .await?;
     log::debug!("get_slice df {:?}", df.height());
 
     // Check what the view height is
@@ -157,7 +159,7 @@ async fn handle_sql_querying(
             manager.with_conn_mut(|conn| sql::query_df(conn, sql, None))
         })?;
         log::debug!("handle_sql_querying got df {df:?}");
-        let paginated_df = transform_new(df.clone().lazy(), opts).await?.collect()?;
+        let paginated_df = tabular::collect_with_opts(df.clone().lazy(), opts.clone()).await?;
 
         let source_schema = if let Some(schema) =
             repositories::data_frames::schemas::get_by_path(repo, &workspace.commit, path)?

--- a/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -256,16 +256,15 @@ pub async fn prepare_modified_or_removed_row(
 
     // let scan_rows = 10000 as usize;
     let version_store = repo.version_store();
-    let committed_df_path = version_store
-        .get_version_path(&commit_merkle_tree.hash.to_string())
-        .await?;
-
-    log::debug!("prepare_modified_or_removed_row() committed_df_path: {committed_df_path:?}");
 
     // TODONOW should not be using all rows - just need to parse delim
-    let lazy_df =
-        tabular::read_df_with_extension(committed_df_path, file_node.extension(), &DFOpts::empty())
-            .await?;
+    let lazy_df = tabular::read_version_df(
+        &version_store,
+        &commit_merkle_tree.hash.to_string(),
+        file_node.extension(),
+        &DFOpts::empty(),
+    )
+    .await?;
 
     // Get the row by index
     let mut row = lazy_df.slice(row_idx_og, 1_usize);

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -172,6 +172,14 @@ pub enum OxenError {
     #[error("{0}")]
     InvalidFileType(StringError),
 
+    /// The user supplied a CSV delimiter that was not exactly one byte.
+    #[error("Delimiter must be a single character")]
+    InvalidDelimiter,
+
+    /// The user supplied an empty CSV quote character.
+    #[error("If provided, the quote character must be non-empty")]
+    InvalidQuoteChar,
+
     //
     // Workspaces
     //

--- a/crates/lib/src/model/diff/tabular_diff_summary.rs
+++ b/crates/lib/src/model/diff/tabular_diff_summary.rs
@@ -141,13 +141,14 @@ impl TabularDiffWrapper {
         match node {
             Some(node) => {
                 let version_store = repo.version_store();
-                let version_path = version_store
-                    .get_version_path(&node.hash().to_string())
-                    .await
-                    .expect("invariant violation: version path not found in maybe_get_df_from_file_node");
-                tabular::read_df_with_extension(&*version_path, node.extension(), &DFOpts::empty())
-                    .await
-                    .ok()
+                tabular::read_version_df(
+                    &version_store,
+                    &node.hash().to_string(),
+                    node.extension(),
+                    &DFOpts::empty(),
+                )
+                .await
+                .ok()
             }
             None => None,
         }

--- a/crates/lib/src/repositories/checkout.rs
+++ b/crates/lib/src/repositories/checkout.rs
@@ -149,23 +149,19 @@ pub async fn checkout_combine<P: AsRef<Path>>(
     {
         if util::fs::is_tabular(&conflict.base_entry.path) {
             let version_store = repo.version_store();
-            let df_base_path = version_store
-                .get_version_path(&conflict.base_entry.hash)
-                .await?;
-            let df_base = tabular::maybe_read_df_with_extension(
+            let df_base = tabular::maybe_read_version_df(
                 repo,
-                &df_base_path,
+                &version_store,
+                &conflict.base_entry.hash,
                 &conflict.base_entry.path,
                 &conflict.base_entry.commit_id,
                 &DFOpts::empty(),
             )
             .await?;
-            let df_merge_path = version_store
-                .get_version_path(&conflict.merge_entry.hash)
-                .await?;
-            let df_merge = tabular::maybe_read_df_with_extension(
+            let df_merge = tabular::maybe_read_version_df(
                 repo,
-                df_merge_path,
+                &version_store,
+                &conflict.merge_entry.hash,
                 &conflict.merge_entry.path,
                 &conflict.merge_entry.commit_id,
                 &DFOpts::empty(),

--- a/crates/lib/src/repositories/diffs.rs
+++ b/crates/lib/src/repositories/diffs.rs
@@ -660,11 +660,9 @@ pub async fn diff_tabular_file_and_file_node(
     let (df_1, df_2) = match file_node {
         Some(file_node) => {
             let version_store = repo.version_store();
-            let file_node_path = version_store
-                .get_version_path(&file_node.hash().to_string())
-                .await?;
-            let df_1 = tabular::read_df_with_extension(
-                file_node_path,
+            let df_1 = tabular::read_version_df(
+                &version_store,
+                &file_node.hash().to_string(),
                 file_node.extension(),
                 &DFOpts::empty(),
             )
@@ -698,20 +696,16 @@ pub async fn diff_tabular_file_nodes(
     match (file_1, file_2) {
         (Some(file_1), Some(file_2)) => {
             let version_store = repo.version_store();
-            let version_path_1 = version_store
-                .get_version_path(&file_1.hash().to_string())
-                .await?;
-            let version_path_2 = version_store
-                .get_version_path(&file_2.hash().to_string())
-                .await?;
-            let df_1 = tabular::read_df_with_extension(
-                version_path_1,
+            let df_1 = tabular::read_version_df(
+                &version_store,
+                &file_1.hash().to_string(),
                 file_1.extension(),
                 &DFOpts::empty(),
             )
             .await?;
-            let df_2 = tabular::read_df_with_extension(
-                version_path_2,
+            let df_2 = tabular::read_version_df(
+                &version_store,
+                &file_2.hash().to_string(),
                 file_2.extension(),
                 &DFOpts::empty(),
             )
@@ -723,11 +717,9 @@ pub async fn diff_tabular_file_nodes(
         }
         (Some(file_1), None) => {
             let version_store = repo.version_store();
-            let version_path_1 = version_store
-                .get_version_path(&file_1.hash().to_string())
-                .await?;
-            let df_1 = tabular::read_df_with_extension(
-                version_path_1,
+            let df_1 = tabular::read_version_df(
+                &version_store,
+                &file_1.hash().to_string(),
                 file_1.extension(),
                 &DFOpts::empty(),
             )
@@ -740,12 +732,10 @@ pub async fn diff_tabular_file_nodes(
         }
         (None, Some(file_2)) => {
             let version_store = repo.version_store();
-            let version_path_2 = version_store
-                .get_version_path(&file_2.hash().to_string())
-                .await?;
             let df_1 = tabular::new_df();
-            let df_2 = tabular::read_df_with_extension(
-                version_path_2,
+            let df_2 = tabular::read_version_df(
+                &version_store,
+                &file_2.hash().to_string(),
                 file_2.extension(),
                 &DFOpts::empty(),
             )

--- a/crates/lib/src/repositories/workspaces/data_frames.rs
+++ b/crates/lib/src/repositories/workspaces/data_frames.rs
@@ -1290,10 +1290,10 @@ mod tests {
             // Make sure version file is updated
             let entry = repositories::entries::get_commit_entry(&repo, &commit, &path)?.unwrap();
             let version_store = repo.version_store();
-            let version_file = version_store.get_version_path(&entry.hash).await?;
             let extension = entry.path.extension().unwrap().to_str().unwrap();
             let data_frame =
-                df::tabular::read_df_with_extension(version_file, extension, &DFOpts::empty()).await?;
+                df::tabular::read_version_df(&version_store, &entry.hash, extension, &DFOpts::empty())
+                    .await?;
             println!("{data_frame}");
             assert_eq!(
                 format!("{data_frame}"),

--- a/crates/lib/src/storage.rs
+++ b/crates/lib/src/storage.rs
@@ -5,5 +5,5 @@ pub mod version_store;
 pub use local::LocalVersionStore;
 pub use s3::{S3Opts, S3VersionStore};
 pub use version_store::{
-    LocalFilePath, StorageConfig, StorageKind, VersionStore, create_version_store,
+    LocalFilePath, StorageConfig, StorageKind, VersionLocation, VersionStore, create_version_store,
 };

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -1638,4 +1638,256 @@ mod tests {
         let versions = store.list_versions().await.unwrap();
         assert_eq!(versions, vec![hash]);
     }
+
+    /// Tabular reads served directly from S3 via `tabular::read_version_df`. Exercises the Polars
+    /// cloud-scan paths (Parquet/CSV/TSV/JSONL/IPC), the in-memory JSON path, and head-sample CSV
+    /// dialect sniffing — all against the s3s fixture.
+    mod cloud_reads {
+        use super::*;
+        use crate::core::df::tabular;
+        use crate::opts::DFOpts;
+        use polars::prelude::*;
+
+        /// Make the s3s fixture credentials discoverable by Polars' `from_env` cloud-scan path
+        /// (used for the columnar formats). All s3s tests share these fixed creds, and nothing else
+        /// in the test binary reads AWS credentials from the environment (the `S3VersionStore`
+        /// client is injected), so a one-time set is safe.
+        fn set_test_aws_env() {
+            use std::sync::Once;
+            static ONCE: Once = Once::new();
+            ONCE.call_once(|| {
+                // SAFETY: Set exactly once to constant values; no concurrent reader of these
+                // variables exists in the test binary, so there is no data race on the environment.
+                unsafe {
+                    std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+                    std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+                    std::env::set_var("AWS_REGION", "us-east-1");
+                }
+            });
+        }
+
+        /// Build an s3s-backed store as a trait object, the form `read_version_df` consumes.
+        async fn setup_dyn() -> (
+            Arc<dyn VersionStore>,
+            async_tempfile::TempDir,
+            tokio::task::JoinHandle<()>,
+        ) {
+            set_test_aws_env();
+            let (store, tmp, server) = setup().await;
+            (Arc::new(store), tmp, server)
+        }
+
+        /// Store `bytes` as a version file and return its hash so the reader can resolve it.
+        async fn upload(store: &Arc<dyn VersionStore>, bytes: Vec<u8>) -> String {
+            let hash = hasher::hash_buffer(&bytes);
+            let len = bytes.len() as u64;
+            store
+                .store_version_from_reader(&hash, Box::new(std::io::Cursor::new(bytes)), len)
+                .await
+                .unwrap();
+            hash
+        }
+
+        async fn read(store: &Arc<dyn VersionStore>, hash: &str, ext: &str) -> DataFrame {
+            tabular::read_version_df(store, hash, ext, &DFOpts::empty())
+                .await
+                .unwrap()
+        }
+
+        fn sample_df() -> DataFrame {
+            df! { "a" => &[1i64, 2, 3], "b" => &["x", "y", "z"] }.unwrap()
+        }
+
+        /// Assert a round-tripped frame matches `sample_df` by value, not just shape — catches
+        /// header-as-data, column swaps, and dtype/null coercion that a shape-only check misses.
+        fn assert_sample_df(df: &DataFrame) {
+            assert_eq!((df.height(), df.width()), (3, 2));
+            assert_eq!(df.column("a").unwrap().i64().unwrap().get(0), Some(1));
+            assert_eq!(df.column("b").unwrap().str().unwrap().get(2), Some("z"));
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_read_s3_parquet() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload_sample_parquet(&store).await;
+
+            let df = read(&store, &hash, "parquet").await;
+            assert_sample_df(&df);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_read_s3_ipc() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload_sample_ipc(&store).await;
+
+            let df = read(&store, &hash, "arrow").await;
+            assert_sample_df(&df);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_read_s3_csv() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload(&store, b"a,b\n1,x\n2,y\n3,z\n".to_vec()).await;
+
+            let df = read(&store, &hash, "csv").await;
+            assert_sample_df(&df);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_read_s3_tsv() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload(&store, b"a\tb\n1\tx\n2\ty\n3\tz\n".to_vec()).await;
+
+            let df = read(&store, &hash, "tsv").await;
+            assert_sample_df(&df);
+        }
+
+        /// A `.csv` file that is actually semicolon-delimited must still parse into two columns:
+        /// proves the head-sample dialect sniff runs against the S3 object, matching local behavior.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_read_s3_csv_sniffs_non_default_delimiter() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload(&store, b"a;b\n1;x\n2;y\n3;z\n".to_vec()).await;
+
+            // Value-level: a mis-sniff (defaulting to comma) would yield width 1, not the (3, 2)
+            // sample, so this asserts the semicolon was sniffed from the S3 head sample.
+            let df = read(&store, &hash, "csv").await;
+            assert_sample_df(&df);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_read_s3_jsonl() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload(
+                &store,
+                b"{\"a\":1,\"b\":\"x\"}\n{\"a\":2,\"b\":\"y\"}\n{\"a\":3,\"b\":\"z\"}\n".to_vec(),
+            )
+            .await;
+
+            let df = read(&store, &hash, "jsonl").await;
+            assert_sample_df(&df);
+        }
+
+        /// Non-line-delimited JSON has no Polars cloud reader, so this exercises the fetch-bytes
+        /// fallback path (`get` the whole object, then `JsonReader`).
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_read_s3_json_array() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload(
+                &store,
+                b"[{\"a\":1,\"b\":\"x\"},{\"a\":2,\"b\":\"y\"},{\"a\":3,\"b\":\"z\"}]".to_vec(),
+            )
+            .await;
+
+            let df = read(&store, &hash, "json").await;
+            assert_sample_df(&df);
+        }
+
+        // The following three tests use the default `#[tokio::test]` (current-thread) runtime to
+        // mirror the actix server. A transform that drives the cloud `LazyFrame` (collect or schema
+        // resolution) must run off the async worker via spawn_blocking, or Polars' `block_in_place`
+        // panics ("can call blocking only when running on the multi-threaded runtime").
+        async fn upload_sample_parquet(store: &Arc<dyn VersionStore>) -> String {
+            let mut buf = Vec::new();
+            ParquetWriter::new(&mut buf)
+                .finish(&mut sample_df())
+                .unwrap();
+            upload(store, buf).await
+        }
+
+        async fn upload_sample_ipc(store: &Arc<dyn VersionStore>) -> String {
+            let mut buf = Vec::new();
+            IpcWriter::new(&mut buf).finish(&mut sample_df()).unwrap();
+            upload(store, buf).await
+        }
+
+        #[tokio::test]
+        async fn test_read_s3_with_take_transform_current_thread() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload_sample_parquet(&store).await;
+            let mut opts = DFOpts::empty();
+            opts.take = Some("0,2".to_string());
+            let df = tabular::read_version_df(&store, &hash, "parquet", &opts)
+                .await
+                .unwrap();
+            assert_eq!((df.height(), df.width()), (2, 2));
+            let a = df.column("a").unwrap().i64().unwrap();
+            assert_eq!((a.get(0), a.get(1)), (Some(1), Some(3)));
+        }
+
+        #[tokio::test]
+        async fn test_read_s3_with_column_at_transform_current_thread() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload_sample_parquet(&store).await;
+            let mut opts = DFOpts::empty();
+            opts.item = Some("b:2".to_string());
+            let df = tabular::read_version_df(&store, &hash, "parquet", &opts)
+                .await
+                .unwrap();
+            assert_eq!(df.get(0).unwrap()[0], AnyValue::String("z"));
+        }
+
+        #[tokio::test]
+        async fn test_read_s3_with_filter_transform_current_thread() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload_sample_parquet(&store).await;
+            let mut opts = DFOpts::empty();
+            opts.filter = Some("a == 2".to_string());
+            let df = tabular::read_version_df(&store, &hash, "parquet", &opts)
+                .await
+                .unwrap();
+            assert_eq!((df.height(), df.width()), (1, 2));
+            assert_eq!(df.column("b").unwrap().str().unwrap().get(0), Some("y"));
+        }
+
+        // Non-parquet variant: the transform fix is format-agnostic, but the cloud-scan root differs
+        // per format, so exercise a filter (which resolves schema) over a JSONL cloud scan too.
+        #[tokio::test]
+        async fn test_read_s3_jsonl_with_filter_transform_current_thread() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload(
+                &store,
+                b"{\"a\":1,\"b\":\"x\"}\n{\"a\":2,\"b\":\"y\"}\n{\"a\":3,\"b\":\"z\"}\n".to_vec(),
+            )
+            .await;
+            let mut opts = DFOpts::empty();
+            opts.filter = Some("a == 2".to_string());
+            let df = tabular::read_version_df(&store, &hash, "jsonl", &opts)
+                .await
+                .unwrap();
+            assert_eq!((df.height(), df.width()), (1, 2));
+            assert_eq!(df.column("b").unwrap().str().unwrap().get(0), Some("y"));
+        }
+
+        // A transform whose collect hits an S3 error (object never stored) must return a clean
+        // error, not panic via `unwrap` — and on the current-thread runtime it must not
+        // `block_in_place`-panic on the way there either.
+        #[tokio::test]
+        async fn test_read_s3_column_at_missing_object_errors_not_panics() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let mut opts = DFOpts::empty();
+            opts.item = Some("b:0".to_string());
+            let result =
+                tabular::read_version_df(&store, "deadbeefdeadbeef", "parquet", &opts).await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn test_read_s3_arrow_with_sql_is_rejected() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload_sample_ipc(&store).await;
+            let mut opts = DFOpts::empty();
+            opts.sql = Some("SELECT * FROM df".to_string());
+            let result = tabular::read_version_df(&store, &hash, "arrow", &opts).await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn test_read_s3_unknown_extension_errors() {
+            let (store, _tmp, _server) = setup_dyn().await;
+            let hash = upload(&store, b"not a data frame".to_vec()).await;
+            let result = tabular::read_version_df(&store, &hash, "xlsx", &DFOpts::empty()).await;
+            assert!(result.is_err());
+        }
+    }
 }


### PR DESCRIPTION
(Stacked on #602)

Before this change, tabular operations (files that represent a table, like parquet files) operated on local files, so we provided them direct access to the file in the backend storage. The initial S3 implementation papered over this by having every operation download the file from S3 to a local temporary file and operating on it there -- but that's really bad for performance, and quickly falls apart entirely for large files. 

This PR updates the polars tabular operations to operate mostly through the `VersionStore` byte interface that grabs portions of the file it needs, with a notable exception for the columnar formats (Parquet/CSV/TSV/JSONL/IPC) where we give Polars direct access to S3 so it's cloud implementation can issue range requests directly to S3.

Note that the cloud implementation has the same limitations for JSON (not JSONL) that we already had for the local file implementation.  JSON, as a format, can't be parsed incrementally. So we punt and download the entire file from S3 into memory and operate on it there--so we should discourage using JSON for anything that needs tabular handling. This is a limitation of JSON, and we have the same problem with the file-based implementation.

