### PR TITLE
S3 (17a2): Restore the multipart workspace file-staging endpoint

### DIFF
--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -225,7 +225,11 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
 
     let mut ret_files = vec![];
     for upload_file in upload_files {
-        let file_name = upload_file.path.file_name().unwrap();
+        let Some(file_name) = upload_file.path.file_name() else {
+            return Err(OxenHttpError::BadRequest(
+                format!("Invalid upload file path: {:?}", upload_file.path).into(),
+            ));
+        };
         let dst_path = PathBuf::from(&directory).join(file_name);
         let version_path = version_store.get_version_path(&upload_file.hash).await?;
 

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -5,18 +5,26 @@ use crate::params::{app_data, path_param};
 use liboxen::core;
 use liboxen::core::staged::get_staged_db_manager;
 use liboxen::error::OxenError;
+use liboxen::model::LocalRepository;
 use liboxen::model::merkle_tree::node::EMerkleTreeNode;
 use liboxen::model::metadata::metadata_image::ImgResize;
 use liboxen::model::metadata::metadata_video::VideoThumbnail;
 use liboxen::repositories;
 use liboxen::util;
+use liboxen::util::hasher;
 use liboxen::view::workspaces::RenameRequest;
 use liboxen::view::{
-    ErrorFilesResponse, FilePathsResponse, FileWithHash, StatusMessage, StatusMessageDescription,
+    ErrorFileInfo, ErrorFilesResponse, FilePathsResponse, FileWithHash, StatusMessage,
+    StatusMessageDescription,
 };
 
+use actix_multipart::Multipart;
+use actix_web::Error;
 use actix_web::{HttpRequest, HttpResponse, web};
+use flate2::read::GzDecoder;
+use futures_util::TryStreamExt as _;
 use serde::Deserialize;
+use std::io::Read as StdRead;
 use std::path::PathBuf;
 use std::sync::Arc;
 use utoipa;
@@ -167,6 +175,84 @@ pub async fn get(
     let stream = version_store.get_version_stream(&hash_str).await?;
 
     Ok(file_stream_response(mime_type, &last_commit_id, Some(num_bytes)).streaming(stream))
+}
+
+/// Add files to workspace
+#[utoipa::path(
+    post,
+    path = "/api/repos/{namespace}/{repo_name}/workspaces/{workspace_id}/files/{path}",
+    description = "Upload and stage files to a workspace. Accept a multipart with either gzipped or uncompressed file parts. Use the filename from the file part and compute the file hash from the content.",
+    tag = "Workspace Files",
+    params(
+        ("namespace" = String, Path, description = "The namespace of the repository", example = "ox"),
+        ("repo_name" = String, Path, description = "The name of the repository", example = "ImageNet-1k"),
+        ("workspace_id" = String, Path, description = "The UUID of the workspace", example = "580c0587-c157-417b-9118-8686d63d2745"),
+        ("path" = String, Path, description = "The target path to upload the file to", example = "data/train")
+    ),
+    request_body(
+        content_type = "multipart/form-data",
+        description = "Multipart upload of file. Each file should be sent as a separate file part",
+        content = FileUpload,
+    ),
+    responses(
+        (status = 200, description = "File successfully uploaded to workspace", body = FilePathsResponse),
+        (status = 404, description = "Workspace not found"),
+        (status = 400, description = "Invalid upload request")
+    )
+)]
+pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?.to_string();
+    let repo_name = path_param(&req, "repo_name")?.to_string();
+    let workspace_id = path_param(&req, "workspace_id")?.to_string();
+    let repo = get_repo(app_data, namespace, &repo_name)?;
+    let directory = path_param(&req, "path")?.to_string();
+
+    let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
+        return Ok(HttpResponse::NotFound()
+            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+    };
+
+    let version_store = repo.version_store();
+
+    let (upload_files, err_files, update_timestamp) = save_parts(payload, &repo).await?;
+    log::debug!("Save multiparts found {} err_files", err_files.len());
+    log::debug!(
+        "Calling add version files from the core workspace logic with {} files (update_timestamp: {})",
+        upload_files.len(),
+        update_timestamp,
+    );
+
+    let mut ret_files = vec![];
+    for upload_file in upload_files {
+        let file_name = upload_file.path.file_name().unwrap();
+        let dst_path = PathBuf::from(&directory).join(file_name);
+        let version_path = version_store.get_version_path(&upload_file.hash).await?;
+
+        let ret_file = match core::v_latest::workspaces::files::add_version_file(
+            &workspace,
+            &version_path,
+            &dst_path,
+            &upload_file.hash,
+            update_timestamp,
+        )
+        .await
+        {
+            Ok(ret_file) => ret_file,
+            Err(e) => {
+                log::error!("Error adding file {version_path:?}: {e:?}");
+                continue;
+            }
+        };
+
+        ret_files.push(ret_file);
+        log::info!("Successfully staged file {upload_file:?}");
+    }
+
+    Ok(HttpResponse::Ok().json(FilePathsResponse {
+        status: StatusMessage::resource_created(),
+        paths: ret_files,
+    }))
 }
 
 /// Stage files to workspace
