### PR TITLE
Harden workspace data-frame commit: error types, atomic export, lock recovery

### DIFF
--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock, Mutex as StdMutex};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex, PoisonError};
 use tokio::fs::File;
 use tokio::io::BufReader;
 use tokio::sync::Mutex as TokioMutex;
@@ -27,27 +27,22 @@ use crate::view::merge::{MergeConflictFile, Mergeable};
 use filetime::FileTime;
 use indicatif::ProgressBar;
 
-// Serializes commits per workspace. A workspace commit reads the staged db,
-// exports indexed data frames into the working dir, writes the commit, then
-// wipes the staged db — none of it under a lock. Two concurrent commits of
-// the same workspace can therefore tear each other's data-frame export
-// mid-read or wipe staged entries out from under the other commit. Keyed by
-// the workspace repo path (unique per workspace); entries are dropped once no
-// commit holds or waits on the lock.
+// Serializes commits of the same workspace so two concurrent commits can't
+// tear each other's data-frame export mid-read or wipe the shared staged db.
+// Keyed by the workspace repo path; in-process, and entries are dropped once
+// no commit holds or waits on the lock.
 static COMMIT_LOCKS: LazyLock<StdMutex<HashMap<PathBuf, Arc<TokioMutex<()>>>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
 fn commit_lock_for(key: &Path) -> Arc<TokioMutex<()>> {
-    let mut locks = COMMIT_LOCKS
-        .lock()
-        .expect("workspace commit lock registry poisoned");
+    // Poisoning only means a holder panicked; the map of Arc handles is still
+    // sound, so recover the guard.
+    let mut locks = COMMIT_LOCKS.lock().unwrap_or_else(PoisonError::into_inner);
     locks.entry(key.to_path_buf()).or_default().clone()
 }
 
 fn cleanup_commit_lock(key: &Path) {
-    let mut locks = COMMIT_LOCKS
-        .lock()
-        .expect("workspace commit lock registry poisoned");
+    let mut locks = COMMIT_LOCKS.lock().unwrap_or_else(PoisonError::into_inner);
     if let Some(lock) = locks.get(key) {
         // The registry's reference is the only one left — no holder, no
         // waiter — so the entry can be dropped. A late-arriving committer
@@ -334,6 +329,7 @@ async fn export_tabular_data_frames(
                             workspace,
                             &exported_path,
                             dir_entry.status,
+                            file_node.data_type().clone(),
                         )
                         .await?;
 
@@ -367,6 +363,7 @@ async fn compute_staged_merkle_tree_node(
     workspace: &Workspace,
     path: &PathBuf,
     status: StagedEntryStatus,
+    data_type: EntryDataType,
 ) -> Result<StagedMerkleTreeNode, OxenError> {
     // This logic is copied from add.rs but add has some optimizations that make it hard to be reused here
     let metadata = util::fs::metadata(path)?;
@@ -375,9 +372,9 @@ async fn compute_staged_merkle_tree_node(
     let num_bytes = metadata.len();
     let hash = MerkleHash::new(hash);
 
-    // Get the data type of the file
+    // Use the committed node's data type for the guard below: an empty export
+    // can mime-detect as non-tabular.
     let mime_type = util::fs::file_mime_type(path);
-    let data_type = util::fs::datatype_from_mimetype(path, &mime_type);
     log::debug!("compute_staged_merkle_tree_node path: {path:?}");
     let mut metadata = repositories::metadata::get_file_metadata(path, &data_type)?;
     log::debug!("compute_staged_merkle_tree_node metadata: {metadata:?}");
@@ -389,10 +386,7 @@ async fn compute_staged_merkle_tree_node(
     // — an empty jsonl/csv has no schema to infer). Failing the commit keeps
     // the last good version readable.
     if data_type == EntryDataType::Tabular && metadata.is_none() {
-        return Err(OxenError::basic_str(format!(
-            "Cannot commit data frame {path:?}: the exported file could not be parsed as tabular data \
-             (it may be empty after row deletions). Refusing to commit a tabular file without metadata."
-        )));
+        return Err(OxenError::TabularExportMissingMetadata(path.clone()));
     }
 
     // Here we give priority to the staged schema, as it can contained metadata that was changed during the

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -338,19 +338,20 @@ pub fn extract_file_node_to_working_dir(
         )?;
     }
 
-    // Export to a temp file in the same directory and rename into place.
-    // DuckDB's COPY truncates and writes the target in place; without the
-    // rename, a concurrent reader of the working path (e.g. another commit of
-    // the same workspace hashing/parsing the file) can observe a torn or
-    // empty file. The temp name keeps the real extension last so
-    // wrap_sql_for_export still picks the right output format.
+    // Export to a sibling temp file, then rename into place so a concurrent
+    // reader of the working path never sees a torn or partial export. The
+    // `.oxentmp.` infix lets fsck reclaim an orphan from a killed export; the
+    // real extension stays last so wrap_sql_for_export picks the right format.
     let file_name = working_path
         .file_name()
-        .ok_or_else(|| OxenError::basic_str(format!("Invalid export path: {working_path:?}")))?
+        .ok_or_else(|| OxenError::internal_error(format!("Invalid export path: {working_path:?}")))?
         .to_string_lossy()
         .to_string();
-    let export_path =
-        working_path.with_file_name(format!(".{}.export-{}", std::process::id(), file_name));
+    let export_path = working_path.with_file_name(format!(
+        ".oxentmp.{}.export-{}",
+        std::process::id(),
+        file_name
+    ));
 
     with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
@@ -372,9 +373,15 @@ pub fn extract_file_node_to_working_dir(
     })?;
 
     // wrap_sql_for_export falls back to a bare SELECT (no COPY, no file) for
-    // extensions it doesn't know how to export; only rename when the COPY
+    // extensions it doesn't know how to export; only publish when the COPY
     // actually produced the temp file.
     if export_path.exists() {
+        // fsync before the rename so a crash can't leave the published file
+        // pointing at unflushed bytes. Open writable: sync_all maps to
+        // FlushFileBuffers on Windows, which rejects a read-only handle.
+        let exported = std::fs::OpenOptions::new().write(true).open(&export_path)?;
+        exported.sync_all()?;
+        drop(exported);
         util::fs::rename(&export_path, &working_path)?;
     }
 

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -203,6 +203,13 @@ pub enum OxenError {
         source: Box<OxenError>,
     },
 
+    /// A workspace commit's indexed tabular export has no schema to infer
+    /// (e.g. every row was staged for removal), so it carries no metadata.
+    #[error(
+        "Cannot commit data frame {0:?}: the exported file has no tabular metadata (it may be empty after row deletions). Refusing to commit a tabular file without metadata."
+    )]
+    TabularExportMissingMetadata(PathBuf),
+
     /// Adding a file into a workspace
     #[error("{0}")]
     ImportFileError(StringError),
@@ -788,6 +795,9 @@ impl OxenError {
             }
             S3BackendMissingServerOpts => {
                 "Set `[storage] s3_bucket = \"<your-bucket>\"` in the server's config TOML and restart oxen-server."
+            }
+            TabularExportMissingMetadata(_) => {
+                "The data frame has no rows to commit. Add at least one row, or discard the workspace edits, then retry."
             }
             _ => return None,
         }

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -525,6 +525,21 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::InternalServerError().json(error_json)
                     }
