### PR TITLE
Repo Integrity (1.8): Serialize name-index DB writes with a RwLock

### DIFF
--- a/crates/liboxen/src/core/workspaces/workspace_name_index.rs
+++ b/crates/liboxen/src/core/workspaces/workspace_name_index.rs
@@ -4,7 +4,7 @@ use std::str::{self, Utf8Error};
 use std::sync::{Arc, LazyLock};
 
 use lru::LruCache;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use rocksdb::{DB, IteratorMode};
 
 use crate::constants::{OXEN_HIDDEN_DIR, WORKSPACE_NAME_INDEX_DIR, WORKSPACES_DIR};
@@ -16,8 +16,10 @@ use crate::util;
 
 const DB_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
 
-// Static cache of DB instances with LRU eviction
-static DB_INSTANCES: LazyLock<Mutex<LruCache<PathBuf, Arc<DB>>>> =
+// Static cache of DB instances with LRU eviction. The inner `RwLock<DB>` lets
+// compound read-modify-write sequences (e.g. `put_if_absent`) run under exclusive
+// access. Never hold the guard across `.await`.
+static DB_INSTANCES: LazyLock<Mutex<LruCache<PathBuf, Arc<RwLock<DB>>>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(DB_CACHE_SIZE)));
 
 #[derive(Debug, thiserror::Error)]
@@ -86,7 +88,7 @@ pub fn remove_from_cache_with_children(repository_path: &Path) {
 }
 
 pub struct WorkspaceNameIndex {
-    db: Arc<DB>,
+    db: Arc<RwLock<DB>>,
 }
 
 /// Returns a [`WorkspaceNameIndex`] handle for the given repository.
@@ -107,7 +109,7 @@ pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, WsError> 
 
     let opts = db::key_val::opts::default();
     let db = DB::open(&opts, dunce::simplified(&dir)).map_err(WsError::OpenError)?;
-    let arc_db = Arc::new(db);
+    let arc_db = Arc::new(RwLock::new(db));
     instances.put(dir, arc_db.clone());
     Ok(WorkspaceNameIndex { db: arc_db })
 }
