### PR TITLE
S3 (20): Migrate video thumbnail generation off get_version_path

### DIFF
--- a/crates/liboxen/src/util/fs.rs
+++ b/crates/liboxen/src/util/fs.rs
@@ -1825,6 +1825,7 @@ async fn generate_video_thumbnail_version_store(
     video_hash: &str,
     derived_filename: &str,
     thumbnail: VideoThumbnail,
+    dir: &Path,
 ) -> Result<(), OxenError> {
     log::debug!(
         "generate thumbnail derived_filename {derived_filename} from video hash {video_hash}"
@@ -1836,8 +1837,11 @@ async fn generate_video_thumbnail_version_store(
         return Ok(());
     }
 
-    // Get the video file path from version store
-    let version_path = version_store.get_version_path(video_hash).await?;
+    // The thumbnails crate reads from a filesystem path, so materialize the video file. The guard
+    // `version_file` is held on the async side (its drop runs after the blocking generation below)
+    // so a materialized S3 temp outlives the read; the closure takes a plain path copy.
+    let version_file = version_store.materialize(video_hash, dir).await?;
+    let version_path = version_file.to_pathbuf();
 
     // Determine output dimensions
     // The thumbnails crate maintains aspect ratio, so we use max dimensions
@@ -1887,10 +1891,11 @@ pub async fn handle_video_thumbnail(
     version_store: Arc<dyn VersionStore>,
     file_hash: String,
     video_thumbnail: VideoThumbnail,
+    dir: &Path,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>, OxenError> {
     #[cfg(not(feature = "ffmpeg"))]
     {
-        let _ = (version_store, file_hash, video_thumbnail);
+        let _ = (version_store, file_hash, video_thumbnail, dir);
         Err(OxenError::ThumbnailingNotEnabled)
     }
 
@@ -1908,6 +1913,7 @@ pub async fn handle_video_thumbnail(
             &file_hash,
             &derived_filename,
             video_thumbnail,
+            dir,
         )
         .await?;
 

--- a/crates/oxen-server/src/controllers/file.rs
+++ b/crates/oxen-server/src/controllers/file.rs
@@ -215,9 +215,14 @@ pub async fn get(
         };
         log::debug!("video_thumbnail {video_thumbnail:?}");
 
-        let stream =
-            util::fs::handle_video_thumbnail(Arc::clone(&version_store), hash_str, video_thumbnail)
-                .await?;
+        let tmp_dir = util::fs::oxen_hidden_dir(&repo.path).join("tmp");
+        let stream = util::fs::handle_video_thumbnail(
+            Arc::clone(&version_store),
+            hash_str,
+            video_thumbnail,
+            &tmp_dir,
+        )
+        .await?;
 
         return Ok(file_stream_response("image/jpeg", &last_commit_id, None).streaming(stream));
     }

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -162,9 +162,13 @@ pub async fn get(
         };
         log::debug!("video_thumbnail {video_thumbnail:?}");
 
-        let stream =
-            util::fs::handle_video_thumbnail(Arc::clone(&version_store), hash_str, video_thumbnail)
-                .await?;
+        let stream = util::fs::handle_video_thumbnail(
+            Arc::clone(&version_store),
+            hash_str,
+            video_thumbnail,
+            &workspace.dir(),
+        )
+        .await?;
 
         return Ok(file_stream_response("image/jpeg", &last_commit_id, None).streaming(stream));
     }


### PR DESCRIPTION
(Stacked on #639)

Stop using `get_version_path` on the server-side video thumbnail path. This time, we can use `materialize`, since the consumer needs a file on disk.

Part of ENG-1090.