### PR TITLE
Merkle Revert (12): Revert #513 refactor to use MerkleStore

### DIFF
--- a/crates/liboxen/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/liboxen/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -4,10 +4,10 @@ use super::Migrate;
 
 use crate::command::migrate::Direction;
 use crate::config::RepositoryConfig;
+use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::merkle_tree_node_cache;
-use crate::model::merkle_tree::merkle_writer::MerkleWriteSession;
 use crate::model::merkle_tree::node::vnode::VNodeOpts;
 use crate::model::merkle_tree::node::{
     CommitNode, DirNode, EMerkleTreeNode, MerkleTreeNode, VNode,
@@ -93,27 +93,14 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
     dir_node_opts.num_entries = num_children as u64;
     let dir_node = DirNode::new(&new_repo, dir_node_opts)?;
 
-    // Write a new commit node via a session on the old repo.
+    // Write a new commit db
     let commit_node = CommitNode::from_commit(commit.clone());
-    let old_store = old_repo.merkle_store();
-    let new_store = new_repo.merkle_store();
-    let old_session = old_store.begin()?;
-    let new_session = new_store.begin()?;
-    let mut root_commit_ns = old_session.create_node(&commit_node, root_node.parent_id)?;
-    root_commit_ns.add_child(&dir_node)?;
-    root_commit_ns.finish()?;
+    let mut root_commit_db =
+        MerkleNodeDB::open_read_write(&old_repo.path, &commit_node, root_node.parent_id)?;
+    root_commit_db.add_child(&dir_node)?;
 
     let current_path = Path::new("");
-    rewrite_nodes(
-        &old_repo,
-        &new_repo,
-        &*old_session,
-        &*new_session,
-        &root_node,
-        current_path,
-    )?;
-    new_session.finish()?;
-    old_session.finish()?;
+    rewrite_nodes(&old_repo, &new_repo, &root_node, current_path)?;
 
     // println!("new tree for commit {}", commit);
     // repositories::tree::print_tree(&new_repo, commit)?;
@@ -129,12 +116,9 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
 
 // Forgive me if you are reading this for reference, we don't have great writers for the
 // merkle tree yet - so there is a lot of duplicate logic with `commit_writer.rs`
-#[allow(clippy::too_many_arguments)]
 fn rewrite_nodes(
     old_repo: &LocalRepository,
     new_repo: &LocalRepository,
-    old_session: &dyn MerkleWriteSession,
-    new_session: &dyn MerkleWriteSession,
     node: &MerkleTreeNode,
     current_dir: &Path,
 ) -> Result<(), OxenError> {
@@ -143,9 +127,18 @@ fn rewrite_nodes(
             EMerkleTreeNode::Directory(dir) => {
                 // Load all the children of children (files and folders)
                 // Then redistribute into buckets...
-                // and then just use the session to write the nodes to the new tree
+                // and then just use the MerkleNodeDB to write the nodes
+                // to the new tree
                 let dir_children = repositories::tree::list_files_and_folders(child)?;
                 let current_dir = current_dir.join(dir.name());
+
+                // log::debug!(
+                //     "rewrite_nodes {} children on current_dir {:?} DIRECTORY {} {}",
+                //     dir_children.len(),
+                //     current_dir,
+                //     dir.hash(),
+                //     dir
+                // );
 
                 let total_children = dir_children.len();
                 let vnode_size = old_repo.vnode_size();
@@ -155,15 +148,16 @@ fn rewrite_nodes(
                 let mut dir_node_opts = dir.get_opts();
                 dir_node_opts.num_entries = total_children as u64;
                 let dir = DirNode::new(new_repo, dir_node_opts)?;
-                let mut dir_ns = old_session.create_node(&dir, node.parent_id)?;
+                let mut dir_db =
+                    MerkleNodeDB::open_read_write(&old_repo.path, &dir, node.parent_id)?;
 
-                log::trace!(
-                    "rewrite_nodes {} VNodes for {} children in {} with vnode size {}",
-                    num_vnodes,
-                    total_children,
-                    dir,
-                    vnode_size
-                );
+                // log::debug!(
+                //     "rewrite_nodes {} VNodes for {} children in {} with vnode size {}",
+                //     num_vnodes,
+                //     total_children,
+                //     dir,
+                //     vnode_size
+                // );
 
                 // Compute buckets
                 let mut buckets: Vec<Vec<MerkleTreeNode>> = vec![vec![]; num_vnodes as usize];
@@ -171,14 +165,14 @@ fn rewrite_nodes(
                     let path = current_dir.join(dir_child.maybe_path().unwrap());
                     let hash = hasher::hash_buffer_128bit(path.to_str().unwrap().as_bytes());
                     let bucket_idx = hash % num_vnodes;
-                    log::trace!(
-                        "\trewrite_nodes dir_child {:?} bucket {} num_vnodes {} hash {} {}",
-                        path,
-                        bucket_idx,
-                        num_vnodes,
-                        hash,
-                        dir_child
-                    );
+                    // log::debug!(
+                    //     "\trewrite_nodes dir_child {:?} bucket {} num_vnodes {} hash {} {}",
+                    //     path,
+                    //     bucket_idx,
+                    //     num_vnodes,
+                    //     hash,
+                    //     dir_child
+                    // );
                     buckets[bucket_idx as usize].push(dir_child);
                 }
 
@@ -207,59 +201,54 @@ fn rewrite_nodes(
                     vnodes.push((vnode_id, bucket.clone()));
                 }
 
-                log::trace!("rewrite_nodes count vnodes: {}", vnodes.len());
+                // log::debug!("rewrite_nodes count vnodes: {}", vnodes.len());
                 for (hash, entries) in vnodes.iter() {
-                    // create a new vnode obj and add to the dir session
+                    // create a new vnode obj and add the the db
                     let opts = VNodeOpts {
                         hash: *hash,
                         num_entries: entries.len() as u64,
                     };
                     let vnode_obj = VNode::new(new_repo, opts)?;
-                    dir_ns.add_child(&vnode_obj)?;
+                    // log::debug!("rewrite_nodes adding VNode to DirNode! {:?}", vnode_obj);
+                    dir_db.add_child(&vnode_obj)?;
 
-                    let dir_ns_id = *dir_ns.node_id();
-                    let mut vnode_ns = new_session.create_node(&vnode_obj, Some(dir_ns_id))?;
+                    let mut vnode_db = MerkleNodeDB::open_read_write(
+                        &new_repo.path,
+                        &vnode_obj,
+                        Some(dir_db.node_id),
+                    )?;
 
+                    // log::debug!("rewrite_nodes count entries {}", entries.len());
                     for entry in entries {
                         match &entry.node {
                             EMerkleTreeNode::File(f_node) => {
-                                vnode_ns.add_child(f_node)?;
+                                // log::debug!("rewrite_nodes adding FileNode to VNode! {}", f_node);
+                                vnode_db.add_child(f_node)?;
                             }
                             EMerkleTreeNode::Directory(d_node) => {
                                 let mut d_node_opts = d_node.get_opts();
                                 let d_children = repositories::tree::list_files_and_folders(entry)?;
                                 d_node_opts.num_entries = d_children.len() as u64;
+                                // log::debug!(
+                                //     "rewrite_nodes adding DirNode to VNode with {} num_entries {}",
+                                //     d_node_opts.num_entries,
+                                //     d_node
+                                // );
                                 let d_node = DirNode::new(new_repo, d_node_opts)?;
-                                vnode_ns.add_child(&d_node)?;
+                                vnode_db.add_child(&d_node)?;
                             }
                             _ => {
                                 panic!("Shouldn't reach here.")
                             }
                         }
                     }
-                    vnode_ns.finish()?;
                 }
-                dir_ns.finish()?;
 
-                rewrite_nodes(
-                    old_repo,
-                    new_repo,
-                    old_session,
-                    new_session,
-                    child,
-                    &current_dir,
-                )?;
+                rewrite_nodes(old_repo, new_repo, child, &current_dir)?;
             }
             EMerkleTreeNode::VNode(_) => {
                 // VNode just needs to traverse to the next dirnode
-                rewrite_nodes(
-                    old_repo,
-                    new_repo,
-                    old_session,
-                    new_session,
-                    child,
-                    current_dir,
-                )?;
+                rewrite_nodes(old_repo, new_repo, child, current_dir)?;
             }
             _ => {
                 // pass, FileNode was not changed, so it is on the latest version

--- a/crates/liboxen/src/core/db/merkle_node/file_backend.rs
+++ b/crates/liboxen/src/core/db/merkle_node/file_backend.rs
@@ -552,7 +552,7 @@ mod tests {
             session.finish()?;
             drop(store);
 
-            let store = repo.merkle_store();
+            let store = FileBackend::new(&repo);
             assert!(
                 store
                     .exists(commit_hash)
@@ -848,7 +848,9 @@ mod tests {
 
             for hash in &installed {
                 assert!(
-                    clone.merkle_store().exists(hash).expect("exists failed"),
+                    FileBackend::new(&clone)
+                        .exists(hash)
+                        .expect("exists failed"),
                     "expected installed hash {hash} to be readable"
                 );
             }
@@ -1037,15 +1039,13 @@ mod tests {
             // Every installed hash must be readable through both stores.
             for h in &new_hashes {
                 assert!(
-                    repo_old
-                        .merkle_store()
+                    FileBackend::new(&repo_old)
                         .exists(h)
                         .expect("old repo exists check failed"),
                     "hash {h} not readable in repo unpacked via legacy unpack_nodes"
                 );
                 assert!(
-                    repo_new
-                        .merkle_store()
+                    FileBackend::new(&repo_new)
                         .exists(h)
                         .expect("new repo exists check failed"),
                     "hash {h} not readable in repo unpacked via trait unpack"
@@ -1138,7 +1138,9 @@ mod tests {
             assert!(!installed.is_empty(), "trait unpack reported no hashes");
             for h in &installed {
                 assert!(
-                    repo_new.merkle_store().exists(h).expect("exists failed"),
+                    FileBackend::new(&repo_new)
+                        .exists(h)
+                        .expect("exists failed"),
                     "hash {h} not readable in repo unpacked via trait unpack"
                 );
             }
@@ -1533,7 +1535,7 @@ mod tests {
     #[test]
     fn test_exists_returns_false_for_missing_hash() -> Result<(), OxenError> {
         test::run_empty_local_repo_test(|repo| {
-            let store = repo.merkle_store();
+            let store = FileBackend::new(&repo);
             let missing = MerkleHash::new(0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF_u128);
             assert!(
                 !store.exists(&missing).expect("exists must not error"),
@@ -1547,7 +1549,7 @@ mod tests {
     #[test]
     fn test_get_node_returns_none_for_missing_hash() -> Result<(), OxenError> {
         test::run_empty_local_repo_test(|repo| {
-            let store = repo.merkle_store();
+            let store = FileBackend::new(&repo);
             let missing = MerkleHash::new(0xDEAD_BEEF_DEAD_BEEF_DEAD_BEEF_DEAD_BEEF_u128);
             assert!(
                 store
@@ -1569,7 +1571,7 @@ mod tests {
             let commit = CommitNode::default();
             let commit_hash = *commit.hash();
             {
-                let store = repo.merkle_store();
+                let store = FileBackend::new(&repo);
                 let session = store.begin().expect("begin failed");
                 let ns = session
                     .create_node(&commit, None)
@@ -1577,7 +1579,7 @@ mod tests {
                 ns.finish().expect("finish node session failed");
                 session.finish().expect("finish session failed");
             }
-            let store = repo.merkle_store();
+            let store = FileBackend::new(&repo);
             let children = store
                 .get_children(&commit_hash)
                 .expect("get_children must not error");
@@ -1595,7 +1597,7 @@ mod tests {
     #[test]
     fn test_writer_session_with_no_nodes() -> Result<(), OxenError> {
         test::run_empty_local_repo_test(|repo| {
-            let store = repo.merkle_store();
+            let store = FileBackend::new(&repo);
             let session = store.begin().expect("begin failed");
             session
                 .finish()
@@ -1742,7 +1744,7 @@ mod tests {
             );
             for h in &installed {
                 assert!(
-                    clone.merkle_store().exists(h).expect("exists failed"),
+                    FileBackend::new(&clone).exists(h).expect("exists failed"),
                     "hash {h} not readable in vfs-cloned repo"
                 );
             }

--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -10,6 +10,7 @@ use time::OffsetDateTime;
 use crate::config::UserConfig;
 use crate::constants::COMMIT_COUNT_DIR;
 use crate::core::db::key_val::{opts, str_val_db};
+use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::refs::with_ref_manager;
 use crate::core::v_latest::index::CommitMerkleTree;
 use crate::error::OxenError;
@@ -289,14 +290,10 @@ pub fn create_empty_commit(
     )?;
 
     let parent_id = Some(existing_node.hash);
-    let store = repo.merkle_store();
-    let session = store.begin()?;
-    let mut commit_ns = session.create_node(&commit_node, parent_id)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &commit_node, parent_id)?;
     // There should always be one child, the root directory
     let dir_node = existing_node.children.first().unwrap().dir()?;
-    commit_ns.add_child(&dir_node)?;
-    commit_ns.finish()?;
-    session.finish()?;
+    commit_db.add_child(&dir_node)?;
 
     // Copy the dir hashes db to the new commit
     repositories::tree::cp_dir_hashes_to(repo, &existing_commit_id, commit_node.hash())?;
@@ -372,13 +369,9 @@ pub fn create_initial_commit(
         },
     )?;
 
-    // Open the commit write session and add the root directory
-    let store = repo.merkle_store();
-    let session = store.begin()?;
-    let mut commit_ns = session.create_node(&commit_node, None)?;
-    commit_ns.add_child(&dir_node)?;
-    commit_ns.finish()?;
-    session.finish()?;
+    // Open the commit database and add the root directory
+    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &commit_node, None)?;
+    commit_db.add_child(&dir_node)?;
 
     // Initialize the dir_hash_db with the root directory hash
     let commit_id_string = commit_id.to_string();

--- a/crates/liboxen/src/core/v_latest/entries.rs
+++ b/crates/liboxen/src/core/v_latest/entries.rs
@@ -1,7 +1,7 @@
 use crate::core;
+use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::error::OxenError;
 use crate::model::entry::metadata_entry::WorkspaceMetadataEntry;
-use crate::model::merkle_tree::merkle_writer::{MerkleWriteSession, NodeWriteSession};
 use crate::model::merkle_tree::node::{DirNode, EMerkleTreeNode, FileNode, MerkleTreeNode};
 use crate::model::metadata::MetadataDir;
 use crate::model::metadata::generic_metadata::GenericMetadata;
@@ -14,7 +14,6 @@ use crate::repositories;
 use crate::util;
 use crate::view::PaginatedDirEntries;
 use crate::view::entries::{EMetadataEntry, ResourceVersion};
-use std::any::type_name_of_val;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -546,18 +545,15 @@ pub fn update_metadata(repo: &LocalRepository, revision: impl AsRef<str>) -> Res
     // Initialize data structures for aggregation
     let mut num_bytes = 0;
 
-    // One merkle write session covers every node written during the traversal.
-    let store = repo.merkle_store();
-    let session = store.begin()?;
-    traverse_and_update_sizes_and_counts(&*session, &mut node, &mut num_bytes)?;
-    session.finish()?;
+    // Start the recursive traversal
+    traverse_and_update_sizes_and_counts(repo, &mut node, &mut num_bytes)?;
 
     Ok(())
 }
 
 #[allow(clippy::type_complexity)]
 fn traverse_and_update_sizes_and_counts(
-    session: &dyn MerkleWriteSession,
+    repo: &LocalRepository,
     node: &mut MerkleTreeNode,
     num_bytes: &mut u64,
 ) -> Result<(HashMap<String, u64>, HashMap<String, u64>), OxenError> {
@@ -570,33 +566,32 @@ fn traverse_and_update_sizes_and_counts(
         EMerkleTreeNode::Commit(commit_node) => {
             log::debug!("Traversing node {commit_node:?}");
             process_children(
-                session,
+                repo,
                 children,
                 &mut local_counts,
                 &mut local_sizes,
                 num_bytes,
             )?;
-            let mut dir_ns = session.create_node(commit_node, node.parent_id)?;
-            add_children_to_session(&mut *dir_ns, &node.children)?;
-            dir_ns.finish()?;
+            let mut dir_db =
+                MerkleNodeDB::open_read_write(&repo.path, commit_node, node.parent_id)?;
+            add_children_to_db(&mut dir_db, &node.children)?;
         }
         EMerkleTreeNode::VNode(vnode) => {
             log::debug!("Traversing vnode {vnode:?}");
             process_children(
-                session,
+                repo,
                 children,
                 &mut local_counts,
                 &mut local_sizes,
                 num_bytes,
             )?;
-            let mut dir_ns = session.create_node(vnode, node.parent_id)?;
-            add_children_to_session(&mut *dir_ns, &node.children)?;
-            dir_ns.finish()?;
+            let mut dir_db = MerkleNodeDB::open_read_write(&repo.path, vnode, node.parent_id)?;
+            add_children_to_db(&mut dir_db, &node.children)?;
         }
         EMerkleTreeNode::Directory(dir_node) => {
             log::debug!("No need to aggregate dir {}", dir_node.name());
             process_children(
-                session,
+                repo,
                 children,
                 &mut local_counts,
                 &mut local_sizes,
@@ -604,9 +599,8 @@ fn traverse_and_update_sizes_and_counts(
             )?;
             dir_node.set_data_type_counts(local_counts.clone());
             dir_node.set_data_type_sizes(local_sizes.clone());
-            let mut dir_ns = session.create_node(dir_node, node.parent_id)?;
-            add_children_to_session(&mut *dir_ns, &node.children)?;
-            dir_ns.finish()?;
+            let mut dir_db = MerkleNodeDB::open_read_write(&repo.path, dir_node, node.parent_id)?;
+            add_children_to_db(&mut dir_db, &node.children)?;
         }
         EMerkleTreeNode::File(file_node) => {
             log::debug!(
@@ -623,7 +617,6 @@ fn traverse_and_update_sizes_and_counts(
                 .or_insert(0) += file_node.num_bytes();
         }
         _ => {
-            // TODO: change to a structured error variant
             return Err(OxenError::basic_str(format!(
                 "compute_dir_node found unexpected node type: {:?}",
                 node.node
@@ -635,7 +628,7 @@ fn traverse_and_update_sizes_and_counts(
 }
 
 fn process_children(
-    session: &dyn MerkleWriteSession,
+    repo: &LocalRepository,
     children: &mut [MerkleTreeNode],
     local_counts: &mut HashMap<String, u64>,
     local_sizes: &mut HashMap<String, u64>,
@@ -643,7 +636,7 @@ fn process_children(
 ) -> Result<(), OxenError> {
     for child in children.iter_mut() {
         let (child_counts, child_sizes) =
-            traverse_and_update_sizes_and_counts(session, child, num_bytes)?;
+            traverse_and_update_sizes_and_counts(repo, child, num_bytes)?;
         for (key, count) in child_counts {
             *local_counts.entry(key).or_insert(0) += count;
         }
@@ -654,26 +647,26 @@ fn process_children(
     Ok(())
 }
 
-fn add_children_to_session(
-    ns: &mut dyn NodeWriteSession,
+fn add_children_to_db(
+    dir_db: &mut MerkleNodeDB,
     children: &[MerkleTreeNode],
 ) -> Result<(), OxenError> {
     for child in children {
         match &child.node {
             EMerkleTreeNode::Commit(commit_node) => {
-                ns.add_child(commit_node)?;
+                dir_db.add_child(commit_node)?;
             }
             EMerkleTreeNode::Directory(dir_node) => {
-                ns.add_child(dir_node)?;
+                dir_db.add_child(dir_node)?;
             }
             EMerkleTreeNode::File(file_node) => {
-                ns.add_child(file_node)?;
+                dir_db.add_child(file_node)?;
             }
             EMerkleTreeNode::VNode(vnode) => {
-                ns.add_child(vnode)?;
+                dir_db.add_child(vnode)?;
             }
-            n => {
-                return Err(OxenError::DisallowedNodeWrite(type_name_of_val(n)));
+            _ => {
+                return Err(OxenError::basic_str("Unsupported node type"));
             }
         }
     }

--- a/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
@@ -6,9 +6,12 @@ use std::str;
 use crate::core::db::dir_hashes::dir_hashes_db::{
     dir_hash_db_path, dir_hash_db_path_from_commit_id, with_dir_hash_db_manager,
 };
+use crate::core::db::merkle_node::MerkleNodeDB;
 
+use crate::model::merkle_tree::node::EMerkleTreeNode;
+
+use crate::model::merkle_tree::node::FileNode;
 use crate::model::merkle_tree::node::MerkleTreeNode;
-use crate::model::merkle_tree::node::{EMerkleTreeNode, FileNode};
 
 use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository, MerkleHash, MerkleTreeNodeType, PartialNode};
@@ -204,7 +207,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashSet<MerkleHash>>,
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !repo.merkle_store().exists(hash)? {
+        if !MerkleNodeDB::exists(&repo.path, hash) {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -229,7 +232,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashMap<(MerkleHash, MerkleTreeNodeType), PathBuf>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !MerkleNodeDB::exists(&repo.path, hash) {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -255,7 +258,7 @@ impl CommitMerkleTree {
         partial_nodes: &mut HashMap<PathBuf, PartialNode>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !MerkleNodeDB::exists(&repo.path, hash) {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -279,7 +282,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read depth {} node hash [{}]", depth, hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !MerkleNodeDB::exists(&repo.path, hash) {
             log::debug!("read_depth merkle node db does not exist for hash: {hash}");
             return Ok(None);
         }
@@ -311,7 +314,7 @@ impl CommitMerkleTree {
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !repo.merkle_store().exists(hash)? {
+        if !MerkleNodeDB::exists(&repo.path, hash) {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -340,7 +343,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !MerkleNodeDB::exists(&repo.path, hash) {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -372,7 +375,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !repo.merkle_store().exists(hash)? {
+        if !MerkleNodeDB::exists(&repo.path, hash) {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }

--- a/crates/liboxen/src/core/v_latest/merge.rs
+++ b/crates/liboxen/src/core/v_latest/merge.rs
@@ -1,6 +1,7 @@
 use crate::config::UserConfig;
 use crate::constants;
 use crate::core::db;
+use crate::core::db::merkle_node::MerkleNodeDB;
 pub use crate::core::merge::entry_merge_conflict_db_reader::EntryMergeConflictDBReader;
 pub use crate::core::merge::node_merge_conflict_db_reader::NodeMergeConflictDBReader;
 use crate::core::merge::node_merge_conflict_reader::NodeMergeConflictReader;
@@ -1073,7 +1074,7 @@ fn create_empty_merge_commit(
         },
     )?;
 
-    // Add base's existing root DirNode as the only child.
+    // Open the new commit's MerkleNodeDB and add base's existing root DirNode as the only child.
     // Tree is content-addressed, so the new commit's tree equals base's tree without any tree
     // rebuild or copy.
     let base_node = repositories::tree::get_node_by_id_with_children(repo, &base_commit_hash)?
@@ -1083,18 +1084,14 @@ fn create_empty_merge_commit(
                 merge_commits.base.id
             ))
         })?;
-
-    let merkle_store = repo.merkle_store();
-    let session = merkle_store.begin()?;
-    let mut ns = session.create_node(&commit_node, Some(base_node.hash))?;
+    let mut commit_db =
+        MerkleNodeDB::open_read_write(&repo.path, &commit_node, Some(base_node.hash))?;
     let root_dir = base_node
         .children
         .first()
         .expect("base commit must have a root dir as its first child")
         .dir()?;
-    ns.add_child(&root_dir)?;
-    ns.finish()?;
-    session.finish()?;
+    commit_db.add_child(&root_dir)?;
 
     // Copy base's path -> dir hash mapping so path-based tree lookups work for the new commit.
     repositories::tree::cp_dir_hashes_to(repo, &base_commit_hash, commit_node.hash())?;

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -247,10 +247,6 @@ pub enum OxenError {
 
     //
     // Version Store
-    //
-    #[error("Version store not initialized")]
-    VersionStoreNotInitialized,
-
     /// An error uploading a file to the version store
     #[error("{0}")]
     Upload(StringError),
@@ -321,12 +317,6 @@ pub enum OxenError {
 
     #[error("No such commit, dir, or vnode Merkle tree node with hash (hex): {0}")]
     MerkleNodeNotFound(HexHash),
-
-    #[error(
-        "Unsupported node type adding to a child file. Only accept Commit, Directory, File, or VNode. Found: {0}"
-    )]
-    /// Contains the name of the incompatible type as reported by [`std::any::type_name_of_val`].
-    DisallowedNodeWrite(&'static str),
 
     //
     // Schema
@@ -798,6 +788,7 @@ impl OxenError {
                 | OxenError::ParsedResourceNotFound(_)
                 | OxenError::WorkspaceNotFound(_)
                 | OxenError::QueryableWorkspaceNotFound
+                | OxenError::MerkleNodeNotFound(_)
         )
     }
 

--- a/crates/liboxen/src/model/merkle_tree/merkle_hash.rs
+++ b/crates/liboxen/src/model/merkle_tree/merkle_hash.rs
@@ -122,7 +122,7 @@ impl HexHash {
     /// Produces a relative path for the 2-level directory structure used to store Merkle nodes.
     /// The first directory name is the first 3 characters of the hex-encoded hash. The second
     /// is the remaining characters.
-    pub(crate) fn node_db_prefix(&self) -> PathBuf {
+    pub fn node_db_prefix(&self) -> PathBuf {
         let hash_str = &self.0;
         const DIR_PREFIX_LEN: usize = 3;
         let dir_prefix = hash_str.chars().take(DIR_PREFIX_LEN).collect::<String>();

--- a/crates/liboxen/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use super::*;
+use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::error::OxenError;
-use crate::model::merkle_tree::merkle_reader::MerkleEntry;
 use crate::model::{LocalRepository, MerkleHash, MerkleTreeNodeType};
 
 use serde::{Deserialize, Serialize};
@@ -41,13 +41,14 @@ impl MerkleTreeNode {
 
     /// Private implementation that loads from disk without caching
     fn from_hash_uncached(repo: &LocalRepository, hash: &MerkleHash) -> Result<Self, OxenError> {
-        let MerkleEntry { node, parent_id } = repo
-            .merkle_store()
-            .get_node(hash)?
-            .ok_or_else(|| OxenError::MerkleNodeNotFound(hash.to_hex_hash()))?;
+        if !MerkleNodeDB::exists(&repo.path, hash) {
+            return Err(OxenError::MerkleNodeNotFound(hash.to_hex_hash()));
+        }
+        let node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let parent_id = node_db.parent_id;
         Ok(MerkleTreeNode {
             hash: *hash,
-            node,
+            node: node_db.node()?,
             parent_id,
             children: Vec::new(),
         })
@@ -76,15 +77,15 @@ impl MerkleTreeNode {
         repo: &LocalRepository,
         hash: &MerkleHash,
     ) -> Result<Vec<(MerkleHash, MerkleTreeNode)>, OxenError> {
-        let store = repo.merkle_store();
-        // We don't return an error here because there are some situations where we won't have
-        // all of the node files. For example, when working in a subtree clone.
-        // However, parse/IO errors from an existing node DO still propagate.
-        if !store.exists(hash)? {
-            log::error!("[assuming no children] no child node db for {hash}");
+        // We don't return an error here because there are some situations where we won't have all
+        // the node files. For example, when working in a subtree clone. However, parse/IO errors
+        // from an existing node DO still propagate.
+        if !MerkleNodeDB::exists(&repo.path, hash) {
+            log::warn!("no child node db: {hash:?}");
             return Ok(Vec::new());
         }
-        repo.merkle_store().get_children(hash)
+        let mut node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        Ok(node_db.map()?)
     }
 
     /// Check if the node is a leaf node (i.e. it has no children)

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -1,10 +1,8 @@
 use crate::config::RepositoryConfig;
 use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE};
-use crate::core::db::merkle_node::file_backend::FileBackend;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::merkle_tree::MerkleStore;
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::{MetadataEntry, Remote, RemoteRepository};
 use crate::storage::{S3Opts, StorageConfig, VersionStore, create_version_store};
@@ -89,29 +87,6 @@ impl LocalRepository {
     /// store can be rebuilt.
     pub fn server_s3_opts(&self) -> Option<&S3Opts> {
         self.server_s3_opts.as_ref()
-    }
-
-    /// Loads the Merkle store for the repository at the specified root path.
-    // NOTE: When new backends (e.g. LMDB) are added, branch on the appropriate config
-    // here and return a `Box::new(<that new backend>)`.
-    #[inline]
-    fn load_merkle_store(repo_path: PathBuf, _is_vfs: bool) -> Box<dyn MerkleStore> {
-        // TODO: Add reading config to select Merkle store implementation that
-        //       the repository uses.
-        //       => Right now, the only option is the FileBackend.
-        Box::new(FileBackend { repo_path })
-    }
-
-    /// Obtain the Merkle tree store for this repository.
-    ///
-    /// All operations with the repository's Merkle tree store **MUST** go through its
-    /// `MerkleStore` implementation.
-    ///
-    /// Returns a boxed trait object so the trait surface stays simple and dyn-dispatch
-    /// handles backend selection. Callers use it purely through the trait surface
-    /// (read, write); backend selection is an implementation detail of this method.
-    pub fn merkle_store(&self) -> Box<dyn MerkleStore> {
-        Self::load_merkle_store(self.path.clone(), self.is_vfs())
     }
 
     /// Get a reference to the version store.

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -17,6 +17,7 @@ use crate::constants::ORIG_HEAD_FILE;
 use crate::constants::{HEAD_FILE, STAGED_DIR};
 use crate::core::db;
 use crate::core::db::key_val::str_val_db;
+use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::refs::with_ref_manager;
 use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_latest::status;
@@ -32,7 +33,6 @@ use crate::model::merkle_tree::node::commit_node::CommitNodeOpts;
 use crate::model::merkle_tree::node::dir_node::DirNodeOpts;
 use crate::model::merkle_tree::node::vnode::VNodeOpts;
 use crate::model::{Commit, LocalRepository, StagedEntryStatus};
-use crate::repositories::merkle_tree::merkle_writer::{MerkleWriteSession, NodeWriteSession};
 
 use crate::util::hasher;
 use crate::util::progress_bar::FinishOnDropProgressBar;
@@ -269,20 +269,15 @@ pub(crate) fn commit_dir_entries_with_parents(
         }
     }
 
-    let store = repo.merkle_store();
-    let session = store.begin()?;
-    let mut commit_ns = session.create_node(&node, parent_id)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, parent_id)?;
     write_commit_entries(
         repo,
         commit_id,
-        &*session,
-        &mut *commit_ns,
+        &mut commit_db,
         &dir_hash_db,
         &dir_hashes,
         &vnode_entries,
     )?;
-    commit_ns.finish()?;
-    session.finish()?;
 
     Ok(node.to_commit())
 }
@@ -367,21 +362,16 @@ pub fn commit_dir_entries_new(
         }
     }
 
-    let store = repo.merkle_store();
-    let session = store.begin()?;
-    let mut commit_ns = session.create_node(&node, parent_id)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, parent_id)?;
 
     write_commit_entries(
         repo,
         commit_id,
-        &*session,
-        &mut *commit_ns,
+        &mut commit_db,
         &dir_hash_db,
         &dir_hashes,
         &vnode_entries,
     )?;
-    commit_ns.finish()?;
-    session.finish()?;
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
@@ -483,20 +473,15 @@ pub fn commit_dir_entries(
         }
     }
 
-    let store = repo.merkle_store();
-    let session = store.begin()?;
-    let mut commit_ns = session.create_node(&node, None)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, None)?;
     write_commit_entries(
         repo,
         commit_id,
-        &*session,
-        &mut *commit_ns,
+        &mut commit_db,
         &dir_hash_db,
         &dir_hashes,
         &vnode_entries,
     )?;
-    commit_ns.finish()?;
-    session.finish()?;
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
@@ -773,12 +758,10 @@ pub fn compute_commit_id(new_commit: &NewCommit) -> Result<MerkleHash, OxenError
     Ok(MerkleHash::new(hasher.digest128()))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn write_commit_entries(
     repo: &LocalRepository,
     commit_id: MerkleHash,
-    session: &dyn MerkleWriteSession,
-    commit_ns: &mut dyn NodeWriteSession,
+    commit_db: &mut MerkleNodeDB,
     dir_hash_db: &DBWithThreadMode<SingleThreaded>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     entries: &HashMap<PathBuf, (Vec<EntryVNode>, Vec<StagedMerkleTreeNode>)>,
@@ -787,7 +770,7 @@ fn write_commit_entries(
     let mut total_written = 0;
     let root_path = PathBuf::from("");
     let dir_node = compute_dir_node(repo, commit_id, entries, dir_hashes, &root_path)?;
-    commit_ns.add_child(&dir_node)?;
+    commit_db.add_child(&dir_node)?;
     total_written += 1;
 
     str_val_db::put(
@@ -795,19 +778,17 @@ fn write_commit_entries(
         root_path.to_str().unwrap(),
         &dir_node.hash().to_string(),
     )?;
-    let mut dir_ns = session.create_node(&dir_node, Some(commit_id))?;
+    let dir_db = MerkleNodeDB::open_read_write(&repo.path, &dir_node, Some(commit_id))?;
     r_create_dir_node(
         repo,
-        session,
         commit_id,
-        Some(&mut *dir_ns),
+        &mut Some(dir_db),
         dir_hash_db,
         dir_hashes,
         entries,
         root_path,
         &mut total_written,
     )?;
-    dir_ns.finish()?;
 
     // The dir_hash_db was pre-populated from the previous commit, so
     // removed directories still have stale entries that must be deleted;
@@ -842,9 +823,8 @@ fn cache_invalidate_dir_hash_db<'a>(
 #[allow(clippy::too_many_arguments)]
 fn r_create_dir_node(
     repo: &LocalRepository,
-    session: &dyn MerkleWriteSession,
     commit_id: MerkleHash,
-    mut maybe_parent_ns: Option<&mut dyn NodeWriteSession>,
+    maybe_dir_db: &mut Option<MerkleNodeDB>,
     dir_hash_db: &DBWithThreadMode<SingleThreaded>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     entries: &HashMap<PathBuf, (Vec<EntryVNode>, Vec<StagedMerkleTreeNode>)>,
@@ -868,62 +848,75 @@ fn r_create_dir_node(
             num_entries: vnode.entries.len() as u64,
         };
         let vnode_obj = VNode::new(repo, opts)?;
-        // Capture the parent's hash before we reborrow `maybe_parent_ns` mutably.
-        let parent_id_for_vnode = maybe_parent_ns.as_deref().map(|ns| *ns.node_id());
-        if let Some(parent_ns) = maybe_parent_ns.as_deref_mut() {
-            parent_ns.add_child(&vnode_obj)?;
+        if let Some(dir_db) = maybe_dir_db {
+            dir_db.add_child(&vnode_obj)?;
             *total_written += 1;
         }
 
-        log::debug!(
-            "Processing vnode {} with {} entries",
-            vnode.id,
-            vnode.entries.len()
-        );
+        // log::debug!(
+        //     "Processing vnode {} with {} entries",
+        //     vnode.id,
+        //     vnode.entries.len()
+        // );
 
-        let mut vnode_ns = session.create_node(&vnode_obj, parent_id_for_vnode)?;
+        let mut vnode_db = MerkleNodeDB::open_read_write(
+            &repo.path,
+            &vnode_obj,
+            maybe_dir_db.as_ref().map(|db| db.node_id),
+        )?;
         for entry in vnode.entries.iter() {
-            log::trace!("Processing entry {} in vnode {}", entry.node, vnode.id);
+            // log::debug!("Processing entry {} in vnode {}", entry.node, vnode.id);
             match &entry.node.node {
                 EMerkleTreeNode::Directory(node) => {
                     // If the dir has updates, we need a new dir db
                     let dir_path = entry.node.maybe_path()?;
+                    // log::debug!("Processing dir node {:?}", dir_path);
                     let dir_node = if entries.contains_key(&dir_path) {
                         let dir_node =
                             compute_dir_node(repo, commit_id, entries, dir_hashes, &dir_path)?;
 
-                        vnode_ns.add_child(&dir_node)?;
+                        // if let Some(vnode_db) = &mut maybe_vnode_db {
+                        vnode_db.add_child(&dir_node)?;
                         *total_written += 1;
+                        // }
 
-                        let mut child_ns = session.create_node(&dir_node, Some(vnode.id))?;
+                        // if the vnode is new, we need a new dir db
+                        // let mut child_db = if maybe_vnode_db.is_some() {
+                        let mut child_db = Some(MerkleNodeDB::open_read_write(
+                            &repo.path,
+                            &dir_node,
+                            Some(vnode.id),
+                        )?);
+
                         r_create_dir_node(
                             repo,
-                            session,
                             commit_id,
-                            Some(&mut *child_ns),
+                            &mut child_db,
                             dir_hash_db,
                             dir_hashes,
                             entries,
                             &dir_path,
                             total_written,
                         )?;
-                        child_ns.finish()?;
-
                         dir_node
                     } else {
+                        // log::debug!("r_create_dir_node skipping {:?}", dir_path);
                         // Look up the old dir node and reference it
                         let Some(old_dir_node) =
                             CommitMerkleTree::read_node(repo, node.hash(), false)?
                         else {
-                            log::trace!(
-                                "r_create_dir_node could not read old dir node {}",
-                                node.hash().to_hex_hash(),
-                            );
+                            // log::debug!(
+                            //     "r_create_dir_node could not read old dir node {:?}",
+                            //     node.hash
+                            // );
                             continue;
                         };
                         let dir_node = old_dir_node.dir()?;
-                        vnode_ns.add_child(&dir_node)?;
+
+                        // if let Some(vnode_db) = &mut maybe_vnode_db {
+                        vnode_db.add_child(&dir_node)?;
                         *total_written += 1;
+                        // }
                         dir_node
                     };
 
@@ -938,12 +931,12 @@ fn r_create_dir_node(
                     let file_path = PathBuf::from(&file_node.name());
                     let file_name = file_path.file_name().unwrap().to_str().unwrap();
 
-                    log::trace!(
-                        "Processing file {:?} in vnode {} in commit {}",
-                        path,
-                        vnode.id,
-                        commit_id.to_hex_hash(),
-                    );
+                    // log::debug!(
+                    //     "Processing file {:?} in vnode {} in commit {}",
+                    //     path,
+                    //     vnode.id,
+                    //     commit_id
+                    // );
 
                     // Just single file chunk for now
                     let chunks = vec![file_node.hash().to_u128()];
@@ -956,8 +949,9 @@ fn r_create_dir_node(
                     file_node.set_last_commit_id(&last_commit_id);
                     file_node.set_name(file_name);
 
-                    vnode_ns.add_child(&file_node)?;
+                    vnode_db.add_child(&file_node)?;
                     *total_written += 1;
+                    // }
                 }
                 _ => {
                     return Err(OxenError::basic_str(format!(
@@ -967,7 +961,6 @@ fn r_create_dir_node(
                 }
             }
         }
-        vnode_ns.finish()?;
     }
 
     log::debug!("Finished processing dir {path:?} total written {total_written} entries");

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -2,13 +2,13 @@ use bytesize::ByteSize;
 use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use std::any::type_name_of_val;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str;
 use tar::Archive;
 
 use crate::constants::{NODES_DIR, OXEN_HIDDEN_DIR, TREE_DIR};
+use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::db::merkle_node::merkle_node_db::node_db_path;
 use crate::core::node_sync_status;
 use crate::core::v_latest::index::CommitMerkleTree as CommitMerkleTreeLatest;
@@ -16,7 +16,6 @@ use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_old::v0_19_0::index::CommitMerkleTree as CommitMerkleTreeV0_19_0;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::merkle_tree::merkle_writer::MerkleWriteSession;
 use crate::model::merkle_tree::node::{
     CommitNode, DirNodeWithPath, EMerkleTreeNode, FileNode, FileNodeWithDir, MerkleTreeNode,
 };
@@ -1018,16 +1017,12 @@ pub fn unpack_nodes(
 }
 
 /// Write a node to disk
-// TODO: this should just accept `&CommitNode`
 pub fn write_tree(repo: &LocalRepository, node: &MerkleTreeNode) -> Result<(), OxenError> {
     let EMerkleTreeNode::Commit(commit_node) = &node.node else {
         return Err(OxenError::basic_str("Expected commit node"));
     };
     let commit_node = CommitNode::new(repo, commit_node.get_opts())?;
-    let store = repo.merkle_store();
-    let session = store.begin()?;
-    p_write_tree(&*session, node, &commit_node)?;
-    session.finish()?;
+    p_write_tree(repo, node, &commit_node)?;
     Ok(())
 }
 
@@ -1035,33 +1030,37 @@ pub fn write_tree(repo: &LocalRepository, node: &MerkleTreeNode) -> Result<(), O
 ///
 /// Recursively writes the node and all its children to disk. To write a full tree, the node
 /// (`node_impl`) **MUST** be the root of the tree -- i.e. a `Commit` node.
-fn p_write_tree(
-    session: &dyn MerkleWriteSession,
+///
+/// [1] https://github.com/rust-lang/rust/issues/20041)
+fn p_write_tree<N: TMerkleTreeNode>(
+    repo: &LocalRepository,
     node: &MerkleTreeNode,
-    node_impl: &dyn TMerkleTreeNode,
+    node_impl: &N,
 ) -> Result<(), OxenError> {
     let parent_id = node.parent_id;
 
-    let mut ns = session.create_node(node_impl, parent_id)?;
+    let mut db = MerkleNodeDB::open_read_write(&repo.path, node_impl, parent_id)?;
     for child in &node.children {
         match &child.node {
             EMerkleTreeNode::VNode(vnode) => {
-                ns.add_child(vnode)?;
-                p_write_tree(session, child, vnode)?;
+                db.add_child(vnode)?;
+                p_write_tree(repo, child, vnode)?;
             }
             EMerkleTreeNode::Directory(dir_node) => {
-                ns.add_child(dir_node)?;
-                p_write_tree(session, child, dir_node)?;
+                db.add_child(dir_node)?;
+                p_write_tree(repo, child, dir_node)?;
             }
             EMerkleTreeNode::File(file_node) => {
-                ns.add_child(file_node)?;
+                db.add_child(file_node)?;
             }
-            n => {
-                return Err(OxenError::DisallowedNodeWrite(type_name_of_val(n)));
+            node => {
+                return Err(OxenError::basic_str(format!(
+                    "p_write_tree unexpected node type: {node:?}"
+                )));
             }
         }
     }
-    ns.finish()?;
+    db.close()?;
     Ok(())
 }
 

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -302,6 +302,18 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::NotFound().json(error_json)
                     }
+                    OxenError::MerkleNodeNotFound(hash) => {
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_RESOURCE_NOT_FOUND,
+                                "title": "Merkle node not found",
+                                "detail": format!("Could not find Merkle tree node with hash: {hash}")
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_RESOURCE_NOT_FOUND,
+                        });
+                        HttpResponse::NotFound().json(error_json)
+                    }
                     OxenError::PathDoesNotExist(path) => {
                         log::debug!("Path does not exist: {path}");
                         let error_json = json!({


### PR DESCRIPTION
Revert #513 as part of backing out our first Merkle tree redesign attempt (12 of 15). We're planning a simpler approach for the next attempt.

Things that we didn't revert from the original PR:
- The structured `OxenError::MerkleNodeNotFound` (and `pub HexHash`), wired into `is_not_found()` and the oxen-server 404 mapping. Why: a missing Merkle node should surface to API callers as a 404, not a 500, and is distinguishable from other errors.
- The `get_children` error-vs-absence distinction in `MerkleTreeNode`. Why: a missing node DB (e.g. a subtree clone) yields empty children, but a parse/IO error on an existing node now propagates instead of being silently swallowed.
- `p_write_tree` returns a plain error on an unexpected node type instead of panicking. Why: a bad node type is a recoverable error, not a crash. (`DisallowedNodeWrite`, which only made sense with the dynamic trait `add_child`, is dropped with the rest of the trait machinery.)

ENG-1142