@@ -115,7 +117,8 @@ pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, WsError> 
 impl WorkspaceNameIndex {
     /// Get workspace ID by name. O(1).
     pub fn get_id_by_name(&self, name: &str) -> Result<Option<String>, WsError> {
-        match self.db.get(name.as_bytes()) {
+        let db = self.db.read();
+        match db.get(name.as_bytes()) {
             Ok(Some(value)) => Ok(Some(String::from(
                 str::from_utf8(&value).map_err(|e| WsError::NonUtf8Key(name.to_string(), e))?,
             ))),
@@ -126,7 +129,8 @@ impl WorkspaceNameIndex {
 
     /// Check if a name exists in the index. O(1).
     pub fn has_name(&self, name: &str) -> Result<bool, OxenError> {
-        match self.db.get_pinned(name.as_bytes()) {
+        let db = self.db.read();
+        match db.get_pinned(name.as_bytes()) {
             Ok(Some(_)) => Ok(true),
             Ok(None) => Ok(false),
             Err(err) => Err(OxenError::basic_str(format!(
@@ -137,42 +141,48 @@ impl WorkspaceNameIndex {
 
     /// Insert a name -> workspace_id mapping.
     pub fn put(&self, name: &str, workspace_id: &str) -> Result<(), WsError> {
-        self.db
-            .put(name.as_bytes(), workspace_id.as_bytes())
-            .map_err(|e| WsError::PutError(name.to_string(), e))?;
-        Ok(())
+        let db = self.db.write();
+        Self::put_locked(&db, name, workspace_id)
+    }
+
+    /// Insert the (name, workspace_id) mapping if `name` is not already present.
+    /// Returns `Ok(None)` on success, or `Ok(Some(existing_id))` if `name` was
+    /// already taken. The get-then-put runs under a single write lock so two
+    /// concurrent callers cannot both observe an absent name and both insert.
+    pub fn put_if_absent(&self, name: &str, workspace_id: &str) -> Result<Option<String>, WsError> {
+        let db = self.db.write();
+        if let Some(existing) = db
+            .get(name.as_bytes())
+            .map_err(|e| WsError::LookupErr(name.to_string(), e))?
+        {
+            let existing_id = str::from_utf8(&existing)
+                .map_err(|e| WsError::NonUtf8Key(name.to_string(), e))?
+                .to_string();
+            return Ok(Some(existing_id));
+        }
+        Self::put_locked(&db, name, workspace_id)?;
+        Ok(None)
     }
 
     /// Remove a name from the index.
     pub fn delete(&self, name: &str) -> Result<(), WsError> {
-        self.db
-            .delete(name.as_bytes())
+        let db = self.db.write();
+        db.delete(name.as_bytes())
             .map_err(|e| WsError::DeleteError(name.to_string(), e))?;
         Ok(())
     }
 
     /// Remove all entries from the index.
     pub fn clear(&self) -> Result<(), WsError> {
-        let iter = self.db.iterator(IteratorMode::Start);
-        for item in iter {
-            match item {
-                Ok((key, _)) => {
-                    self.db.delete(&key).map_err(|e| {
-                        WsError::PutError(String::from_utf8_lossy(&key).to_string(), e)
-                    })?;
-                }
-                Err(err) => {
-                    return Err(WsError::IterationError(err));
-                }
-            }
-        }
-        Ok(())
+        let db = self.db.write();
+        Self::clear_locked(&db)
     }
 
     /// List all (name, workspace_id) entries for debugging/testing.
     #[cfg(test)]
     pub fn list(&self) -> Result<Vec<(String, String)>, WsError> {
-        let iter = self.db.iterator(IteratorMode::Start);
+        let db = self.db.read();
+        let iter = db.iterator(IteratorMode::Start);
         let mut results = Vec::new();
         for item in iter {
             match item {
@@ -197,15 +207,18 @@ impl WorkspaceNameIndex {
     /// Rebuild the index from existing workspace configs on disk.
     /// Clears all existing entries first, then scans `.oxen/workspaces/` directories.
     pub fn rebuild_from_disk(&self, repo: &LocalRepository) -> Result<(), WsError> {
-        self.clear()?;
-
         let workspaces_dir = repo.path.join(OXEN_HIDDEN_DIR).join(WORKSPACES_DIR);
-        if !workspaces_dir.exists() {
-            return Ok(());
-        }
+        let workspace_dirs = if workspaces_dir.exists() {
+            util::fs::list_dirs_in_dir(&workspaces_dir)
+                .map_err(|e| WsError::ListWsErr(Box::new(e)))?
+        } else {
+            Vec::new()
+        };
 
-        let workspace_dirs = util::fs::list_dirs_in_dir(&workspaces_dir)
-            .map_err(|e| WsError::ListWsErr(Box::new(e)))?;
+        // Hold the write lock across clear + every put so a concurrent reader
+        // never sees the index in a half-rebuilt state.
+        let db = self.db.write();
+        Self::clear_locked(&db)?;
 
         for workspace_dir in workspace_dirs {
             let config_path = workspace_dir
@@ -236,10 +249,32 @@ impl WorkspaceNameIndex {
             };
 
             if let (Some(name), Some(id)) = (&config.workspace_name, &config.workspace_id) {
-                self.put(name, id)?;
+                Self::put_locked(&db, name, id)?;
             }
         }
 
+        Ok(())
+    }
+
+    fn put_locked(db: &DB, name: &str, workspace_id: &str) -> Result<(), WsError> {
+        db.put(name.as_bytes(), workspace_id.as_bytes())
+            .map_err(|e| WsError::PutError(name.to_string(), e))
+    }
+
+    fn clear_locked(db: &DB) -> Result<(), WsError> {
+        let iter = db.iterator(IteratorMode::Start);
+        for item in iter {
+            match item {
+                Ok((key, _)) => {
+                    db.delete(&key).map_err(|e| {
+                        WsError::PutError(String::from_utf8_lossy(&key).to_string(), e)
+                    })?;
+                }
+                Err(err) => {
+                    return Err(WsError::IterationError(err));
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -318,6 +353,67 @@ mod tests {
             assert_eq!(entries.len(), 2);
             assert!(entries.contains(&("alpha".to_string(), "id-a".to_string())));
             assert!(entries.contains(&("beta".to_string(), "id-b".to_string())));
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_put_if_absent_inserts_on_first_call() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let idx = get_index(&repo)?;
+            let result = idx.put_if_absent("alpha", "id-a")?;
+            assert_eq!(result, None);
+            assert_eq!(idx.get_id_by_name("alpha")?, Some("id-a".to_string()));
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_put_if_absent_returns_existing_on_collision() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let idx = get_index(&repo)?;
+            assert_eq!(idx.put_if_absent("alpha", "id-a")?, None);
+
+            // Second insert for the same name must report the existing id and
+            // must NOT overwrite the stored value.
+            let result = idx.put_if_absent("alpha", "id-b")?;
+            assert_eq!(result, Some("id-a".to_string()));
+            assert_eq!(idx.get_id_by_name("alpha")?, Some("id-a".to_string()));
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_put_if_absent_exactly_one_winner() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let idx = std::sync::Arc::new(get_index(&repo)?);
+
+            let mut handles = Vec::new();
+            for i in 0..10 {
+                let idx = idx.clone();
+                let id = format!("id-{i}");
+                handles.push(tokio::task::spawn_blocking(move || {
+                    idx.put_if_absent("shared-name", &id)
+                        .map(|existing| (id, existing))
+                }));
+            }
+
+            let mut winner_count = 0;
+            let mut winner_id = None;
+            for handle in handles {
+                let (id, existing) = handle.await.expect("task panic")?;
+                if existing.is_none() {
+                    winner_count += 1;
+                    winner_id = Some(id);
+                }
+            }
+
+            assert_eq!(winner_count, 1, "exactly one put_if_absent caller wins");
+            let stored = idx.get_id_by_name("shared-name")?;
+            assert_eq!(stored, winner_id, "the winner's id is the one persisted");
             Ok(())
         })
         .await

--- a/crates/liboxen/src/repositories/size.rs
+++ b/crates/liboxen/src/repositories/size.rs
@@ -86,7 +86,9 @@ pub fn update_size(repo: &LocalRepository) -> Result<(), OxenError> {
                     status: SizeStatus::Error,
                     size: 0,
                 };
-                let _ = AtomicFile::new(&path_clone).write(size.to_string().as_bytes());
+                if let Err(e) = AtomicFile::new(&path_clone).write(size.to_string().as_bytes()) {
+                    log::error!("Failed to write size error status: {e}");
+                }
             }
         }
     });

--- a/crates/liboxen/src/repositories/workspaces.rs
+++ b/crates/liboxen/src/repositories/workspaces.rs
@@ -157,13 +157,32 @@ pub async fn create_with_name(
     is_editable: bool,
 ) -> Result<Workspace, OxenError> {
     let workspace_id = workspace_id.as_ref();
+
+    // Materialize the name index before `create_on_disk` so the one-time
+    // `rebuild_from_disk` doesn't observe (and pre-claim) the workspace we are
+    // about to create — which would make the closing `put_if_absent` look like
+    // a collision against ourselves.
+    if workspace_name.is_some() {
+        ensure_name_index(base_repo).await?;
+    }
+
     let workspace = create_on_disk(base_repo, commit, workspace_id, workspace_name, is_editable)?;
 
-    // Update the name index (async: rebuild_from_disk may run on a blocking thread)
+    // `put_if_absent` closes the TOCTOU between `validate_create_constraints`'s
+    // `has_name` check and the write — two concurrent `create_with_name` calls
+    // for the same name will both pass validation, but only one wins the atomic
+    // insert; the loser rolls back its just-created workspace dir.
     if let Some(ref name) = workspace.name {
-        ensure_name_index(base_repo).await?;
         let idx = workspace_name_index::get_index(base_repo)?;
-        idx.put(name, workspace_id)?;
+        if idx.put_if_absent(name, workspace_id)?.is_some() {
+            if let Err(e) = util::fs::remove_dir_all(&workspace.workspace_repo.path) {
+                log::error!(
+                    "Failed to clean up workspace dir {:?} after losing name-index race: {e}",
+                    workspace.workspace_repo.path
+                );
+            }
+            return Err(OxenError::WorkspaceAlreadyExists(name.to_string()));
+        }
     }
 
     Ok(workspace)
@@ -1077,6 +1096,73 @@ mod tests {
             }
 
             Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_create_with_name_exactly_one_succeeds() -> Result<(), OxenError> {
+        const NUM_TASKS: usize = 10;
+        const SHARED_NAME: &str = "shared-workspace-name";
+
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+
+            let mut handles = Vec::with_capacity(NUM_TASKS);
+            for i in 0..NUM_TASKS {
+                let repo = repo.clone();
+                let commit = commit.clone();
+                handles.push(tokio::spawn(async move {
+                    let workspace_id = format!("ws-id-{i}");
+                    create_with_name(
+                        &repo,
+                        &commit,
+                        &workspace_id,
+                        Some(SHARED_NAME.to_string()),
+                        true,
+                    )
+                    .await
+                }));
+            }
+
+            let mut winners = Vec::new();
+            let mut already_exists_count = 0;
+            for handle in handles {
+                match handle.await.expect("task panicked") {
+                    Ok(ws) => winners.push(ws),
+                    Err(OxenError::WorkspaceAlreadyExists(_)) => already_exists_count += 1,
+                    Err(e) => return Err(e),
+                }
+            }
+
+            assert_eq!(winners.len(), 1, "exactly one create_with_name must win");
+            assert_eq!(
+                already_exists_count,
+                NUM_TASKS - 1,
+                "every loser must return WorkspaceAlreadyExists",
+            );
+
+            // The winner's workspace dir must still be on disk; loser dirs are rolled back.
+            let winner = &winners[0];
+            assert!(winner.workspace_repo.path.exists());
+            for i in 0..NUM_TASKS {
+                let loser_id = format!("ws-id-{i}");
+                if loser_id == winner.id {
+                    continue;
+                }
+                let loser_id_hash = util::hasher::hash_str_sha256(&loser_id);
+                let loser_dir = Workspace::workspace_dir(&repo, &loser_id_hash);
+                assert!(
+                    !loser_dir.exists(),
+                    "loser workspace dir {loser_dir:?} should have been rolled back",
+                );
+            }
+
+            // The index maps the name to the winner.
+            let idx = workspace_name_index::get_index(&repo)?;
+            assert_eq!(idx.get_id_by_name(SHARED_NAME)?, Some(winner.id.clone()));
+
+            Ok(())
         })
         .await
     }

--- a/crates/oxen-server/src/auth/access_keys.rs
+++ b/crates/oxen-server/src/auth/access_keys.rs
@@ -55,7 +55,6 @@ impl AccessKeyManager {
             // Just generating a random UUID for now
             let secret = uuid::Uuid::new_v4();
             let key = hex::encode(secret.as_bytes());
-            log::debug!("Got secret key: {key}");
             AtomicFile::new(&secret_file).write(key.as_bytes())?;
         }
 


### PR DESCRIPTION
Very similar concurrency fixes to what we've done with other RocksDB instances.

- Wrap the workspace name-index DB (`workspace_name_index.rs`) in `parking_lot::RwLock<DB>`
- Add `put_if_absent(name, id)` that runs the get-then-put under a single write lock.
- `create_with_name` now publishes the name via `put_if_absent` and, on collision, removes the just-created workspace dir before returning `WorkspaceAlreadyExists` so two concurrent `create_with_name` calls for the same name can no longer both succeed.
- `ensure_name_index` is moved to run before `create_on_disk` so the one-time `rebuild_from_disk` doesn't observe the workspace we're about to create and pre-claim its name (which would make our own `put_if_absent` look like a collision against ourselves).
- `rebuild_from_disk` and `clear` now hold one write guard across the full sequence via private `put_locked` / `clear_locked` helpers, so concurrent readers can't observe a half-rebuilt index.

Drive-by fixes:
- `repositories/size.rs`: log the error on the size-file write in the error arm
- `oxen-server/src/auth/access_keys.rs`: drop the `log::debug!("Got secret key: ...")` that wrote the JWT signing key in plaintext.

Refs ENG-1057.