### PR TITLE
LMDB (2b) - Rewire MerkleNodeDB to read/write through MerkleNodeStore

### DIFF
--- a/crates/liboxen/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/liboxen/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -95,9 +95,13 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
 
     // Write a new commit db
     let commit_node = CommitNode::from_commit(commit.clone());
-    let mut root_commit_db =
-        MerkleNodeDB::open_read_write(&old_repo.path, &commit_node, root_node.parent_id)?;
+    let mut root_commit_db = MerkleNodeDB::open_read_write(
+        old_repo.merkle_node_store(),
+        &commit_node,
+        root_node.parent_id,
+    )?;
     root_commit_db.add_child(&dir_node)?;
+    root_commit_db.close()?;
 
     let current_path = Path::new("");
     rewrite_nodes(&old_repo, &new_repo, &root_node, current_path)?;
@@ -148,8 +152,11 @@ fn rewrite_nodes(
                 let mut dir_node_opts = dir.get_opts();
                 dir_node_opts.num_entries = total_children as u64;
                 let dir = DirNode::new(new_repo, dir_node_opts)?;
-                let mut dir_db =
-                    MerkleNodeDB::open_read_write(&old_repo.path, &dir, node.parent_id)?;
+                let mut dir_db = MerkleNodeDB::open_read_write(
+                    old_repo.merkle_node_store(),
+                    &dir,
+                    node.parent_id,
+                )?;
 
                 // log::debug!(
                 //     "rewrite_nodes {} VNodes for {} children in {} with vnode size {}",
@@ -213,7 +220,7 @@ fn rewrite_nodes(
                     dir_db.add_child(&vnode_obj)?;
 
                     let mut vnode_db = MerkleNodeDB::open_read_write(
-                        &new_repo.path,
+                        new_repo.merkle_node_store(),
                         &vnode_obj,
                         Some(dir_db.node_id),
                     )?;
@@ -242,7 +249,9 @@ fn rewrite_nodes(
                             }
                         }
                     }
+                    vnode_db.close()?;
                 }
+                dir_db.close()?;
 
                 rewrite_nodes(old_repo, new_repo, child, &current_dir)?;
             }

--- a/crates/liboxen/src/core/db/merkle_node.rs
+++ b/crates/liboxen/src/core/db/merkle_node.rs
@@ -3,3 +3,4 @@ pub mod merkle_node_db;
 pub mod merkle_node_store;
 
 pub(crate) use merkle_node_db::MerkleNodeDB;
+pub(crate) use merkle_node_store::{MerkleNodeStore, create_merkle_node_store};

--- a/crates/liboxen/src/core/db/merkle_node/fs_merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/fs_merkle_node_store.rs
@@ -19,9 +19,6 @@ pub(crate) struct FsMerkleNodeStore {
     repo_path: PathBuf,
 }
 
