### PR TITLE
S3 (17c): Add VersionStore::materialize

### DIFF
--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -1,4 +1,3 @@
-use async_tempfile::TempFile;
 use duckdb::Connection;
 
 use crate::constants::{DIFF_HASH_COL, DIFF_STATUS_COL, EXCLUDE_OXEN_COLS, TABLE_NAME};
@@ -17,7 +16,6 @@ use crate::model::{
     Commit, EntryDataType, LocalRepository, MerkleHash, StagedEntryStatus, Workspace,
 };
 use crate::repositories;
-use crate::storage::version_store::VersionLocation;
 use crate::{error::OxenError, util};
 use std::path::{Path, PathBuf};
 
@@ -144,24 +142,11 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     let version_store = repo.version_store();
     let hash_str = file_hash.to_string();
 
-    // DuckDB's `read_*()` can only ingest a local filesystem path. Local stores expose the
-    // on-disk version file directly (zero copy); S3 streams the object to a temp file kept alive
-    // until indexing finishes (RAII cleanup on drop). The temp file is created in the workspace's
-    // DuckDB directory (`parent`) rather than the OS temp dir: that directory lives on the
-    // oxen-server data volume, which is sized to hold version files, whereas `/tmp` may be tiny.
-    let (version_path, _temp_file) = match version_store.version_location(&hash_str).await? {
-        VersionLocation::Local(path) => (path, None),
-        VersionLocation::S3 { .. } => {
-            let temp = TempFile::new_in(parent)
-                .await
-                .map_err(|e| OxenError::basic_str(format!("Failed to create temp file: {e}")))?;
-            let temp_path = temp.file_path().to_path_buf();
-            version_store
-                .copy_version_to_path(&hash_str, &temp_path)
-                .await?;
-            (temp_path, Some(temp))
-        }
-    };
+    // DuckDB's `read_*()` can only ingest a local filesystem path, so materialize the version file.
+    // The guard `version_file` is held on the async side (its drop runs after the blocking index
+    // below) so a materialized S3 temp outlives the read; the closure takes a plain path copy.
+    let version_file = version_store.materialize(&hash_str, parent).await?;
+    let version_path = version_file.to_pathbuf();
 
     log::debug!(
         "core::v_latest::index::workspaces::data_frames::index({path:?}) got version path: {version_path:?}"
@@ -176,7 +161,7 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
 
     // DuckDB indexing is blocking file IO plus a full parse, so run it off the async runtime per
     // the sync-core / async-edge policy. The DuckDB connection lives entirely inside the closure
-    // (it never crosses an `.await`), and `_temp_file` is held on the async side until the
+    // (it never crosses an `.await`), and `version_file` is held on the async side until the
     // blocking work finishes, so a materialized S3 temp file outlives the read.
     tokio::task::spawn_blocking(move || {
         with_df_db_manager(&db_path, |manager| {

--- a/crates/liboxen/src/core/v_latest/workspaces/files.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/files.rs
@@ -68,20 +68,23 @@ pub async fn rm(
 
 pub async fn add_version_file(
     workspace: &Workspace,
-    version_path: impl AsRef<Path>,
     dst_path: impl AsRef<Path>,
     file_hash: &str,
 ) -> Result<PathBuf, OxenError> {
-    // version_path is where the file is stored, dst_path is the relative path to the repo
-    // let version_path = version_path.as_ref();
     let dst_path = dst_path.as_ref();
-    // let workspace_repo = &workspace.workspace_repo;
-    // let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
+
+    // Materialize the version blob so the staging metadata computation has a local file to read.
+    // The returned guard cleans up any temp file once staging has read it.
+    let version_path = workspace
+        .base_repo
+        .version_store()
+        .materialize(file_hash, &workspace.dir())
+        .await?;
 
     let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
     stage_file_with_hash(
         workspace,
-        version_path.as_ref(),
+        &version_path,
         dst_path,
         file_hash,
         &staged_db_manager,
@@ -106,9 +109,11 @@ pub async fn add_version_files(
 
     let mut err_files: Vec<ErrorFileInfo> = vec![];
     let staged_db_manager = get_staged_db_manager(workspace_repo)?;
+    let dir = workspace.dir();
     for item in files_with_hash.iter() {
         let target_path = PathBuf::from(directory).join(&item.path);
-        let version_path = match version_store.get_version_path(&item.hash).await {
+        // The returned guard keeps any S3-materialized temp file alive until staging reads it below.
+        let version_path = match version_store.materialize(&item.hash, &dir).await {
             Ok(path) => path,
             Err(e) => {
                 let error = format!("Failed to resolve version path: {e}");

--- a/crates/liboxen/src/storage/version_store.rs
+++ b/crates/liboxen/src/storage/version_store.rs
@@ -20,9 +20,9 @@ use crate::view::versions::CleanCorruptedVersionsResult;
 
 /// A local filesystem path to a version file.
 ///
-/// The path is guaranteed to be readable on the local filesystem, but callers must NOT assume it is
+/// The path is guaranteed to be readable on the local filesystem, but callers MUST NOT assume it is
 /// stable: non-local backends (e.g. S3) materialize the file into a temporary location that is
-/// cleaned up when this value is dropped.
+/// cleaned up when this value is dropped. Callers must treat the file as read-only.
 ///
 /// - Implements `Deref<Target = Path>` so that `&LocalFilePath` can be passed directly to any
 ///   function that accepts `&Path`.
@@ -31,9 +31,12 @@ use crate::view::versions::CleanCorruptedVersionsResult;
 ///
 /// TODO: See how many of our own functions can be updated to accept LocalFilePath directly. Perhaps we can remove the need for `AsRef<Path>`.
 pub enum LocalFilePath {
-    /// A stable path (e.g. from `LocalVersionStore`) that outlives this value.
+    /// A stable path (e.g. from `LocalVersionStore`) that outlives this value. It points at the
+    /// blob inside the content-addressed version store, so callers must treat it as read-only:
+    /// mutating it corrupts the stored content for every reference to that hash.
     Stable(PathBuf),
-    /// A temporary file that is deleted when this value is dropped.
+    /// A temporary file that is deleted when this value is dropped. Callers must treat it as
+    /// read-only.
     Temp(async_tempfile::TempFile),
 }
 
@@ -337,6 +340,11 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// **Callers must keep the returned value alive for as long as they use the
     /// path.**
     ///
+    /// **The returned file is read-only: callers MUST NOT alter it in any way.** For local stores
+    /// the path points straight at the blob inside the content-addressed version store, so mutating
+    /// it corrupts that blob for every reference to `hash` (its bytes would no longer match its
+    /// content hash). Copy the file elsewhere first if you need a mutable version.
+    ///
     /// # Arguments
     /// * `hash` - The content hash of the version file to retrieve
     async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError>;
@@ -363,6 +371,49 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// * `hash` - The content hash of the version to retrieve
     /// * `dest_path` - Destination path to copy the file to
     async fn copy_version_to_path(&self, hash: &str, dest_path: &Path) -> Result<(), OxenError>;
+
+    /// Materialize the version file for `hash` to a readable local path, placing any temporary
+    /// copy under `dir`.
+    ///
+    /// **Use this only when you need direct read access to a version file's bytes through a
+    /// filesystem path** — typically an external library that takes a path and only reads from it
+    /// (e.g. DuckDB `read_*`, an ffmpeg invocation). For remote stores it forces a full local copy
+    /// (network download plus a disk write on the data volume), so it is the most expensive way to
+    /// reach the data. Under any other condition, find a cheaper path: read via
+    /// [`Self::version_location`] with a cloud-aware reader (Polars `scan_*` with `CloudOptions`,
+    /// DuckDB `httpfs`) or stream the bytes — and if an internal caller only takes a `&Path` just to
+    /// read the file, prefer refactoring it to accept a `Read` handle (or `version_location`)
+    /// rather than reaching for `materialize`.
+    ///
+    /// Local-backed stores return the on-disk version path directly (zero copy); remote stores
+    /// (e.g. S3) stream the object into a temp file under `dir`, carried alive by the returned
+    /// [`LocalFilePath::Temp`] guard. `dir` must live on the data volume, not the OS temp dir, so
+    /// large blobs cannot exhaust a small `/tmp`.
+    ///
+    /// **The returned file is read-only: callers MUST NOT alter it in any way.** For local stores
+    /// the path points straight at the blob inside the content-addressed version store, so mutating
+    /// it corrupts that blob for every reference to `hash` (its bytes would no longer match its
+    /// content hash). Copy the file elsewhere first if you need a mutable version.
+    ///
+    /// Prefer this over [`Self::get_version_path`], which always writes to the OS temp dir and
+    /// buffers the whole blob in memory.
+    ///
+    /// # Arguments
+    /// * `hash` - The content hash of the version file
+    /// * `dir` - Directory on the data volume to hold any temporary copy
+    async fn materialize(&self, hash: &str, dir: &Path) -> Result<LocalFilePath, OxenError> {
+        match self.version_location(hash).await? {
+            VersionLocation::Local(path) => Ok(LocalFilePath::Stable(path)),
+            VersionLocation::S3 { .. } => {
+                util::fs::create_dir_all(dir)?;
+                let temp = async_tempfile::TempFile::new_in(dir).await.map_err(|e| {
+                    OxenError::basic_str(format!("Failed to create temp file: {e}"))
+                })?;
+                self.copy_version_to_path(hash, temp.file_path()).await?;
+                Ok(LocalFilePath::Temp(temp))
+            }
+        }
+    }
 
     /// Check if a version exists
     ///

--- a/crates/oxen-server/src/controllers/versions/chunks.rs
+++ b/crates/oxen-server/src/controllers/versions/chunks.rs
@@ -112,20 +112,14 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
                     "Workspace not found: {workspace_id}"
                 ))));
             };
-            let version_path = version_store.get_version_path(&version_id).await?;
             let dst_path = if let Some(dst_dir) = &file.dst_dir {
                 dst_dir.join(file.file_name.clone())
             } else {
                 PathBuf::from(file.file_name.clone())
             };
 
-            core::v_latest::workspaces::files::add_version_file(
-                &workspace,
-                &*version_path,
-                &dst_path,
-                &version_id,
-            )
-            .await?;
+            core::v_latest::workspaces::files::add_version_file(&workspace, &dst_path, &version_id)
+                .await?;
         }
 
         return Ok(HttpResponse::Ok().json(StatusMessage::resource_found()));

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -207,8 +207,6 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
     };
 
-    let version_store = repo.version_store();
-
     let (upload_files, err_files) = save_parts(payload, &repo).await?;
     log::debug!("Save multiparts found {} err_files", err_files.len());
     log::debug!(
@@ -224,11 +222,9 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
             ));
         };
         let dst_path = PathBuf::from(&directory).join(file_name);
-        let version_path = version_store.get_version_path(&upload_file.hash).await?;
 
         let ret_file = match core::v_latest::workspaces::files::add_version_file(
             &workspace,
-            &version_path,
             &dst_path,
             &upload_file.hash,
         )
@@ -236,7 +232,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
         {
             Ok(ret_file) => ret_file,
             Err(e) => {
-                log::error!("Error adding file {version_path:?}: {e:?}");
+                log::error!("Error adding file {dst_path:?}: {e:?}");
                 continue;
             }
         };


### PR DESCRIPTION
A few things like workspace staging and DuckDB tabular indexing need an actual local file to read, since we use libraries that take file names rather than file handles. We're switching away from `VersionStore::get_version_path` that had the implicit assumption that files were always on disk, to a new method that ensures there is a local file on disk (though it may be a temp file downloaded from S3).

The new method is `VersionStore::materialize(hash, dir) -> LocalFilePath`. Since the behavior is exactly the same between S3 and local implementations, it is implemented as a default trait method. It calls the `version_location` method internally and returns the on-disk path, which is the existing version store file for local stores a temp file on the data volume for S3 stores. The returned `LocalFilePath::Temp` guard cleans up the temp on drop.

We also update three places to use the new `materialize` method, instead of manually doing their own handling of the situation.

We'll migrate the remaining places in the next PR.

Closes ENG-1070