### PR TITLE
S3 (17a): Cleanup - Consolidate workspace upload paths

### DIFF
--- a/crates/lib/src/api/client/workspaces/files.rs
+++ b/crates/lib/src/api/client/workspaces/files.rs
@@ -6,10 +6,9 @@ use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository, RemoteRepository};
 use crate::opts::GlobOpts;
 use crate::util::{self, concurrency};
-use crate::view::{ErrorFileInfo, ErrorFilesResponse, FilePathsResponse, FileWithHash};
+use crate::view::{ErrorFileInfo, ErrorFilesResponse, FileWithHash};
 use crate::{api, repositories, view, view::workspaces::ValidateUploadFeasibilityRequest};
 
-use bytesize::ByteSize;
 use futures_util::StreamExt;
 use glob_match::glob_match;
 
@@ -31,7 +30,6 @@ use flate2::write::GzEncoder;
 
 const BASE_WAIT_TIME: usize = 300;
 const MAX_WAIT_TIME: usize = 10_000;
-const WORKSPACE_ADD_LIMIT: u64 = 100_000_000;
 
 #[derive(Debug)]
 pub struct UploadResult {
@@ -221,72 +219,37 @@ pub async fn add_files(
     }
 }
 
-pub async fn add_bytes(
-    remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<str>,
-    path: PathBuf,
-    buf: &[u8],
-) -> Result<(), OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let directory = directory.as_ref();
-
-    match upload_bytes_as_file(remote_repo, workspace_id, directory, &path, buf).await {
-        Ok(path) => {
-            println!("🐂 oxen added entry {path:?} to workspace {workspace_id}");
-        }
-        Err(e) => {
-            return Err(e);
-        }
-    }
-
-    Ok(())
-}
-
+/// Stage a single file from disk to a workspace, returning its remote path.
+#[cfg(any(test, feature = "test-utils"))]
 pub async fn upload_single_file(
     remote_repo: &RemoteRepository,
     workspace_id: impl AsRef<str>,
     directory: impl AsRef<Path>,
     path: impl AsRef<Path>,
 ) -> Result<PathBuf, OxenError> {
+    let directory = directory.as_ref();
     let path = path.as_ref();
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| OxenError::basic_str(format!("Path has no file name: {path:?}")))?;
+    let dst_path = directory.join(file_name);
 
-    let Ok(metadata) = path.metadata() else {
-        return Err(OxenError::path_does_not_exist(path));
-    };
+    // Route through the shared dispatcher so small files batch and large files chunk-upload,
+    // exactly like a multi-file add of a single file.
+    let err_files = upload_multiple_files(
+        remote_repo,
+        workspace_id,
+        directory,
+        vec![path.to_path_buf()],
+        None,
+        false,
+    )
+    .await?;
 
