### PR TITLE
Merkle Revert (9): Revert #516 refactor to Packer/Unpacker

### DIFF
--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1,15 +1,21 @@
 use bytesize::ByteSize;
+use flate2::Compression;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
 use std::any::type_name_of_val;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::str;
+use tar::Archive;
 
+use crate::constants::{NODES_DIR, OXEN_HIDDEN_DIR, TREE_DIR};
+use crate::core::db::merkle_node::merkle_node_db::node_db_path;
 use crate::core::node_sync_status;
 use crate::core::v_latest::index::CommitMerkleTree as CommitMerkleTreeLatest;
 use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_old::v0_19_0::index::CommitMerkleTree as CommitMerkleTreeV0_19_0;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::merkle_tree::merkle_transport::UnpackOptions;
 use crate::model::merkle_tree::merkle_writer::MerkleWriteSession;
 use crate::model::merkle_tree::node::{
     CommitNode, DirNodeWithPath, EMerkleTreeNode, FileNode, FileNodeWithDir, MerkleTreeNode,
@@ -835,24 +841,180 @@ pub fn cp_dir_hashes_to(
 }
 
 pub fn compress_tree(repository: &LocalRepository) -> Result<Vec<u8>, OxenError> {
-    let mut buf = Vec::new();
-    repository.merkle_store().pack_all(&mut buf)?;
-    let total_size: u64 = u64::try_from(buf.len()).unwrap_or(u64::MAX);
+    let enc = GzEncoder::new(Vec::new(), Compression::fast());
+    let mut tar = tar::Builder::new(enc);
+    compress_full_tree(repository, &mut tar)?;
+    tar.finish()?;
+
+    let buffer: Vec<u8> = tar.into_inner()?.finish()?;
+    let total_size: u64 = u64::try_from(buffer.len()).unwrap_or(u64::MAX);
+
     log::debug!("Compressed entire tree size is {}", ByteSize::b(total_size));
-    Ok(buf)
+
+    Ok(buffer)
+}
+
+pub fn compress_full_tree(
+    repository: &LocalRepository,
+    tar: &mut tar::Builder<GzEncoder<Vec<u8>>>,
+) -> Result<(), OxenError> {
+    // This will be the subdir within the tarball,
+    // so when we untar it, all the subdirs will be extracted to
+    // tree/nodes/...
+    let tar_subdir = Path::new(TREE_DIR).join(NODES_DIR);
+    let nodes_dir = repository
+        .path
+        .join(OXEN_HIDDEN_DIR)
+        .join(TREE_DIR)
+        .join(NODES_DIR);
+
+    log::debug!("Compressing tree in dir {nodes_dir:?}");
+
+    if nodes_dir.exists() {
+        tar.append_dir_all(&tar_subdir, nodes_dir)?;
+    }
+
+    Ok(())
+}
+
+pub fn compress_nodes(
+    repository: &LocalRepository,
+    hashes: &HashSet<MerkleHash>,
+) -> Result<Vec<u8>, OxenError> {
+    // zip up the node directories for each commit tree
+    let enc = GzEncoder::new(Vec::new(), Compression::fast());
+    let mut tar = tar::Builder::new(enc);
+
+    log::debug!("Compressing {} unique nodes...", hashes.len());
+    for hash in hashes {
+        // This will be the subdir within the tarball
+        // so when we untar it, all the subdirs will be extracted to
+        // tree/nodes/...
+        let dir_prefix = hash.to_hex_hash().node_db_prefix();
+        let tar_subdir = Path::new(TREE_DIR).join(NODES_DIR).join(dir_prefix);
+
+        let node_dir = node_db_path(&repository.path, hash);
+        // log::debug!("Compressing node from dir {:?}", node_dir);
+        if node_dir.exists() {
+            tar.append_dir_all(&tar_subdir, node_dir)?;
+        }
+    }
+    tar.finish()?;
+
+    let buffer: Vec<u8> = tar.into_inner()?.finish()?;
+    Ok(buffer)
+}
+
+pub fn compress_node(
+    repository: &LocalRepository,
+    hash: &MerkleHash,
+) -> Result<Vec<u8>, OxenError> {
+    // This will be the subdir within the tarball
+    // so when we untar it, all the subdirs will be extracted to
+    // tree/nodes/...
+    let dir_prefix = hash.to_hex_hash().node_db_prefix();
+    let tar_subdir = Path::new(TREE_DIR).join(NODES_DIR).join(dir_prefix);
+
+    // zip up the node directory
+    let enc = GzEncoder::new(Vec::new(), Compression::fast());
+    let mut tar = tar::Builder::new(enc);
+    let node_dir = node_db_path(&repository.path, hash);
+
+    // log::debug!("Compressing node {} from dir {:?}", hash, node_dir);
+    if node_dir.exists() {
+        tar.append_dir_all(&tar_subdir, node_dir)?;
+    }
+    tar.finish()?;
+
+    let buffer: Vec<u8> = tar.into_inner()?.finish()?;
+    let total_size: u64 = u64::try_from(buffer.len()).unwrap_or(u64::MAX);
+    log::debug!(
+        "Compressed node {} size is {}",
+        hash,
+        ByteSize::b(total_size)
+    );
+
+    Ok(buffer)
+}
+
+pub fn compress_commits(
+    repository: &LocalRepository,
+    commits: &Vec<Commit>,
+) -> Result<Vec<u8>, OxenError> {
+    // zip up the node directory
+    let enc = GzEncoder::new(Vec::new(), Compression::fast());
+    let mut tar = tar::Builder::new(enc);
+
+    for commit in commits {
+        let hash = commit.hash()?;
+        // This will be the subdir within the tarball
+        // so when we untar it, all the subdirs will be extracted to
+        // tree/nodes/...
+        let dir_prefix = hash.to_hex_hash().node_db_prefix();
+        let tar_subdir = Path::new(TREE_DIR).join(NODES_DIR).join(dir_prefix);
+
+        let node_dir = node_db_path(&repository.path, &hash);
+        log::debug!("Compressing commit from dir {node_dir:?}");
+        if node_dir.exists() {
+            tar.append_dir_all(&tar_subdir, node_dir)?;
+        }
+    }
+    tar.finish()?;
+
+    let buffer: Vec<u8> = tar.into_inner()?.finish()?;
+    Ok(buffer)
 }
 
 pub fn unpack_nodes(
     repository: &LocalRepository,
     buffer: &[u8],
 ) -> Result<HashSet<MerkleHash>, OxenError> {
-    log::debug!("Unpacking nodes from buffer ({} bytes)", buffer.len());
-    // `&[u8]` doesn't auto-coerce to `&mut dyn Read`, so we hand the unpacker
-    // a `&mut` over a fresh slice cursor that advances as bytes are consumed.
-    let mut reader: &[u8] = buffer;
-    repository
-        .merkle_store()
-        .unpack(&mut reader, UnpackOptions::SkipExisting)
+    let mut hashes: HashSet<MerkleHash> = HashSet::new();
+    log::debug!("Unpacking nodes from buffer...");
+    let decoder = GzDecoder::new(buffer);
+    log::debug!("Decoder created");
+    let mut archive = Archive::new(decoder);
+    log::debug!("Archive created");
+    let Ok(entries) = archive.entries() else {
+        return Err(OxenError::basic_str(
+            "Could not unpack tree database from archive",
+        ));
+    };
+    log::debug!("Extracting entries...");
+    for file in entries {
+        let Ok(mut file) = file else {
+            log::error!("Could not unpack file in archive...");
+            continue;
+        };
+        let path = file.path().unwrap();
+        let oxen_hidden_path = repository.path.join(OXEN_HIDDEN_DIR);
+        let dst_path = oxen_hidden_path.join(TREE_DIR).join(NODES_DIR).join(path);
+
+        if let Some(parent) = dst_path.parent() {
+            util::fs::create_dir_all(parent).expect("Could not create parent dir");
+        }
+        // log::debug!("create_node writing {:?}", dst_path);
+        if dst_path.exists() {
+            log::debug!("Node already exists at {dst_path:?}");
+            continue;
+        }
+        file.unpack(&dst_path)?;
+
+        // the hash is the last two path components combined
+        if !dst_path.ends_with("node") && !dst_path.ends_with("children") {
+            let id = dst_path
+                .components()
+                .rev()
+                .take(2)
+                .map(|c| c.as_os_str().to_str().unwrap())
+                .collect::<Vec<&str>>()
+                .into_iter()
+                .rev()
+                .collect::<String>();
+            hashes.insert(id.parse()?);
+        }
+    }
+    Ok(hashes)
 }
 
 /// Write a node to disk

--- a/crates/oxen-server/src/controllers/tree.rs
+++ b/crates/oxen-server/src/controllers/tree.rs
@@ -5,13 +5,11 @@ use liboxen::core::node_sync_status;
 use liboxen::error::OxenError;
 use liboxen::model::Commit;
 use liboxen::model::LocalRepository;
-use liboxen::model::merkle_tree::PackOptions;
 use liboxen::view::MerkleHashesResponse;
 use liboxen::view::StatusMessage;
 use liboxen::view::tree::MerkleHashResponse;
 use liboxen::view::tree::merkle_hashes::MerkleHashes;
 
-use std::collections::HashSet;
 use std::path::PathBuf;
 
 use liboxen::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
@@ -271,16 +269,7 @@ pub async fn download_tree_nodes(
         )?
     };
 