-// `new` is unconsumed until `MerkleNodeDB` delegates to a `MerkleNodeStore` (exercised by the tests
-// below meanwhile); the trait impl methods carry the rest. Drop the allow when a consumer lands.
-#[allow(dead_code)]
 impl FsMerkleNodeStore {
     pub(crate) fn new(repo_path: impl Into<PathBuf>) -> Self {
         Self {

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -46,22 +46,25 @@ For example, data for a vnode of hash 1234 with two children:
     {dir data node}
 */
 
-use std::fs::File;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
-use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use bytes::{Bytes, BytesMut};
 
 use crate::constants;
 use crate::error::OxenError;
 use crate::model::MerkleHash;
 use crate::model::merkle_tree::node_type::InvalidMerkleTreeNodeType;
-use crate::util;
 
 use crate::model::merkle_tree::node::{
     EMerkleTreeNode, MerkleTreeNode, MerkleTreeNodeType, TMerkleTreeNode,
 };
+
+use super::fs_merkle_node_store::FsMerkleNodeStore;
+use super::merkle_node_store::MerkleNodeStore;
 
 pub(crate) const NODE_FILE: &str = "node";
 pub(crate) const CHILDREN_FILE: &str = "children";
@@ -138,10 +141,6 @@ impl MerkleDbError {
         Self::DirCreate(Box::new(err))
     }
 
-    fn open(err: OxenError) -> Self {
-        Self::Open(Box::new(err))
-    }
-
     pub(crate) fn fs_transport(err: OxenError) -> Self {
         Self::FsTransport(Box::new(err))
     }
@@ -157,20 +156,9 @@ struct MerkleNodeLookup {
 }
 
 impl MerkleNodeLookup {
-    fn load(node_table_file: &mut File) -> Result<Self, MerkleDbError> {
-        // log::debug!("MerkleNodeLookup.load() {:?}", node_table_file);
-        let mut file_data = Vec::new();
-        node_table_file.read_to_end(&mut file_data)?;
-        // log::debug!(
-        //     "MerkleNodeLookup.load() read file_data: {}",
-        //     file_data.len()
-        // );
-        Self::deserialize(file_data)
-    }
-
-    /// Takes the on-disk bytes of a `node` file and deserializes it into a [`MerkleNodeLookup`].
+    /// Takes the bytes of a node's `node` blob and deserializes it into a [`MerkleNodeLookup`].
     #[inline(always)]
-    fn deserialize(file_data: Vec<u8>) -> Result<Self, MerkleDbError> {
+    fn deserialize(file_data: Bytes) -> Result<Self, MerkleDbError> {
         // Create a cursor to iterate over data
         let mut cursor = std::io::Cursor::new(file_data);
 
@@ -254,25 +242,45 @@ impl MerkleNodeLookup {
     }
 }
 
+/// Reads and writes a single Merkle tree node and its children list.
+///
+/// The on-engine format is owned here (the `node` blob header + child lookup table, and the
+/// concatenated `children` blob); *where* those two blobs are persisted is delegated to a
+/// [`MerkleNodeStore`]. In read-write mode the blobs are accumulated in memory and persisted as one
+/// unit by [`close`](Self::close) — there is no incremental flushing, so a node is written exactly
+/// once and atomically. A write-mode db dropped without `close` discards its buffers unwritten (see
+/// the `Drop` impl) rather than risk persisting a partial node.
+///
+/// The constructors take a `repo_path` and resolve the file backend internally; a later change
+/// hands the store in from the repo so the backend (file vs. another engine) is selected once at
+/// repository construction.
 pub(crate) struct MerkleNodeDB {
     pub dtype: MerkleTreeNodeType,
     pub node_id: MerkleHash,
     pub parent_id: Option<MerkleHash>,
     read_only: bool,
-    node_file: Option<File>,
-    children_file: Option<File>,
+    store: Arc<dyn MerkleNodeStore>,
+    /// `node` blob accumulator (header + child lookup entries). `Some` in read-write mode until the
+    /// node is persisted, then `None`.
+    node_buf: Option<BytesMut>,
+    /// `children` blob accumulator (concatenated child node data). `Some`/`None` in lockstep with
+    /// `node_buf`.
+    children_buf: Option<BytesMut>,
+    /// True once the write buffers have been persisted by `close`. A write-mode db must reach this
+    /// state before being dropped; `Drop` checks it to detect (and assert on) a forgotten `close`.
+    flushed: bool,
+    /// Decoded `node` blob; `Some` only in read-only mode.
     lookup: Option<MerkleNodeLookup>,
-    data: Vec<u8>,
+    /// Running length of `children_buf`, written into each child's lookup entry.
     data_offset: u64,
 }
 
 impl MerkleNodeDB {
     pub fn data(&self) -> Vec<u8> {
-        if let Some(lookup) = &self.lookup {
-            return lookup.data.to_owned();
-        }
-
-        self.data.to_owned()
+        self.lookup
+            .as_ref()
+            .map(|lookup| lookup.data.to_owned())
+            .unwrap_or_default()
     }
 
     pub fn node(&self) -> Result<EMerkleTreeNode, MerkleDbError> {
@@ -287,17 +295,41 @@ impl MerkleNodeDB {
         EMerkleTreeNode::from_type_and_bytes(dtype, data)
     }
 
+    /// Whether a node has been written for `hash`. A store error is reported as `false`, mirroring
+    /// `Path::exists()` (which the file backend is built on).
     pub(crate) fn exists(repo_path: &Path, hash: &MerkleHash) -> bool {
-        let db_path = node_db_path(repo_path, hash);
-        db_path.join(NODE_FILE).exists() && db_path.join(CHILDREN_FILE).exists()
+        Self::fs_store(repo_path).exists(hash).unwrap_or(false)
+    }
+
+    /// The file backend for the repo at `repo_path`. Resolved per-open for now; a later change has
+    /// the repo own a single store and hand it in.
+    fn fs_store(repo_path: &Path) -> Arc<dyn MerkleNodeStore> {
+        Arc::new(FsMerkleNodeStore::new(repo_path))
     }
 
     pub(crate) fn open_read_only(
         repo_path: &Path,
         hash: &MerkleHash,
     ) -> Result<Self, MerkleDbError> {
-        let path = node_db_path(repo_path, hash);
-        Self::open(path, true, *hash)
+        let store = Self::fs_store(repo_path);
+        let node_bytes = store.read_node(hash)?;
+        let lookup = MerkleNodeLookup::deserialize(node_bytes)?;
+        let dtype = MerkleTreeNodeType::from_u8(lookup.data_type)?;
+        // A zero parent id round-trips as `Some(MerkleHash::new(0))`, matching the historical
+        // behavior that callers (e.g. `MerkleTreeNode::from_hash_uncached`) read directly.
+        let parent_id = Some(MerkleHash::new(lookup.parent_id));
+        Ok(Self {
+            dtype,
+            node_id: *hash,
+            parent_id,
+            read_only: true,
+            store,
+            node_buf: None,
+            children_buf: None,
+            flushed: true,
+            lookup: Some(lookup),
+            data_offset: 0,
+        })
     }
 
     pub(crate) fn open_read_write(
@@ -305,94 +337,45 @@ impl MerkleNodeDB {
         node: &impl TMerkleTreeNode,
         parent_id: Option<MerkleHash>,
     ) -> Result<Self, MerkleDbError> {
-        let path = node_db_path(repo_path, &node.hash());
-        if !path.exists() {
-            util::fs::create_dir_all(&path).map_err(MerkleDbError::dir_create)?;
-        }
-        log::debug!("open_read_write merkle node db at {}", path.display());
-        let mut db = Self::open(path, false, node.hash())?;
+        let mut db = Self {
+            dtype: node.node_type(),
+            node_id: node.hash(),
+            parent_id,
+            read_only: false,
+            store: Self::fs_store(repo_path),
+            node_buf: Some(BytesMut::new()),
+            children_buf: Some(BytesMut::new()),
+            flushed: false,
+            lookup: None,
+            data_offset: 0,
+        };
         db.write_node(node, parent_id)?;
         Ok(db)
     }
 
-    /// The `node_id: MerkleHash` **MUST** be the same one that the `path` was derived from!
-    fn open(path: PathBuf, read_only: bool, node_id: MerkleHash) -> Result<Self, MerkleDbError> {
-        // mkdir if not exists
-        if !path.exists() {
-            util::fs::create_dir_all(&path).map_err(MerkleDbError::dir_create)?;
+    /// Persist the buffered node and children blobs through the store. Call before the node is read
+    /// back. A second call after a successful flush errors with [`MerkleDbError::CloseBeforeOpen`].
+    /// A write-mode db dropped without calling this discards its buffers unwritten rather than
+    /// persisting a partial node.
+    pub(crate) fn close(&mut self) -> Result<(), MerkleDbError> {
+        if self.read_only {
+            return Ok(());
         }
-
-        let node_path = path.join(NODE_FILE);
-        let children_path = path.join(CHILDREN_FILE);
-
-        // log::debug!(
-        //     "Opening merkle node db read_only {} at {}",
-        //     read_only,
-        //     path.display()
-        // );
-        let (lookup, node_file, children_file): (
-            Option<MerkleNodeLookup>,
-            Option<File>,
-            Option<File>,
-        ) = if read_only {
-            let mut node_file = util::fs::open_file(node_path).map_err(MerkleDbError::open)?;
-            let children_file = util::fs::open_file(children_path).map_err(MerkleDbError::open)?;
-            // log::debug!("Opened merkle node db read_only at {}", path.display());
-            (
-                Some(MerkleNodeLookup::load(&mut node_file)?),
-                Some(node_file),
-                Some(children_file),
-            )
-        } else {
-            // self.lookup does not exist yet if we are writing (only write once)
-            let node_file = File::create(node_path)?;
-            let children_file = File::create(children_path)?;
-            (None, Some(node_file), Some(children_file))
-        };
-
-        let dtype = match lookup.as_ref() {
-            Some(l) => MerkleTreeNodeType::from_u8(l.data_type)?,
-            None => MerkleTreeNodeType::Commit,
-        };
-
-        let parent_id = lookup.as_ref().map(|l| l.parent_id);
-        Ok(Self {
-            read_only,
-            node_file,
-            children_file,
-            lookup,
-            data: vec![],
-            dtype,
-            node_id,
-            parent_id: parent_id.map(MerkleHash::new),
-            data_offset: 0,
-        })
+        self.flush()
     }
 
-    /// Closes the open node and children file handles.
-    /// WARNING: Sets the internal node_file, children_file, and lookup to None.
-    pub(crate) fn close(&mut self) -> Result<(), MerkleDbError> {
-        if let Some(node_file) = &mut self.node_file {
-            node_file.flush()?;
-            node_file.sync_data()?;
-        } else {
+    fn flush(&mut self) -> Result<(), MerkleDbError> {
+        let (Some(node_buf), Some(children_buf)) = (self.node_buf.take(), self.children_buf.take())
+        else {
             return Err(MerkleDbError::CloseBeforeOpen);
-        }
-
-        if let Some(children_file) = &mut self.children_file {
-            children_file.flush()?;
-            children_file.sync_data()?;
-        } else {
-            return Err(MerkleDbError::CloseBeforeOpen);
-        }
-
-        self.node_file = None;
-        self.children_file = None;
-        self.lookup = None;
+        };
+        self.store
+            .write_node(&self.node_id, node_buf.freeze(), children_buf.freeze())?;
+        self.flushed = true;
         Ok(())
     }
 
-    /// Writes the content of the Merkle tree node according to the specific `node` file format.
+    /// Writes the node header (type, parent id, data) into the `node` blob buffer.
     /// WARNING: Sets the internal dtype, node_id, parent_id of `self` to the values from `node`.
     fn write_node(
         &mut self,
@@ -407,72 +390,60 @@ impl MerkleNodeDB {
             return Err(MerkleDbError::IllegalOperationWriteSizeFirst);
         }
 
-        let Some(node_file) = self.node_file.as_mut() else {
+        let Some(node_buf) = self.node_buf.as_mut() else {
             return Err(MerkleDbError::WriteBeforeOpen);
         };
 
         log::trace!("write_node node: {}", node);
 
-        node_file.write_all(&node.node_type().to_u8().to_le_bytes())?;
+        node_buf.extend_from_slice(&node.node_type().to_u8().to_le_bytes());
 
         // Write parent id
         if let Some(parent_id) = parent_id {
-            node_file.write_all(&parent_id.to_le_bytes())?;
+            node_buf.extend_from_slice(&parent_id.to_le_bytes());
         } else {
             // write 16 bytes, each is zero => write a 0_u128
-            node_file.write_all(&[0u8; 16])?;
+            node_buf.extend_from_slice(&[0u8; 16]);
         }
 
         // Write data length
         let buf = rmp_serde::to_vec(node)?;
         let data_len = buf.len() as u32;
-        node_file.write_all(&data_len.to_le_bytes())?;
+        node_buf.extend_from_slice(&data_len.to_le_bytes());
         log::trace!("write_node Wrote data length {}", data_len);
 
         // Write data
-        node_file.write_all(&buf)?;
+        node_buf.extend_from_slice(&buf);
 
         self.dtype = node.node_type();
         self.node_id = node.hash();
         self.parent_id = parent_id;
-        // log::debug!(
-        //     "write_node wrote id {} dtype: {:?}",
-        //     node.hash(),
-        //     node.node_type()
-        // );
         Ok(())
     }
 
-    /// Writes the content of a node's child as the child would appear in the `children` file.
+    /// Appends a child: its lookup entry to the `node` blob and its data to the `children` blob.
     pub(crate) fn add_child(&mut self, item: &impl TMerkleTreeNode) -> Result<(), MerkleDbError> {
         if self.read_only {
             return Err(MerkleDbError::ReadOnly);
         }
 
-        let Some(node_file) = self.node_file.as_mut() else {
+        let data_offset = self.data_offset;
+        let Some(node_buf) = self.node_buf.as_mut() else {
             return Err(MerkleDbError::WriteBeforeOpen);
         };
-        let Some(children_file) = self.children_file.as_mut() else {
+        let Some(children_buf) = self.children_buf.as_mut() else {
             return Err(MerkleDbError::WriteBeforeOpen);
         };
 
         let buf = rmp_serde::to_vec(item)?;
         let data_len = buf.len() as u64;
-        // log::debug!("--add_child-- node_file {:?}", node_file);
-        // log::debug!("--add_child-- dtype {:?}", item.dtype());
-        // log::debug!("--add_child-- hash {:x}", item.id());
-        // log::debug!("--add_child-- data_offset {}", self.data_offset);
-        // log::debug!("--add_child-- data_len {}", data_len);
-        // log::debug!("--add_child-- child {}", item);
 
-        node_file.write_all(&item.node_type().to_u8().to_le_bytes())?;
-        node_file.write_all(&item.hash().to_le_bytes())?; // id of child
-        node_file.write_all(&self.data_offset.to_le_bytes())?;
-        node_file.write_all(&data_len.to_le_bytes())?;
+        node_buf.extend_from_slice(&item.node_type().to_u8().to_le_bytes());
+        node_buf.extend_from_slice(&item.hash().to_le_bytes()); // id of child
+        node_buf.extend_from_slice(&data_offset.to_le_bytes());
+        node_buf.extend_from_slice(&data_len.to_le_bytes());
 
-        // log::debug!("--add_child-- children_file {:?}", children_file);
-        // log::debug!("--add_child-- buf.len() {}", buf.len());
-        children_file.write_all(&buf)?;
+        children_buf.extend_from_slice(&buf);
 
         self.data_offset += data_len;
 
@@ -484,22 +455,18 @@ impl MerkleNodeDB {
         let Some(lookup) = self.lookup.as_ref() else {
             return Err(MerkleDbError::ReadBeforeOpen);
         };
-        let Some(children_file) = self.children_file.as_mut() else {
-            return Err(MerkleDbError::WriteBeforeOpen);
-        };
 
         // Parse the node parent id
         let data_type = MerkleTreeNodeType::from_u8(lookup.data_type)?;
         let parent_id = MerkleTreeNode::deserialize_id(&lookup.data, data_type)?;
 
-        let mut file_data = Vec::new();
-        children_file.read_to_end(&mut file_data)?;
-        // log::debug!("Loading merkle node db map got {} bytes", file_data.len());
+        let children_bytes = self.store.read_children(&self.node_id)?;
+        // log::debug!("Loading merkle node db map got {} bytes", children_bytes.len());
 
         let mut ret: Vec<(MerkleHash, MerkleTreeNode)> =
             Vec::with_capacity(lookup.num_children as usize);
 
-        let mut cursor = std::io::Cursor::new(file_data);
+        let mut cursor = std::io::Cursor::new(children_bytes);
         // Iterate over offsets and read the data
         for (hash, (dtype, offset, len)) in lookup.offsets.iter() {
             // log::debug!("Loading dtype {:?}", MerkleTreeNodeType::from_u8(*dtype));
@@ -520,5 +487,34 @@ impl MerkleNodeDB {
         }
 
         Ok(ret)
+    }
+}
+
+impl Drop for MerkleNodeDB {
+    /// A write-mode db must be explicitly `close`d so its buffered node is persisted as one unit and
+    /// any persist error can propagate. `Drop` deliberately does **not** flush: a flush here could
+    /// only ever persist whatever children happened to be buffered before an early return — a
+    /// silently truncated node. Instead the buffers are dropped unwritten (no write is issued), so a
+    /// forgotten `close()` trips a debug assertion (failing the test) rather than corrupting the
+    /// store; in release it is logged and the node is simply never written, surfacing downstream as
+    /// a missing node.
+    fn drop(&mut self) {
+        // Normal drop: read-only, already flushed, or buffers already taken — nothing to do.
+        if self.read_only || self.flushed || self.node_buf.is_none() {
+            return;
+        }
+        // Reached Drop in write mode without close(): a bug. Don't mask an in-flight panic by
+        // panicking again while unwinding.
+        if !std::thread::panicking() {
+            debug_assert!(
+                false,
+                "MerkleNodeDB for node {} dropped without close(); buffered node discarded unwritten",
+                self.node_id
+            );
+        }
+        log::error!(
+            "MerkleNodeDB for node {} dropped without close(); buffered node discarded unwritten",
+            self.node_id
+        );
     }
 }

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -63,7 +63,6 @@ use crate::model::merkle_tree::node::{
     EMerkleTreeNode, MerkleTreeNode, MerkleTreeNodeType, TMerkleTreeNode,
 };
 
-use super::fs_merkle_node_store::FsMerkleNodeStore;
 use super::merkle_node_store::MerkleNodeStore;
 
 pub(crate) const NODE_FILE: &str = "node";
@@ -249,10 +248,6 @@ impl MerkleNodeLookup {
 /// [`MerkleNodeStore`]. In read-write mode the blobs are accumulated in memory and persisted as one
 /// unit by [`close`](Self::close) (or by `Drop` as a fallback) — there is no incremental flushing,
 /// so a node is written exactly once and atomically.
-///
-/// The constructors take a `repo_path` and resolve the file backend internally; a later change
-/// hands the store in from the repo so the backend (file vs. another engine) is selected once at
-/// repository construction.
 pub(crate) struct MerkleNodeDB {
     pub dtype: MerkleTreeNodeType,
     pub node_id: MerkleHash,
@@ -293,23 +288,10 @@ impl MerkleNodeDB {
         EMerkleTreeNode::from_type_and_bytes(dtype, data)
     }
 
-    /// Whether a node has been written for `hash`. A store error is reported as `false`, mirroring
-    /// `Path::exists()` (which the file backend is built on).
-    pub(crate) fn exists(repo_path: &Path, hash: &MerkleHash) -> bool {
-        Self::fs_store(repo_path).exists(hash).unwrap_or(false)
-    }
-
-    /// The file backend for the repo at `repo_path`. Resolved per-open for now; a later change has
-    /// the repo own a single store and hand it in.
-    fn fs_store(repo_path: &Path) -> Arc<dyn MerkleNodeStore> {
-        Arc::new(FsMerkleNodeStore::new(repo_path))
-    }
-
     pub(crate) fn open_read_only(
-        repo_path: &Path,
+        store: Arc<dyn MerkleNodeStore>,
         hash: &MerkleHash,
     ) -> Result<Self, MerkleDbError> {
-        let store = Self::fs_store(repo_path);
         let node_bytes = store.read_node(hash)?;
         let lookup = MerkleNodeLookup::deserialize(node_bytes)?;
         let dtype = MerkleTreeNodeType::from_u8(lookup.data_type)?;
@@ -331,7 +313,7 @@ impl MerkleNodeDB {
     }
 
     pub(crate) fn open_read_write(
-        repo_path: &Path,
+        store: Arc<dyn MerkleNodeStore>,
         node: &impl TMerkleTreeNode,
         parent_id: Option<MerkleHash>,
     ) -> Result<Self, MerkleDbError> {
@@ -340,7 +322,7 @@ impl MerkleNodeDB {
             node_id: node.hash(),
             parent_id,
             read_only: false,
-            store: Self::fs_store(repo_path),
+            store,
             node_buf: Some(BytesMut::new()),
             children_buf: Some(BytesMut::new()),
             flushed: false,

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -46,22 +46,25 @@ For example, data for a vnode of hash 1234 with two children:
     {dir data node}
 */
 
-use std::fs::File;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
-use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use bytes::{Bytes, BytesMut};
 
 use crate::constants;
 use crate::error::OxenError;
 use crate::model::MerkleHash;
 use crate::model::merkle_tree::node_type::InvalidMerkleTreeNodeType;
-use crate::util;
 
 use crate::model::merkle_tree::node::{
     EMerkleTreeNode, MerkleTreeNode, MerkleTreeNodeType, TMerkleTreeNode,
 };
+
+use super::fs_merkle_node_store::FsMerkleNodeStore;
+use super::merkle_node_store::MerkleNodeStore;
 
 pub(crate) const NODE_FILE: &str = "node";
 pub(crate) const CHILDREN_FILE: &str = "children";
@@ -138,10 +141,6 @@ impl MerkleDbError {
         Self::DirCreate(Box::new(err))
     }
 
-    fn open(err: OxenError) -> Self {
-        Self::Open(Box::new(err))
-    }
-
     pub(crate) fn fs_transport(err: OxenError) -> Self {
         Self::FsTransport(Box::new(err))
     }
@@ -157,20 +156,9 @@ struct MerkleNodeLookup {
 }
 
 impl MerkleNodeLookup {
-    fn load(node_table_file: &mut File) -> Result<Self, MerkleDbError> {
-        // log::debug!("MerkleNodeLookup.load() {:?}", node_table_file);
-        let mut file_data = Vec::new();
-        node_table_file.read_to_end(&mut file_data)?;
-        // log::debug!(
-        //     "MerkleNodeLookup.load() read file_data: {}",
-        //     file_data.len()
-        // );
-        Self::deserialize(file_data)
-    }
-
-    /// Takes the on-disk bytes of a `node` file and deserializes it into a [`MerkleNodeLookup`].
+    /// Takes the bytes of a node's `node` blob and deserializes it into a [`MerkleNodeLookup`].
     #[inline(always)]
-    fn deserialize(file_data: Vec<u8>) -> Result<Self, MerkleDbError> {
+    fn deserialize(file_data: Bytes) -> Result<Self, MerkleDbError> {
         // Create a cursor to iterate over data
         let mut cursor = std::io::Cursor::new(file_data);
 
@@ -254,25 +242,43 @@ impl MerkleNodeLookup {
     }
 }
 
+/// Reads and writes a single Merkle tree node and its children list.
+///
+/// The on-engine format is owned here (the `node` blob header + child lookup table, and the
+/// concatenated `children` blob); *where* those two blobs are persisted is delegated to a
+/// [`MerkleNodeStore`]. In read-write mode the blobs are accumulated in memory and persisted as one
+/// unit by [`close`](Self::close) (or by `Drop` as a fallback) — there is no incremental flushing,
+/// so a node is written exactly once and atomically.
+///
+/// The constructors take a `repo_path` and resolve the file backend internally; a later change
+/// hands the store in from the repo so the backend (file vs. another engine) is selected once at
+/// repository construction.
 pub(crate) struct MerkleNodeDB {
     pub dtype: MerkleTreeNodeType,
     pub node_id: MerkleHash,
     pub parent_id: Option<MerkleHash>,
     read_only: bool,
-    node_file: Option<File>,
-    children_file: Option<File>,
+    store: Arc<dyn MerkleNodeStore>,
+    /// `node` blob accumulator (header + child lookup entries). `Some` in read-write mode until the
+    /// node is persisted, then `None`.
+    node_buf: Option<BytesMut>,
+    /// `children` blob accumulator (concatenated child node data). `Some`/`None` in lockstep with
+    /// `node_buf`.
+    children_buf: Option<BytesMut>,
+    /// True once the write buffers have been persisted, so `Drop` does not flush again.
+    flushed: bool,
+    /// Decoded `node` blob; `Some` only in read-only mode.
     lookup: Option<MerkleNodeLookup>,
-    data: Vec<u8>,
+    /// Running length of `children_buf`, written into each child's lookup entry.
     data_offset: u64,
 }
 
 impl MerkleNodeDB {
     pub fn data(&self) -> Vec<u8> {
-        if let Some(lookup) = &self.lookup {
-            return lookup.data.to_owned();
-        }
-
-        self.data.to_owned()
+        self.lookup
+            .as_ref()
+            .map(|lookup| lookup.data.to_owned())
+            .unwrap_or_default()
     }
 
     pub fn node(&self) -> Result<EMerkleTreeNode, MerkleDbError> {
@@ -287,17 +293,41 @@ impl MerkleNodeDB {
         EMerkleTreeNode::from_type_and_bytes(dtype, data)
     }
 
+    /// Whether a node has been written for `hash`. A store error is reported as `false`, mirroring
+    /// `Path::exists()` (which the file backend is built on).
     pub(crate) fn exists(repo_path: &Path, hash: &MerkleHash) -> bool {
-        let db_path = node_db_path(repo_path, hash);
-        db_path.join(NODE_FILE).exists() && db_path.join(CHILDREN_FILE).exists()
+        Self::fs_store(repo_path).exists(hash).unwrap_or(false)
+    }
+
+    /// The file backend for the repo at `repo_path`. Resolved per-open for now; a later change has
+    /// the repo own a single store and hand it in.
+    fn fs_store(repo_path: &Path) -> Arc<dyn MerkleNodeStore> {
+        Arc::new(FsMerkleNodeStore::new(repo_path))
     }
 
     pub(crate) fn open_read_only(
         repo_path: &Path,
         hash: &MerkleHash,
     ) -> Result<Self, MerkleDbError> {
-        let path = node_db_path(repo_path, hash);
-        Self::open(path, true, *hash)
+        let store = Self::fs_store(repo_path);
+        let node_bytes = store.read_node(hash)?;
+        let lookup = MerkleNodeLookup::deserialize(node_bytes)?;
+        let dtype = MerkleTreeNodeType::from_u8(lookup.data_type)?;
+        // A zero parent id round-trips as `Some(MerkleHash::new(0))`, matching the historical
+        // behavior that callers (e.g. `MerkleTreeNode::from_hash_uncached`) read directly.
+        let parent_id = Some(MerkleHash::new(lookup.parent_id));
+        Ok(Self {
+            dtype,
+            node_id: *hash,
+            parent_id,
+            read_only: true,
+            store,
+            node_buf: None,
+            children_buf: None,
+            flushed: true,
+            lookup: Some(lookup),
+            data_offset: 0,
+        })
     }
 
     pub(crate) fn open_read_write(
@@ -305,94 +335,44 @@ impl MerkleNodeDB {
         node: &impl TMerkleTreeNode,
         parent_id: Option<MerkleHash>,
     ) -> Result<Self, MerkleDbError> {
-        let path = node_db_path(repo_path, &node.hash());
-        if !path.exists() {
-            util::fs::create_dir_all(&path).map_err(MerkleDbError::dir_create)?;
-        }
-        log::debug!("open_read_write merkle node db at {}", path.display());
-        let mut db = Self::open(path, false, node.hash())?;
+        let mut db = Self {
+            dtype: node.node_type(),
+            node_id: node.hash(),
+            parent_id,
+            read_only: false,
+            store: Self::fs_store(repo_path),
+            node_buf: Some(BytesMut::new()),
+            children_buf: Some(BytesMut::new()),
+            flushed: false,
+            lookup: None,
+            data_offset: 0,
+        };
         db.write_node(node, parent_id)?;
         Ok(db)
     }
 
-    /// The `node_id: MerkleHash` **MUST** be the same one that the `path` was derived from!
-    fn open(path: PathBuf, read_only: bool, node_id: MerkleHash) -> Result<Self, MerkleDbError> {
-        // mkdir if not exists
-        if !path.exists() {
-            util::fs::create_dir_all(&path).map_err(MerkleDbError::dir_create)?;
+    /// Persist the buffered node and children blobs through the store. Call before the node is read
+    /// back. A second call after a successful flush errors with [`MerkleDbError::CloseBeforeOpen`];
+    /// `Drop` flushes as a fallback if this is never called.
+    pub(crate) fn close(&mut self) -> Result<(), MerkleDbError> {
+        if self.read_only {
+            return Ok(());
         }
-
-        let node_path = path.join(NODE_FILE);
-        let children_path = path.join(CHILDREN_FILE);
-
-        // log::debug!(
-        //     "Opening merkle node db read_only {} at {}",
-        //     read_only,
-        //     path.display()
-        // );
-        let (lookup, node_file, children_file): (
-            Option<MerkleNodeLookup>,
-            Option<File>,
-            Option<File>,
-        ) = if read_only {
-            let mut node_file = util::fs::open_file(node_path).map_err(MerkleDbError::open)?;
-            let children_file = util::fs::open_file(children_path).map_err(MerkleDbError::open)?;
-            // log::debug!("Opened merkle node db read_only at {}", path.display());
-            (
-                Some(MerkleNodeLookup::load(&mut node_file)?),
-                Some(node_file),
-                Some(children_file),
-            )
-        } else {
-            // self.lookup does not exist yet if we are writing (only write once)
-            let node_file = File::create(node_path)?;
-            let children_file = File::create(children_path)?;
-            (None, Some(node_file), Some(children_file))
-        };
-
-        let dtype = match lookup.as_ref() {
-            Some(l) => MerkleTreeNodeType::from_u8(l.data_type)?,
-            None => MerkleTreeNodeType::Commit,
-        };
-
-        let parent_id = lookup.as_ref().map(|l| l.parent_id);
-        Ok(Self {
-            read_only,
-            node_file,
-            children_file,
-            lookup,
-            data: vec![],
-            dtype,
-            node_id,
-            parent_id: parent_id.map(MerkleHash::new),
-            data_offset: 0,
-        })
+        self.flush()
     }
 
-    /// Closes the open node and children file handles.
-    /// WARNING: Sets the internal node_file, children_file, and lookup to None.
-    pub(crate) fn close(&mut self) -> Result<(), MerkleDbError> {
-        if let Some(node_file) = &mut self.node_file {
-            node_file.flush()?;
-            node_file.sync_data()?;
-        } else {
+    fn flush(&mut self) -> Result<(), MerkleDbError> {
+        let (Some(node_buf), Some(children_buf)) = (self.node_buf.take(), self.children_buf.take())
+        else {
             return Err(MerkleDbError::CloseBeforeOpen);
-        }
-
-        if let Some(children_file) = &mut self.children_file {
-            children_file.flush()?;
-            children_file.sync_data()?;
-        } else {
-            return Err(MerkleDbError::CloseBeforeOpen);
-        }
-
-        self.node_file = None;
-        self.children_file = None;
-        self.lookup = None;
+        };
+        self.store
+            .write_node(&self.node_id, node_buf.freeze(), children_buf.freeze())?;
+        self.flushed = true;
         Ok(())
     }
 
-    /// Writes the content of the Merkle tree node according to the specific `node` file format.
+    /// Writes the node header (type, parent id, data) into the `node` blob buffer.
     /// WARNING: Sets the internal dtype, node_id, parent_id of `self` to the values from `node`.
     fn write_node(
         &mut self,
@@ -407,72 +387,60 @@ impl MerkleNodeDB {
             return Err(MerkleDbError::IllegalOperationWriteSizeFirst);
         }
 
-        let Some(node_file) = self.node_file.as_mut() else {
+        let Some(node_buf) = self.node_buf.as_mut() else {
             return Err(MerkleDbError::WriteBeforeOpen);
         };
 
         log::trace!("write_node node: {}", node);
 
-        node_file.write_all(&node.node_type().to_u8().to_le_bytes())?;
+        node_buf.extend_from_slice(&node.node_type().to_u8().to_le_bytes());
 
         // Write parent id
         if let Some(parent_id) = parent_id {
-            node_file.write_all(&parent_id.to_le_bytes())?;
+            node_buf.extend_from_slice(&parent_id.to_le_bytes());
         } else {
             // write 16 bytes, each is zero => write a 0_u128
-            node_file.write_all(&[0u8; 16])?;
+            node_buf.extend_from_slice(&[0u8; 16]);
         }
 
         // Write data length
         let buf = rmp_serde::to_vec(node)?;
         let data_len = buf.len() as u32;
-        node_file.write_all(&data_len.to_le_bytes())?;
+        node_buf.extend_from_slice(&data_len.to_le_bytes());
         log::trace!("write_node Wrote data length {}", data_len);
 
         // Write data
-        node_file.write_all(&buf)?;
+        node_buf.extend_from_slice(&buf);
 
         self.dtype = node.node_type();
         self.node_id = node.hash();
         self.parent_id = parent_id;
-        // log::debug!(
-        //     "write_node wrote id {} dtype: {:?}",
-        //     node.hash(),
-        //     node.node_type()
-        // );
         Ok(())
     }
 
-    /// Writes the content of a node's child as the child would appear in the `children` file.
+    /// Appends a child: its lookup entry to the `node` blob and its data to the `children` blob.
     pub(crate) fn add_child(&mut self, item: &impl TMerkleTreeNode) -> Result<(), MerkleDbError> {
         if self.read_only {
             return Err(MerkleDbError::ReadOnly);
         }
 
-        let Some(node_file) = self.node_file.as_mut() else {
+        let data_offset = self.data_offset;
+        let Some(node_buf) = self.node_buf.as_mut() else {
             return Err(MerkleDbError::WriteBeforeOpen);
         };
-        let Some(children_file) = self.children_file.as_mut() else {
+        let Some(children_buf) = self.children_buf.as_mut() else {
             return Err(MerkleDbError::WriteBeforeOpen);
         };
 
         let buf = rmp_serde::to_vec(item)?;
         let data_len = buf.len() as u64;
-        // log::debug!("--add_child-- node_file {:?}", node_file);
-        // log::debug!("--add_child-- dtype {:?}", item.dtype());
-        // log::debug!("--add_child-- hash {:x}", item.id());
-        // log::debug!("--add_child-- data_offset {}", self.data_offset);
-        // log::debug!("--add_child-- data_len {}", data_len);
-        // log::debug!("--add_child-- child {}", item);
 
-        node_file.write_all(&item.node_type().to_u8().to_le_bytes())?;
-        node_file.write_all(&item.hash().to_le_bytes())?; // id of child
-        node_file.write_all(&self.data_offset.to_le_bytes())?;
-        node_file.write_all(&data_len.to_le_bytes())?;
+        node_buf.extend_from_slice(&item.node_type().to_u8().to_le_bytes());
+        node_buf.extend_from_slice(&item.hash().to_le_bytes()); // id of child
+        node_buf.extend_from_slice(&data_offset.to_le_bytes());
+        node_buf.extend_from_slice(&data_len.to_le_bytes());
 
-        // log::debug!("--add_child-- children_file {:?}", children_file);
-        // log::debug!("--add_child-- buf.len() {}", buf.len());
-        children_file.write_all(&buf)?;
+        children_buf.extend_from_slice(&buf);
 
         self.data_offset += data_len;
 
@@ -484,22 +452,18 @@ impl MerkleNodeDB {
         let Some(lookup) = self.lookup.as_ref() else {
             return Err(MerkleDbError::ReadBeforeOpen);
         };
-        let Some(children_file) = self.children_file.as_mut() else {
-            return Err(MerkleDbError::WriteBeforeOpen);
-        };
 
         // Parse the node parent id
         let data_type = MerkleTreeNodeType::from_u8(lookup.data_type)?;
         let parent_id = MerkleTreeNode::deserialize_id(&lookup.data, data_type)?;
 
-        let mut file_data = Vec::new();
-        children_file.read_to_end(&mut file_data)?;
-        // log::debug!("Loading merkle node db map got {} bytes", file_data.len());
+        let children_bytes = self.store.read_children(&self.node_id)?;
+        // log::debug!("Loading merkle node db map got {} bytes", children_bytes.len());
 
         let mut ret: Vec<(MerkleHash, MerkleTreeNode)> =
             Vec::with_capacity(lookup.num_children as usize);
 
-        let mut cursor = std::io::Cursor::new(file_data);
+        let mut cursor = std::io::Cursor::new(children_bytes);
         // Iterate over offsets and read the data
         for (hash, (dtype, offset, len)) in lookup.offsets.iter() {
             // log::debug!("Loading dtype {:?}", MerkleTreeNodeType::from_u8(*dtype));
@@ -520,5 +484,21 @@ impl MerkleNodeDB {
         }
 
         Ok(ret)
+    }
+}
+
+impl Drop for MerkleNodeDB {
+    /// Fallback flush for write-mode dbs that were never explicitly `close`d. Callers should prefer
+    /// `close()` so the persist error can propagate; here it can only be logged.
+    fn drop(&mut self) {
+        if self.read_only || self.flushed || self.node_buf.is_none() {
+            return;
+        }
+        if let Err(err) = self.flush() {
+            log::error!(
+                "MerkleNodeDB: failed to flush node {} on drop: {err}",
+                self.node_id
+            );
+        }
     }
 }

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -12,9 +12,8 @@
 //! untouched. Keeping the bytes identical across engines is what makes a future engine-to-engine
 //! bridge trivial.
 //!
-//! This module is the reusable foundation; nothing consumes it yet. `MerkleNodeDB` is rewired to
-//! read and write through a `MerkleNodeStore` in a follow-up change, mirroring how the low-level
-//! `lmdb` layer landed before it had a consumer.
+//! [`MerkleNodeDB`](super::merkle_node_db) reads and writes through a `MerkleNodeStore`;
+//! [`FsMerkleNodeStore`](super::fs_merkle_node_store) is the only implementation today.
 
 use std::fmt::Debug;
 
@@ -34,8 +33,6 @@ use super::merkle_node_db::MerkleDbError;
 ///
 /// `Debug` is required (like [`VersionStore`](crate::storage::VersionStore)) so a store can be held
 /// by `#[derive(Debug)]` types such as `LocalRepository`.
-// Unconsumed until `MerkleNodeDB` delegates to it; see the module docs. Drop the allow then.
-#[allow(dead_code)]
 pub(crate) trait MerkleNodeStore: Debug + Send + Sync {
     /// Whether a node has been written for `hash`.
     fn exists(&self, hash: &MerkleHash) -> Result<bool, MerkleDbError>;

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -16,11 +16,15 @@
 //! [`FsMerkleNodeStore`](super::fs_merkle_node_store) is the only implementation today.
 
 use std::fmt::Debug;
+use std::path::Path;
+use std::sync::Arc;
 
 use bytes::Bytes;
 
+use crate::error::OxenError;
 use crate::model::MerkleHash;
 
+use super::fs_merkle_node_store::FsMerkleNodeStore;
 use super::merkle_node_db::MerkleDbError;
 
 /// Engine-agnostic persistence for Merkle tree node bytes, keyed by [`MerkleHash`]. A node is two
@@ -51,4 +55,15 @@ pub(crate) trait MerkleNodeStore: Debug + Send + Sync {
         node: Bytes,
         children: Bytes,
     ) -> Result<(), MerkleDbError>;
+}
+
+/// Build the node store for the repo rooted at `repo_path`.
+///
+/// Mirrors [`create_version_store`](crate::storage::create_version_store): the backend is chosen
+/// here, once, at repository construction. Today it is always the on-disk [`FsMerkleNodeStore`] —
+/// this is the single seam where config/env-driven backend selection will later plug in.
+pub(crate) fn create_merkle_node_store(
+    repo_path: &Path,
+) -> Result<Arc<dyn MerkleNodeStore>, OxenError> {
+    Ok(Arc::new(FsMerkleNodeStore::new(repo_path)))
 }

--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -290,10 +290,12 @@ pub fn create_empty_commit(
     )?;
 
     let parent_id = Some(existing_node.hash);
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &commit_node, parent_id)?;
+    let mut commit_db =
+        MerkleNodeDB::open_read_write(repo.merkle_node_store(), &commit_node, parent_id)?;
     // There should always be one child, the root directory
     let dir_node = existing_node.children.first().unwrap().dir()?;
     commit_db.add_child(&dir_node)?;
+    commit_db.close()?;
 
     // Copy the dir hashes db to the new commit
     repositories::tree::cp_dir_hashes_to(repo, &existing_commit_id, commit_node.hash())?;
@@ -370,8 +372,10 @@ pub fn create_initial_commit(
     )?;
 
     // Open the commit database and add the root directory
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &commit_node, None)?;
+    let mut commit_db =
+        MerkleNodeDB::open_read_write(repo.merkle_node_store(), &commit_node, None)?;
     commit_db.add_child(&dir_node)?;
+    commit_db.close()?;
 
     // Initialize the dir_hash_db with the root directory hash
     let commit_id_string = commit_id.to_string();

--- a/crates/liboxen/src/core/v_latest/entries.rs
+++ b/crates/liboxen/src/core/v_latest/entries.rs
@@ -572,9 +572,13 @@ fn traverse_and_update_sizes_and_counts(
                 &mut local_sizes,
                 num_bytes,
             )?;
-            let mut dir_db =
-                MerkleNodeDB::open_read_write(&repo.path, commit_node, node.parent_id)?;
+            let mut dir_db = MerkleNodeDB::open_read_write(
+                repo.merkle_node_store(),
+                commit_node,
+                node.parent_id,
+            )?;
             add_children_to_db(&mut dir_db, &node.children)?;
+            dir_db.close()?;
         }
         EMerkleTreeNode::VNode(vnode) => {
             log::debug!("Traversing vnode {vnode:?}");
@@ -585,8 +589,10 @@ fn traverse_and_update_sizes_and_counts(
                 &mut local_sizes,
                 num_bytes,
             )?;
-            let mut dir_db = MerkleNodeDB::open_read_write(&repo.path, vnode, node.parent_id)?;
+            let mut dir_db =
+                MerkleNodeDB::open_read_write(repo.merkle_node_store(), vnode, node.parent_id)?;
             add_children_to_db(&mut dir_db, &node.children)?;
+            dir_db.close()?;
         }
         EMerkleTreeNode::Directory(dir_node) => {
             log::debug!("No need to aggregate dir {}", dir_node.name());
@@ -599,8 +605,10 @@ fn traverse_and_update_sizes_and_counts(
             )?;
             dir_node.set_data_type_counts(local_counts.clone());
             dir_node.set_data_type_sizes(local_sizes.clone());
-            let mut dir_db = MerkleNodeDB::open_read_write(&repo.path, dir_node, node.parent_id)?;
+            let mut dir_db =
+                MerkleNodeDB::open_read_write(repo.merkle_node_store(), dir_node, node.parent_id)?;
             add_children_to_db(&mut dir_db, &node.children)?;
+            dir_db.close()?;
         }
         EMerkleTreeNode::File(file_node) => {
             log::debug!(

--- a/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
@@ -6,8 +6,6 @@ use std::str;
 use crate::core::db::dir_hashes::dir_hashes_db::{
     dir_hash_db_path, dir_hash_db_path_from_commit_id, with_dir_hash_db_manager,
 };
-use crate::core::db::merkle_node::MerkleNodeDB;
-
 use crate::model::merkle_tree::node::EMerkleTreeNode;
 
 use crate::model::merkle_tree::node::FileNode;
@@ -207,7 +205,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashSet<MerkleHash>>,
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -232,7 +230,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashMap<(MerkleHash, MerkleTreeNodeType), PathBuf>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -258,7 +256,7 @@ impl CommitMerkleTree {
         partial_nodes: &mut HashMap<PathBuf, PartialNode>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -282,7 +280,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read depth {} node hash [{}]", depth, hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             log::debug!("read_depth merkle node db does not exist for hash: {hash}");
             return Ok(None);
         }
@@ -314,7 +312,7 @@ impl CommitMerkleTree {
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -343,7 +341,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -375,7 +373,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }

--- a/crates/liboxen/src/core/v_latest/merge.rs
+++ b/crates/liboxen/src/core/v_latest/merge.rs
@@ -1084,14 +1084,18 @@ fn create_empty_merge_commit(
                 merge_commits.base.id
             ))
         })?;
-    let mut commit_db =
-        MerkleNodeDB::open_read_write(&repo.path, &commit_node, Some(base_node.hash))?;
+    let mut commit_db = MerkleNodeDB::open_read_write(
+        repo.merkle_node_store(),
+        &commit_node,
+        Some(base_node.hash),
+    )?;
     let root_dir = base_node
         .children
         .first()
         .expect("base commit must have a root dir as its first child")
         .dir()?;
     commit_db.add_child(&root_dir)?;
+    commit_db.close()?;
 
     // Copy base's path -> dir hash mapping so path-based tree lookups work for the new commit.
     repositories::tree::cp_dir_hashes_to(repo, &base_commit_hash, commit_node.hash())?;

--- a/crates/liboxen/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
@@ -195,13 +195,13 @@ impl CommitMerkleTree {
         recurse: bool,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node v0.19.0 hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
 
         let mut node = MerkleTreeNode::from_hash(repo, hash)?;
-        let mut node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let mut node_db = MerkleNodeDB::open_read_only(repo.merkle_node_store(), hash)?;
         CommitMerkleTree::read_children_from_node(repo, &mut node_db, &mut node, recurse)?;
         // log::debug!("read_node v0.19.0 done: {:?} recurse: {}", node.hash, recurse);
         Ok(Some(node))
@@ -213,13 +213,13 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read depth {} node hash [{}]", depth, hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             log::debug!("read_depth merkle node db does not exist for hash: {hash}");
             return Ok(None);
         }
 
         let mut node = MerkleTreeNode::from_hash(repo, hash)?;
-        let mut node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let mut node_db = MerkleNodeDB::open_read_only(repo.merkle_node_store(), hash)?;
 
         CommitMerkleTree::read_children_until_depth(repo, &mut node_db, &mut node, depth, 0)?;
         // log::debug!("Read depth {} node done: {:?}", depth, node.hash);
@@ -471,7 +471,7 @@ impl CommitMerkleTree {
                         // Here we have to not panic on error, because if we clone a subtree we might not have all of the children nodes of a particular dir
                         // given that we are only loading the nodes that are needed.
                         if let Ok(mut node_db) =
-                            MerkleNodeDB::open_read_only(&repo.path, &child.hash)
+                            MerkleNodeDB::open_read_only(repo.merkle_node_store(), &child.hash)
                         {
                             CommitMerkleTree::read_children_until_depth(
                                 repo,
@@ -535,7 +535,8 @@ impl CommitMerkleTree {
                 | MerkleTreeNodeType::VNode => {
                     if recurse {
                         // log::debug!("read_children_from_node recurse: {:?}", child.hash);
-                        let Ok(mut node_db) = MerkleNodeDB::open_read_only(&repo.path, &child.hash)
+                        let Ok(mut node_db) =
+                            MerkleNodeDB::open_read_only(repo.merkle_node_store(), &child.hash)
                         else {
                             log::warn!("no child node db: {:?}", child.hash);
                             return Ok(());

--- a/crates/liboxen/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -41,10 +41,11 @@ impl MerkleTreeNode {
 
     /// Private implementation that loads from disk without caching
     fn from_hash_uncached(repo: &LocalRepository, hash: &MerkleHash) -> Result<Self, OxenError> {
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        let store = repo.merkle_node_store();
+        if !store.exists(hash)? {
             return Err(OxenError::MerkleNodeNotFound(hash.to_hex_hash()));
         }
-        let node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let node_db = MerkleNodeDB::open_read_only(store, hash)?;
         let parent_id = node_db.parent_id;
         Ok(MerkleTreeNode {
             hash: *hash,
@@ -80,11 +81,12 @@ impl MerkleTreeNode {
         // We don't return an error here because there are some situations where we won't have all
         // the node files. For example, when working in a subtree clone. However, parse/IO errors
         // from an existing node DO still propagate.
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        let store = repo.merkle_node_store();
+        if !store.exists(hash)? {
             log::warn!("no child node db: {hash:?}");
             return Ok(Vec::new());
         }
-        let mut node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let mut node_db = MerkleNodeDB::open_read_only(store, hash)?;
         Ok(node_db.map()?)
     }
 

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -1,6 +1,7 @@
 use crate::config::RepositoryConfig;
 use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE};
+use crate::core::db::merkle_node::{MerkleNodeStore, create_merkle_node_store};
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
@@ -48,6 +49,10 @@ pub struct LocalRepository {
     server_s3_opts: Option<S3Opts>,
     /// Built from `storage_config` + `server_s3_opts` at construction. Never replaced.
     version_store: Arc<dyn VersionStore>,
+    /// Where Merkle tree nodes are read from and written to. Built from the repo path at
+    /// construction and never replaced, mirroring `version_store`. The backend (file vs. another
+    /// engine) is a property of the repo chosen once in `create_merkle_node_store`.
+    merkle_node_store: Arc<dyn MerkleNodeStore>,
 }
 
 #[derive(Debug, Clone)]
@@ -95,6 +100,11 @@ impl LocalRepository {
         Arc::clone(&self.version_store)
     }
 
+    /// Get a handle to the Merkle node store backing this repo's tree nodes.
+    pub(crate) fn merkle_node_store(&self) -> Arc<dyn MerkleNodeStore> {
+        Arc::clone(&self.merkle_node_store)
+    }
+
     /// Load a repository from the current directory
     /// this traverses up the directory tree until it finds a .oxen/ directory
     pub fn from_current_dir() -> Result<LocalRepository, OxenError> {
@@ -128,6 +138,7 @@ impl LocalRepository {
         let path = path.as_ref().to_path_buf();
         let storage_config = config.storage.unwrap_or_default();
         let version_store = create_version_store(&path, &storage_config, server_s3_opts)?;
+        let merkle_node_store = create_merkle_node_store(&path)?;
         Ok(LocalRepository {
             path,
             remote_name: config.remote_name,
@@ -143,6 +154,7 @@ impl LocalRepository {
             storage_config,
             server_s3_opts: server_s3_opts.cloned(),
             version_store,
+            merkle_node_store,
         })
     }
 
@@ -166,6 +178,7 @@ impl LocalRepository {
         let path = std::env::current_dir()?.join(view.name);
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config, None)?;
+        let merkle_node_store = create_merkle_node_store(&path)?;
         Ok(LocalRepository {
             path,
             remotes: vec![],
@@ -181,6 +194,7 @@ impl LocalRepository {
             storage_config,
             server_s3_opts: None,
             version_store,
+            merkle_node_store,
         })
     }
 
@@ -188,6 +202,7 @@ impl LocalRepository {
         let path = path.to_owned();
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config, None)?;
+        let merkle_node_store = create_merkle_node_store(&path)?;
         Ok(LocalRepository {
             path,
             remotes: vec![repo.remote],
@@ -203,6 +218,7 @@ impl LocalRepository {
             storage_config,
             server_s3_opts: None,
             version_store,
+            merkle_node_store,
         })
     }
 

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -269,7 +269,7 @@ pub(crate) fn commit_dir_entries_with_parents(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, parent_id)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, parent_id)?;
     write_commit_entries(
         repo,
         commit_id,
@@ -278,6 +278,7 @@ pub(crate) fn commit_dir_entries_with_parents(
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_db.close()?;
 
     Ok(node.to_commit())
 }
@@ -362,7 +363,7 @@ pub fn commit_dir_entries_new(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, parent_id)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, parent_id)?;
 
     write_commit_entries(
         repo,
@@ -372,6 +373,7 @@ pub fn commit_dir_entries_new(
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_db.close()?;
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
@@ -473,7 +475,7 @@ pub fn commit_dir_entries(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, None)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, None)?;
     write_commit_entries(
         repo,
         commit_id,
@@ -482,6 +484,7 @@ pub fn commit_dir_entries(
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_db.close()?;
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
@@ -778,17 +781,22 @@ fn write_commit_entries(
         root_path.to_str().unwrap(),
         &dir_node.hash().to_string(),
     )?;
-    let dir_db = MerkleNodeDB::open_read_write(&repo.path, &dir_node, Some(commit_id))?;
+    let dir_db =
+        MerkleNodeDB::open_read_write(repo.merkle_node_store(), &dir_node, Some(commit_id))?;
+    let mut maybe_dir_db = Some(dir_db);
     r_create_dir_node(
         repo,
         commit_id,
-        &mut Some(dir_db),
+        &mut maybe_dir_db,
         dir_hash_db,
         dir_hashes,
         entries,
         root_path,
         &mut total_written,
     )?;
+    if let Some(mut dir_db) = maybe_dir_db {
+        dir_db.close()?;
+    }
 
     // The dir_hash_db was pre-populated from the previous commit, so
     // removed directories still have stale entries that must be deleted;
@@ -860,7 +868,7 @@ fn r_create_dir_node(
         // );
 
         let mut vnode_db = MerkleNodeDB::open_read_write(
-            &repo.path,
+            repo.merkle_node_store(),
             &vnode_obj,
             maybe_dir_db.as_ref().map(|db| db.node_id),
         )?;
@@ -883,7 +891,7 @@ fn r_create_dir_node(
                         // if the vnode is new, we need a new dir db
                         // let mut child_db = if maybe_vnode_db.is_some() {
                         let mut child_db = Some(MerkleNodeDB::open_read_write(
-                            &repo.path,
+                            repo.merkle_node_store(),
                             &dir_node,
                             Some(vnode.id),
                         )?);
@@ -898,6 +906,9 @@ fn r_create_dir_node(
                             &dir_path,
                             total_written,
                         )?;
+                        if let Some(mut child_db) = child_db {
+                            child_db.close()?;
+                        }
                         dir_node
                     } else {
                         // log::debug!("r_create_dir_node skipping {:?}", dir_path);
@@ -961,6 +972,7 @@ fn r_create_dir_node(
                 }
             }
         }
+        vnode_db.close()?;
     }
 
     log::debug!("Finished processing dir {path:?} total written {total_written} entries");

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1247,7 +1247,7 @@ fn p_write_tree(
 ) -> Result<(), OxenError> {
     let parent_id = node.parent_id;
 
-    let mut db = MerkleNodeDB::open_read_write(&repo.path, node_impl, parent_id)?;
+    let mut db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), node_impl, parent_id)?;
     for child in &node.children {
         match &child.node {
             EMerkleTreeNode::VNode(vnode) => {
@@ -2115,7 +2115,7 @@ mod tests {
 
             for hash in &installed {
                 assert!(
-                    MerkleNodeDB::exists(&clone.path, hash),
+                    clone.merkle_node_store().exists(hash)?,
                     "expected installed hash {hash} to be readable"
                 );
             }
@@ -2304,11 +2304,11 @@ mod tests {
             // Every installed hash must be readable through both stores.
             for h in &new_hashes {
                 assert!(
-                    MerkleNodeDB::exists(&repo_old.path, h),
+                    repo_old.merkle_node_store().exists(h)?,
                     "hash {h} not readable in repo unpacked via legacy unpack_nodes"
                 );
                 assert!(
-                    MerkleNodeDB::exists(&repo_new.path, h),
+                    repo_new.merkle_node_store().exists(h)?,
                     "hash {h} not readable in repo unpacked via unpack"
                 );
             }
@@ -2399,7 +2399,7 @@ mod tests {
             assert!(!installed.is_empty(), "unpack reported no hashes");
             for h in &installed {
                 assert!(
-                    MerkleNodeDB::exists(&repo_new.path, h),
+                    repo_new.merkle_node_store().exists(h)?,
                     "hash {h} not readable in repo unpacked via unpack"
                 );
             }
@@ -2928,7 +2928,7 @@ mod tests {
             );
             for h in &installed {
                 assert!(
-                    MerkleNodeDB::exists(&clone.path, h),
+                    clone.merkle_node_store().exists(h)?,
                     "hash {h} not readable in vfs-cloned repo"
                 );
             }


### PR DESCRIPTION
Replace MerkleNodeDB's direct file IO with delegation to a MerkleNodeStore (the trait + file backend added in the previous change). Writing now accumulates the `node` and `children` blobs in memory and persists them as one unit via `close()` (with `Drop` as a logged fallback); reading pulls the two blobs from the store and runs the existing lookup-table decode unchanged.