+                    OxenError::TabularExportMissingMetadata(path) => {
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_BAD_REQUEST,
+                                "title": "Cannot commit an empty data frame",
+                                "detail": format!(
+                                    "The data frame '{}' has no rows to commit (it may be empty after row deletions), so it has no tabular schema. Add at least one row before committing.",
+                                    path.to_string_lossy()
+                                )
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
                     OxenError::Basic(error) | OxenError::InternalError(error) => {
                         let error_json = json!({
                             "error": {


### PR DESCRIPTION
Follow-ups from review of #624

- Recover from a poisoned `COMMIT_LOCKS` registry with `PoisonError::into_inner` instead of panicking. The guarded map of `Arc` handles stays sound across a holder panic.
- Add `OxenError::TabularExportMissingMetadata `and map it to HTTP 400 in oxen-server. Refusing to commit a schemaless tabular export (e.g. every row staged for removal) is a client-caused condition, so a structured 4xx fits better than a generic 500.
- Name the DuckDB export scratch with the `.oxentmp.` infix and `fsync` it before the rename, so the publish matches the atomic-write helpers and an orphan from a killed export is fsck-recognizable.
- Key the empty-export guard on the committed node's `data_type` rather than re-sniffing the export's mime type, which an empty file can misclassify as non-tabular and slip the guard.
- Use `internal_error` for the internal "invalid export path" invariant.
- Document that the per-workspace commit lock guards same-workspace races only; the branch-head update is still last-writer-wins. We won't fix that here -- it will be addressed in the larger Repository Integrity project.