-    let buffer = {
-        let mut buffer = Vec::new();
-        repository.merkle_store().pack_nodes(
-            &node_hashes,
-            PackOptions::ServerCanonical,
-            &mut buffer,
-        )?;
-        buffer
-    };
-
+    let buffer = repositories::tree::compress_nodes(&repository, &node_hashes)?;
     let total_size: u64 = u64::try_from(buffer.len()).unwrap_or(u64::MAX);
     log::debug!(
         "Compressed {} commits size is {}",
@@ -328,15 +317,7 @@ pub async fn download_node(req: HttpRequest) -> actix_web::Result<HttpResponse, 
     let hash = hash_str.parse()?;
     let repository = get_repo(app_data, namespace, name)?;
 
-    let buffer = {
-        let mut buffer = Vec::new();
-        repository.merkle_store().pack_nodes(
-            &HashSet::from_iter([hash]),
-            PackOptions::ServerCanonical,
-            &mut buffer,
-        )?;
-        buffer
-    };
+    let buffer = repositories::tree::compress_node(&repository, &hash)?;
 
     Ok(HttpResponse::Ok().body(buffer))
 }


### PR DESCRIPTION
Revert #516 as part of backing out our first Merkle tree redesign attempt (9 of 15). We're planning a simpler approach for the next attempt.

Things that we didn't revert from the original PR:
- The streaming merkle-node push/download scaffold in `api/client/tree.rs` (`CountingWriter`, `tokio::io::duplex`, `spawn_blocking` pack, `ReaderStream`/`SyncIoBridge`). Why: it streams the pack/unpack so the hot push/pull path never buffers the whole tar archive (plus a copy) in memory.
- `PushProgress`/`SyncProgress::inc_total_bytes`. Why: a self-contained progress-bar helper with no merkle coupling that lets the scaffold layer node bytes onto the bar for an accurate ETA.
- The `OxenError::JoinError { context, cause }` struct variant. Why: it lets a joined-task panic carry a context string and is relied on independently outside the merkle code (e.g. `fsck.rs`).

ENG-1138