### PR TITLE
LMDB (2c) Make the Merkle node store repo-owned

### DIFF
--- a/crates/liboxen/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/crates/liboxen/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -95,9 +95,13 @@ fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), Ox
 
     // Write a new commit db
     let commit_node = CommitNode::from_commit(commit.clone());
-    let mut root_commit_db =
-        MerkleNodeDB::open_read_write(&old_repo.path, &commit_node, root_node.parent_id)?;
+    let mut root_commit_db = MerkleNodeDB::open_read_write(
+        old_repo.merkle_node_store(),
+        &commit_node,
+        root_node.parent_id,
+    )?;
     root_commit_db.add_child(&dir_node)?;
+    root_commit_db.close()?;
 
     let current_path = Path::new("");
     rewrite_nodes(&old_repo, &new_repo, &root_node, current_path)?;
@@ -148,8 +152,11 @@ fn rewrite_nodes(
                 let mut dir_node_opts = dir.get_opts();
                 dir_node_opts.num_entries = total_children as u64;
                 let dir = DirNode::new(new_repo, dir_node_opts)?;
-                let mut dir_db =
-                    MerkleNodeDB::open_read_write(&old_repo.path, &dir, node.parent_id)?;
+                let mut dir_db = MerkleNodeDB::open_read_write(
+                    old_repo.merkle_node_store(),
+                    &dir,
+                    node.parent_id,
+                )?;
 
                 // log::debug!(
                 //     "rewrite_nodes {} VNodes for {} children in {} with vnode size {}",
@@ -213,7 +220,7 @@ fn rewrite_nodes(
                     dir_db.add_child(&vnode_obj)?;
 
                     let mut vnode_db = MerkleNodeDB::open_read_write(
-                        &new_repo.path,
+                        new_repo.merkle_node_store(),
                         &vnode_obj,
                         Some(dir_db.node_id),
                     )?;
@@ -242,7 +249,9 @@ fn rewrite_nodes(
                             }
                         }
                     }
+                    vnode_db.close()?;
                 }
+                dir_db.close()?;
 
                 rewrite_nodes(old_repo, new_repo, child, &current_dir)?;
             }

--- a/crates/liboxen/src/core/db/merkle_node.rs
+++ b/crates/liboxen/src/core/db/merkle_node.rs
@@ -3,3 +3,4 @@ pub mod merkle_node_db;
 pub mod merkle_node_store;
 
 pub(crate) use merkle_node_db::MerkleNodeDB;
+pub(crate) use merkle_node_store::{MerkleNodeStore, create_merkle_node_store};

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -63,7 +63,6 @@ use crate::model::merkle_tree::node::{
     EMerkleTreeNode, MerkleTreeNode, MerkleTreeNodeType, TMerkleTreeNode,
 };
 
-use super::fs_merkle_node_store::FsMerkleNodeStore;
 use super::merkle_node_store::MerkleNodeStore;
 
 pub(crate) const NODE_FILE: &str = "node";