-    log::debug!("Uploading file with size: {}", metadata.len());
-    // If the file is above the streamed-transfer segment size, use the parallel upload strategy
-    if metadata.len() > stream_segment_size() {
-        let directory = directory.as_ref();
-        match api::client::versions::parallel_large_file_upload(
-            remote_repo,
-            path,
-            Some(directory),
-            Some(workspace_id.as_ref().to_string()),
-            false,
-            None,
-            None,
-        )
-        .await
-        {
-            Ok(upload) => Ok(upload.local_path),
-            Err(err) => Err(err),
-        }
-    } else {
-        // Single multipart request
-        p_upload_single_file(remote_repo, workspace_id, directory, path).await
+    match err_files.into_iter().next() {
+        Some(err) => Err(OxenError::basic_str(err.error)),
+        None => Ok(dst_path),
     }
-}
-
-pub async fn upload_bytes_as_file(
-    remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
-    path: impl AsRef<Path>,
-    buf: &[u8],
-) -> Result<PathBuf, OxenError> {
-    p_upload_bytes_as_file(remote_repo, workspace_id, directory, path, buf).await
 }
 
 async fn upload_multiple_files(
@@ -900,123 +863,6 @@ pub async fn stage_files_to_workspace(
     let response: ErrorFilesResponse = serde_json::from_str(&body)?;
 
     Ok(response.err_files)
-}
-
-async fn p_upload_single_file(
-    remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
-    path: impl AsRef<Path>,
-) -> Result<PathBuf, OxenError> {
-    let workspace_id = workspace_id.as_ref();
-    let directory = directory.as_ref();
-    let directory_name = directory.to_string_lossy();
-    let path = path.as_ref();
-    log::debug!("multipart_file_upload path: {path:?}");
-    let Ok(file) = std::fs::read(path) else {
-        let err = format!("Error reading file at path: {path:?}");
-        return Err(OxenError::basic_str(err));
-    };
-
-    let uri = format!("/workspaces/{workspace_id}/files/{directory_name}");
-    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
-
-    let file_name: String = path.file_name().unwrap().to_string_lossy().into();
-    log::info!("api::client::workspaces::files::add sending file_name: {file_name:?}");
-
-    let file_part = reqwest::multipart::Part::bytes(file).file_name(file_name);
-    let form = reqwest::multipart::Form::new().part("file", file_part);
-    let client = client::new_for_url(&url)?;
-    let response = client.post(&url).multipart(form).send().await?;
-    let body = client::parse_json_body(&url, response).await?;
-    let result: Result<FilePathsResponse, serde_json::Error> = serde_json::from_str(&body);
-    match result {
-        Ok(val) => {
-            log::debug!("File path response: {val:?}");
-            if let Some(path) = val.paths.first() {
-                Ok(path.clone())
-            } else {
-                Err(OxenError::basic_str("No file path returned from server"))
-            }
-        }
-        Err(err) => {
-            let err = format!(
-                "api::staging::add_file error parsing response from {url}\n\nErr {err:?} \n\n{body}"
-            );
-            Err(OxenError::basic_str(err))
-        }
-    }
-}
-
-async fn p_upload_bytes_as_file(
-    remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<Path>,
-    path: impl AsRef<Path>,
-    mut buf: &[u8],
-) -> Result<PathBuf, OxenError> {
-    // Check if the total size of the files is too large (over 100mb for now)
-    let limit = WORKSPACE_ADD_LIMIT;
-    let total_size: u64 = buf.len().try_into().unwrap();
-    if total_size > limit {
-        let error_msg = format!(
-            "Total size of files to upload is too large. {} > {} Consider using `oxen push` instead for now until upload supports bulk push.",
-            ByteSize::b(total_size),
-            ByteSize::b(limit)
-        );
-        return Err(OxenError::basic_str(error_msg));
-    }
-
-    let workspace_id = workspace_id.as_ref();
-    let directory = directory.as_ref();
-    let directory_name = directory.to_string_lossy();
-    let path = path.as_ref();
-    log::debug!("multipart_file_upload path: {path:?}");
-
-    let file_name: String = path.file_name().unwrap().to_string_lossy().into();
-    log::info!("uploading bytes with file_name: {file_name:?}");
-
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-    std::io::copy(&mut buf, &mut encoder)?;
-    let compressed_bytes = match encoder.finish() {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            return Err(OxenError::basic_str(format!(
-                "Failed to finish gzip for file {}: {}",
-                &file_name, e
-            )));
-        }
-    };
-
-    let file_part = reqwest::multipart::Part::bytes(compressed_bytes)
-        .file_name(file_name)
-        .mime_str("application/gzip")?;
-
-    let form = reqwest::multipart::Form::new().part("file[]", file_part);
-
-    let uri = format!("/workspaces/{workspace_id}/files/{directory_name}");
-    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
-
-    let client = client::new_for_url(&url)?;
-    let response = client.post(&url).multipart(form).send().await?;
-    let body = client::parse_json_body(&url, response).await?;
-    let result: Result<FilePathsResponse, serde_json::Error> = serde_json::from_str(&body);
-    match result {
-        Ok(val) => {
-            log::debug!("File path response: {val:?}");
-            if let Some(path) = val.paths.first() {
-                Ok(path.clone())
-            } else {
-                Err(OxenError::basic_str("No file path returned from server"))
-            }
-        }
-        Err(err) => {
-            let err = format!(
-                "api::staging::add_file error parsing response from {url}\n\nErr {err:?} \n\n{body}"
-            );
-            Err(OxenError::basic_str(err))
-        }
-    }
 }
 
 // TODO: Merge this with 'rm_files'

--- a/crates/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -1,3 +1,4 @@
+use async_tempfile::TempFile;
 use duckdb::Connection;
 
 use crate::constants::{DIFF_HASH_COL, DIFF_STATUS_COL, EXCLUDE_OXEN_COLS, TABLE_NAME};
