### PR TITLE
Fix bump-version version parsing from cargo pkgid

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -11,7 +11,13 @@ set -euo pipefail
 
 # Get current version from the main Cargo.toml
 get_current_version() {
-    cargo pkgid -p liboxen | cut -f2 -d@
+    # cargo pkgid emits "<source>#<version>" when the crate name matches its
+    # path's final segment, and "<source>#<name>@<version>" otherwise. Strip
+    # everything up to the last '#', then drop any optional "<name>@" prefix.
+    local pkgid
+    pkgid=$(cargo pkgid -p liboxen)
+    pkgid="${pkgid##*#}"
+    echo "${pkgid##*@}"
 }
 
 # Parse and validate semver format


### PR DESCRIPTION
cargo pkgid emits the liboxen version after '#' (e.g. path+file:///.../crates/liboxen#0.50.4), not '@', because the crate name matches its path's final segment. The old 'cut -f2 -d@' found no '@' and returned the whole pkgid string, so the version became a file URL and the downstream sed substitution failed with 'unknown option to s'.

Parse the version by stripping up to the last '#' then any optional '<name>@' prefix, handling both cargo pkgid formats.