### PR TITLE
S3 (17b): Remove the unused update_timestamp feature

### DIFF
--- a/crates/liboxen/src/api/client/import.rs
+++ b/crates/liboxen/src/api/client/import.rs
@@ -64,7 +64,6 @@ pub async fn import_url(
     directory: impl AsRef<str>,
     download_url: impl AsRef<str>,
     commit: &NewCommitBody,
-    update_timestamp: bool,
 ) -> Result<crate::model::Commit, OxenError> {
     let branch_name = branch_name.as_ref();
     let directory = directory.as_ref();
@@ -72,15 +71,12 @@ pub async fn import_url(
     let uri = format!("/import/{branch_name}/{directory}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
-    let mut body = serde_json::json!({
+    let body = serde_json::json!({
         "download_url": download_url.as_ref(),
         "name": commit.author,
         "email": commit.email,
         "message": commit.message,
     });
-    if update_timestamp {
-        body["update_timestamp"] = serde_json::Value::Bool(true);
-    }
 
     let client = client::new_for_url(&url)?;
     let response = client
@@ -108,7 +104,6 @@ mod tests {
     use crate::api;
 
     use std::io::Write;
-    use std::path::Path;
 
     #[tokio::test]
     async fn test_upload_zip_file() -> Result<(), OxenError> {
@@ -227,14 +222,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_import_url_with_update_timestamp() -> Result<(), OxenError> {
+    async fn test_import_url_reupload_unchanged_is_noop() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
             let branch_name = DEFAULT_BRANCH_NAME;
 
-            // Serve stable, identical bytes from a local mock server so the three imports below
-            // hash to the same version, exercising re-import dedup. The oxen-server process
-            // performs the fetch, so it must run in test mode to permit the loopback target. The
-            // mock and server stay in scope for the whole closure so every GET is served.
+            // Serve stable, identical bytes from a local mock server so both imports below hash to
+            // the same version, exercising re-import dedup. The oxen-server process performs the
+            // fetch, so it must run in test mode to permit the loopback target. The mock and server
+            // stay in scope for the whole closure so every GET is served.
             let mut server = mockito::Server::new_async().await;
             let _mock = server
                 .mock("GET", "/images/bloxy_white_background.png")
@@ -259,59 +254,25 @@ mod tests {
                 "imported",
                 download_url,
                 &commit_body,
-                false,
             )
             .await?;
             assert!(!first_commit.id.is_empty());
 
-            // Second import of same file WITHOUT update_timestamp should fail (no changes)
+            // Second import of the same file should fail (no changes to commit)
             let result = api::client::import::import_url(
                 &remote_repo,
                 branch_name,
                 "imported",
                 download_url,
                 &NewCommitBody {
-                    message: "Second import no force".to_string(),
+                    message: "Second import".to_string(),
                     ..commit_body.clone()
                 },
-                false,
             )
             .await;
             assert!(
                 result.is_err(),
                 "Expected import to fail with no changes: {result:?}"
-            );
-
-            // Third import of same file WITH update_timestamp should succeed
-            let third_commit = api::client::import::import_url(
-                &remote_repo,
-                branch_name,
-                "imported",
-                download_url,
-                &NewCommitBody {
-                    message: "Force update import".to_string(),
-                    ..commit_body.clone()
-                },
-                true,
-            )
-            .await?;
-            assert_ne!(first_commit.id, third_commit.id);
-
-            // Verify latest_commit on the entry matches the update_timestamp commit
-            let entries =
-                api::client::dir::list(&remote_repo, branch_name, Path::new("imported"), 1, 100)
-                    .await?;
-            let file_entry = entries
-                .entries
-                .iter()
-                .find(|e| e.filename() == "bloxy_white_background.png")
-                .expect("Should find the imported file");
-            let latest_commit = file_entry
-                .latest_commit()
-                .expect("Entry should have latest_commit");
-            assert_eq!(
-                latest_commit.id, third_commit.id,
-                "latest_commit should match the update_timestamp commit"
             );
 
             Ok(remote_repo)

--- a/crates/liboxen/src/api/client/versions.rs
+++ b/crates/liboxen/src/api/client/versions.rs
@@ -101,7 +101,6 @@ pub async fn parallel_large_file_upload(
     file_path: impl AsRef<Path>,
     dst_dir: Option<impl AsRef<Path>>, // dst_dir is provided for workspace add workflow
     workspace_id: Option<String>,
-    update_timestamp: bool,
     commit_entry: Option<CommitEntry>, // entry is provided for push workflow
     progress: Option<&Arc<PushProgress>>, // for push workflow
 ) -> Result<MultipartLargeFileUpload, OxenError> {
@@ -124,14 +123,7 @@ pub async fn parallel_large_file_upload(
     .await?;
     let num_chunks = results.len();
     log::debug!("multipart_large_file_upload num_chunks: {num_chunks:?}");
-    complete_multipart_large_file_upload(
-        remote_repo,
-        upload,
-        num_chunks,
-        workspace_id,
-        update_timestamp,
-    )
-    .await
+    complete_multipart_large_file_upload(remote_repo, upload, num_chunks, workspace_id).await
 }
 
 /// Creates a new multipart large file upload
@@ -471,7 +463,6 @@ async fn complete_multipart_large_file_upload(
     upload: MultipartLargeFileUpload,
     num_chunks: usize,
     workspace_id: Option<String>,
-    update_timestamp: bool,
 ) -> Result<MultipartLargeFileUpload, OxenError> {
     let file_hash = &upload.hash.to_string();
 
@@ -494,7 +485,6 @@ async fn complete_multipart_large_file_upload(
             upload_results: None,
         }],
         workspace_id,
-        update_timestamp,
     };
 
     let body = serde_json::to_string(&body)?;
@@ -858,7 +848,6 @@ mod tests {
                 path,
                 dst_dir,
                 workspace_id,
-                false,
                 None,
                 None,
             )

--- a/crates/liboxen/src/api/client/workspaces/commits.rs
+++ b/crates/liboxen/src/api/client/workspaces/commits.rs
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reupload_same_file_without_update_timestamp_fails() -> Result<(), OxenError> {
+    async fn test_reupload_unchanged_file_does_not_commit() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
             let branch_name = "main";
 
@@ -544,7 +544,7 @@ mod tests {
                     .await?;
             assert!(!first_commit.id.is_empty());
 
-            // Re-upload the same file without update_timestamp
+            // Re-upload the same unchanged file
             let workspace_id_2 = UserConfig::identifier()? + "_2";
             api::client::workspaces::create(&remote_repo, branch_name, &workspace_id_2).await?;
 
@@ -571,173 +571,6 @@ mod tests {
             assert!(
                 result.is_err(),
                 "Expected commit to fail with no changes, but got: {result:?}"
-            );
-
-            Ok(remote_repo)
-        })
-        .await
-    }
-
-    #[tokio::test]
-    async fn test_reupload_same_file_with_update_timestamp_succeeds() -> Result<(), OxenError> {
-        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
-            let branch_name = "main";
-
-            // First upload and commit
-            let workspace_id = UserConfig::identifier()?;
-            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
-
-            let paths = vec![test::test_img_file()];
-            let result = api::client::workspaces::files::add(
-                &remote_repo,
-                &workspace_id,
-                "images",
-                paths,
-                &None,
-            )
-            .await;
-            assert!(result.is_ok(), "{result:?}");
-
-            let body = NewCommitBody {
-                message: "Add image".to_string(),
-                author: "Test User".to_string(),
-                email: "test@oxen.ai".to_string(),
-            };
-            let first_commit =
-                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id, &body)
-                    .await?;
-            assert!(!first_commit.id.is_empty());
-
-            // Re-upload the same file WITH update_timestamp
-            let workspace_id_2 = UserConfig::identifier()? + "_2";
-            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id_2).await?;
-
-            let paths = vec![test::test_img_file()];
-            let result = api::client::workspaces::files::add_with_opts(
-                &remote_repo,
-                &workspace_id_2,
-                "images",
-                paths,
-                &None,
-                true, // update_timestamp
-            )
-            .await;
-            assert!(result.is_ok(), "{result:?}");
-
-            // Commit should succeed because update_timestamp forces timestamp update
-            let body = NewCommitBody {
-                message: "Force update same image".to_string(),
-                author: "Test User".to_string(),
-                email: "test@oxen.ai".to_string(),
-            };
-            let second_commit =
-                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id_2, &body)
-                    .await?;
-            assert!(!second_commit.id.is_empty());
-
-            // The commit IDs should be different
-            assert_ne!(
-                first_commit.id, second_commit.id,
-                "Expected different commit IDs after force update"
-            );
-
-            // Verify latest_commit on the file entry matches the second commit
-            let entries =
-                api::client::dir::list(&remote_repo, branch_name, Path::new("images"), 1, 100)
-                    .await?;
-            let file_entry = entries
-                .entries
-                .iter()
-                .find(|e| e.filename() == "dwight_vince.jpeg")
-                .expect("Should find the uploaded file in the directory listing");
-            let latest_commit = file_entry
-                .latest_commit()
-                .expect("File entry should have a latest_commit");
-            assert_eq!(
-                latest_commit.id, second_commit.id,
-                "latest_commit on the file entry should match the update_timestamp commit, got {} expected {}",
-                latest_commit.id, second_commit.id,
-            );
-
-            Ok(remote_repo)
-        })
-        .await
-    }
-
-    #[tokio::test]
-    async fn test_reupload_same_large_file_with_update_timestamp_succeeds() -> Result<(), OxenError>
-    {
-        test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
-            let branch_name = "main";
-
-            let workspace_id = UserConfig::identifier()?;
-            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id).await?;
-
-            let paths = vec![test::test_30k_parquet()];
-            let result = api::client::workspaces::files::add(
-                &remote_repo,
-                &workspace_id,
-                "parquet",
-                paths.clone(),
-                &None,
-            )
-            .await;
-            assert!(result.is_ok(), "{result:?}");
-
-            let body = NewCommitBody {
-                message: "Add large parquet".to_string(),
-                author: "Test User".to_string(),
-                email: "test@oxen.ai".to_string(),
-            };
-            let first_commit =
-                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id, &body)
-                    .await?;
-            assert!(!first_commit.id.is_empty());
-
-            let workspace_id_2 = UserConfig::identifier()? + "_2";
-            api::client::workspaces::create(&remote_repo, branch_name, &workspace_id_2).await?;
-
-            let result = api::client::workspaces::files::add_with_opts(
-                &remote_repo,
-                &workspace_id_2,
-                "parquet",
-                paths,
-                &None,
-                true,
-            )
-            .await;
-            assert!(result.is_ok(), "{result:?}");
-
-            let body = NewCommitBody {
-                message: "Force update same large parquet".to_string(),
-                author: "Test User".to_string(),
-                email: "test@oxen.ai".to_string(),
-            };
-            let second_commit =
-                api::client::workspaces::commit(&remote_repo, branch_name, &workspace_id_2, &body)
-                    .await?;
-            assert!(!second_commit.id.is_empty());
-
-            assert_ne!(
-                first_commit.id, second_commit.id,
-                "Expected different commit IDs after force update on a large file"
-            );
-
-            let entries =
-                api::client::dir::list(&remote_repo, branch_name, Path::new("parquet"), 1, 100)
-                    .await?;
-            let file_entry = entries
-                .entries
-                .iter()
-                .find(|e| e.filename() == "wiki_30k.parquet")
-                .expect("Should find the uploaded large file in the directory listing");
-            let latest_commit = file_entry
-                .latest_commit()
-                .expect("File entry should have a latest_commit");
-            assert_eq!(
-                latest_commit.id, second_commit.id,
-                "latest_commit on the large file entry should match the update_timestamp commit, got {} expected {}",
-                latest_commit.id, second_commit.id,
             );
 
             Ok(remote_repo)

--- a/crates/liboxen/src/api/client/workspaces/files.rs
+++ b/crates/liboxen/src/api/client/workspaces/files.rs
@@ -51,25 +51,6 @@ pub async fn add(
     paths: Vec<PathBuf>,
     local_repo: &Option<LocalRepository>,
 ) -> Result<UploadFails, OxenError> {
-    add_with_opts(
-        remote_repo,
-        workspace_id,
-        directory,
-        paths,
-        local_repo,
-        false,
-    )
-    .await
-}
-
-pub async fn add_with_opts(
-    remote_repo: &RemoteRepository,
-    workspace_id: impl AsRef<str>,
-    directory: impl AsRef<str>,
-    paths: Vec<PathBuf>,
-    local_repo: &Option<LocalRepository>,
-    update_timestamp: bool,
-) -> Result<UploadFails, OxenError> {
     let workspace_id = workspace_id.as_ref();
     let directory = directory.as_ref();
 
@@ -102,7 +83,6 @@ pub async fn add_with_opts(
             .clone()
             .map(|local| LocalOrBase::Local(Box::new(local.clone())))
             .as_ref(),
-        update_timestamp,
     )
     .await;
 
@@ -207,7 +187,6 @@ pub async fn add_files(
         //    for a single API call.
         paths,
         Some(&base_dir_enum),
-        false,
     )
     .await
     {
@@ -242,7 +221,6 @@ pub async fn upload_single_file(
         directory,
         vec![path.to_path_buf()],
         None,
-        false,
     )
     .await?;
 
@@ -258,7 +236,6 @@ async fn upload_multiple_files(
     directory: impl AsRef<Path>,
     paths: Vec<PathBuf>,
     local_or_base: Option<&LocalOrBase>,
-    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     if paths.is_empty() {
         return Ok(vec![]);
@@ -334,7 +311,6 @@ async fn upload_multiple_files(
             &path,
             Some(&dst_dir),
             Some(workspace_id.to_string()),
-            update_timestamp,
             None,
             None,
         )
@@ -361,7 +337,6 @@ async fn upload_multiple_files(
         small_files,
         small_files_size,
         local_or_base,
-        update_timestamp,
     )
     .await?;
 
@@ -377,7 +352,6 @@ pub(crate) async fn parallel_batched_small_file_upload(
     small_files: Vec<(PathBuf, u64)>,
     small_files_size: u64,
     local_or_base: Option<&LocalOrBase>,
-    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     if small_files.is_empty() {
         return Ok(vec![]);
@@ -488,12 +462,11 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                 )?;
 
                                 // In remote-mode repos, skip adding files already present in
-                                // the tree unless update_timestamp is set. Done here in async
-                                // context (rather than inside `spawn_blocking` below) so the
-                                // mtime-tolerance comparison can `.await`.
-                                if !update_timestamp
-                                    && let Some((ref head_commit, ref local_repository)) =
-                                        head_commit_local_repo_maybe_clone
+                                // the tree and unmodified. Done here in async context (rather
+                                // than inside `spawn_blocking` below) so the mtime-tolerance
+                                // comparison can `.await`.
+                                if let Some((ref head_commit, ref local_repository)) =
+                                    head_commit_local_repo_maybe_clone
                                     && let Some(file_node) = repositories::tree::get_file_by_path(
                                         local_repository,
                                         head_commit,
@@ -664,7 +637,6 @@ pub(crate) async fn parallel_batched_small_file_upload(
                                         Arc::new(files_to_stage),
                                         &directory_str,
                                         upload_err_files,
-                                        update_timestamp,
                                     )
                                     .await
                                     {
@@ -777,7 +749,6 @@ pub async fn stage_files_to_workspace_with_retry(
     files_to_add: Arc<Vec<FileWithHash>>,
     directory_str: impl AsRef<str>,
     err_files: Vec<ErrorFileInfo>,
-    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let mut retry_count: usize = 0;
     let directory_str = directory_str.as_ref();
@@ -794,7 +765,6 @@ pub async fn stage_files_to_workspace_with_retry(
             files_to_add.clone(),
             directory_str,
             err_files.clone(),
-            update_timestamp,
         )
         .await
         {
@@ -833,15 +803,10 @@ pub async fn stage_files_to_workspace(
     files_to_add: Arc<Vec<FileWithHash>>,
     directory_str: impl AsRef<str>,
     err_files: Vec<ErrorFileInfo>,
-    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let workspace_id = workspace_id.as_ref();
     let directory_str = directory_str.as_ref();
-    let uri = if update_timestamp {
-        format!("/workspaces/{workspace_id}/versions/{directory_str}?update_timestamp=true")
-    } else {
-        format!("/workspaces/{workspace_id}/versions/{directory_str}")
-    };
+    let uri = format!("/workspaces/{workspace_id}/versions/{directory_str}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let files_to_send = if !err_files.is_empty() {

--- a/crates/liboxen/src/core/v_latest/add.rs
+++ b/crates/liboxen/src/core/v_latest/add.rs
@@ -985,7 +985,6 @@ pub async fn stage_file_with_hash(
     hash: &str,
     staged_db_manager: &StagedDBManager,
     seen_dirs: &Arc<Mutex<HashSet<PathBuf>>>,
-    update_timestamp: bool,
 ) -> Result<(), OxenError> {
     let workspace_repo = &workspace.workspace_repo;
     let base_repo = &workspace.base_repo;
@@ -993,12 +992,7 @@ pub async fn stage_file_with_hash(
 
     let relative_path = util::fs::path_relative_to_dir(dst_path, base_repo.path.clone())?;
     let metadata = util::fs::metadata(data_path)?;
-    let mtime = if update_timestamp {
-        // Use current time to force a timestamp update
-        FileTime::now()
-    } else {
-        FileTime::from_last_modification_time(&metadata)
-    };
+    let mtime = FileTime::from_last_modification_time(&metadata);
     let maybe_file_node =
         repositories::tree::get_file_by_path(base_repo, head_commit, &relative_path)?;
 
@@ -1008,12 +1002,6 @@ pub async fn stage_file_with_hash(
             .is_modified_from_node(data_path, &file_node)
             .await?
         {
-            StagedEntryStatus::Modified
-        } else if update_timestamp {
-            // Force staging even though the content hasn't changed
-            log::info!(
-                "file {data_path:?} has not changed but update_timestamp is set - staging as modified"
-            );
             StagedEntryStatus::Modified
         } else {
             // Don't add the file if it hasn't changed

--- a/crates/liboxen/src/core/v_latest/push.rs
+++ b/crates/liboxen/src/core/v_latest/push.rs
@@ -667,7 +667,6 @@ async fn chunk_and_send_large_entries(
                     &*version_path,
                     None::<PathBuf>,
                     None,
-                    false,
                     Some(commit_entry.clone()),
                     Some(&bar),
                 )

--- a/crates/liboxen/src/core/v_latest/workspaces/files.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/files.rs
@@ -1,5 +1,4 @@
 use bytes::BytesMut;
-use filetime::FileTime;
 use futures::StreamExt;
 use parking_lot::Mutex;
 use reqwest::Client;
@@ -39,28 +38,13 @@ const MAX_COMPRESSION_RATIO: u64 = 100; // Maximum allowed
 
 // TODO: Do we depreciate this, if we always upload to version store?
 pub async fn add(workspace: &Workspace, filepath: impl AsRef<Path>) -> Result<PathBuf, OxenError> {
-    add_with_opts(workspace, filepath, false).await
-}
-
-pub async fn add_with_opts(
-    workspace: &Workspace,
-    filepath: impl AsRef<Path>,
-    update_timestamp: bool,
-) -> Result<PathBuf, OxenError> {
     let filepath = filepath.as_ref();
     let workspace_repo = &workspace.workspace_repo;
     let base_repo = &workspace.base_repo;
 
     // Stage the file using the repositories::add method
     let commit = workspace.commit.clone();
-    p_add_file(
-        base_repo,
-        workspace_repo,
-        &Some(commit),
-        filepath,
-        update_timestamp,
-    )
-    .await?;
+    p_add_file(base_repo, workspace_repo, &Some(commit), filepath).await?;
 
     // Return the relative path of the file in the workspace
     let relative_path = util::fs::path_relative_to_dir(filepath, &workspace_repo.path)?;
@@ -87,7 +71,6 @@ pub async fn add_version_file(
     version_path: impl AsRef<Path>,
     dst_path: impl AsRef<Path>,
     file_hash: &str,
-    update_timestamp: bool,
 ) -> Result<PathBuf, OxenError> {
     // version_path is where the file is stored, dst_path is the relative path to the repo
     // let version_path = version_path.as_ref();
@@ -103,7 +86,6 @@ pub async fn add_version_file(
         file_hash,
         &staged_db_manager,
         &Arc::new(Mutex::new(HashSet::new())),
-        update_timestamp,
     )
     .await?;
 
@@ -115,7 +97,6 @@ pub async fn add_version_files(
     workspace: &Workspace,
     files_with_hash: &[FileWithHash],
     directory: impl AsRef<str>,
-    update_timestamp: bool,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let version_store = repo.version_store();
 
@@ -147,7 +128,6 @@ pub async fn add_version_files(
             &item.hash,
             &staged_db_manager,
             &seen_dirs,
-            update_timestamp,
         )
         .await
         {
@@ -387,7 +367,6 @@ pub async fn import(
     directory: PathBuf,
     filename: Option<String>,
     workspace: &Workspace,
-    update_timestamp: bool,
     allow_loopback: bool,
 ) -> Result<(), OxenError> {
     let parsed_url =
@@ -413,7 +392,6 @@ pub async fn import(
         directory,
         filename,
         workspace,
-        update_timestamp,
         allow_loopback,
     )
     .await?;
@@ -485,7 +463,6 @@ async fn fetch_file(
     directory: PathBuf,
     caller_filename: Option<String>,
     workspace: &Workspace,
-    update_timestamp: bool,
     allow_loopback: bool,
 ) -> Result<(), OxenError> {
     let client = Client::builder()
@@ -658,16 +635,12 @@ async fn fetch_file(
 
         for file in files.iter() {
             log::debug!("file::import add file {file:?}");
-            let path =
-                repositories::workspaces::files::add_with_opts(workspace, file, update_timestamp)
-                    .await?;
+            let path = repositories::workspaces::files::add(workspace, file).await?;
             log::debug!("file::import add file ✅ success! staged file {path:?}");
         }
     } else {
         log::debug!("file::import add file {:?}", &filepath);
-        let path =
-            repositories::workspaces::files::add_with_opts(workspace, &save_path, update_timestamp)
-                .await?;
+        let path = repositories::workspaces::files::add(workspace, &save_path).await?;
         log::debug!("file::import add file ✅ success! staged file {path:?}");
     }
 
@@ -876,7 +849,6 @@ async fn p_add_file(
     workspace_repo: &LocalRepository,
     maybe_head_commit: &Option<Commit>,
     path: &Path,
-    update_timestamp: bool,
 ) -> Result<(), OxenError> {
     let version_store = base_repo.version_store();
     let mut maybe_dir_node = None;
@@ -897,23 +869,13 @@ async fn p_add_file(
     }
 
     // See if this is a new file or a modified file
-    let mut file_status = core::v_latest::add::determine_file_status(
+    let file_status = core::v_latest::add::determine_file_status(
         base_repo,
         &maybe_dir_node,
         &file_name,
         &full_path,
     )
     .await?;
-
-    // When update_timestamp is set, override Unmodified status to Modified
-    // and use the current time so the commit gets a new merkle tree hash
-    if update_timestamp && file_status.status == StagedEntryStatus::Unmodified {
-        log::info!(
-            "file {full_path:?} has not changed but update_timestamp is set - staging as modified"
-        );
-        file_status.status = StagedEntryStatus::Modified;
-        file_status.mtime = FileTime::now();
-    }
 
     // Store the file in the version store using the hash as the key
     let hash_str = file_status.hash.to_string();

--- a/crates/liboxen/src/repositories/workspaces/files.rs
+++ b/crates/liboxen/src/repositories/workspaces/files.rs
@@ -8,8 +8,6 @@ pub use crate::core::v_latest::workspaces::files::exists;
 
 pub use crate::core::v_latest::workspaces::files::add;
 
-pub use crate::core::v_latest::workspaces::files::add_with_opts;
-
 pub use crate::core::v_latest::workspaces::files::rm;
 
 pub use crate::core::v_latest::workspaces::files::unstage;
@@ -20,7 +18,6 @@ pub async fn import(
     directory: PathBuf,
     filename: Option<String>,
     workspace: &Workspace,
-    update_timestamp: bool,
     allow_loopback: bool,
 ) -> Result<(), OxenError> {
     core::v_latest::workspaces::files::import(
@@ -29,7 +26,6 @@ pub async fn import(
         directory,
         filename,
         workspace,
-        update_timestamp,
         allow_loopback,
     )
     .await?;
@@ -217,7 +213,6 @@ mod tests {
                     std::path::PathBuf::from("data"),
                     None,
                     &workspace,
-                    false,
                     false,
                 )
                 .await;

--- a/crates/liboxen/src/view/versions.rs
+++ b/crates/liboxen/src/view/versions.rs
@@ -55,8 +55,6 @@ pub struct CompleteVersionUploadRequest {
     // If the workspace_id is provided, we will add the file to the workspace
     // otherwise, we will just add the file to the versions store
     pub workspace_id: Option<String>,
-    #[serde(default)]
-    pub update_timestamp: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/oxen-server/src/controllers/import.rs
+++ b/crates/oxen-server/src/controllers/import.rs
@@ -180,15 +180,6 @@ pub async fn import(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let update_timestamp = match body.get("update_timestamp") {
-        Some(value) => value.as_bool().ok_or_else(|| {
-            OxenHttpError::BadRequest(
-                "Invalid type for `update_timestamp`, expected boolean".into(),
-            )
-        })?,
-        None => false,
-    };
-
     // download and save the file into the workspace
     repositories::workspaces::files::import(
         download_url,
@@ -196,7 +187,6 @@ pub async fn import(
         directory,
         filename,
         &workspace,
-        update_timestamp,
         allow_loopback,
     )
     .await?;

--- a/crates/oxen-server/src/controllers/versions/chunks.rs
+++ b/crates/oxen-server/src/controllers/versions/chunks.rs
@@ -124,7 +124,6 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                 &*version_path,
                 &dst_path,
                 &version_id,
-                request.update_timestamp,
             )
             .await?;
         }

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -35,12 +35,6 @@ pub struct FileUpload {
     pub file: Vec<u8>,
 }
 
-/// Query parameters for staging operations
-#[derive(Deserialize, Debug, Default)]
-pub struct StagingQueryParams {
-    pub update_timestamp: Option<bool>,
-}
-
 /// Combined query parameters for workspace file operations (image resize and video thumbnail)
 #[derive(Deserialize, Debug)]
 pub struct WorkspaceFileQueryParams {
@@ -215,12 +209,11 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
 
     let version_store = repo.version_store();
 
-    let (upload_files, err_files, update_timestamp) = save_parts(payload, &repo).await?;
+    let (upload_files, err_files) = save_parts(payload, &repo).await?;
     log::debug!("Save multiparts found {} err_files", err_files.len());
     log::debug!(
-        "Calling add version files from the core workspace logic with {} files (update_timestamp: {})",
+        "Calling add version files from the core workspace logic with {} files",
         upload_files.len(),
-        update_timestamp,
     );
 
     let mut ret_files = vec![];
@@ -238,7 +231,6 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
             &version_path,
             &dst_path,
             &upload_file.hash,
-            update_timestamp,
         )
         .await
         {
@@ -269,8 +261,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
         ("namespace" = String, Path, description = "The namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "The name of the repository", example = "ImageNet-1k"),
         ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745"),
-        ("directory" = String, Path, description = "The directory to stage the files into", example = "data/train"),
-        ("update_timestamp" = Option<bool>, Query, description = "Force staging even if file content has not changed, updating the file timestamp", example = false)
+        ("directory" = String, Path, description = "The directory to stage the files into", example = "data/train")
     ),
     request_body(
         content = Vec<FileWithHash>,
@@ -290,7 +281,6 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
 pub async fn add_version_files(
     req: HttpRequest,
     payload: web::Json<Vec<FileWithHash>>,
-    query: web::Query<StagingQueryParams>,
 ) -> Result<HttpResponse, OxenHttpError> {
     // Add file to staging
     let app_data = app_data(&req)?;
@@ -298,7 +288,6 @@ pub async fn add_version_files(
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let directory = path_param(&req, "directory")?.to_string();
-    let update_timestamp = query.update_timestamp.unwrap_or(false);
 
     let repo = get_repo(app_data, namespace, repo_name)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -307,16 +296,14 @@ pub async fn add_version_files(
     };
     let files_with_hash: Vec<FileWithHash> = payload.into_inner();
     log::debug!(
-        "Calling add version files from the core workspace logic with {} files (update_timestamp: {})",
+        "Calling add version files from the core workspace logic with {} files",
         files_with_hash.len(),
-        update_timestamp,
     );
     let err_files = core::v_latest::workspaces::files::add_version_files(
         &repo,
         &workspace,
         &files_with_hash,
         &directory,
-        update_timestamp,
     )
     .await?;
 
@@ -483,26 +470,18 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
 pub async fn save_parts(
     mut payload: Multipart,
     repo: &LocalRepository,
-) -> Result<(Vec<FileWithHash>, Vec<ErrorFileInfo>, bool), Error> {
+) -> Result<(Vec<FileWithHash>, Vec<ErrorFileInfo>), Error> {
     // Receive a multipart request and save the files to the version store
     let version_store = repo.version_store();
     let gzip_mime: mime::Mime = "application/gzip".parse().unwrap();
 
     let mut upload_files: Vec<FileWithHash> = vec![];
     let mut err_files: Vec<ErrorFileInfo> = vec![];
-    let mut update_timestamp = false;
 
     while let Some(mut field) = payload.try_next().await? {
         let Some(content_disposition) = field.content_disposition().cloned() else {
             continue;
         };
-
-        if let Some(name) = content_disposition.get_name()
-            && name == "update_timestamp"
-        {
-            update_timestamp = parse_bool_field(&mut field).await?;
-            continue;
-        }
 
         if let Some(name) = content_disposition.get_name()
             && (name == "file[]" || name == "file")
@@ -619,22 +598,7 @@ pub async fn save_parts(
         }
     }
 
-    Ok((upload_files, err_files, update_timestamp))
-}
-
-async fn parse_bool_field(field: &mut actix_multipart::Field) -> Result<bool, Error> {
-    let mut bytes = Vec::new();
-    while let Some(chunk) = field.try_next().await? {
-        bytes.extend_from_slice(&chunk);
-    }
-    let value = String::from_utf8_lossy(&bytes);
-    match value.as_ref() {
-        "true" | "1" => Ok(true),
-        "false" | "0" => Ok(false),
-        _ => Err(actix_web::error::ErrorBadRequest(format!(
-            "Invalid boolean value: {value}"
-        ))),
-    }
+    Ok((upload_files, err_files))
 }
 
 // Record the error file info for retry


### PR DESCRIPTION
(Stacked on #619)

Nothing except tests used the `update_timestamp` parameter, which had a lot of plumbing to force a byte-identical file to re-stage and bump its recorded timestamp so a commit would register a change, so I'm cleaning it out before I make some changes to this area of the code to support the S3 version store.

This just deletes things and doesn't change any behavior.

Closes ENG-1095