@@ -16,6 +17,7 @@ use crate::model::{
     Commit, EntryDataType, LocalRepository, MerkleHash, StagedEntryStatus, Workspace,
 };
 use crate::repositories;
+use crate::storage::version_store::VersionLocation;
 use crate::{error::OxenError, util};
 use std::path::{Path, PathBuf};
 
@@ -140,36 +142,58 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     util::fs::create_dir_all(parent)?;
 
     let version_store = repo.version_store();
-    let version_path = version_store
-        .get_version_path(&file_hash.to_string())
-        .await?;
+    let hash_str = file_hash.to_string();
+
+    // DuckDB's `read_*()` can only ingest a local filesystem path. Local stores expose the
+    // on-disk version file directly (zero copy); S3 streams the object to a temp file kept alive
+    // until indexing finishes (RAII cleanup on drop). The temp file is created in the workspace's
+    // DuckDB directory (`parent`) rather than the OS temp dir: that directory lives on the
+    // oxen-server data volume, which is sized to hold version files, whereas `/tmp` may be tiny.
+    let (version_path, _temp_file) = match version_store.version_location(&hash_str).await? {
+        VersionLocation::Local(path) => (path, None),
+        VersionLocation::S3 { .. } => {
+            let temp = TempFile::new_in(parent)
+                .await
+                .map_err(|e| OxenError::basic_str(format!("Failed to create temp file: {e}")))?;
+            let temp_path = temp.file_path().to_path_buf();
+            version_store
+                .copy_version_to_path(&hash_str, &temp_path)
+                .await?;
+            (temp_path, Some(temp))
+        }
+    };
 
     log::debug!(
         "core::v_latest::index::workspaces::data_frames::index({path:?}) got version path: {version_path:?}"
     );
 
     let extension = match &commit_merkle_tree.node {
-        EMerkleTreeNode::File(file_node) => file_node.extension(),
+        EMerkleTreeNode::File(file_node) => file_node.extension().to_string(),
         _ => {
             return Err(OxenError::basic_str("File node is not a file node"));
         }
     };
 
-    with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| {
-            if df_db::table_exists(conn, TABLE_NAME)? {
-                df_db::drop_table(conn, TABLE_NAME)?;
-            }
+    // DuckDB indexing is blocking file IO plus a full parse, so run it off the async runtime per
+    // the sync-core / async-edge policy. The DuckDB connection lives entirely inside the closure
+    // (it never crosses an `.await`), and `_temp_file` is held on the async side until the
+    // blocking work finishes, so a materialized S3 temp file outlives the read.
+    tokio::task::spawn_blocking(move || {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| {
+                if df_db::table_exists(conn, TABLE_NAME)? {
+                    df_db::drop_table(conn, TABLE_NAME)?;
+                }
 
-            df_db::index_file_with_id(&version_path, conn, extension)?;
-            log::debug!(
-                "core::v_latest::index::workspaces::data_frames::index({path:?}) finished!"
-            );
-
-            add_row_status_cols(conn)?;
-            Ok(())
+                df_db::index_file_with_id(&version_path, conn, &extension)?;
+                add_row_status_cols(conn)?;
+                Ok(())
+            })
         })
-    })?;
+    })
+    .await??;
+
+    log::debug!("core::v_latest::index::workspaces::data_frames::index({path:?}) finished!");
 
     // Save the current commit id so we know if the branch has advanced
     let commit_path =

--- a/crates/lib/src/model/repository/local_repository.rs
+++ b/crates/lib/src/model/repository/local_repository.rs
@@ -220,6 +220,22 @@ impl LocalRepository {
         })
     }
 
