### PR TITLE
LMDB (2): Reusable LmdbStore lifecycle trait

### DIFF
--- a/crates/liboxen/src/lmdb.rs
+++ b/crates/liboxen/src/lmdb.rs
@@ -16,11 +16,14 @@
 //!   * [`handle_cache`] — [`LmdbEnvRegistry`] (the ONE path-keyed, weak-retention env cache that
 //!     enforces "at most one live env per canonical path") plus [`open_shared_env`], the
 //!     process-global entry point a store calls instead of standing up its own registry.
+//!   * [`store`] — the `LmdbStore` default-method lifecycle trait: an implementor supplies the
+//!     env + database hook and inherits `read`/`write`/`snapshot_to`; its domain ops stay inherent.
 
 pub mod handle_cache;
 pub mod lmdb_db;
 pub mod lmdb_env;
 pub mod lmdb_error;
+pub mod store;
 pub mod txn;
 
 pub use handle_cache::{LmdbEnvRegistry, open_shared_env, shared_env_is_live};

--- a/crates/liboxen/src/lmdb/CLAUDE.md
+++ b/crates/liboxen/src/lmdb/CLAUDE.md
@@ -1,0 +1,13 @@
+# LMDB layer — notes for AI agents
+
+This is the reusable, low-level LMDB layer. **Before writing or modifying a store that builds on it, read [`README.md`](./README.md) in this directory** — it is the authoritative implementor's guide (opening an env through `open_shared_env`, the `LmdbStore` trait, key/value framing, transactions, and the async edge). The bullets below are a quick reference, not a replacement for it.
+
+Load-bearing invariants:
+
+- **Don't use this layer directly from application code.** Write a thin per-domain store wrapper (see the README's worked example).
+- **One logical store per env**, and open envs **only** through `lmdb::open_shared_env` (the layer's process-global registry; the raw open primitive is module-private on purpose), so a path is opened at most once and the env is shared — a store does not stand up its own registry.
+- **Never hold a transaction across `.await`.** Read txns are `Send` here, so the compiler will *not* catch this — it is a written discipline. Copy what you need out of a read txn into owned `bytes::Bytes` and drop the txn promptly.
+- **One `write` closure = one atomic commit** (commit on `Ok`, roll back on `Err`/panic). The layer is synchronous; wrap each operation in a single `spawn_blocking` at the async edge per `docs/async_policy.md`.
+- **Fixed per-store `map_size`, no runtime resize.** Exhausting it is `LmdbLayerError::MapFull`, whose only remedy is to raise the store's constant and rebuild — never a runtime recovery path.
+- **Errors stay in `OxenError`.** `LmdbLayerError` bridges in via `#[from]`; store methods return `Result<_, OxenError>` and don't leak `LmdbLayerError` to callers.
+- **Least visibility for new items.** Keep additions as private as possible and add public surface only when a consumer actually needs it.

--- a/crates/liboxen/src/lmdb/README.md
+++ b/crates/liboxen/src/lmdb/README.md
@@ -1,0 +1,123 @@
+# Writing an LMDB-backed store
+
+This directory is the reusable, **low-level LMDB layer**. Application code should **not** use it directly. Instead, write a thin per-domain *store wrapper* that owns its env, names its databases, and chooses its own key encoding and value framing. This guide walks through writing one. (For the layer's internal design, read the module doc in `../lmdb.rs` and the per-file docs; this README is the implementor's how-to.)
+
+## The shape, in one breath
+
+A store is **one LMDB env** (one logical store per env) holding **one or more named databases**, opened through **`open_shared_env`** (the layer's process-global registry, so a path is opened at most once), implementing the **`LmdbStore`** trait to get its lifecycle (`read` / `write` / `snapshot_to`) for free, exposing **inherent domain methods** written over `self.read` / `self.write`, and wrapped in **`spawn_blocking`** at the async edge (the layer is synchronous).
+
+## Worked example
+
+A minimal single-database store. Read it top to bottom — every line is explained in the steps below.
+
+```rust
+use std::path::Path;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use bytesize::ByteSize;
+
+use crate::error::OxenError;
+use crate::lmdb::store::LmdbStore;
+use crate::lmdb::{LmdbDb, LmdbEnv, LmdbEnvConfig, open_db, open_shared_env};
+
+pub struct RefsStore {
+    env: Arc<LmdbEnv>,
+    db: LmdbDb,
+}
+
+impl RefsStore {
+    /// Open (or share) the refs env for the repo at `dir`.
+    pub fn open(dir: &Path) -> Result<Self, OxenError> {
+        // `max_dbs = 1` (single database); the map size is this store's fixed budget (step 1).
+        // No per-store registry — the layer's process-global one dedups by path.
+        let env = open_shared_env(dir, &LmdbEnvConfig::new(1, ByteSize::mib(256)))?;
+        let db = open_db(&env, "refs")?;
+        Ok(RefsStore { env, db })
+    }
+
+    /// Resolve a ref name to its commit id.
+    pub fn get(&self, name: &str) -> Result<Option<Bytes>, OxenError> {
+        self.read(|db, txn| Ok(db.get(txn, name.as_bytes())?))
+    }
+
+    /// Point a ref name at a commit id — one atomic commit.
+    pub fn set(&self, name: &str, commit_id: &[u8]) -> Result<(), OxenError> {
+        self.write(|db, txn| Ok(db.put(txn, name.as_bytes(), commit_id)?))
+    }
+}
+
+impl LmdbStore for RefsStore {
+    fn lmdb_env(&self) -> &LmdbEnv {
+        &self.env
+    }
+
+    fn lmdb_db(&self) -> &LmdbDb {
+        &self.db
+    }
+}
+```
+
+## Step 1 — pick a fixed map size
+
+Each store names its own `map_size`; the layer defines no default. It is a **sparse virtual-address reservation, not committed RAM** — resident memory tracks your working set, not the map size — so choose generously *for that store*: a small, bounded index (refs, a name index) picks a conservative size; a large graph store reserves much more. The map is **never resized at runtime**: if a store exhausts it, that surfaces as `LmdbLayerError::MapFull`, whose only remedy is to raise the constant and rebuild — deliberately a code change, not a runtime path. Fleet-wide virtual address is additive across stores × concurrently-open repos, so don't reserve terabytes "to be safe."
+
+## Step 2 — one logical store per env
+
+Build an `LmdbEnvConfig::new(max_dbs, map_size)` where `max_dbs` is the number of databases *this* store uses. Keep one logical store per env. Do **not** lump several unrelated stores into a single env: LMDB allows **one writer per env**, so a shared env serializes every write through one lock and throws away cross-store write concurrency. (Consolidating *many instances of the same store* — e.g. per-resource directories — into one env with composite keys is fine and encouraged; that's different from mixing distinct stores.)
+
+## Step 3 — open through `open_shared_env`, never directly
+
+Open envs only through `open_shared_env(dir, &config)` (the raw open primitive is module-private precisely so this can't be bypassed). It returns a shared `Arc<LmdbEnv>` from the layer's **process-global** registry, enforcing **at most one live env per canonical path** and deduping overlapping opens — so a store does **not** stand up its own registry; it just names its `config`. The registry is **weak-retention**: it does not keep the env alive — *your store does*, by holding the returned `Arc<LmdbEnv>`. When the last `Arc` drops, the env closes; a later `open_shared_env` reopens it cheaply (an idle env's hot pages stay warm in the OS page cache). `config` is consulted only on an actual open; on a shared hit it is ignored. (A higher layer — a per-repo cache — may eventually own env handles instead.)
+
+## Step 4 — open your database(s)
+
+Call `open_db(&env, "name")` for each database; it runs the write txn that heed requires for opening a database, so a single-database store opens in one line (as in the example). To open several databases together, run them inside one `with_write_txn` closure with the lower primitive `LmdbDb::open(&env, txn, "name")` rather than paying a separate write txn per database. A `LmdbDb` is a raw-bytes key / opaque-bytes value accessor; it is cheap to clone and you hold it for the store's lifetime. Keys are plain `&[u8]` and values are opaque bytes — **you** decide how to encode keys and frame values (including any magic/version bytes). LMDB orders keys by lexicographic byte comparison; that is correct for point lookups and for byte/string-ordered scans, but a store needing *numeric*-ordered range scans over a multi-byte integer would first need a big-endian key codec added to the layer (not present yet — add it when a verified consumer needs it).
+
+## Step 5 — implement `LmdbStore` for the lifecycle
+
+Implement the two-method hook (`lmdb_env`, `lmdb_db`) and you inherit:
+
+- `read(|db, txn| …)` / `write(|db, txn| …)` — the transaction brackets with your primary database pre-bound. `read` opens a read snapshot; `write` commits iff your closure returns `Ok` and rolls back on `Err` (or panic). Both are generic over the closure's error type, so you can return `OxenError` directly (the `LmdbLayerError → OxenError` bridge is `#[from]`, so `?` just works, as in the example).
+- `snapshot_to(dst_dir)` — a point-in-time env copy (for forks), which always uses `CompactionOption::Disabled` so you can't accidentally trip `MDB_INCOMPATIBLE` on a multi-database env.
+
+If your store has multiple databases, implement the hook with your *primary* database and reach the others inside a `with_read_txn` / `with_write_txn` closure directly (or hold each `LmdbDb` and use them within the txn the bracket gives you).
+
+## Step 6 — write domain methods
+
+Your store's actual API (`get` / `set` above; a node store's `read_tree` / `put_nodes`) are **inherent methods** over `self.read` / `self.write`. One logical unit of work = one `write` closure = one atomic commit (e.g. a whole batch of node writes goes in a single `write`). Reads copy their results out into owned `bytes::Bytes`, so a returned value safely outlives the short transaction it came from — you never hand a caller a borrow into the mmap.
+
+## Step 7 — go async at the edge
+
+The layer is synchronous. Per the repo's sync-core / async-edge policy ([docs/async_policy.md](../../../../docs/async_policy.md)), expose async methods that wrap **one operation** in a single `spawn_blocking`, with the whole transaction living inside that closure:
+
+```rust
+impl RefsStore {
+    pub async fn get_async(self: &Arc<Self>, name: String) -> Result<Option<Bytes>, OxenError> {
+        let store = Arc::clone(self);
+        // One operation, one spawn_blocking; the txn never spans an `.await`.
+        // Map the JoinError to OxenError per docs/async_policy.md.
+        tokio::task::spawn_blocking(move || store.get(&name)).await?
+    }
+}
+```
+
+The store (an `Arc<LmdbEnv>` plus `LmdbDb`s) is `Send + Sync`, so wrap it in `Arc` and clone it into the closure.
+
+## Rules you must follow
+
+- **Never hold a transaction across `.await`.** Read txns are `Send` here (a side effect of `WithoutTls`), so the compiler will *not* catch this for you — it is a written discipline. Beyond unsoundness, a long-lived reader pins old B-tree pages and starves the writer of free pages, pushing a fixed-map store toward `MapFull`. Copy what you need out and drop the txn.
+- **One `write` closure = one atomic commit.** Group a logical unit of work into a single `write`; don't split it across multiple commits unless you mean to.
+- **Always open through `open_shared_env`.** Never construct a second env for the same path yourself — that breaks the one-live-env-per-path invariant the shared registry exists to hold.
+- **The map size is fixed.** Plan step 1; treat `MapFull` as "raise the constant and rebuild," not a runtime condition to recover from.
+- **Errors stay in `OxenError`.** Domain methods return `Result<_, OxenError>`; `LmdbLayerError` bridges in via `#[from]`. Don't surface `LmdbLayerError` to callers of the store.
+- **Before deleting / renaming an env directory** (or choosing a fork snapshot destination), check `lmdb::shared_env_is_live(path)` — under weak retention a `false` confirms no open mmap is blocking the filesystem operation; a `true` means the precondition ("this repo is not in use") is violated and you should refuse.
+
+## Module map
+
+- `lmdb_env.rs` — `LmdbEnv` (heed `Env<WithoutTls>`), `LmdbEnvConfig`, the open primitive, and `copy_lmdb_env_to_dir` (backing `snapshot_to`).
+- `lmdb_db.rs` — `LmdbDb` (the raw-bytes key / opaque-value accessor and its full-scan `iter`) plus `open_db`, the one-line single-database open.
+- `txn.rs` — `with_read_txn` / `with_write_txn`, the only sanctioned read/write entry points, and the txn-lifetime rule.
+- `handle_cache.rs` — `LmdbEnvRegistry` plus `open_shared_env` / `shared_env_is_live`: the path-keyed, weak-retention env cache and its process-global accessors.
+- `store.rs` — `LmdbStore`: the default-method lifecycle trait you implement.
+- `lmdb_error.rs` — `LmdbLayerError`, the leaf error bridged into `OxenError`.

--- a/crates/liboxen/src/lmdb/lmdb_env.rs
+++ b/crates/liboxen/src/lmdb/lmdb_env.rs
@@ -18,10 +18,10 @@
 //! repo." This makes the registry's identity model unambiguous.
 
 use std::fs::create_dir_all;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use bytesize::ByteSize;
-use heed::{Env, EnvOpenOptions, WithoutTls};
+use heed::{CompactionOption, Env, EnvOpenOptions, WithoutTls};
 
 use super::lmdb_error::LmdbLayerError;
 
@@ -35,6 +35,12 @@ pub type LmdbEnv = Env<WithoutTls>;
 /// Default reader-lock-table size for `LmdbEnvConfig::new`. Generous because the server can hold
 /// many concurrent readers; stores expecting few readers can set `max_readers` smaller directly.
 const DEFAULT_MAX_READERS: u32 = 1024;
+
+/// The name LMDB gives the data file inside an env directory.
+// Used only by `copy_lmdb_env_to_dir`; drop this `allow` together with the one on that function
+// once a non-test `LmdbStore` implementor exists.
+#[allow(dead_code)]
+const LMDB_DATA_FILE: &str = "data.mdb";
 
 /// Tunables for opening one LMDB env. Field meanings are backend-shaped so future stores reuse the
 /// same surface. This layer deliberately defines **no** default `map_size`: it is a per-store
@@ -68,7 +74,7 @@ impl LmdbEnvConfig {
 /// Build page-aligned `EnvOpenOptions<WithoutTls>` (rounds size up to runtime page size, sets
 /// max_dbs + max_readers, selects `WithoutTls`). Opens WITHOUT `MDB_NOSYNC`/`MDB_NOMETASYNC`, so
 /// each `RwTxn::commit` fsyncs — commit is the durability boundary; no drop-time `force_sync` is
-/// needed. Errors only if the size doesn't fit in `usize`.
+/// needed (see `copy_lmdb_env_to_dir`). Errors only if the size doesn't fit in `usize`.
 fn build_options(config: &LmdbEnvConfig) -> Result<EnvOpenOptions<WithoutTls>, LmdbLayerError> {
     // LMDB requires `map_size` to be a multiple of the OS page size; round up rather than
     // surface a confusing `EINVAL` from `mdb_env_set_mapsize`.
@@ -116,6 +122,34 @@ pub(in crate::lmdb) fn open_lmdb_env(
         source,
     })?;
     Ok(lmdb_env)
+}
+
+/// Copy the env's data file to `dst_dir` (fork snapshots), returning the path of the copied data
+/// file. The copy runs under its own read txn, so a live env is copied point-in-time
+/// consistently; LMDB durability is per-`commit`, so a snapshot taken after a committed write
+/// needs no `force_sync`. Compaction is hard-wired off (`CompactionOption::Disabled`) rather than
+/// exposed as a parameter: the compacting path runs a page-size-dependent free-page check that
+/// fails `MDB_INCOMPATIBLE` on multi-sub-DB envs, and no store wants it.
+// `pub(crate)`: an internal layer primitive backing `LmdbStore::snapshot_to`. Until a non-test
+// store implements `LmdbStore`, its only callers are that trait's default method and tests, so drop
+// this `#[allow(dead_code)]` (and the one on `LMDB_DATA_FILE`) once an implementor lands.
+#[allow(dead_code)]
+pub(crate) fn copy_lmdb_env_to_dir(
+    lmdb_env: &LmdbEnv,
+    dst_dir: &Path,
+) -> Result<PathBuf, LmdbLayerError> {
+    create_dir_all(dst_dir).map_err(|source| LmdbLayerError::CreateDir {
+        path: dst_dir.to_path_buf(),
+        source,
+    })?;
+    let dst = dst_dir.join(LMDB_DATA_FILE);
+    lmdb_env
+        .copy_to_path(&dst, CompactionOption::Disabled)
+        .map_err(|source| LmdbLayerError::Copy {
+            dst: dst.clone(),
+            source,
+        })?;
+    Ok(dst)
 }
 
 #[cfg(test)]

--- a/crates/liboxen/src/lmdb/lmdb_error.rs
+++ b/crates/liboxen/src/lmdb/lmdb_error.rs
@@ -1,9 +1,9 @@
 //! Leaf error type for the low-level LMDB layer, bridged into `OxenError` via the
 //! `#[from]`-derived `OxenError::LmdbLayer` variant (the same module-local-enum pattern as
-//! `LmdbError`, `MerkleDbError`, and `RepoConfigError`).
+//! `MerkleDbError` and `RepoConfigError`).
 //!
 //! A dedicated enum, rather than variants on `OxenError`, for two reasons. It keeps `heed::Error`
-//! (carried by `Open`/`Txn`/`Read`/`Write`) out of the top-level `OxenError` surface, so
+//! (carried by `Open`/`Txn`/`Read`/`Write`/`Copy`) out of the top-level `OxenError` surface, so
 //! the heed dependency stays contained to this layer. And it keeps this cohesive cluster of
 //! low-level infra errors — none of which a public-API caller branches on — together and out of
 //! the already-large `OxenError`, while still letting in-layer code branch on a specific heed
@@ -61,6 +61,13 @@ pub enum LmdbLayerError {
          store; increase it and rebuild."
     )]
     MapFull { capacity: ByteSize },
+
+    #[error("Could not copy LMDB environment to {dst}: {source}")]
+    Copy {
+        dst: PathBuf,
+        #[source]
+        source: heed::Error,
+    },
 }
 
 impl LmdbLayerError {

--- a/crates/liboxen/src/lmdb/store.rs
+++ b/crates/liboxen/src/lmdb/store.rs
@@ -1,0 +1,136 @@
+//! The `LmdbStore` lifecycle trait: the shared env lifecycle every LMDB-backed store gets for
+//! free. An implementor supplies only the env + primary-database hook; the trait default-implements
+//! `read`/`write` (the transaction brackets pre-bound to the store's database) and `snapshot_to`
+//! (env copy). The point is correctness via shared code — the lifecycle is written once here, not
+//! re-derived per store where it could drift (e.g. forgetting `CompactionOption::Disabled` on a
+//! snapshot). A store's own domain operations stay inherent methods written over
+//! `self.read`/`self.write`.
+//!
+//! This is distinct from a future cross-engine store trait (e.g. File vs LMDB): that contract's
+//! impls necessarily differ by engine and so can't be defaulted, whereas `LmdbStore` is
+//! cross-LMDB-store and shares one impl.
+
+use std::path::{Path, PathBuf};
+
+use heed::{RoTxn, RwTxn, WithoutTls};
+
+use super::lmdb_db::LmdbDb;
+use super::lmdb_env::{LmdbEnv, copy_lmdb_env_to_dir};
+use super::lmdb_error::LmdbLayerError;
+use super::txn::{with_read_txn, with_write_txn};
+
+/// Shared lifecycle for an LMDB-backed store: one env, one primary database, the transaction
+/// brackets, and env snapshotting — supplied as defaults so every store behaves identically.
+///
+/// An implementor provides only [`LmdbStore::lmdb_env`] and [`LmdbStore::lmdb_db`]; it then calls
+/// `self.read` / `self.write` from its own inherent domain methods.
+// `pub(crate)` + `#[allow(dead_code)]`: consumer-less until the first real implementor lands — a
+// test impl exercises the defaults meanwhile. Drop the `allow` (and the ones on
+// `copy_lmdb_env_to_dir` / `LMDB_DATA_FILE`) once an implementor exists.
+#[allow(dead_code)]
+pub(crate) trait LmdbStore {
+    /// The store's environment (one logical store per env).
+    fn lmdb_env(&self) -> &LmdbEnv;
+
+    /// The store's primary database.
+    fn lmdb_db(&self) -> &LmdbDb;
+
+    /// Run `f` inside a read transaction with the store's database pre-bound. The txn cannot escape
+    /// the closure (see the txn-lifetime rule in `txn`); copy out what you need. `E` is generic so
+    /// the closure can return a domain error (e.g. `OxenError`) directly.
+    fn read<R, E>(
+        &self,
+        f: impl FnOnce(&LmdbDb, &RoTxn<'_, WithoutTls>) -> Result<R, E>,
+    ) -> Result<R, E>
+    where
+        E: From<LmdbLayerError>,
+    {
+        with_read_txn(self.lmdb_env(), |txn| f(self.lmdb_db(), txn))
+    }
+
+    /// Run `f` inside a write transaction with the store's database pre-bound, committing iff `f`
+    /// returns `Ok` (one logical unit of work = one closure = one atomic commit).
+    fn write<R, E>(&self, f: impl FnOnce(&LmdbDb, &mut RwTxn<'_>) -> Result<R, E>) -> Result<R, E>
+    where
+        E: From<LmdbLayerError>,
+    {
+        with_write_txn(self.lmdb_env(), |txn| f(self.lmdb_db(), txn))
+    }
+
+    /// Snapshot the store's env into `dst_dir` (point-in-time consistent), returning the copied
+    /// data file's path. See `copy_lmdb_env_to_dir` for the snapshot/compaction semantics.
+    fn snapshot_to(&self, dst_dir: &Path) -> Result<PathBuf, LmdbLayerError> {
+        copy_lmdb_env_to_dir(self.lmdb_env(), dst_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytesize::ByteSize;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::lmdb::lmdb_env::{LmdbEnvConfig, open_lmdb_env};
+
+    /// A minimal `LmdbStore` to exercise the default methods until a real store implements it.
+    struct TestStore {
+        lmdb_env: LmdbEnv,
+        db: LmdbDb,
+    }
+
+    impl LmdbStore for TestStore {
+        fn lmdb_env(&self) -> &LmdbEnv {
+            &self.lmdb_env
+        }
+
+        fn lmdb_db(&self) -> &LmdbDb {
+            &self.db
+        }
+    }
+
+    fn test_store() -> (TempDir, TestStore) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let lmdb_env =
+            open_lmdb_env(dir.path(), &LmdbEnvConfig::new(1, ByteSize::mib(16))).expect("open env");
+        let db =
+            with_write_txn(&lmdb_env, |txn| LmdbDb::open(&lmdb_env, txn, "data")).expect("open db");
+        (dir, TestStore { lmdb_env, db })
+    }
+
+    /// `write` commits on `Ok` and `read` sees the committed value — both through the database the
+    /// hook pre-binds, so the store never touches a raw txn.
+    #[test]
+    fn read_and_write_go_through_the_brackets() {
+        let (_dir, store) = test_store();
+        store
+            .write(|db, txn| db.put(txn, b"key", b"value"))
+            .expect("write");
+        let value = store
+            .read(|db, txn| db.get(txn, b"key"))
+            .expect("read")
+            .expect("value present");
+        assert_eq!(value.as_ref(), b"value");
+    }
+
+    /// `snapshot_to` copies committed state; reopening the snapshot yields the same data.
+    #[test]
+    fn snapshot_to_copies_committed_state() {
+        let (_dir, store) = test_store();
+        store
+            .write(|db, txn| db.put(txn, b"key", b"value"))
+            .expect("write");
+
+        let dst = tempfile::tempdir().expect("create temp dir");
+        let data_file = store.snapshot_to(dst.path()).expect("snapshot");
+        assert!(data_file.exists());
+
+        let copied = open_lmdb_env(dst.path(), &LmdbEnvConfig::new(1, ByteSize::mib(16)))
+            .expect("open snapshot");
+        let copied_db =
+            with_write_txn(&copied, |txn| LmdbDb::open(&copied, txn, "data")).expect("open db");
+        let value = with_read_txn(&copied, |txn| copied_db.get(txn, b"key"))
+            .expect("read")
+            .expect("value present");
+        assert_eq!(value.as_ref(), b"value");
+    }
+}


### PR DESCRIPTION
(Stacked on #646)

This is the 2nd and final PR for the (initial) low-level LMDB layer. This PR makes it much easier to use the primitives from the last PR.

- Add a `README.md` with an implementor's guide and an example high-level store implementation.
- Add a `CLAUDE.md` pointing AI to the readme and listing invariants to follow.
- Add the `LmdbStore` trait. Implementing the two required methods (`lmdb_env` and `lmdb_db`) gets you the rest of the shared lifecycle as default methods for free:
  - `read`
  - `write`
  - `snapshot_to`