@@ -387,6 +473,181 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))
 }
 
+// Read the payload files into memory, compute the hash, and save to version store
+// Unlike controllers::versions::save_multiparts, the hash must be computed here,
+// As this function expects the filename to be the file path, not the hash
+pub async fn save_parts(
+    mut payload: Multipart,
+    repo: &LocalRepository,
+) -> Result<(Vec<FileWithHash>, Vec<ErrorFileInfo>, bool), Error> {
+    // Receive a multipart request and save the files to the version store
+    let version_store = repo.version_store();
+    let gzip_mime: mime::Mime = "application/gzip".parse().unwrap();
+
+    let mut upload_files: Vec<FileWithHash> = vec![];
+    let mut err_files: Vec<ErrorFileInfo> = vec![];
+    let mut update_timestamp = false;
+
+    while let Some(mut field) = payload.try_next().await? {
+        let Some(content_disposition) = field.content_disposition().cloned() else {
+            continue;
+        };
+
+        if let Some(name) = content_disposition.get_name()
+            && name == "update_timestamp"
+        {
+            update_timestamp = parse_bool_field(&mut field).await?;
+            continue;
+        }
+
+        if let Some(name) = content_disposition.get_name()
+            && (name == "file[]" || name == "file")
+        {
+            // The file path is passed in as the filename
+            let upload_filename = content_disposition.get_filename().map_or_else(
+                || {
+                    Err(actix_web::error::ErrorBadRequest(
+                        "Missing hash in multipart request",
+                    ))
+                },
+                |fhash_os_str| Ok(fhash_os_str.to_string()),
+            )?;
+
+            let mut field_bytes = Vec::new();
+            while let Some(chunk) = field.try_next().await? {
+                field_bytes.extend_from_slice(&chunk);
+            }
+
+            let is_gzipped = field
+                .content_type()
+                .map(|mime| {
+                    mime.type_() == gzip_mime.type_() && mime.subtype() == gzip_mime.subtype()
+                })
+                .unwrap_or(false);
+
+            let upload_filename_copy = upload_filename.clone();
+
+            let (upload_filehash, data_to_store) =
+                match actix_web::web::block(move || -> Result<(String, Vec<u8>), OxenError> {
+                    if is_gzipped {
+                        log::debug!(
+                            "Decompressing gzipped data for file: {upload_filename_copy:?}"
+                        );
+
+                        // Decompress the data if it is gzipped
+                        let mut decoder = GzDecoder::new(&field_bytes[..]);
+                        let mut decompressed_bytes: Vec<u8> = Vec::new();
+                        decoder.read_to_end(&mut decompressed_bytes).map_err(|e| {
+                            OxenError::basic_str(format!("Failed to decompress gzipped data: {e}"))
+                        })?;
+
+                        // Hash file contents
+                        let hash = hasher::hash_buffer(&decompressed_bytes);
+
+                        Ok((hash, decompressed_bytes))
+                    } else {
+                        log::debug!("Data for file {upload_filename_copy:?} is not gzipped.");
+
+                        // Only hash file contents
+                        let hash = hasher::hash_buffer(&field_bytes);
+                        Ok((hash, field_bytes))
+                    }
+                })
+                .await
+                {
+                    Ok(Ok((hash, data))) => (hash, data),
+                    Ok(Err(e)) => {
+                        log::error!(
+                            "Failed to decompress data for file {}: {:?}",
+                            &upload_filename,
+                            e
+                        );
+                        record_error_file(
+                            &mut err_files,
+                            upload_filename.clone(),
+                            None,
+                            format!("Failed to decompress data: {e:?}"),
+                        );
+                        continue;
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "Failed to execute blocking decompression task for file {}: {}",
+                            &upload_filename,
+                            e
+                        );
+                        record_error_file(
+                            &mut err_files,
+                            upload_filename.clone(),
+                            None,
+                            format!("Failed to execute blocking decompression: {e}"),
+                        );
+                        continue;
+                    }
+                };
+
+            match version_store
+                .store_version(&upload_filehash, data_to_store.into())
+                .await
+            {
+                Ok(_) => {
+                    upload_files.push(FileWithHash {
+                        hash: upload_filehash.to_string(),
+                        path: upload_filename.into(),
+                    });
+                    log::info!("Successfully stored version for hash: {}", &upload_filehash);
+                }
+                Err(e) => {
+                    log::error!(
+                        "Failed to store version for hash {}: {}",
+                        &upload_filehash,
+                        e
+                    );
+                    record_error_file(
+                        &mut err_files,
+                        upload_filehash.clone(),
+                        None,
+                        format!("Failed to store version: {e}"),
+                    );
+                    continue;
+                }
+            }
+        }
+    }
+
+    Ok((upload_files, err_files, update_timestamp))
+}
+
+async fn parse_bool_field(field: &mut actix_multipart::Field) -> Result<bool, Error> {
+    let mut bytes = Vec::new();
+    while let Some(chunk) = field.try_next().await? {
+        bytes.extend_from_slice(&chunk);
+    }
+    let value = String::from_utf8_lossy(&bytes);
+    match value.as_ref() {
+        "true" | "1" => Ok(true),
+        "false" | "0" => Ok(false),
+        _ => Err(actix_web::error::ErrorBadRequest(format!(
+            "Invalid boolean value: {value}"
+        ))),
+    }
+}
+
+// Record the error file info for retry
+fn record_error_file(
+    err_files: &mut Vec<ErrorFileInfo>,
+    filehash: String,
+    filepath: Option<PathBuf>,
+    error: String,
+) {
+    let info = ErrorFileInfo {
+        hash: filehash,
+        path: filepath,
+        error,
+    };
+    err_files.push(info);
+}
+
 #[cfg(test)]
 mod tests {
     use crate::app_data::OxenAppData;
@@ -397,6 +658,11 @@ mod tests {
     use liboxen::error::OxenError;
     use liboxen::repositories;
     use liboxen::util;
+    use liboxen::view::FilePathsResponse;
+
+    use actix_multipart::test::create_form_data_payload_and_headers;
+    use actix_web::web::Bytes;
+    use mime;
 
     #[actix_web::test]
     async fn test_get_nonexistent_file_returns_404() -> Result<(), OxenError> {
@@ -485,6 +751,80 @@ mod tests {
                 .unwrap(),
             header::CONTENT_LENGTH.as_str()
         );
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_controllers_workspace_files_add_stages_multipart_upload() -> Result<(), OxenError>
+    {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Workspace-Add-Multipart";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        // Seed a commit so the workspace has a base commit
+        let hello_file = repo.path.join("hello.txt");
+        util::fs::write_to_path(&hello_file, "Hello")?;
+        repositories::add(&repo, &hello_file).await?;
+        let commit = repositories::commit(&repo, "First commit")?;
+
+        let workspace_id = uuid::Uuid::new_v4().to_string();
+        repositories::workspaces::create(&repo, &commit, &workspace_id, false)?;
+
+        // Upload a raw (uncompressed) file via multipart; the server hashes the content, stores it
+        // in the version store, and stages it. The form-data filename carries the destination path
+        // within the target directory ("data").
+        let file_content = "uploaded contents";
+        let (body, headers) = create_form_data_payload_and_headers(
+            "file[]",
+            Some("uploaded.txt".to_string()),
+            Some(mime::TEXT_PLAIN),
+            Bytes::from(file_content),
+        );
+
+        let uri = format!("/oxen/{namespace}/{repo_name}/workspaces/{workspace_id}/files/data");
+
+        let req = actix_web::test::TestRequest::post()
+            .uri(&uri)
+            .app_data(OxenAppData::new(sync_dir.to_path_buf()));
+        let req = headers
+            .into_iter()
+            .fold(req, |req, hdr| req.insert_header(hdr))
+            .set_payload(body)
+            .to_request();
+
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.clone()))
+                .route(
+                    "/oxen/{namespace}/{repo_name}/workspaces/{workspace_id}/files/{path:.*}",
+                    web::post().to(controllers::workspaces::files::add),
+                ),
+        )
+        .await;
+
+        let resp = actix_web::test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+
+        let bytes = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let response: FilePathsResponse = serde_json::from_slice(&bytes)?;
+        assert_eq!(response.status.status, "success");
+        assert!(
+            response
+                .paths
+                .iter()
+                .any(|p| p.file_name().and_then(|f| f.to_str()) == Some("uploaded.txt")),
+            "expected a staged path ending in uploaded.txt, got {:?}",
+            response.paths
+        );
+
+        // The server computed the content hash and stored the blob in the version store.
+        let file_hash = util::hasher::hash_buffer(file_content.as_bytes());
+        let stored = repo.version_store().get_version(&file_hash).await?;
+        assert_eq!(stored, file_content.as_bytes());
 
         test::cleanup_sync_dir(&sync_dir)?;
         Ok(())

--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -143,6 +143,7 @@ const START_SERVER_USAGE: &str = "Usage: `oxen-server start -i 0.0.0.0 -p 3000`"
         crate::controllers::workspaces::changes::unstage_many,
         // Workspaces - files
         crate::controllers::workspaces::files::get,
+        crate::controllers::workspaces::files::add,
         crate::controllers::workspaces::files::add_version_files,
         crate::controllers::workspaces::files::rm_files,
         // Branches

--- a/crates/oxen-server/src/services/workspaces.rs
+++ b/crates/oxen-server/src/services/workspaces.rs
@@ -55,6 +55,10 @@ pub fn workspace() -> Scope {
                     web::get().to(controllers::workspaces::files::get),
                 )
                 .route(
+                    "/files/{path:.*}",
+                    web::post().to(controllers::workspaces::files::add),
+                )
+                .route(
                     "/files",
                     web::delete().to(controllers::workspaces::files::rm_files),
                 )


### PR DESCRIPTION
(Based off of discussion with Josh at the Herd House)

#608 consolidated the workspace upload paths and removed the single-multipart server endpoint (POST /workspaces/{id}/files/{path} -> save_parts) along with its client helper. But the web UI needed that upload path, and Josh pointed out that we preferred multipart uploads and server-side metadata calculation (since we don't want to re-implement that in the browser path), so we went the wrong direction in the last PR.

This PR restores just the second server-side endpoint just as it was so the browser can stage again, and restores test coverage.

The client-side consolidation from #608 (`upload_single_file` routing, the `add_bytes` Python sugar) is left untouched and `p_upload_single_file` stays deleted.

I plan to make another run at merging the two server workspace file staging endpoints, but next time we'll:
- use multipart upload
- compute the metadata on the server side

Closes ENG-1110