+    /// Test-only constructor: clone an existing repo but back it with a caller-supplied version
+    /// store.
+    ///
+    /// `create_version_store` only ever builds an `S3VersionStore` against real AWS, so tests
+    /// can't otherwise point a repo at an in-process fixture (e.g. an s3s-backed store). This
+    /// clones `base` and swaps in `version_store`, leaving the on-disk path, merkle store, and
+    /// config untouched so the repo still resolves its commit/merkle metadata locally while
+    /// reading version files from the injected store.
+    #[cfg(test)]
+    pub fn new_for_testing(base: &LocalRepository, version_store: Arc<dyn VersionStore>) -> Self {
+        LocalRepository {
+            version_store,
+            ..base.clone()
+        }
+    }
+
     pub fn from_view(view: RepositoryView) -> Result<LocalRepository, OxenError> {
         let path = std::env::current_dir()?.join(view.name);
         let storage_config = StorageConfig::default();

--- a/crates/lib/src/storage/s3.rs
+++ b/crates/lib/src/storage/s3.rs
@@ -632,7 +632,6 @@ impl VersionStore for S3VersionStore {
             .unwrap_or_else(|| "us-east-1".to_string());
         Ok(VersionLocation::S3 {
             url: format!("s3://{}/{}", self.bucket, self.generate_key(hash)),
-            bucket: self.bucket.clone(),
             region,
             endpoint_url: self.endpoint_url.clone(),
         })
@@ -657,6 +656,12 @@ impl VersionStore for S3VersionStore {
         tokio::io::copy_buf(&mut stream, &mut writer)
             .await
             .map_err(|e| OxenError::basic_str(format!("Failed to copy S3 stream to file: {e}")))?;
+        // `BufWriter::Drop` does not flush; flush explicitly so every byte reaches the file before
+        // a reader (e.g. DuckDB) opens the destination path.
+        writer
+            .flush()
+            .await
+            .map_err(|e| OxenError::basic_str(format!("Failed to flush S3 stream to file: {e}")))?;
 
         Ok(())
     }
@@ -1110,7 +1115,6 @@ mod tests {
         match location {
             VersionLocation::S3 {
                 url,
-                bucket,
                 region,
                 endpoint_url,
             } => {
@@ -1118,7 +1122,6 @@ mod tests {
                     url,
                     format!("s3://test-bucket/test-namespace/test-repo/{hash}/data")
                 );
-                assert_eq!(bucket, "test-bucket");
                 assert_eq!(region, "us-east-1");
                 let endpoint = endpoint_url.expect("test setup configures a loopback endpoint");
                 assert!(
@@ -1888,6 +1891,79 @@ mod tests {
             let hash = upload(&store, b"not a data frame".to_vec()).await;
             let result = tabular::read_version_df(&store, &hash, "xlsx", &DFOpts::empty()).await;
             assert!(result.is_err());
+        }
+
+        /// End-to-end: index a workspace data frame whose version file lives in S3.
+        ///
+        /// Drives 16c's S3 branch of `workspaces::data_frames::index`: `version_location` returns
+        /// `S3`, so the bytes are streamed to a temp file via `copy_version_to_path` and DuckDB
+        /// reads that local path. The DuckDB database itself stays on local disk; only the version
+        /// file is sourced from the s3s fixture, exercising the path that has no local version
+        /// file to fall back on.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_index_workspace_data_frame_from_s3() -> Result<(), crate::error::OxenError> {
+            // DuckDB indexing is skipped on Windows across the workspace tests; mirror that.
+            if std::env::consts::OS == "windows" {
+                return Ok(());
+            }
+
+            use crate::config::UserConfig;
+            use crate::constants::TABLE_NAME;
+            use crate::core::db::data_frames::df_db;
+            use crate::core::db::data_frames::df_db::with_df_db_manager;
+            use crate::model::{LocalRepository, Workspace};
+            use crate::repositories;
+            use std::path::Path;
+
+            let (s3_store, _tmp, _server) = setup_dyn().await;
+
+            crate::test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+                let file_path = Path::new("annotations")
+                    .join("train")
+                    .join("bounding_box.csv");
+                let commit = repositories::commits::head_commit(&repo)?;
+
+                // Mirror the committed file's version bytes into the S3 store under the same hash
+                // so the S3-backed index path has them to fetch.
+                let node =
+                    repositories::tree::get_node_by_path_with_children(&repo, &commit, &file_path)?
+                        .expect("committed file should resolve in the merkle tree");
+                let hash = node.hash.to_string();
+                let bytes = repo.version_store().get_version(&hash).await?;
+                s3_store.store_version(&hash, bytes.into()).await?;
+
+                // Build a workspace, then point its base repo at the S3-backed store.
+                let workspace_id = UserConfig::identifier()?;
+                let workspace =
+                    repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+                let s3_base = LocalRepository::new_for_testing(&workspace.base_repo, s3_store);
+                let s3_workspace = Workspace {
+                    base_repo: s3_base,
+                    ..workspace
+                };
+
+                // version_location -> S3 -> copy_version_to_path(temp) -> DuckDB read of the temp.
+                repositories::workspaces::data_frames::index(
+                    &s3_workspace.base_repo,
+                    &s3_workspace,
+                    &file_path,
+                )
+                .await?;
+
+                // The indexed table should be populated from the S3-sourced bytes.
+                let db_path =
+                    repositories::workspaces::data_frames::duckdb_path(&s3_workspace, &file_path);
+                let count = with_df_db_manager(&db_path, |manager| {
+                    manager.with_conn(|conn| {
+                        let n = df_db::count(conn, TABLE_NAME)?;
+                        Ok(n)
+                    })
+                })?;
+                assert!(count > 0, "expected the S3-indexed table to have rows");
+
+                Ok(())
+            })
+            .await
         }
     }
 }

--- a/crates/lib/src/storage/version_store.rs
+++ b/crates/lib/src/storage/version_store.rs
@@ -91,7 +91,6 @@ pub enum VersionLocation {
         /// Fully-qualified S3 URL of the combined version file:
         /// `s3://{bucket}/{prefix}/{hash}/data`.
         url: String,
-        bucket: String,
         region: String,
         /// `Some(host:port)` for non-AWS S3-compatible endpoints (s3s test fixture, MinIO,
         /// etc.). `None` selects the default AWS endpoint.
@@ -346,8 +345,8 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// cloud-aware reader can consume without materializing it to a temp file on local disk.
     ///
     /// Local-backed stores return [`VersionLocation::Local`] with the on-disk path; S3-backed
-    /// stores return [`VersionLocation::S3`] carrying the s3:// URL plus the bucket, region, and
-    /// endpoint override the caller needs to configure Polars `CloudOptions` or DuckDB `httpfs`.
+    /// stores return [`VersionLocation::S3`] carrying the s3:// URL plus the region and endpoint
+    /// override the caller needs to configure Polars `CloudOptions` or DuckDB `httpfs`.
     ///
     /// Prefer this over [`Self::get_version_path`] whenever the consumer has a cloud-aware
     /// reader available (Polars `scan_*`, DuckDB `read_parquet`, …): `get_version_path`

--- a/crates/oxen-py/src/py_workspace.rs
+++ b/crates/oxen-py/src/py_workspace.rs
@@ -133,20 +133,6 @@ impl PyWorkspace {
         Ok(PyStagedData::from(remote_status))
     }
 
-    fn add_bytes(&self, src: PathBuf, buf: Vec<u8>, dst: String) -> Result<(), PyOxenError> {
-        pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::workspaces::files::add_bytes(
-                &self.repo.repo,
-                &self.get_identifier(),
-                &dst,
-                src,
-                &buf,
-            )
-            .await
-        })?;
-        Ok(())
-    }
-
     fn add(&self, src: Vec<PathBuf>, dst: String) -> Result<Vec<PyErrorFileInfo>, PyOxenError> {
         let errors = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::files::add(

--- a/crates/server/src/controllers/workspaces/files.rs
+++ b/crates/server/src/controllers/workspaces/files.rs
@@ -5,26 +5,18 @@ use crate::params::{app_data, path_param};
 use liboxen::core;
 use liboxen::core::staged::get_staged_db_manager;
 use liboxen::error::OxenError;
-use liboxen::model::LocalRepository;
 use liboxen::model::merkle_tree::node::EMerkleTreeNode;
 use liboxen::model::metadata::metadata_image::ImgResize;
 use liboxen::model::metadata::metadata_video::VideoThumbnail;
 use liboxen::repositories;
 use liboxen::util;
-use liboxen::util::hasher;
 use liboxen::view::workspaces::RenameRequest;
 use liboxen::view::{
-    ErrorFileInfo, ErrorFilesResponse, FilePathsResponse, FileWithHash, StatusMessage,
-    StatusMessageDescription,
+    ErrorFilesResponse, FilePathsResponse, FileWithHash, StatusMessage, StatusMessageDescription,
 };
 
-use actix_multipart::Multipart;
-use actix_web::Error;
 use actix_web::{HttpRequest, HttpResponse, web};
-use flate2::read::GzDecoder;
-use futures_util::TryStreamExt as _;
 use serde::Deserialize;
-use std::io::Read as StdRead;
 use std::path::PathBuf;
 use std::sync::Arc;
 use utoipa;
@@ -175,84 +167,6 @@ pub async fn get(
     let stream = version_store.get_version_stream(&hash_str).await?;
 
     Ok(file_stream_response(mime_type, &last_commit_id, Some(num_bytes)).streaming(stream))
-}
-
-/// Add files to workspace
-#[utoipa::path(
-    post,
-    path = "/api/repos/{namespace}/{repo_name}/workspaces/{workspace_id}/files/{path}",
-    description = "Upload and stage files to a workspace. Accept a multipart with either gzipped or uncompressed file parts. Use the filename from the file part and compute the file hash from the content.",
-    tag = "Workspace Files",
-    params(
-        ("namespace" = String, Path, description = "The namespace of the repository", example = "ox"),
-        ("repo_name" = String, Path, description = "The name of the repository", example = "ImageNet-1k"),
-        ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745"),
-        ("path" = String, Path, description = "The target path to upload the file to", example = "data/train")
-    ),
-    request_body(
-        content_type = "multipart/form-data",
-        description = "Multipart upload of file. Each file should be sent as a separate file part",
-        content = FileUpload,
-    ),
-    responses(
-        (status = 200, description = "File successfully uploaded to workspace", body = FilePathsResponse),
-        (status = 404, description = "Workspace not found"),
-        (status = 400, description = "Invalid upload request")
-    )
-)]
-pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, OxenHttpError> {
-    let app_data = app_data(&req)?;
-    let namespace = path_param(&req, "namespace")?.to_string();
-    let repo_name = path_param(&req, "repo_name")?.to_string();
-    let workspace_id = path_param(&req, "workspace_id")?.to_string();
-    let repo = get_repo(app_data, namespace, &repo_name)?;
-    let directory = path_param(&req, "path")?.to_string();
-
-    let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
-        return Ok(HttpResponse::NotFound()
-            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
-    };
-
-    let version_store = repo.version_store();
-
-    let (upload_files, err_files, update_timestamp) = save_parts(payload, &repo).await?;
-    log::debug!("Save multiparts found {} err_files", err_files.len());
-    log::debug!(
-        "Calling add version files from the core workspace logic with {} files (update_timestamp: {})",
-        upload_files.len(),
-        update_timestamp,
-    );
-
-    let mut ret_files = vec![];
-    for upload_file in upload_files {
-        let file_name = upload_file.path.file_name().unwrap();
-        let dst_path = PathBuf::from(&directory).join(file_name);
-        let version_path = version_store.get_version_path(&upload_file.hash).await?;
-
-        let ret_file = match core::v_latest::workspaces::files::add_version_file(
-            &workspace,
-            &version_path,
-            &dst_path,
-            &upload_file.hash,
-            update_timestamp,
-        )
-        .await
-        {
-            Ok(ret_file) => ret_file,
-            Err(e) => {
-                log::error!("Error adding file {version_path:?}: {e:?}");
-                continue;
-            }
-        };
-
-        ret_files.push(ret_file);
-        log::info!("Successfully staged file {upload_file:?}");
-    }
-
-    Ok(HttpResponse::Ok().json(FilePathsResponse {
-        status: StatusMessage::resource_created(),
-        paths: ret_files,
-    }))
 }
 
 /// Stage files to workspace
