### PR TITLE
Merkle Revert (11): Revert #514 MerkleTransport trait

### DIFF
--- a/crates/liboxen/src/api/client/tree.rs
+++ b/crates/liboxen/src/api/client/tree.rs
@@ -363,10 +363,10 @@ pub async fn download_trees_between(
 }
 
 /// Download a merkle-tree tarball from the remote repository and unpack it into the
-/// local store. Streams the response body straight into the `MerkleUnpacker` so nothing
+/// local store. Streams the response body straight into the unpacker so nothing
 /// buffers the whole payload in memory.
 ///
-/// The VFS branch is preserved but no longer lives here: `FileBackend::unpack` handles
+/// The VFS branch is preserved but no longer lives here: the `unpack` free function handles
 /// the `is_vfs` case internally (tempdir + `copy_dir_all` dance). That keeps the client
 /// logic generic across backends.
 async fn node_download_request(

--- a/crates/liboxen/src/core/db/merkle_node/file_backend.rs
+++ b/crates/liboxen/src/core/db/merkle_node/file_backend.rs
@@ -589,8 +589,7 @@ mod tests {
     //
     // Retained for reference during review; never called at runtime.
     // These functions preserve the existing Merkle tree operations (both reading, writing,
-    // and tree packing & unpacking) **before** the refactor to use these MerkleStore and
-    // MerkleTransport traits.
+    // and tree packing & unpacking) **before** the refactor to use the MerkleStore trait.
     //
     // Tests use these here to ensure that we're backwards compatible and that older clients
     // and servers are inoperable with their newer counterparts.
@@ -1132,7 +1131,7 @@ mod tests {
             assert_eq!(
                 old_tree, new_tree,
                 "on-disk merkle node trees differ between old node_download_request \
-                 unpack and new MerkleUnpacker::unpack"
+                 unpack and new unpack"
             );
 
             // 2. Every installed hash must be readable through the new store.

--- a/crates/liboxen/src/model/merkle_tree.rs
+++ b/crates/liboxen/src/model/merkle_tree.rs
@@ -7,9 +7,7 @@ pub mod node_type;
 
 pub use crate::model::merkle_tree::merkle_hash::MerkleHash;
 pub use crate::model::merkle_tree::merkle_reader::MerkleReader;
-pub use crate::model::merkle_tree::merkle_transport::{
-    MerklePacker, MerkleTransport, MerkleUnpacker, PackOptions, UnpackOptions,
-};
+pub use crate::model::merkle_tree::merkle_transport::{PackOptions, UnpackOptions};
 pub use crate::model::merkle_tree::merkle_writer::MerkleWriter;
 pub use crate::model::merkle_tree::node::merkle_tree_node_cache;
 pub use crate::model::merkle_tree::node_type::{
@@ -29,11 +27,3 @@ pub trait MerkleStore: MerkleReader + MerkleWriter {}
 /// automatically a [`MerkleStore`]. The `?Sized` bound lets the marker apply
 /// to `dyn MerkleStore` itself.
 impl<T: MerkleReader + MerkleWriter + ?Sized> MerkleStore for T {}
-
-/// A [`MerkleStore`] that can also pack and unpack Merkle tree nodes for transport.
-pub trait TransportableMerkleStore: MerkleStore + MerkleTransport {}
-
-/// Any type that is a [`MerkleStore`] and a [`MerkleTransport`] is automatically a
-/// [`TransportableMerkleStore`]. The `?Sized` bound lets the marker apply to
-/// `dyn TransportableMerkleStore` itself.
-impl<T: MerkleStore + MerkleTransport + ?Sized> TransportableMerkleStore for T {}

--- a/crates/liboxen/src/model/merkle_tree/merkle_transport.rs
+++ b/crates/liboxen/src/model/merkle_tree/merkle_transport.rs
@@ -1,14 +1,8 @@
-use std::collections::HashSet;
-use std::io::{Read, Write};
-
-use crate::error::OxenError;
-use crate::model::MerkleHash;
-
-/// Wire-format selector for [`MerklePacker::pack_nodes`].
+/// Wire-format selector for packing Merkle tree nodes.
 ///
 /// Two on-the-wire tar-gz layouts have coexisted as long as the merkle transport has
 /// existed. Each call site must pick the variant that matches the peer it's writing
-/// to; the trait makes no claim that a single canonical format exists.
+/// to; there is no claim that a single canonical format exists.
 // **No `Default` impl on purpose.** Picking a wire format is a protocol decision and
 // must be made explicitly at every call site. **No `#[non_exhaustive]` on purpose.**
 // Adding a future variant should be a deliberate breaking change that surfaces at
@@ -32,7 +26,7 @@ pub enum PackOptions {
     LegacyClientPush,
 }
 
-/// Per-call extraction policy for [`MerkleUnpacker::unpack`].
+/// Per-call extraction policy for unpacking Merkle tree nodes.
 ///
 /// **No `Default` impl on purpose.** The choice between overwriting and skipping is
 /// path-dependent and must be made explicitly at every call site.
@@ -46,66 +40,3 @@ pub enum UnpackOptions {
     /// `repositories::tree::unpack_nodes` — the server-side upload-consumer path.
     SkipExisting,
 }
-
-/// Produce transport-ready bytes from some subset (or all) of the backend's Merkle tree nodes.
-///
-/// Writes a tar-gz wire stream directly into the caller-provided sink. No buffer is
-/// materialized inside the trait, so memory use is O(compressor window). Callers can
-/// plug in HTTP response bodies, pipes, files, or in-memory `Vec<u8>` sinks as the writer.
-///
-/// dyn-compatible: callers can store this as `Box<dyn MerklePacker + '_>` or
-/// `&dyn MerklePacker`. Methods take `&mut dyn Write` instead of generic `W: Write`
-/// so the trait carries no per-call type parameters.
-pub trait MerklePacker: Send + Sync {
-    /// Pack the given node `hashes` into `out` as a tar-gz stream, in the layout
-    /// selected by `opts`.
-    ///
-    /// Hashes not present in the store are silently skipped, and an empty `hashes`
-    /// produces a valid but empty tarball. See [`PackOptions`] for the per-variant
-    /// wire-format details.
-    fn pack_nodes(
-        &self,
-        hashes: &HashSet<MerkleHash>,
-        opts: PackOptions,
-        out: &mut dyn Write,
-    ) -> Result<(), OxenError>;
-
-    /// Pack every node the backend currently holds into `out` as a tar-gz stream.
-    ///
-    /// Single-format: only the server-canonical layout has ever been emitted for a
-    /// whole-tree pack on `main`. There is no legacy whole-tree variant, so this
-    /// method does not accept [`PackOptions`].
-    fn pack_all(&self, out: &mut dyn Write) -> Result<(), OxenError>;
-}
-
-/// Consume transport bytes and install the nodes they contain into the backend.
-///
-/// Reads the tar-gz wire format incrementally from `reader`. Nothing buffers the full
-/// payload inside the trait. Async callers bridge a `Stream<Item = Bytes>` to a sync
-/// [`Read`] via [`tokio_util::io::SyncIoBridge`] inside a [`tokio::task::spawn_blocking`].
-///
-/// dyn-compatible: callers can store this as `Box<dyn MerkleUnpacker + '_>` or
-/// `&dyn MerkleUnpacker`. The reader is taken as `&mut dyn Read` for the same
-/// reason as [`MerklePacker`]'s `&mut dyn Write` argument.
-pub trait MerkleUnpacker: Send + Sync {
-    /// Unpack the tar-gz stream from `reader` into the store, applying the existing-file
-    /// policy in `opts`.
-    ///
-    /// Returns the set of hashes parsed from the tarball (not necessarily only those
-    /// newly installed — entries skipped per [`UnpackOptions::SkipExisting`] still appear
-    /// in the result, matching `main`'s `repositories::tree::unpack_nodes` behaviour).
-    fn unpack(
-        &self,
-        reader: &mut dyn Read,
-        opts: UnpackOptions,
-    ) -> Result<HashSet<MerkleHash>, OxenError>;
-}
-
-/// Marker super-trait: a type that can both pack and unpack Merkle tree nodes for transport.
-pub trait MerkleTransport: MerklePacker + MerkleUnpacker {}
-
-/// This blanket impl makes any type that implements [`MerklePacker`] and
-/// [`MerkleUnpacker`] automatically a [`MerkleTransport`]. The `?Sized` bound lets
-/// the marker apply to `dyn MerkleTransport` itself, so the impl works for both
-/// concrete backends and trait-object views over them.
-impl<T: MerklePacker + MerkleUnpacker + ?Sized> MerkleTransport for T {}

--- a/crates/liboxen/src/util/fs.rs
+++ b/crates/liboxen/src/util/fs.rs
@@ -513,7 +513,7 @@ where
 
 /// Sync counterpart to [`atomic_write_from_reader`]. Same write-temp-then-rename guarantees,
 /// driven by `std::io` so it's callable from sync code paths that can't host a tokio runtime
-/// (e.g. impls of sync traits like [`MerkleUnpacker`]).
+/// (e.g. the sync merkle-node unpack path).
 pub(crate) fn atomic_write_from_reader<R>(target: &Path, reader: &mut R) -> Result<(), OxenError>
 where
     R: std::io::Read + ?Sized,


### PR DESCRIPTION
(Stacked on #638)

Revert #514 as part of backing out our first Merkle tree redesign attempt (11 of 15). We're planning a simpler approach for the next attempt.

Things that we didn't revert from the original PR:
- The `PackOptions` / `UnpackOptions` enums. Why: the kept c2/c3 streaming pack/unpack free functions take them to select the on-the-wire tar layout and the existing-file policy.

ENG-1141