### PR TITLE
S3 (16c): Migrate DuckDB tabular read path off get_version_path

### DIFF
--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -1,3 +1,4 @@
+use async_tempfile::TempFile;
 use duckdb::Connection;
 
 use crate::constants::{DIFF_HASH_COL, DIFF_STATUS_COL, EXCLUDE_OXEN_COLS, TABLE_NAME};
@@ -16,6 +17,7 @@ use crate::model::{
     Commit, EntryDataType, LocalRepository, MerkleHash, StagedEntryStatus, Workspace,
 };
 use crate::repositories;
+use crate::storage::version_store::VersionLocation;
 use crate::{error::OxenError, util};
 use std::path::{Path, PathBuf};
 
@@ -140,36 +142,58 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     util::fs::create_dir_all(parent)?;
 
     let version_store = repo.version_store();
-    let version_path = version_store
-        .get_version_path(&file_hash.to_string())
-        .await?;
+    let hash_str = file_hash.to_string();
+
+    // DuckDB's `read_*()` can only ingest a local filesystem path. Local stores expose the
+    // on-disk version file directly (zero copy); S3 streams the object to a temp file kept alive
+    // until indexing finishes (RAII cleanup on drop). The temp file is created in the workspace's
+    // DuckDB directory (`parent`) rather than the OS temp dir: that directory lives on the
+    // oxen-server data volume, which is sized to hold version files, whereas `/tmp` may be tiny.
+    let (version_path, _temp_file) = match version_store.version_location(&hash_str).await? {
+        VersionLocation::Local(path) => (path, None),
+        VersionLocation::S3 { .. } => {
+            let temp = TempFile::new_in(parent)
+                .await
+                .map_err(|e| OxenError::basic_str(format!("Failed to create temp file: {e}")))?;
+            let temp_path = temp.file_path().to_path_buf();
+            version_store
+                .copy_version_to_path(&hash_str, &temp_path)
+                .await?;
+            (temp_path, Some(temp))
+        }
+    };
 
     log::debug!(
         "core::v_latest::index::workspaces::data_frames::index({path:?}) got version path: {version_path:?}"
     );
 
     let extension = match &commit_merkle_tree.node {
-        EMerkleTreeNode::File(file_node) => file_node.extension(),
+        EMerkleTreeNode::File(file_node) => file_node.extension().to_string(),
         _ => {
             return Err(OxenError::basic_str("File node is not a file node"));
         }
     };
 
-    with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| {
-            if df_db::table_exists(conn, TABLE_NAME)? {
-                df_db::drop_table(conn, TABLE_NAME)?;
-            }
+    // DuckDB indexing is blocking file IO plus a full parse, so run it off the async runtime per
+    // the sync-core / async-edge policy. The DuckDB connection lives entirely inside the closure
+    // (it never crosses an `.await`), and `_temp_file` is held on the async side until the
+    // blocking work finishes, so a materialized S3 temp file outlives the read.
+    tokio::task::spawn_blocking(move || {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| {
+                if df_db::table_exists(conn, TABLE_NAME)? {
+                    df_db::drop_table(conn, TABLE_NAME)?;
+                }
 
-            df_db::index_file_with_id(&version_path, conn, extension)?;
-            log::debug!(
-                "core::v_latest::index::workspaces::data_frames::index({path:?}) finished!"
-            );
-
-            add_row_status_cols(conn)?;
-            Ok(())
+                df_db::index_file_with_id(&version_path, conn, &extension)?;
+                add_row_status_cols(conn)?;
+                Ok(())
+            })
         })
-    })?;
+    })
+    .await??;
+
+    log::debug!("core::v_latest::index::workspaces::data_frames::index({path:?}) finished!");
 
     // Save the current commit id so we know if the branch has advanced
     let commit_path =

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -220,6 +220,22 @@ impl LocalRepository {
         })
     }
 