@@ -249,10 +248,6 @@ impl MerkleNodeLookup {
 /// [`MerkleNodeStore`]. In read-write mode the blobs are accumulated in memory and persisted as one
 /// unit by [`close`](Self::close) (or by `Drop` as a fallback) — there is no incremental flushing,
 /// so a node is written exactly once and atomically.
-///
-/// The constructors take a `repo_path` and resolve the file backend internally; a later change
-/// hands the store in from the repo so the backend (file vs. another engine) is selected once at
-/// repository construction.
 pub(crate) struct MerkleNodeDB {
     pub dtype: MerkleTreeNodeType,
     pub node_id: MerkleHash,
@@ -293,23 +288,10 @@ impl MerkleNodeDB {
         EMerkleTreeNode::from_type_and_bytes(dtype, data)
     }
 
-    /// Whether a node has been written for `hash`. A store error is reported as `false`, mirroring
-    /// `Path::exists()` (which the file backend is built on).
-    pub(crate) fn exists(repo_path: &Path, hash: &MerkleHash) -> bool {
-        Self::fs_store(repo_path).exists(hash).unwrap_or(false)
-    }
-
-    /// The file backend for the repo at `repo_path`. Resolved per-open for now; a later change has
-    /// the repo own a single store and hand it in.
-    fn fs_store(repo_path: &Path) -> Arc<dyn MerkleNodeStore> {
-        Arc::new(FsMerkleNodeStore::new(repo_path))
-    }
-
     pub(crate) fn open_read_only(
-        repo_path: &Path,
+        store: Arc<dyn MerkleNodeStore>,
         hash: &MerkleHash,
     ) -> Result<Self, MerkleDbError> {
-        let store = Self::fs_store(repo_path);
         let node_bytes = store.read_node(hash)?;
         let lookup = MerkleNodeLookup::deserialize(node_bytes)?;
         let dtype = MerkleTreeNodeType::from_u8(lookup.data_type)?;
@@ -331,7 +313,7 @@ impl MerkleNodeDB {
     }
 
     pub(crate) fn open_read_write(
-        repo_path: &Path,
+        store: Arc<dyn MerkleNodeStore>,
         node: &impl TMerkleTreeNode,
         parent_id: Option<MerkleHash>,
     ) -> Result<Self, MerkleDbError> {
@@ -340,7 +322,7 @@ impl MerkleNodeDB {
             node_id: node.hash(),
             parent_id,
             read_only: false,
-            store: Self::fs_store(repo_path),
+            store,
             node_buf: Some(BytesMut::new()),
             children_buf: Some(BytesMut::new()),
             flushed: false,

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -16,11 +16,15 @@
 //! [`FsMerkleNodeStore`](super::fs_merkle_node_store) is the only implementation today.
 
 use std::fmt::Debug;
+use std::path::Path;
+use std::sync::Arc;
 
 use bytes::Bytes;
 
+use crate::error::OxenError;
 use crate::model::MerkleHash;
 
+use super::fs_merkle_node_store::FsMerkleNodeStore;
 use super::merkle_node_db::MerkleDbError;
 
 /// Engine-agnostic persistence for Merkle tree node bytes, keyed by [`MerkleHash`]. A node is two
@@ -51,4 +55,15 @@ pub(crate) trait MerkleNodeStore: Debug + Send + Sync {
         node: Bytes,
         children: Bytes,
     ) -> Result<(), MerkleDbError>;
+}
+
+/// Build the node store for the repo rooted at `repo_path`.
+///
+/// Mirrors [`create_version_store`](crate::storage::create_version_store): the backend is chosen
+/// here, once, at repository construction. Today it is always the on-disk [`FsMerkleNodeStore`] —
+/// this is the single seam where config/env-driven backend selection will later plug in.
+pub(crate) fn create_merkle_node_store(
+    repo_path: &Path,
+) -> Result<Arc<dyn MerkleNodeStore>, OxenError> {
+    Ok(Arc::new(FsMerkleNodeStore::new(repo_path)))
 }

--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -290,10 +290,12 @@ pub fn create_empty_commit(
     )?;
 
     let parent_id = Some(existing_node.hash);
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &commit_node, parent_id)?;
+    let mut commit_db =
+        MerkleNodeDB::open_read_write(repo.merkle_node_store(), &commit_node, parent_id)?;
     // There should always be one child, the root directory
     let dir_node = existing_node.children.first().unwrap().dir()?;
     commit_db.add_child(&dir_node)?;
+    commit_db.close()?;
 
     // Copy the dir hashes db to the new commit
     repositories::tree::cp_dir_hashes_to(repo, &existing_commit_id, commit_node.hash())?;
@@ -370,8 +372,10 @@ pub fn create_initial_commit(
     )?;
 
     // Open the commit database and add the root directory
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &commit_node, None)?;
+    let mut commit_db =
+        MerkleNodeDB::open_read_write(repo.merkle_node_store(), &commit_node, None)?;
     commit_db.add_child(&dir_node)?;
+    commit_db.close()?;
 
     // Initialize the dir_hash_db with the root directory hash
     let commit_id_string = commit_id.to_string();

--- a/crates/liboxen/src/core/v_latest/entries.rs
+++ b/crates/liboxen/src/core/v_latest/entries.rs
@@ -572,9 +572,13 @@ fn traverse_and_update_sizes_and_counts(
                 &mut local_sizes,
                 num_bytes,
             )?;
-            let mut dir_db =
-                MerkleNodeDB::open_read_write(&repo.path, commit_node, node.parent_id)?;
+            let mut dir_db = MerkleNodeDB::open_read_write(
+                repo.merkle_node_store(),
+                commit_node,
+                node.parent_id,
+            )?;
             add_children_to_db(&mut dir_db, &node.children)?;
+            dir_db.close()?;
         }
         EMerkleTreeNode::VNode(vnode) => {
             log::debug!("Traversing vnode {vnode:?}");
@@ -585,8 +589,10 @@ fn traverse_and_update_sizes_and_counts(
                 &mut local_sizes,
                 num_bytes,
             )?;
-            let mut dir_db = MerkleNodeDB::open_read_write(&repo.path, vnode, node.parent_id)?;
+            let mut dir_db =
+                MerkleNodeDB::open_read_write(repo.merkle_node_store(), vnode, node.parent_id)?;
             add_children_to_db(&mut dir_db, &node.children)?;
+            dir_db.close()?;
         }
         EMerkleTreeNode::Directory(dir_node) => {
             log::debug!("No need to aggregate dir {}", dir_node.name());
@@ -599,8 +605,10 @@ fn traverse_and_update_sizes_and_counts(
             )?;
             dir_node.set_data_type_counts(local_counts.clone());
             dir_node.set_data_type_sizes(local_sizes.clone());
-            let mut dir_db = MerkleNodeDB::open_read_write(&repo.path, dir_node, node.parent_id)?;
+            let mut dir_db =
+                MerkleNodeDB::open_read_write(repo.merkle_node_store(), dir_node, node.parent_id)?;
             add_children_to_db(&mut dir_db, &node.children)?;
+            dir_db.close()?;
         }
         EMerkleTreeNode::File(file_node) => {
             log::debug!(

--- a/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
@@ -6,8 +6,6 @@ use std::str;
 use crate::core::db::dir_hashes::dir_hashes_db::{
     dir_hash_db_path, dir_hash_db_path_from_commit_id, with_dir_hash_db_manager,
 };
-use crate::core::db::merkle_node::MerkleNodeDB;
-
 use crate::model::merkle_tree::node::EMerkleTreeNode;
 
 use crate::model::merkle_tree::node::FileNode;
@@ -207,7 +205,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashSet<MerkleHash>>,
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -232,7 +230,7 @@ impl CommitMerkleTree {
         unique_hashes: Option<&mut HashMap<(MerkleHash, MerkleTreeNodeType), PathBuf>>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -258,7 +256,7 @@ impl CommitMerkleTree {
         partial_nodes: &mut HashMap<PathBuf, PartialNode>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -282,7 +280,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read depth {} node hash [{}]", depth, hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             log::debug!("read_depth merkle node db does not exist for hash: {hash}");
             return Ok(None);
         }
@@ -314,7 +312,7 @@ impl CommitMerkleTree {
         shared_hashes: Option<&mut HashSet<MerkleHash>>,
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -343,7 +341,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
@@ -375,7 +373,7 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }

--- a/crates/liboxen/src/core/v_latest/merge.rs
+++ b/crates/liboxen/src/core/v_latest/merge.rs
@@ -1084,14 +1084,18 @@ fn create_empty_merge_commit(
                 merge_commits.base.id
             ))
         })?;
-    let mut commit_db =
-        MerkleNodeDB::open_read_write(&repo.path, &commit_node, Some(base_node.hash))?;
+    let mut commit_db = MerkleNodeDB::open_read_write(
+        repo.merkle_node_store(),
+        &commit_node,
+        Some(base_node.hash),
+    )?;
     let root_dir = base_node
         .children
         .first()
         .expect("base commit must have a root dir as its first child")
         .dir()?;
     commit_db.add_child(&root_dir)?;
+    commit_db.close()?;
 
     // Copy base's path -> dir hash mapping so path-based tree lookups work for the new commit.
     repositories::tree::cp_dir_hashes_to(repo, &base_commit_hash, commit_node.hash())?;

--- a/crates/liboxen/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
@@ -195,13 +195,13 @@ impl CommitMerkleTree {
         recurse: bool,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read node v0.19.0 hash [{}]", hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
             return Ok(None);
         }
 
         let mut node = MerkleTreeNode::from_hash(repo, hash)?;
-        let mut node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let mut node_db = MerkleNodeDB::open_read_only(repo.merkle_node_store(), hash)?;
         CommitMerkleTree::read_children_from_node(repo, &mut node_db, &mut node, recurse)?;
         // log::debug!("read_node v0.19.0 done: {:?} recurse: {}", node.hash, recurse);
         Ok(Some(node))
@@ -213,13 +213,13 @@ impl CommitMerkleTree {
         depth: i32,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
         // log::debug!("Read depth {} node hash [{}]", depth, hash);
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        if !repo.merkle_node_store().exists(hash)? {
             log::debug!("read_depth merkle node db does not exist for hash: {hash}");
             return Ok(None);
         }
 
         let mut node = MerkleTreeNode::from_hash(repo, hash)?;
-        let mut node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let mut node_db = MerkleNodeDB::open_read_only(repo.merkle_node_store(), hash)?;
 
         CommitMerkleTree::read_children_until_depth(repo, &mut node_db, &mut node, depth, 0)?;
         // log::debug!("Read depth {} node done: {:?}", depth, node.hash);
@@ -471,7 +471,7 @@ impl CommitMerkleTree {
                         // Here we have to not panic on error, because if we clone a subtree we might not have all of the children nodes of a particular dir
                         // given that we are only loading the nodes that are needed.
                         if let Ok(mut node_db) =
-                            MerkleNodeDB::open_read_only(&repo.path, &child.hash)
+                            MerkleNodeDB::open_read_only(repo.merkle_node_store(), &child.hash)
                         {
                             CommitMerkleTree::read_children_until_depth(
                                 repo,
@@ -535,7 +535,8 @@ impl CommitMerkleTree {
                 | MerkleTreeNodeType::VNode => {
                     if recurse {
                         // log::debug!("read_children_from_node recurse: {:?}", child.hash);
-                        let Ok(mut node_db) = MerkleNodeDB::open_read_only(&repo.path, &child.hash)
+                        let Ok(mut node_db) =
+                            MerkleNodeDB::open_read_only(repo.merkle_node_store(), &child.hash)
                         else {
                             log::warn!("no child node db: {:?}", child.hash);
                             return Ok(());

--- a/crates/liboxen/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -41,10 +41,11 @@ impl MerkleTreeNode {
 
     /// Private implementation that loads from disk without caching
     fn from_hash_uncached(repo: &LocalRepository, hash: &MerkleHash) -> Result<Self, OxenError> {
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        let store = repo.merkle_node_store();
+        if !store.exists(hash)? {
             return Err(OxenError::MerkleNodeNotFound(hash.to_hex_hash()));
         }
-        let node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let node_db = MerkleNodeDB::open_read_only(store, hash)?;
         let parent_id = node_db.parent_id;
         Ok(MerkleTreeNode {
             hash: *hash,
@@ -80,11 +81,12 @@ impl MerkleTreeNode {
         // We don't return an error here because there are some situations where we won't have all
         // the node files. For example, when working in a subtree clone. However, parse/IO errors
         // from an existing node DO still propagate.
-        if !MerkleNodeDB::exists(&repo.path, hash) {
+        let store = repo.merkle_node_store();
+        if !store.exists(hash)? {
             log::warn!("no child node db: {hash:?}");
             return Ok(Vec::new());
         }
-        let mut node_db = MerkleNodeDB::open_read_only(&repo.path, hash)?;
+        let mut node_db = MerkleNodeDB::open_read_only(store, hash)?;
         Ok(node_db.map()?)
     }
 

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -1,6 +1,7 @@
 use crate::config::RepositoryConfig;
 use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE};
+use crate::core::db::merkle_node::{MerkleNodeStore, create_merkle_node_store};
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
@@ -48,6 +49,10 @@ pub struct LocalRepository {
     server_s3_opts: Option<S3Opts>,
     /// Built from `storage_config` + `server_s3_opts` at construction. Never replaced.
     version_store: Arc<dyn VersionStore>,
+    /// Where Merkle tree nodes are read from and written to. Built from the repo path at
+    /// construction and never replaced, mirroring `version_store`. The backend (file vs. another
+    /// engine) is a property of the repo chosen once in `create_merkle_node_store`.
+    merkle_node_store: Arc<dyn MerkleNodeStore>,
 }
 
 #[derive(Debug, Clone)]
@@ -95,6 +100,11 @@ impl LocalRepository {
         Arc::clone(&self.version_store)
     }
 
+    /// Get a handle to the Merkle node store backing this repo's tree nodes.
+    pub(crate) fn merkle_node_store(&self) -> Arc<dyn MerkleNodeStore> {
+        Arc::clone(&self.merkle_node_store)
+    }
+
     /// Load a repository from the current directory
     /// this traverses up the directory tree until it finds a .oxen/ directory
     pub fn from_current_dir() -> Result<LocalRepository, OxenError> {
@@ -128,6 +138,7 @@ impl LocalRepository {
         let path = path.as_ref().to_path_buf();
         let storage_config = config.storage.unwrap_or_default();
         let version_store = create_version_store(&path, &storage_config, server_s3_opts)?;
+        let merkle_node_store = create_merkle_node_store(&path)?;
         Ok(LocalRepository {
             path,
             remote_name: config.remote_name,
@@ -143,6 +154,7 @@ impl LocalRepository {
             storage_config,
             server_s3_opts: server_s3_opts.cloned(),
             version_store,
+            merkle_node_store,
         })
     }
 
@@ -166,6 +178,7 @@ impl LocalRepository {
         let path = std::env::current_dir()?.join(view.name);
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config, None)?;
+        let merkle_node_store = create_merkle_node_store(&path)?;
         Ok(LocalRepository {
             path,
             remotes: vec![],
@@ -181,6 +194,7 @@ impl LocalRepository {
             storage_config,
             server_s3_opts: None,
             version_store,
+            merkle_node_store,
         })
     }
 
@@ -188,6 +202,7 @@ impl LocalRepository {
         let path = path.to_owned();
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config, None)?;
+        let merkle_node_store = create_merkle_node_store(&path)?;
         Ok(LocalRepository {
             path,
             remotes: vec![repo.remote],
@@ -203,6 +218,7 @@ impl LocalRepository {
             storage_config,
             server_s3_opts: None,
             version_store,
+            merkle_node_store,
         })
     }
 

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -269,7 +269,7 @@ pub(crate) fn commit_dir_entries_with_parents(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, parent_id)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, parent_id)?;
     write_commit_entries(
         repo,
         commit_id,
@@ -278,6 +278,7 @@ pub(crate) fn commit_dir_entries_with_parents(
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_db.close()?;
 
     Ok(node.to_commit())
 }
@@ -362,7 +363,7 @@ pub fn commit_dir_entries_new(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, parent_id)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, parent_id)?;
 
     write_commit_entries(
         repo,
@@ -372,6 +373,7 @@ pub fn commit_dir_entries_new(
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_db.close()?;
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
@@ -473,7 +475,7 @@ pub fn commit_dir_entries(
         }
     }
 
-    let mut commit_db = MerkleNodeDB::open_read_write(&repo.path, &node, None)?;
+    let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, None)?;
     write_commit_entries(
         repo,
         commit_id,
@@ -482,6 +484,7 @@ pub fn commit_dir_entries(
         &dir_hashes,
         &vnode_entries,
     )?;
+    commit_db.close()?;
 
     // Remove all the directories that are staged for removal
     cache_invalidate_dir_hash_db(&dir_hash_db, dir_entries.values())?;
@@ -778,17 +781,22 @@ fn write_commit_entries(
         root_path.to_str().unwrap(),
         &dir_node.hash().to_string(),
     )?;
-    let dir_db = MerkleNodeDB::open_read_write(&repo.path, &dir_node, Some(commit_id))?;
+    let dir_db =
+        MerkleNodeDB::open_read_write(repo.merkle_node_store(), &dir_node, Some(commit_id))?;
+    let mut maybe_dir_db = Some(dir_db);
     r_create_dir_node(
         repo,
         commit_id,
-        &mut Some(dir_db),
+        &mut maybe_dir_db,
         dir_hash_db,
         dir_hashes,
         entries,
         root_path,
         &mut total_written,
     )?;
+    if let Some(mut dir_db) = maybe_dir_db {
+        dir_db.close()?;
+    }
 
     // The dir_hash_db was pre-populated from the previous commit, so
     // removed directories still have stale entries that must be deleted;
@@ -860,7 +868,7 @@ fn r_create_dir_node(
         // );
 
         let mut vnode_db = MerkleNodeDB::open_read_write(
-            &repo.path,
+            repo.merkle_node_store(),
             &vnode_obj,
             maybe_dir_db.as_ref().map(|db| db.node_id),
         )?;
@@ -883,7 +891,7 @@ fn r_create_dir_node(
                         // if the vnode is new, we need a new dir db
                         // let mut child_db = if maybe_vnode_db.is_some() {
                         let mut child_db = Some(MerkleNodeDB::open_read_write(
-                            &repo.path,
+                            repo.merkle_node_store(),
                             &dir_node,
                             Some(vnode.id),
                         )?);
@@ -898,6 +906,9 @@ fn r_create_dir_node(
                             &dir_path,
                             total_written,
                         )?;
+                        if let Some(mut child_db) = child_db {
+                            child_db.close()?;
+                        }
                         dir_node
                     } else {
                         // log::debug!("r_create_dir_node skipping {:?}", dir_path);
@@ -961,6 +972,7 @@ fn r_create_dir_node(
                 }
             }
         }
+        vnode_db.close()?;
     }
 
     log::debug!("Finished processing dir {path:?} total written {total_written} entries");

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1247,7 +1247,7 @@ fn p_write_tree(
 ) -> Result<(), OxenError> {
     let parent_id = node.parent_id;
 
-    let mut db = MerkleNodeDB::open_read_write(&repo.path, node_impl, parent_id)?;
+    let mut db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), node_impl, parent_id)?;
     for child in &node.children {
         match &child.node {
             EMerkleTreeNode::VNode(vnode) => {
@@ -2115,7 +2115,7 @@ mod tests {
 
             for hash in &installed {
                 assert!(
-                    MerkleNodeDB::exists(&clone.path, hash),
+                    clone.merkle_node_store().exists(hash)?,
                     "expected installed hash {hash} to be readable"
                 );
             }
@@ -2304,11 +2304,11 @@ mod tests {
             // Every installed hash must be readable through both stores.
             for h in &new_hashes {
                 assert!(
-                    MerkleNodeDB::exists(&repo_old.path, h),
+                    repo_old.merkle_node_store().exists(h)?,
                     "hash {h} not readable in repo unpacked via legacy unpack_nodes"
                 );
                 assert!(
-                    MerkleNodeDB::exists(&repo_new.path, h),
+                    repo_new.merkle_node_store().exists(h)?,
                     "hash {h} not readable in repo unpacked via unpack"
                 );
             }
@@ -2399,7 +2399,7 @@ mod tests {
             assert!(!installed.is_empty(), "unpack reported no hashes");
             for h in &installed {
                 assert!(
-                    MerkleNodeDB::exists(&repo_new.path, h),
+                    repo_new.merkle_node_store().exists(h)?,
                     "hash {h} not readable in repo unpacked via unpack"
                 );
             }
@@ -2928,7 +2928,7 @@ mod tests {
             );
             for h in &installed {
                 assert!(
-                    MerkleNodeDB::exists(&clone.path, h),
+                    clone.merkle_node_store().exists(h)?,
                     "hash {h} not readable in vfs-cloned repo"
                 );
             }


### PR DESCRIPTION
Have LocalRepository own an Arc<dyn MerkleNodeStore>, built once at construction via create_merkle_node_store (mirroring version_store / create_version_store), and hand it to MerkleNodeDB instead of resolving the file backend per-open. MerkleNodeDB::open_read_only/open_read_write now take the store; the static `exists` helper is gone — call sites use repo.merkle_node_store().exists(hash) directly.

No behavior change - the only backend create_merkle_node_store builds is the file store. This is the seam where config/env-driven backend selection (and an alternate engine) will plug in.