@@ -471,181 +385,6 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     }
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))
-}
-
-// Read the payload files into memory, compute the hash, and save to version store
-// Unlike controllers::versions::save_multiparts, the hash must be computed here,
-// As this function expects the filename to be the file path, not the hash
-pub async fn save_parts(
-    mut payload: Multipart,
-    repo: &LocalRepository,
-) -> Result<(Vec<FileWithHash>, Vec<ErrorFileInfo>, bool), Error> {
-    // Receive a multipart request and save the files to the version store
-    let version_store = repo.version_store();
-    let gzip_mime: mime::Mime = "application/gzip".parse().unwrap();
-
-    let mut upload_files: Vec<FileWithHash> = vec![];
-    let mut err_files: Vec<ErrorFileInfo> = vec![];
-    let mut update_timestamp = false;
-
-    while let Some(mut field) = payload.try_next().await? {
-        let Some(content_disposition) = field.content_disposition().cloned() else {
-            continue;
-        };
-
-        if let Some(name) = content_disposition.get_name()
-            && name == "update_timestamp"
-        {
-            update_timestamp = parse_bool_field(&mut field).await?;
-            continue;
-        }
-
-        if let Some(name) = content_disposition.get_name()
-            && (name == "file[]" || name == "file")
-        {
-            // The file path is passed in as the filename
-            let upload_filename = content_disposition.get_filename().map_or_else(
-                || {
-                    Err(actix_web::error::ErrorBadRequest(
-                        "Missing hash in multipart request",
-                    ))
-                },
-                |fhash_os_str| Ok(fhash_os_str.to_string()),
-            )?;
-
-            let mut field_bytes = Vec::new();
-            while let Some(chunk) = field.try_next().await? {
-                field_bytes.extend_from_slice(&chunk);
-            }
-
-            let is_gzipped = field
-                .content_type()
-                .map(|mime| {
-                    mime.type_() == gzip_mime.type_() && mime.subtype() == gzip_mime.subtype()
-                })
-                .unwrap_or(false);
-
-            let upload_filename_copy = upload_filename.clone();
-
-            let (upload_filehash, data_to_store) =
-                match actix_web::web::block(move || -> Result<(String, Vec<u8>), OxenError> {
-                    if is_gzipped {
-                        log::debug!(
-                            "Decompressing gzipped data for file: {upload_filename_copy:?}"
-                        );
-
-                        // Decompress the data if it is gzipped
-                        let mut decoder = GzDecoder::new(&field_bytes[..]);
-                        let mut decompressed_bytes: Vec<u8> = Vec::new();
-                        decoder.read_to_end(&mut decompressed_bytes).map_err(|e| {
-                            OxenError::basic_str(format!("Failed to decompress gzipped data: {e}"))
-                        })?;
-
-                        // Hash file contents
-                        let hash = hasher::hash_buffer(&decompressed_bytes);
-
-                        Ok((hash, decompressed_bytes))
-                    } else {
-                        log::debug!("Data for file {upload_filename_copy:?} is not gzipped.");
-
-                        // Only hash file contents
-                        let hash = hasher::hash_buffer(&field_bytes);
-                        Ok((hash, field_bytes))
-                    }
-                })
-                .await
-                {
-                    Ok(Ok((hash, data))) => (hash, data),
-                    Ok(Err(e)) => {
-                        log::error!(
-                            "Failed to decompress data for file {}: {:?}",
-                            &upload_filename,
-                            e
-                        );
-                        record_error_file(
-                            &mut err_files,
-                            upload_filename.clone(),
-                            None,
-                            format!("Failed to decompress data: {e:?}"),
-                        );
-                        continue;
-                    }
-                    Err(e) => {
-                        log::error!(
-                            "Failed to execute blocking decompression task for file {}: {}",
-                            &upload_filename,
-                            e
-                        );
-                        record_error_file(
-                            &mut err_files,
-                            upload_filename.clone(),
-                            None,
-                            format!("Failed to execute blocking decompression: {e}"),
-                        );
-                        continue;
-                    }
-                };
-
-            match version_store
-                .store_version(&upload_filehash, data_to_store.into())
-                .await
-            {
-                Ok(_) => {
-                    upload_files.push(FileWithHash {
-                        hash: upload_filehash.to_string(),
-                        path: upload_filename.into(),
-                    });
-                    log::info!("Successfully stored version for hash: {}", &upload_filehash);
-                }
-                Err(e) => {
-                    log::error!(
-                        "Failed to store version for hash {}: {}",
-                        &upload_filehash,
-                        e
-                    );
-                    record_error_file(
-                        &mut err_files,
-                        upload_filehash.clone(),
-                        None,
-                        format!("Failed to store version: {e}"),
-                    );
-                    continue;
-                }
-            }
-        }
-    }
-
-    Ok((upload_files, err_files, update_timestamp))
-}
-
-async fn parse_bool_field(field: &mut actix_multipart::Field) -> Result<bool, Error> {
-    let mut bytes = Vec::new();
-    while let Some(chunk) = field.try_next().await? {
-        bytes.extend_from_slice(&chunk);
-    }
-    let value = String::from_utf8_lossy(&bytes);
-    match value.as_ref() {
-        "true" | "1" => Ok(true),
-        "false" | "0" => Ok(false),
-        _ => Err(actix_web::error::ErrorBadRequest(format!(
-            "Invalid boolean value: {value}"
-        ))),
-    }
-}
-
-// Record the error file info for retry
-fn record_error_file(
-    err_files: &mut Vec<ErrorFileInfo>,
-    filehash: String,
-    filepath: Option<PathBuf>,
-    error: String,
-) {
-    let info = ErrorFileInfo {
-        hash: filehash,
-        path: filepath,
-        error,
-    };
-    err_files.push(info);
 }
 
 #[cfg(test)]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -143,7 +143,6 @@ const START_SERVER_USAGE: &str = "Usage: `oxen-server start -i 0.0.0.0 -p 3000`"
         crate::controllers::workspaces::changes::unstage_many,
         // Workspaces - files
         crate::controllers::workspaces::files::get,
