### PR TITLE
Merkle Revert (15): Revert #406 TMerkleTreeNode dyn-compatibility

### DIFF
--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -298,7 +298,7 @@ impl MerkleNodeDB {
 
     pub(crate) fn open_read_write(
         repo_path: &Path,
-        node: &dyn TMerkleTreeNode,
+        node: &impl TMerkleTreeNode,
         parent_id: Option<MerkleHash>,
     ) -> Result<Self, MerkleDbError> {
         let path = node_db_path(repo_path, &node.hash());
@@ -392,7 +392,7 @@ impl MerkleNodeDB {
     /// WARNING: Sets the internal dtype, node_id, parent_id of `self` to the values from `node`.
     fn write_node(
         &mut self,
-        node: &dyn TMerkleTreeNode,
+        node: &impl TMerkleTreeNode,
         parent_id: Option<MerkleHash>,
     ) -> Result<(), MerkleDbError> {
         if self.read_only {
@@ -420,7 +420,7 @@ impl MerkleNodeDB {
         }
 
         // Write data length
-        let buf = node.to_msgpack_bytes()?;
+        let buf = rmp_serde::to_vec(node)?;
         let data_len = buf.len() as u32;
         node_file.write_all(&data_len.to_le_bytes())?;
         log::trace!("write_node Wrote data length {}", data_len);
@@ -440,7 +440,7 @@ impl MerkleNodeDB {
     }
 
     /// Writes the content of a node's child as the child would appear in the `children` file.
-    pub(crate) fn add_child(&mut self, item: &dyn TMerkleTreeNode) -> Result<(), MerkleDbError> {
+    pub(crate) fn add_child(&mut self, item: &impl TMerkleTreeNode) -> Result<(), MerkleDbError> {
         if self.read_only {
             return Err(MerkleDbError::ReadOnly);
         }
@@ -452,7 +452,7 @@ impl MerkleNodeDB {
             return Err(MerkleDbError::WriteBeforeOpen);
         };
 
-        let buf = item.to_msgpack_bytes()?;
+        let buf = rmp_serde::to_vec(item)?;
         let data_len = buf.len() as u64;
         // log::debug!("--add_child-- node_file {:?}", node_file);
         // log::debug!("--add_child-- dtype {:?}", item.dtype());

--- a/crates/liboxen/src/model/merkle_tree/node/commit_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/commit_node.rs
@@ -9,7 +9,7 @@ use crate::core::v_old::v0_19_0::model::merkle_tree::node::commit_node::CommitNo
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository};
-use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType};
+use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode};
 
 pub trait TCommitNode {
     fn node_type(&self) -> &MerkleTreeNodeType;
@@ -201,6 +201,8 @@ impl MerkleTreeNodeIdType for CommitNode {
         *self.node().hash()
     }
 }
+
+impl TMerkleTreeNode for CommitNode {}
 
 /// Debug is used for verbose multi-line output with println!("{:?}", node)
 impl fmt::Debug for CommitNode {

--- a/crates/liboxen/src/model/merkle_tree/node/dir_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/dir_node.rs
@@ -8,7 +8,9 @@ use crate::core::v_latest::model::merkle_tree::node::dir_node::DirNodeData as Di
 use crate::core::v_old::v0_19_0::model::merkle_tree::node::dir_node::DirNodeData as DirNodeDataV0_19_0;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::{LocalRepository, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType};
+use crate::model::{
+    LocalRepository, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode,
+};
 use crate::view::DataTypeCount;
 
 pub trait TDirNode {
@@ -256,6 +258,8 @@ impl MerkleTreeNodeIdType for DirNode {
         *self.node().hash()
     }
 }
+
+impl TMerkleTreeNode for DirNode {}
 
 /// Debug is used for verbose multi-line output with println!("{:?}", node)
 impl fmt::Debug for DirNode {

--- a/crates/liboxen/src/model/merkle_tree/node/file_chunk_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/file_chunk_node.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType};
+use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode};
 
 use std::fmt;
 
@@ -41,6 +41,8 @@ impl MerkleTreeNodeIdType for FileChunkNode {
         self.hash
     }
 }
+
+impl TMerkleTreeNode for FileChunkNode {}
 
 /// Debug is used for verbose multi-line output with println!("{:?}", node)
 impl fmt::Debug for FileChunkNode {

--- a/crates/liboxen/src/model/merkle_tree/node/file_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/file_node.rs
@@ -7,6 +7,7 @@ use crate::model::merkle_tree::node::file_node_types::{FileChunkType, FileStorag
 use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::{
     EntryDataType, LocalRepository, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType,
+    TMerkleTreeNode,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -257,6 +258,8 @@ impl Hash for FileNode {
         self.hash().hash(state);
     }
 }
+
+impl TMerkleTreeNode for FileNode {}
 
 /// Debug is used for verbose multi-line output with println!("{:?}", node)
 impl fmt::Debug for FileNode {

--- a/crates/liboxen/src/model/merkle_tree/node/vnode.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/vnode.rs
@@ -9,7 +9,9 @@ use crate::core::v_latest::model::merkle_tree::node::vnode::VNodeData as VNodeIm
 use crate::core::v_old::v0_19_0::model::merkle_tree::node::vnode::VNodeData as VNodeImplV0_19_0;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::{LocalRepository, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType};
+use crate::model::{
+    LocalRepository, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode,
+};
 
 pub trait TVNode {
     fn node_type(&self) -> &MerkleTreeNodeType;
@@ -151,3 +153,5 @@ impl fmt::Display for VNode {
         write!(f, "")
     }
 }
+
+impl TMerkleTreeNode for VNode {}

--- a/crates/liboxen/src/model/merkle_tree/node_type.rs
+++ b/crates/liboxen/src/model/merkle_tree/node_type.rs
@@ -32,7 +32,7 @@ pub enum MerkleTreeNodeType {
     /// Directories can be very large, so we split their contents into (potentially) multiple
     /// virtual directory nodes: a `VNode`. A `VNode` is like a directory: it contains some
     /// number of files and directories. It is always a subset of a real directory. If a
-    /// directory has multiple `VNode` children, these children form a strict paritioning.
+    /// directory has multiple `VNode` children, these children form a strict partitioning.
     VNode,
 
     /// A chunk of a file in the repository. (TODO: unused at this point, but planned)
@@ -67,7 +67,7 @@ impl MerkleTreeNodeType {
     changed for existing `MerkleTreeNode` variants.
 
     **NEW** variants can be added without a migration. New variants must have an incremented `u8`
-    value to not conflcit with any existing variants. Older repositories will still be able to be
+    value to not conflict with any existing variants. Older repositories will still be able to be
     read by newer variants: they will simply not contain nodes of the new variant.
 
     If there is some **OTHER** backwards-incompatible change with how the repository data is stored
@@ -116,31 +116,10 @@ pub trait MerkleTreeNodeIdType {
 
 /// Trait for things that are Merkle tree nodes.
 ///
-/// Critical functionality is to be able to serialize node, compute a stable merkle hash, and
+/// Critical functionality is to be able to serialize the node, compute a stable merkle hash, and
 /// identify the node as a `MerkleTreeNodeType`. The Debug & Display constraints are for
 /// convenience.
-///
-/// Since this trait is used as a parameter for generic functions, it must be object-safe. This
-/// means that it cannot extend `Serialize` since that has a `<S: Serializer>` parameter on the
-/// `serialize` method, which causes the type to not be implementable as a vtable lookup.
-///
-/// This is why the trait contains a manual serialization (`to_msgpack_bytes`) method. For types
-/// that do implement `Serialize`, there's a blanket implementation that delegates the `serialize`
-/// call to the `to_msgpack_bytes` method.
-pub trait TMerkleTreeNode: MerkleTreeNodeIdType + Debug + Display {
-    /// Serialize this node to a MsgPack byte array.
-    fn to_msgpack_bytes(&self) -> Result<Vec<u8>, rmp_serde::encode::Error>;
-}
-
-/// Blanket implementation for Merkle tree nodes that implement serde's `Serialize` trait.
-impl<T: Serialize + MerkleTreeNodeIdType + Debug + Display> TMerkleTreeNode for T {
-    /// Uses serde to serialize this node.
-    fn to_msgpack_bytes(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
-        let mut buf = Vec::new();
-        let x = self.serialize(&mut rmp_serde::Serializer::new(&mut buf));
-        x.map(|_| buf)
-    }
-}
+pub trait TMerkleTreeNode: MerkleTreeNodeIdType + Serialize + Debug + Display {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1240,12 +1240,10 @@ pub fn write_tree(repo: &LocalRepository, node: &MerkleTreeNode) -> Result<(), O
 ///
 /// Recursively writes the node and all its children to disk. To write a full tree, the node
 /// (`node_impl`) **MUST** be the root of the tree -- i.e. a `Commit` node.
-///
-/// [1] https://github.com/rust-lang/rust/issues/20041)
-fn p_write_tree<N: TMerkleTreeNode>(
+fn p_write_tree(
     repo: &LocalRepository,
     node: &MerkleTreeNode,
-    node_impl: &N,
+    node_impl: &impl TMerkleTreeNode,
 ) -> Result<(), OxenError> {
     let parent_id = node.parent_id;
 


### PR DESCRIPTION
(Stacked on #652)

THIS IS THE LAST REVERT PR 🎉 

Revert #406 as part of backing out our first Merkle tree redesign attempt (15 of 15). We're planning a simpler approach for the next attempt.

Things that we didn't revert from the original PR:
- The fallible `from_u8`, which returns an `InvalidMerkleTreeNodeType` error instead of `panic!`-ing on an unknown node-type byte. Why: a corrupt or unrecognized on-disk node-type marker should surface as a recoverable error, not crash the process.
- The "DO NOT MODIFY" doc on the u8 -> node-type mapping plus the per-variant doc comments (with the `paritioning`/`conflcit` typo fixes). Why: that mapping is a load-bearing on-disk contract, and the warning keeps a future editor from silently breaking existing repositories.
- Error propagation, instead of `.unwrap()` panics, when serializing a node during a write. Why: a msgpack serialization failure should be a recoverable error, so we keep the `?` propagation #406 introduced, now via a direct `rmp_serde::to_vec(node)?`.

ENG-1151