### PR TITLE
Fix ffmpeg compilation on macos

### DIFF
--- a/bin/test-rust
+++ b/bin/test-rust
@@ -39,6 +39,16 @@ done
 
 set -euo pipefail
 
+# On macOS, ffmpeg@7 is keg-only, so Homebrew does not symlink its pkgconfig dir onto the
+# default pkg-config search path. ffmpeg-sys-next locates libav* via pkg-config, so without
+# this the `ffmpeg` feature build fails with "system library libavutil was not found".
+if [ -n "$FEATURE_ARGS" ] && [ "$(uname)" = "Darwin" ] && command -v brew &>/dev/null; then
+    FFMPEG_PKGCONFIG="$(brew --prefix ffmpeg@7 2>/dev/null)/lib/pkgconfig"
+    if [ -d "$FFMPEG_PKGCONFIG" ]; then
+        export PKG_CONFIG_PATH="$FFMPEG_PKGCONFIG:${PKG_CONFIG_PATH:-}"
+    fi
+fi
+
 # we don't need oxen-server collecting metrics during tests
 export OXEN_METRICS_PORT='off'
 

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -42,7 +42,7 @@ set -euo pipefail
 # On macOS, ffmpeg@7 is keg-only, so Homebrew does not symlink its pkgconfig dir onto the
 # default pkg-config search path. ffmpeg-sys-next locates libav* via pkg-config, so without
 # this the `ffmpeg` feature build fails with "system library libavutil was not found".
-if [ -n "$FEATURE_ARGS" ] && [ "$(uname)" = "Darwin" ] && command -v brew &>/dev/null; then
+if [[ "$FEATURE_ARGS" == *ffmpeg* ]] && [ "$(uname)" = "Darwin" ] && command -v brew &>/dev/null; then
     FFMPEG_PKGCONFIG="$(brew --prefix ffmpeg@7 2>/dev/null)/lib/pkgconfig"
     if [ -d "$FFMPEG_PKGCONFIG" ]; then
         export PKG_CONFIG_PATH="$FFMPEG_PKGCONFIG:${PKG_CONFIG_PATH:-}"

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -43,9 +43,9 @@ set -euo pipefail
 # default pkg-config search path. ffmpeg-sys-next locates libav* via pkg-config, so without
 # this the `ffmpeg` feature build fails with "system library libavutil was not found".
 if [[ "$FEATURE_ARGS" == *ffmpeg* ]] && [ "$(uname)" = "Darwin" ] && command -v brew &>/dev/null; then
-    FFMPEG_PKGCONFIG="$(brew --prefix ffmpeg@7 2>/dev/null)/lib/pkgconfig"
-    if [ -d "$FFMPEG_PKGCONFIG" ]; then
-        export PKG_CONFIG_PATH="$FFMPEG_PKGCONFIG:${PKG_CONFIG_PATH:-}"
+    FFMPEG_PREFIX="$(brew --prefix ffmpeg@7 2>/dev/null)"
+    if [ -n "$FFMPEG_PREFIX" ] && [ -d "$FFMPEG_PREFIX/lib/pkgconfig" ]; then
+        export PKG_CONFIG_PATH="$FFMPEG_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
     fi
 fi
 


### PR DESCRIPTION
When `--ffmpeg` is requested on macOS, prepend `$(brew --prefix ffmpeg@7)/lib/pkgconfig` to `PKG_CONFIG_PATH` so the keg-only formula is discoverable.

The `ffmpeg-sys-next` crate locates the `libav*` libraries via `pkg-config`. On macOS the `ffmpeg@7` Homebrew formula (what `bin/install-prereqs` installs) is keg-only, so Homebrew does not symlink its `pkgconfig` directory onto the default `pkg-config` search path. When no plain `ffmpeg` formula is also linked, `pkg-config` can't find `libavutil` and the build script panics with "system library libavutil was not found".

This worked previously only by accident on boxes that happened to also have the non-keg-only `ffmpeg` formula linked; a `brew upgrade` removed it, recently.

Longer term we should move to ffmpeg 8 and drop the keg-only pin (ENG-1164).