-        crate::controllers::workspaces::files::add,
         crate::controllers::workspaces::files::add_version_files,
         crate::controllers::workspaces::files::rm_files,
         // Branches

--- a/crates/server/src/services/workspaces.rs
+++ b/crates/server/src/services/workspaces.rs
@@ -55,10 +55,6 @@ pub fn workspace() -> Scope {
                     web::get().to(controllers::workspaces::files::get),
                 )
                 .route(
-                    "/files/{path:.*}",
-                    web::post().to(controllers::workspaces::files::add),
-                )
-                .route(
                     "/files",
                     web::delete().to(controllers::workspaces::files::rm_files),
                 )

--- a/oxen-python/python/oxen/workspace.py
+++ b/oxen-python/python/oxen/workspace.py
@@ -1,3 +1,4 @@
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Iterator, Optional
 
@@ -272,7 +273,15 @@ class Workspace:
                 The path in the remote repo where the file will be added
         """
 
-        self._workspace.add_bytes(src, buf, dst)
+        # An in-memory buffer has no file on disk, so write it to a client-side temp file
+        # (named so the entry keeps its intended name) and route through the on-disk add path.
+        name = Path(src).name
+        if not name:
+            raise ValueError(f"src has no file name: {src!r}")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir) / name
+            tmp_path.write_bytes(buf)
+            self.add(tmp_path, dst)
 
     def rm(self, path: str) -> None:
         """

