### PR TITLE
Fix the publish action by freeing up disk space before the build

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,29 @@
+name: Free up disk space
+description: >
+  Reclaim disk space on a GitHub-hosted Ubuntu runner by removing large
+  preinstalled toolchains our Rust/Python builds never use (dotnet, swift,
+  powershell, android, ghc). Heavy Cargo builds — notably the workspace
+  package/verify in the publish workflow, which compiles the dependency tree
+  once per publishable crate — can otherwise exhaust the runner's small root
+  partition. Requires the repository to be checked out first (it is a local
+  composite action) and a Linux runner (it uses sudo + apt).
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        echo "=== Before cleanup ==="
+        df -h
+
+        # Remove large preinstalled toolchains our builds don't use.
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+
+        # Clean apt cache
+        sudo apt-get clean
+
+        echo "=== After cleanup ==="
+        df -h

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -13,21 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Free up disk space
-        run: |
-          echo "=== Before cleanup ==="
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo apt-get clean
-          echo "=== After cleanup ==="
-          df -h
-
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -45,28 +45,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Free up disk space
-        if: matrix.platform == 'linux'
-        run: |
-          echo "=== Before cleanup ==="
-          df -h
-
-          # Remove unnecessary tools and files to free up space
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-
-          # Clean apt cache
-          sudo apt-get clean
-
-          echo "=== After cleanup ==="
-          df -h
-
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Free up disk space
+        if: matrix.platform == 'linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -208,28 +192,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Free up disk space
-        if: matrix.platform == 'linux'
-        run: |
-          echo "=== Before cleanup ==="
-          df -h
-
-          # Remove unnecessary tools and files to free up space
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-
-          # Clean apt cache
-          sudo apt-get clean
-
-          echo "=== After cleanup ==="
-          df -h
-
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Free up disk space
+        if: matrix.platform == 'linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
       - name: Package and verify crates
         run: |
           # Package and verify the workspace before getting the temporary API key.


### PR DESCRIPTION
- Fix the publish action by freeing up disk space before the build (`.github/workflows/publish.yml`)
- Consolidate our disk-freeing code into an internal action and call it from all the places we use it