### PR TITLE
S3 (21): Remove get_version_path from the VersionStore trait

### DIFF
--- a/crates/liboxen/src/repositories/fsck.rs
+++ b/crates/liboxen/src/repositories/fsck.rs
@@ -159,7 +159,7 @@ mod tests {
 
     use crate::error::OxenError;
     use crate::repositories;
-    use crate::storage::version_store::LocalFilePath;
+    use crate::storage::version_store::VersionLocation;
     use crate::test;
     use crate::util;
 
@@ -180,11 +180,10 @@ mod tests {
             // This test relies on writing directly to the version store's
             // on-disk path, which only works with LocalVersionStore.
             let hash = &versions[0];
-            let version_path = version_store.get_version_path(hash).await?;
-            let LocalFilePath::Stable(ref path) = version_path else {
-                panic!("Expected LocalVersionStore (Stable path), got a Temp path. This test only works with local storage.");
+            let VersionLocation::Local(path) = version_store.version_location(hash).await? else {
+                panic!("Expected a local version store (Local path). This test only works with local storage.");
             };
-            std::fs::write(path, b"corrupted data")?;
+            std::fs::write(&path, b"corrupted data")?;
 
             // Dry run should detect corruption but not delete
             let result = version_store.clean_corrupted_versions(true).await?;
@@ -216,11 +215,10 @@ mod tests {
             // This test relies on writing directly to the version store's
             // on-disk path, which only works with LocalVersionStore.
             let hash = &versions[0];
-            let version_path = version_store.get_version_path(hash).await?;
-            let LocalFilePath::Stable(ref path) = version_path else {
-                panic!("Expected LocalVersionStore (Stable path), got a Temp path. This test only works with local storage.");
+            let VersionLocation::Local(path) = version_store.version_location(hash).await? else {
+                panic!("Expected a local version store (Local path). This test only works with local storage.");
             };
-            std::fs::write(path, b"corrupted data")?;
+            std::fs::write(&path, b"corrupted data")?;
 
             // Clean should detect and remove the corrupted file
             let result = version_store.clean_corrupted_versions(false).await?;

--- a/crates/liboxen/src/repositories/pull.rs
+++ b/crates/liboxen/src/repositories/pull.rs
@@ -1325,12 +1325,13 @@ mod tests {
                 .expect("second.txt must be reachable from the second commit's tree");
                 let blob_hash = second_node.hash.to_string();
                 let version_store = cloned_repo.version_store();
-                let blob_path = version_store.get_version_path(&blob_hash).await?;
-                assert!(blob_path.exists(), "blob should be present after clone");
-                util::fs::remove_file(&*blob_path)?;
-                let blob_path_after_wipe = version_store.get_version_path(&blob_hash).await?;
                 assert!(
-                    !blob_path_after_wipe.exists(),
+                    version_store.version_exists(&blob_hash).await?,
+                    "blob should be present after clone"
+                );
+                version_store.delete_version(&blob_hash).await?;
+                assert!(
+                    !version_store.version_exists(&blob_hash).await?,
                     "blob should be gone after wipe"
                 );
 
@@ -1339,9 +1340,8 @@ mod tests {
                 repositories::pull(&cloned_repo).await?;
 
                 // Blob is back in the version store.
-                let blob_path_after_pull = version_store.get_version_path(&blob_hash).await?;
                 assert!(
-                    blob_path_after_pull.exists(),
+                    version_store.version_exists(&blob_hash).await?,
                     "pull should have re-fetched the wiped blob"
                 );
 

--- a/crates/liboxen/src/repositories/status.rs
+++ b/crates/liboxen/src/repositories/status.rs
@@ -110,9 +110,8 @@ mod tests {
                 .expect("hello.txt must be in HEAD's tree");
             let blob_hash = head_node.hash.to_string();
             let version_store = repo.version_store();
-            let blob_path = version_store.get_version_path(&blob_hash).await?;
-            assert!(blob_path.exists());
-            util::fs::remove_file(&*blob_path)?;
+            assert!(version_store.version_exists(&blob_hash).await?);
+            version_store.delete_version(&blob_hash).await?;
 
             let status_after = repositories::status(&repo).await?;
             assert!(

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -522,6 +522,7 @@ fn add_exclude_to_sql(sql: &str) -> Result<String, DataFrameError> {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::time::SystemTime;
 
     use serde_json::json;
 
@@ -815,7 +816,7 @@ mod tests {
                 .expect("file should exist in commit");
             let file_1_csv = repo.path.join("version_1.csv");
             version_store
-                .copy_version_to_path(&node_1.hash().to_string(), &file_1_csv)
+                .copy_version_to_path(&node_1.hash().to_string(), &file_1_csv, SystemTime::now())
                 .await?;
             log::debug!("copied file 1 to {file_1_csv:?}");
 
@@ -823,7 +824,7 @@ mod tests {
                 .expect("file should exist in commit_2");
             let file_2_csv = repo.path.join("version_2.csv");
             version_store
-                .copy_version_to_path(&node_2.hash().to_string(), &file_2_csv)
+                .copy_version_to_path(&node_2.hash().to_string(), &file_2_csv, SystemTime::now())
                 .await?;
             log::debug!("copied file 2 to {file_2_csv:?}");
             let diff_result =
@@ -1424,11 +1425,14 @@ mod tests {
             // The committed file round-trips: re-read it and confirm every row survived.
             let entry = repositories::entries::get_commit_entry(&repo, &commit, path)?.unwrap();
             let version_store = repo.version_store();
-            let version_file = version_store.get_version_path(&entry.hash).await?;
             let extension = entry.path.extension().unwrap().to_str().unwrap();
-            let data_frame =
-                df::tabular::read_df_with_extension(version_file, extension, &DFOpts::empty())
-                    .await?;
+            let data_frame = df::tabular::read_version_df(
+                &version_store,
+                &entry.hash,
+                extension,
+                &DFOpts::empty(),
+            )
+            .await?;
             assert_eq!(data_frame.height(), 3);
             assert!(data_frame.column("error_details").is_ok());
             Ok(())

--- a/crates/liboxen/src/storage/local.rs
+++ b/crates/liboxen/src/storage/local.rs
@@ -6,7 +6,7 @@ use std::time::SystemTime;
 use crate::constants::{VERSION_CHUNK_FILE_NAME, VERSION_CHUNKS_DIR, VERSION_FILE_NAME};
 use crate::error::OxenError;
 use crate::model::MerkleHash;
-use crate::storage::version_store::{LocalFilePath, VersionLocation, VersionStore};
+use crate::storage::version_store::{VersionLocation, VersionStore};
 use crate::util::fs::AtomicFile;
 use crate::util::{concurrency, hasher};
 use crate::view::versions::CleanCorruptedVersionsResult;
@@ -194,10 +194,6 @@ impl VersionStore for LocalVersionStore {
                 _ => Err(err)?,
             },
         }
-    }
-
-    async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError> {
-        Ok(LocalFilePath::Stable(self.version_path(hash)))
     }
 
     async fn version_location(&self, hash: &str) -> Result<VersionLocation, OxenError> {

--- a/crates/liboxen/src/storage/s3.rs
+++ b/crates/liboxen/src/storage/s3.rs
@@ -1,5 +1,4 @@
 use crate::error::OxenError;
-use async_tempfile::TempFile;
 use async_trait::async_trait;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::error::SdkError;
@@ -12,12 +11,12 @@ use log;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncReadExt;
 use tokio::sync::OnceCell;
 use tokio_stream::Stream;
 use tokio_util::io::StreamReader;
 
-use super::version_store::{LocalFilePath, VersionLocation, VersionStore};
+use super::version_store::{VersionLocation, VersionStore};
 use crate::constants::VERSION_FILE_NAME;
 use crate::util::fs::AtomicFile;
 use crate::util::hasher;
@@ -610,18 +609,6 @@ impl VersionStore for S3VersionStore {
                 "derived_exists failed with S3 head_object error: {err:?}"
             ))),
         }
-    }
-
-    async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError> {
-        // TODO: This needs to be updated to handle large files that won't fit in memory
-        let data = self.get_version(hash).await?;
-        let mut tmp = TempFile::new()
-            .await
-            .map_err(|e| OxenError::basic_str(format!("Failed to create temp file: {e}")))?;
-        tmp.write_all(&data)
-            .await
-            .map_err(|e| OxenError::basic_str(format!("Failed to write temp file: {e}")))?;
-        Ok(LocalFilePath::Temp(tmp))
     }
 
     async fn version_location(&self, hash: &str) -> Result<VersionLocation, OxenError> {

--- a/crates/liboxen/src/storage/version_store.rs
+++ b/crates/liboxen/src/storage/version_store.rs
@@ -331,25 +331,6 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         derived_filename: &str,
     ) -> Result<bool, OxenError>;
 
-    /// Get a local filesystem path to a version file.
-    ///
-    /// The returned `LocalFilePath` is guaranteed to be readable on the local
-    /// filesystem. For local backends the path points into the version store
-    /// directly; for remote backends (e.g. S3) the file is downloaded to a
-    /// temporary location that is cleaned up when the `LocalFilePath` is dropped.
-    ///
-    /// **Callers must keep the returned value alive for as long as they use the
-    /// path.**
-    ///
-    /// **The returned file is read-only: callers MUST NOT alter it in any way.** For local stores
-    /// the path points straight at the blob inside the content-addressed version store, so mutating
-    /// it corrupts that blob for every reference to `hash` (its bytes would no longer match its
-    /// content hash). Copy the file elsewhere first if you need a mutable version.
-    ///
-    /// # Arguments
-    /// * `hash` - The content hash of the version file to retrieve
-    async fn get_version_path(&self, hash: &str) -> Result<LocalFilePath, OxenError>;
-
     /// Return a [`VersionLocation`] describing where the version file lives, in a form a
     /// cloud-aware reader can consume without materializing it to a temp file on local disk.
     ///
@@ -357,10 +338,10 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// stores return [`VersionLocation::S3`] carrying the s3:// URL plus the region and endpoint
     /// override the caller needs to configure Polars `CloudOptions` or DuckDB `httpfs`.
     ///
-    /// Prefer this over [`Self::get_version_path`] whenever the consumer has a cloud-aware
-    /// reader available (Polars `scan_*`, DuckDB `read_parquet`, …): `get_version_path`
-    /// materializes the entire version file to a temp file on S3, which is fine for small
-    /// files but OOMs at the multi-GB scale customers care about.
+    /// Prefer this over [`Self::materialize`] whenever the consumer has a cloud-aware
+    /// reader available (Polars `scan_*`, DuckDB `read_parquet`, …): on an S3-backed store
+    /// `materialize` copies the entire version file to local disk, which is fine for small
+    /// files but is needless IO at the multi-GB scale customers care about.
     ///
     /// Also reach for it instead of [`Self::materialize`] when the caller only ever runs against a
     /// local store (e.g. client/CLI paths, which hold no S3 backend): match
@@ -413,9 +394,6 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// the path points straight at the blob inside the content-addressed version store, so mutating
     /// it corrupts that blob for every reference to `hash` (its bytes would no longer match its
     /// content hash). Copy the file elsewhere first if you need a mutable version.
-    ///
-    /// Prefer this over [`Self::get_version_path`], which always writes to the OS temp dir and
-    /// buffers the whole blob in memory.
     ///
     /// # Arguments
     /// * `hash` - The content hash of the version file


### PR DESCRIPTION
(Stacked on #640)

`get_version_path` always materialized a whole version file to a local path from S3 into the OS temp dir, buffering the entire blob in memory -- which OOMs at the multi-GB scale customers care about and unexpectedly downloads a file. Every production caller now uses `version_location` (cloud-aware readers) or `materialize` (data-volume temp, only when a local path is truly required), so we can now remove `get_version_path`.

Part of ENG-1090.