--- a/oxen-python/tests/test_workspace_add_bytes.py
+++ b/oxen-python/tests/test_workspace_add_bytes.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from oxen import RemoteRepo, Workspace
+
+
+def test_workspace_add_bytes_to_folder(
+    celeba_remote_repo_one_image_pushed: RemoteRepo,
+):
+    _, remote_repo = celeba_remote_repo_one_image_pushed
+    workspace = Workspace(remote_repo, "main", "test-workspace-add-bytes")
+
+    workspace.add_bytes("hello.txt", b"hello from memory", "a-folder")
+
+    status = workspace.status()
+    added_files = status.added_files()
+
+    assert len(added_files) == 1
+    assert added_files[0] == str(Path("a-folder") / "hello.txt")
+
+
+def test_workspace_add_bytes_to_root(
+    celeba_remote_repo_one_image_pushed: RemoteRepo,
+):
+    _, remote_repo = celeba_remote_repo_one_image_pushed
+    workspace = Workspace(remote_repo, "main", "test-workspace-add-bytes-root")
+
+    # default dst -> entry lands at the workspace root under its src name
+    workspace.add_bytes("greeting.txt", b"hi there")
+
+    status = workspace.status()
+    added_files = status.added_files()
+
+    assert len(added_files) == 1
+    assert added_files[0] == "greeting.txt"


### PR DESCRIPTION
(Stacked on #605)

This PR removes one of the three workspace file upload paths, because it was duplicate functionality, so this is almost all code removal. This cleans up an area of code that needs to be updated to support the S3 version store.

Details:
- Delete the single-multipart server path: the `POST /workspaces/{id}/files/{path}` route and its controller (`add`, `save_parts`, `parse_bool_field`, `record_error_file`), plus the OpenAPI entry and the client helper `p_upload_single_file`.
- Route `upload_single_file` through `upload_multiple_files`, since it's just a special case of that.
- Collapse `Workspace.add_bytes` to pure-Python sugar over `add()`
- Gate `upload_single_file` behind `cfg(any(test, feature = "test-utils"))`, since it's only used by tests.
- Add `tests/test_workspace_add_bytes.py`, since the Python portion was untested before.
