### PR TITLE
Don't emit ansi colors to log files -- just to the terminal

### DIFF
--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use thiserror::Error;
@@ -142,10 +143,13 @@ pub fn init_tracing(app_name: &str, default: LevelFilter) -> Result<TracingGuard
         .map(|v| parse_fmt_span(&v))
         .unwrap_or(FmtSpan::NONE);
 
-    // Always: human-readable stderr output (with optional span events)
+    // Always: human-readable stderr output (with optional span events).
+    // ANSI color codes only when stderr is a terminal, so redirected output
+    // (files, CloudWatch) stays clean instead of carrying escape sequences.
     let stderr_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
         .with_target(true)
+        .with_ansi(std::io::stderr().is_terminal())
         .with_span_events(span_events);
 
     let maybe_log_dir = match std::env::var("OXEN_LOG_DIR").ok() {


### PR DESCRIPTION
The CloudWatch logs contain ANSI color codes, which CloudWatch doesn't parse, which makes it difficult to read the logs:

`[2m2026-06-19T21:50:21.931142Z[0m [31mERROR[0m [1mHTTP request[0m[1m{[0m[3mhttp.method[0m[2m=[0mPOST [3mhttp.route[0m[2m=[0m/api/repos/{namespace}/{repo_name}/merge/{base_head:.*} [3mhttp.flavor[0m[2m=[0m1.1 [3mhttp.scheme[0m[2m=[0mhttp [3mhttp.host[0m[2m=[0mip-10-0-0-4.us-west-1.compute.internal [3mhttp.client_ip[0m[2m=[0m10.0.10.66 [3mhttp.user_agent[0m[2m=[0mreq/0.5.15 [3mhttp.target[0m[2m=[0m/api/repos/[redacted]/merge/production..staging [3motel.name[0m[2m=[0mPOST /api/repos/{namespace}/{repo_name}/merge/{base_head:.*} [3motel.kind[0m[2m=[0m"server" [3mrequest_id[0m[2m=[0m[redacted][1m}[0m[2m:[0m [2moxen_server::errors[0m[2m:[0m Internal server error: UserConfigNotFound`

This PR disables ANSI color codes whenever we're not connected to an interactive terminal (so you can still get pretty colors when you're running the server in a terminal).