### PR TITLE
  Streamline Tests (5): Speed up pull tests

### DIFF
--- a/crates/lib/src/repositories/pull.rs
+++ b/crates/lib/src/repositories/pull.rs
@@ -61,13 +61,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_command_push_clone_pull_push() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_no_commits_async(|mut repo| async move {
-            // Track the file
+        test::run_empty_local_repo_test_async(|mut repo| async move {
+            // Track an inline data directory
             let train_dirname = "train";
             let train_dir = repo.path.join(train_dirname);
+            util::fs::create_dir_all(&train_dir)?;
+            for i in 0..3 {
+                test::write_txt_file_to_path(
+                    train_dir.join(format!("train_{i}.txt")),
+                    format!("train {i}"),
+                )?;
+            }
             let og_num_files = util::fs::rcount_files_in_dir(&train_dir);
             repositories::add(&repo, &train_dir).await?;
-            // Commit the train dir
             repositories::commit(&repo, "Adding training data")?;
 
             // Set the proper remote
@@ -673,7 +679,7 @@ mod tests {
     #[tokio::test]
     async fn test_push_pull_moved_files() -> Result<(), OxenError> {
         // Push the Remote Repo
-        test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
+        test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {
             let remote_repo_copy = remote_repo.clone();
             let contents = "this is the file";
             let path = &local_repo.path.join("a.txt");
@@ -723,7 +729,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_push_new_branch_default_clone() -> Result<(), OxenError> {
-        test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
+        test::run_readme_remote_repo_test(|_, remote_repo| async move {
             let remote_repo_copy = remote_repo.clone();
             test::run_empty_dir_test_async(|repo_dir| async move {
                 // Clone the remote repo
@@ -958,7 +964,7 @@ mod tests {
     #[tokio::test]
     async fn test_flags_merge_conflict_on_pull() -> Result<(), OxenError> {
         // Push the Remote Repo
-        test::run_training_data_fully_sync_remote(|_, remote_repo| async move {
+        test::run_readme_remote_repo_test(|_, remote_repo| async move {
             let remote_repo_copy = remote_repo.clone();
 
             // Clone Repo to User A
@@ -1214,39 +1220,52 @@ mod tests {
 
     #[tokio::test]
     async fn test_pull_multiple_commits() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_no_commits_async(|mut repo| async move {
-            // Track a file
-            let filename = "labels.txt";
-            let file_path = repo.path.join(filename);
+        test::run_empty_local_repo_test_async(|mut repo| async move {
+            // First commit: a single inline file
+            let file_path = repo.path.join("labels.txt");
+            test::write_txt_file_to_path(&file_path, "label_a\nlabel_b")?;
             repositories::add(&repo, &file_path).await?;
             repositories::commit(&repo, "Adding labels file")?;
 
+            // Second commit: inline `train` dir with 2 files
             let train_path = repo.path.join("train");
+            util::fs::create_dir_all(&train_path)?;
+            for i in 0..2 {
+                test::write_txt_file_to_path(
+                    train_path.join(format!("train_{i}.txt")),
+                    format!("train {i}"),
+                )?;
+            }
             repositories::add(&repo, &train_path).await?;
             repositories::commit(&repo, "Adding train dir")?;
 
+            // Third commit: inline `test` dir with 2 files
             let test_path = repo.path.join("test");
+            util::fs::create_dir_all(&test_path)?;
+            for i in 0..2 {
+                test::write_txt_file_to_path(
+                    test_path.join(format!("test_{i}.txt")),
+                    format!("test {i}"),
+                )?;
+            }
             repositories::add(&repo, &test_path).await?;
             repositories::commit(&repo, "Adding test dir")?;
 
             // Set the proper remote
             let remote = test::repo_remote_url_from(&repo.dirname());
             command::config::set_remote(&mut repo, constants::DEFAULT_REMOTE_NAME, &remote)?;
-
-            // Create Remote
             let remote_repo = test::create_remote_repo(&repo).await?;
-
-            // Push it
             repositories::push(&repo).await?;
 
-            // run another test with a new repo dir that we are going to sync to
+            let expected_files = util::fs::rcount_files_in_dir(&repo.path);
+
+            // Clone elsewhere and confirm all the committed files come back
             test::run_empty_dir_test_async(|new_repo_dir| async move {
                 let new_repo_dir = new_repo_dir.join("repoo");
                 let cloned_repo =
                     repositories::clone_url(&remote_repo.remote.url, &new_repo_dir).await?;
                 let cloned_num_files = util::fs::rcount_files_in_dir(&cloned_repo.path);
-                // 4 test, 7 train, 1 labels
-                assert_eq!(12, cloned_num_files);
+                assert_eq!(expected_files, cloned_num_files);
 
                 api::client::repositories::delete(&remote_repo).await?;
 
@@ -1260,9 +1279,10 @@ mod tests {
     #[tokio::test]
     /// `oxen pull` should always walks the merkle tree and re-fetch any missing blobs.
     async fn test_pull_re_fetches_missing_blobs() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_no_commits_async(|mut repo| async move {
+        test::run_empty_local_repo_test_async(|mut repo| async move {
             // Two commits on the remote so the cloned repo has somewhere to lag back to.
             let labels = repo.path.join("labels.txt");
+            test::write_txt_file_to_path(&labels, "first commit content")?;
             repositories::add(&repo, &labels).await?;
             let first_commit = repositories::commit(&repo, "First commit")?;
 
@@ -1460,27 +1480,40 @@ mod tests {
 
     #[tokio::test]
     async fn test_pull_full_commit_history() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_no_commits_async(|mut repo| async move {
+        test::run_empty_local_repo_test_async(|mut repo| async move {
             // First commit
-            let filename = "labels.txt";
-            let filepath = repo.path.join(filename);
+            let filepath = repo.path.join("labels.txt");
+            test::write_txt_file_to_path(&filepath, "label_a\nlabel_b")?;
             repositories::add(&repo, &filepath).await?;
             repositories::commit(&repo, "Adding labels file")?;
 
             // Second commit
-            let new_filename = "new.txt";
-            let new_filepath = repo.path.join(new_filename);
+            let new_filepath = repo.path.join("new.txt");
             util::fs::write_to_path(&new_filepath, "hallo")?;
             repositories::add(&repo, &new_filepath).await?;
             repositories::commit(&repo, "Adding a new file")?;
 
-            // Third commit
+            // Third commit: inline train dir
             let train_path = repo.path.join("train");
+            util::fs::create_dir_all(&train_path)?;
+            for i in 0..2 {
+                test::write_txt_file_to_path(
+                    train_path.join(format!("train_{i}.txt")),
+                    format!("train {i}"),
+                )?;
+            }
             repositories::add(&repo, &train_path).await?;
             repositories::commit(&repo, "Adding train dir")?;
 
-            // Fourth commit
+            // Fourth commit: inline test dir
             let test_path = repo.path.join("test");
+            util::fs::create_dir_all(&test_path)?;
+            for i in 0..2 {
+                test::write_txt_file_to_path(
+                    test_path.join(format!("test_{i}.txt")),
+                    format!("test {i}"),
+                )?;
+            }
             repositories::add(&repo, &test_path).await?;
             repositories::commit(&repo, "Adding test dir")?;
 


### PR DESCRIPTION
(stacked on #610)

Downgrade 7 `pull` tests off heavy training-data helpers to lighter helpers.

Measured results:
- Test count: 28 -> 28 (same)
- nextest wall-clock: 3.283s → 2.907s (−11%)
- Cumulative CPU: ~47.8s → ~42.7s (−11%)
- Slowest test: 3.033s → 2.460s (−19%)