+    /// Test-only constructor: clone an existing repo but back it with a caller-supplied version
+    /// store.
+    ///
+    /// `create_version_store` only ever builds an `S3VersionStore` against real AWS, so tests
+    /// can't otherwise point a repo at an in-process fixture (e.g. an s3s-backed store). This
+    /// clones `base` and swaps in `version_store`, leaving the on-disk path, merkle store, and
+    /// config untouched so the repo still resolves its commit/merkle metadata locally while
+    /// reading version files from the injected store.
+    #[cfg(test)]
+    pub fn new_for_testing(base: &LocalRepository, version_store: Arc<dyn VersionStore>) -> Self {
+        LocalRepository {
+            version_store,
+            ..base.clone()
+        }
+    }
+
     pub fn from_view(view: RepositoryView) -> Result<LocalRepository, OxenError> {
         let path = std::env::current_dir()?.join(view.name);
         let storage_config = StorageConfig::default();

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -632,7 +632,6 @@ impl VersionStore for S3VersionStore {
             .unwrap_or_else(|| "us-east-1".to_string());
         Ok(VersionLocation::S3 {
             url: format!("s3://{}/{}", self.bucket, self.generate_key(hash)),
-            bucket: self.bucket.clone(),
             region,
             endpoint_url: self.endpoint_url.clone(),
         })
@@ -657,6 +656,12 @@ impl VersionStore for S3VersionStore {
         tokio::io::copy_buf(&mut stream, &mut writer)
             .await
             .map_err(|e| OxenError::basic_str(format!("Failed to copy S3 stream to file: {e}")))?;
+        // `BufWriter::Drop` does not flush; flush explicitly so every byte reaches the file before
+        // a reader (e.g. DuckDB) opens the destination path.
+        writer
+            .flush()
+            .await
+            .map_err(|e| OxenError::basic_str(format!("Failed to flush S3 stream to file: {e}")))?;
 
         Ok(())
     }
@@ -1110,7 +1115,6 @@ mod tests {
         match location {
             VersionLocation::S3 {
                 url,
-                bucket,
                 region,
                 endpoint_url,
             } => {
@@ -1118,7 +1122,6 @@ mod tests {
                     url,
                     format!("s3://test-bucket/test-namespace/test-repo/{hash}/data")
                 );
-                assert_eq!(bucket, "test-bucket");
                 assert_eq!(region, "us-east-1");
                 let endpoint = endpoint_url.expect("test setup configures a loopback endpoint");
                 assert!(
@@ -1888,6 +1891,79 @@ mod tests {
             let hash = upload(&store, b"not a data frame".to_vec()).await;
             let result = tabular::read_version_df(&store, &hash, "xlsx", &DFOpts::empty()).await;
             assert!(result.is_err());
+        }
+
+        /// End-to-end: index a workspace data frame whose version file lives in S3.
+        ///
+        /// Drives 16c's S3 branch of `workspaces::data_frames::index`: `version_location` returns
+        /// `S3`, so the bytes are streamed to a temp file via `copy_version_to_path` and DuckDB
+        /// reads that local path. The DuckDB database itself stays on local disk; only the version
+        /// file is sourced from the s3s fixture, exercising the path that has no local version
+        /// file to fall back on.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_index_workspace_data_frame_from_s3() -> Result<(), crate::error::OxenError> {
+            // DuckDB indexing is skipped on Windows across the workspace tests; mirror that.
+            if std::env::consts::OS == "windows" {
+                return Ok(());
+            }
+
+            use crate::config::UserConfig;
+            use crate::constants::TABLE_NAME;
+            use crate::core::db::data_frames::df_db;
+            use crate::core::db::data_frames::df_db::with_df_db_manager;
+            use crate::model::{LocalRepository, Workspace};
+            use crate::repositories;
+            use std::path::Path;
+
+            let (s3_store, _tmp, _server) = setup_dyn().await;
+
+            crate::test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+                let file_path = Path::new("annotations")
+                    .join("train")
+                    .join("bounding_box.csv");
+                let commit = repositories::commits::head_commit(&repo)?;
+
+                // Mirror the committed file's version bytes into the S3 store under the same hash
+                // so the S3-backed index path has them to fetch.
+                let node =
+                    repositories::tree::get_node_by_path_with_children(&repo, &commit, &file_path)?
+                        .expect("committed file should resolve in the merkle tree");
+                let hash = node.hash.to_string();
+                let bytes = repo.version_store().get_version(&hash).await?;
+                s3_store.store_version(&hash, bytes.into()).await?;
+
+                // Build a workspace, then point its base repo at the S3-backed store.
+                let workspace_id = UserConfig::identifier()?;
+                let workspace =
+                    repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+                let s3_base = LocalRepository::new_for_testing(&workspace.base_repo, s3_store);
+                let s3_workspace = Workspace {
+                    base_repo: s3_base,
+                    ..workspace
+                };
+
+                // version_location -> S3 -> copy_version_to_path(temp) -> DuckDB read of the temp.
+                repositories::workspaces::data_frames::index(
+                    &s3_workspace.base_repo,
+                    &s3_workspace,
+                    &file_path,
+                )
+                .await?;
+
+                // The indexed table should be populated from the S3-sourced bytes.
+                let db_path =
+                    repositories::workspaces::data_frames::duckdb_path(&s3_workspace, &file_path);
+                let count = with_df_db_manager(&db_path, |manager| {
+                    manager.with_conn(|conn| {
+                        let n = df_db::count(conn, TABLE_NAME)?;
+                        Ok(n)
+                    })
+                })?;
+                assert!(count > 0, "expected the S3-indexed table to have rows");
+
+                Ok(())
+            })
+            .await
         }
     }
 }

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -91,7 +91,6 @@ pub enum VersionLocation {
         /// Fully-qualified S3 URL of the combined version file:
         /// `s3://{bucket}/{prefix}/{hash}/data`.
         url: String,
-        bucket: String,
         region: String,
         /// `Some(host:port)` for non-AWS S3-compatible endpoints (s3s test fixture, MinIO,
         /// etc.). `None` selects the default AWS endpoint.
@@ -346,8 +345,8 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// cloud-aware reader can consume without materializing it to a temp file on local disk.
     ///
     /// Local-backed stores return [`VersionLocation::Local`] with the on-disk path; S3-backed
-    /// stores return [`VersionLocation::S3`] carrying the s3:// URL plus the bucket, region, and
-    /// endpoint override the caller needs to configure Polars `CloudOptions` or DuckDB `httpfs`.
+    /// stores return [`VersionLocation::S3`] carrying the s3:// URL plus the region and endpoint
+    /// override the caller needs to configure Polars `CloudOptions` or DuckDB `httpfs`.
     ///
     /// Prefer this over [`Self::get_version_path`] whenever the consumer has a cloud-aware
     /// reader available (Polars `scan_*`, DuckDB `read_parquet`, …): `get_version_path`


### PR DESCRIPTION
Workspace data-frame indexing was the last tabular read still routed through `get_version_path`, whose S3 implementation buffers the whole object in memory before writing it to a file. This PR eliminates the intermediate buffering of the entire file in memory to avoid causing OOMs, allow dealing with larger files, and improve performance. We switch to using`copy_version_to_path` when using the S3 version store to stream the temp file.

Future note: If we find a solution other than DuckDB that doesn't require local files, and could deal with cloud locations, we could avoid creating the temporary file.

Other improvements/fixes along the way:
- (Bug fix) Create the S3 temp file on the oxen-server data volume, since `/tmp` may be tiny in production.
- (Performance fix) Run the DuckDB indexing inside `spawn_blocking` which moves it to a dedicated thread that doesn't block the async runtime that's servicing this request.
- (Cleanup) Drop the now-unused `bucket` field from `VersionLocation::S3`.
- (Bug fix) Flush the S3 `copy_version_to_path` `BufWriter` before returning. Its `Drop` does not flush.
- (Testing) Add `LocalRepository::new_for_testing` to swap in a caller-supplied `VersionStore`, plus an end-to-end test that indexes a workspace data frame whose version file lives only in S3.

ENG-1084