### PR TITLE
S3 (19): Migrate large-file push upload off `get_version_path`

### DIFF
--- a/crates/liboxen/src/core/v_latest/push.rs
+++ b/crates/liboxen/src/core/v_latest/push.rs
@@ -16,6 +16,7 @@ use crate::model::{
 };
 
 use crate::opts::PushOpts;
+use crate::storage::VersionLocation;
 use crate::util::concurrency;
 use crate::{api, repositories};
 
@@ -652,10 +653,23 @@ async fn chunk_and_send_large_entries(
                     break;
                 };
 
-                let version_path = match version_store.get_version_path(&commit_entry.hash).await {
+                // Client push runs against the local repo store; a non-local store is unreachable
+                // here (the CLI has no S3 backend), so resolve the on-disk path and surface a
+                // non-local store as an error rather than fetching it.
+                let version_path = version_store
+                    .version_location(&commit_entry.hash)
+                    .await
+                    .and_then(|location| match location {
+                        VersionLocation::Local(path) => Ok(path),
+                        _ => Err(OxenError::internal_error(format!(
+                            "client push requires a local version store for {}",
+                            commit_entry.hash
+                        ))),
+                    });
+                let version_path = match version_path {
                     Ok(path) => path,
                     Err(e) => {
-                        log::error!("Failed to get version path: {e}");
+                        log::error!("Failed to resolve local version path: {e}");
                         should_stop.store(true, Ordering::Relaxed);
                         *first_error.lock().await = Some(e.to_string());
                         break;

--- a/crates/liboxen/src/storage/version_store.rs
+++ b/crates/liboxen/src/storage/version_store.rs
@@ -361,6 +361,11 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// materializes the entire version file to a temp file on S3, which is fine for small
     /// files but OOMs at the multi-GB scale customers care about.
     ///
+    /// Also reach for it instead of [`Self::materialize`] when the caller only ever runs against a
+    /// local store (e.g. client/CLI paths, which hold no S3 backend): match
+    /// [`VersionLocation::Local`] for the path and return an error for any other backend, so an
+    /// unexpected non-local store fails loudly rather than triggering a silent download.
+    ///
     /// # Arguments
     /// * `hash` - The content hash of the version file
     async fn version_location(&self, hash: &str) -> Result<VersionLocation, OxenError>;
@@ -383,7 +388,10 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// [`Self::version_location`] with a cloud-aware reader (Polars `scan_*` with `CloudOptions`,
     /// DuckDB `httpfs`) or stream the bytes — and if an internal caller only takes a `&Path` just to
     /// read the file, prefer refactoring it to accept a `Read` handle (or `version_location`)
-    /// rather than reaching for `materialize`.
+    /// rather than reaching for `materialize`. And for a caller that can never run against a remote
+    /// store (client/CLI-only paths), prefer [`Self::version_location`] and the
+    /// [`VersionLocation::Local`] path with an explicit error on any non-local store: `materialize`
+    /// would otherwise silently download on a backend that is supposed to be unreachable there.
     ///
     /// Local-backed stores return the on-disk version path directly (zero copy); remote stores
     /// (e.g. S3) stream the object into a temp file under `dir`, carried alive by the returned


### PR DESCRIPTION
(Stacks on #637)

Stop using the deprecated `get_version_path` in the large-file push path. Instead, use `version_location`.

Also document this approach on the `VersionStore` trait so future migrations pick correctly: `version_location` + an error on a non-local store for client-only paths, vs `materialize` for server / S3-reachable paths.