### PR TITLE
Add `oxen cat` and stream client file reads instead of buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5468,6 +5468,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
  "uuid",
@@ -5488,6 +5489,7 @@ dependencies = [
  "pyo3-polars",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]

--- a/crates/liboxen/src/api/client/file.rs
+++ b/crates/liboxen/src/api/client/file.rs
@@ -3,9 +3,9 @@ use crate::api::client;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
 use crate::model::commit::NewCommitBody;
+use crate::storage::BoxedByteStream;
 use crate::view::CommitResponse;
 
-use bytes::{Bytes, BytesMut};
 use futures_util::StreamExt;
 use reqwest::multipart::{Form, Part};
 use std::path::Path;
@@ -92,84 +92,58 @@ fn apply_commit_body(mut form: Form, commit_body: Option<NewCommitBody>) -> Form
     form
 }
 
+/// Optional query parameters for [`get_file`]: thumbnail generation and image resizing.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GetFileOpts {
+    pub thumbnail: bool,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub timestamp: Option<f64>,
+}
+
+/// Streams a file's raw bytes from the remote at `revision`, without buffering the whole file in
+/// memory. `revision` may be a branch name or a commit id. `opts` carry optional thumbnail/resize
+/// query parameters. Callers that need the whole file in memory must drain the stream into a
+/// buffer at the call site.
 pub async fn get_file(
     remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    file_path: impl AsRef<Path>,
-) -> Result<Bytes, OxenError> {
-    get_file_with_params(remote_repo, branch, file_path, None, None, None, None).await
-}
-
-/// Get a file with optional query parameters (for thumbnails, image resizing, etc.)
-pub async fn get_file_with_params(
-    remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    file_path: impl AsRef<Path>,
-    thumbnail: Option<bool>,
-    width: Option<u32>,
-    height: Option<u32>,
-    timestamp: Option<f64>,
-) -> Result<Bytes, OxenError> {
-    let branch = branch.as_ref();
-    let path_ref = file_path.as_ref();
-    let file_path = path_ref
-        .to_str()
-        .ok_or_else(|| OxenError::basic_str(format!("Invalid UTF-8 in file path: {path_ref:?}")))?;
-    let uri = format!("/file/{branch}/{file_path}");
+    revision: &str,
+    file_path: &Path,
+    opts: GetFileOpts,
+) -> Result<BoxedByteStream, OxenError> {
+    let file_path = file_path.to_str().ok_or_else(|| {
+        OxenError::basic_str(format!("Invalid UTF-8 in file path: {file_path:?}"))
+    })?;
+    let uri = format!("/file/{revision}/{file_path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
-
     let client = client::new_for_url(&url)?;
 
-    // Build query parameters only for Some(...) values
     let mut query_params: Vec<(&str, String)> = Vec::new();
-    if let Some(thumb) = thumbnail {
-        query_params.push(("thumbnail", thumb.to_string()));
+    if opts.thumbnail {
+        query_params.push(("thumbnail", "true".to_string()));
     }
-    if let Some(w) = width {
-        query_params.push(("width", w.to_string()));
+    if let Some(width) = opts.width {
+        query_params.push(("width", width.to_string()));
     }
-    if let Some(h) = height {
-        query_params.push(("height", h.to_string()));
+    if let Some(height) = opts.height {
+        query_params.push(("height", height.to_string()));
     }
-    if let Some(ts) = timestamp {
-        query_params.push(("timestamp", ts.to_string()));
-    }
-
-    let req = client.get(&url).query(&query_params);
-
-    let res = req.send().await?;
-
-    let res = res.error_for_status()?;
-    let mut stream = res.bytes_stream();
-    let mut buffer = BytesMut::new();
-    while let Some(chunk_result) = stream.next().await {
-        let chunk =
-            chunk_result.map_err(|e| OxenError::basic_str(format!("Failed to read chunk: {e}")))?;
-        buffer.extend_from_slice(&chunk);
+    if let Some(timestamp) = opts.timestamp {
+        query_params.push(("timestamp", timestamp.to_string()));
     }
 
-    Ok(buffer.freeze())
-}
+    let res = client
+        .get(&url)
+        .query(&query_params)
+        .send()
+        .await?
+        .error_for_status()?;
 
-/// Get a video thumbnail
-pub async fn get_file_thumbnail(
-    remote_repo: &RemoteRepository,
-    branch: impl AsRef<str>,
-    file_path: impl AsRef<Path>,
-    width: Option<u32>,
-    height: Option<u32>,
-    timestamp: Option<f64>,
-) -> Result<Bytes, OxenError> {
-    get_file_with_params(
-        remote_repo,
-        branch,
-        file_path,
-        Some(true),
-        width,
-        height,
-        timestamp,
-    )
-    .await
+    let stream = res
+        .bytes_stream()
+        .map(|chunk| chunk.map_err(std::io::Error::other));
+    // Pin on the heap so the boxed reqwest stream satisfies the `Unpin` bound.
+    Ok(Box::new(Box::pin(stream)))
 }
 
 /// Move/rename a file in place (mv in a temp workspace and commit)
@@ -252,6 +226,7 @@ pub async fn delete_file(
 mod tests {
 
     use bytes::Bytes;
+    use tokio_stream::StreamExt;
 
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::error::OxenError;
@@ -402,10 +377,19 @@ mod tests {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
             let branch_name = "main";
             let file_path = test::test_bounding_box_csv();
-            let bytes = api::client::file::get_file(&remote_repo, branch_name, file_path).await;
+            let mut stream = api::client::file::get_file(
+                &remote_repo,
+                branch_name,
+                &file_path,
+                api::client::file::GetFileOpts::default(),
+            )
+            .await?;
+            let mut bytes = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
 
-            assert!(bytes.is_ok());
-            assert!(!bytes.unwrap().is_empty());
+            assert!(!bytes.is_empty());
 
             Ok(remote_repo)
         })
@@ -597,11 +581,20 @@ mod tests {
             )
             .await;
 
-            let bytes = api::client::file::get_file(&remote_repo, workspace_id, file_path).await;
+            let mut stream = api::client::file::get_file(
+                &remote_repo,
+                workspace_id,
+                Path::new(&file_path),
+                api::client::file::GetFileOpts::default(),
+            )
+            .await?;
+            let mut bytes = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
 
-            assert!(bytes.is_ok());
-            assert!(!bytes.as_ref().unwrap().is_empty());
-            assert_eq!(bytes.unwrap(), Bytes::from_static(b"test content"));
+            assert!(!bytes.is_empty());
+            assert_eq!(bytes, Bytes::from_static(b"test content"));
 
             Ok(remote_repo)
         })
@@ -643,15 +636,20 @@ mod tests {
 
             // Download the thumbnail with default settings
             let thumbnail_path = format!("{directory_name}/basketball.mp4");
-            let thumbnail_bytes = api::client::file::get_file_thumbnail(
+            let mut thumbnail_stream = api::client::file::get_file(
                 &remote_repo,
                 branch_name,
-                thumbnail_path.as_str(),
-                None,
-                None,
-                None,
+                Path::new(&thumbnail_path),
+                api::client::file::GetFileOpts {
+                    thumbnail: true,
+                    ..Default::default()
+                },
             )
             .await?;
+            let mut thumbnail_bytes = Vec::new();
+            while let Some(chunk) = thumbnail_stream.next().await {
+                thumbnail_bytes.extend_from_slice(&chunk?);
+            }
 
             // Verify thumbnail is not empty
             assert!(!thumbnail_bytes.is_empty(), "Thumbnail should not be empty");
@@ -675,15 +673,22 @@ mod tests {
             );
 
             // Test with custom dimensions
-            let thumbnail_bytes_custom = api::client::file::get_file_thumbnail(
+            let mut custom_stream = api::client::file::get_file(
                 &remote_repo,
                 branch_name,
-                thumbnail_path.as_str(),
-                Some(640),
-                Some(480),
-                Some(0.5),
+                Path::new(&thumbnail_path),
+                api::client::file::GetFileOpts {
+                    thumbnail: true,
+                    width: Some(640),
+                    height: Some(480),
+                    timestamp: Some(0.5),
+                },
             )
             .await?;
+            let mut thumbnail_bytes_custom = Vec::new();
+            while let Some(chunk) = custom_stream.next().await {
+                thumbnail_bytes_custom.extend_from_slice(&chunk?);
+            }
 
             assert!(
                 !thumbnail_bytes_custom.is_empty(),
@@ -726,13 +731,14 @@ mod tests {
 
             println!("deleted {} as commit {}", train_d.display(), c.commit.id);
 
-            let contents =
-                api::client::file::get_file(&remote_repo, DEFAULT_BRANCH_NAME, &file).await;
-            assert!(
-                contents.is_err(),
-                "Fetching deleted file should be an error, but got: {:?}",
-                contents
-            );
+            let result = api::client::file::get_file(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                &file,
+                api::client::file::GetFileOpts::default(),
+            )
+            .await;
+            assert!(result.is_err(), "Fetching deleted file should be an error");
 
             Ok(remote_repo)
         })

--- a/crates/liboxen/src/api/client/import.rs
+++ b/crates/liboxen/src/api/client/import.rs
@@ -96,6 +96,8 @@ pub async fn import_url(
 mod tests {
     use crate::test;
     use bytes::Bytes;
+    use std::path::Path;
+    use tokio_stream::StreamExt;
 
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::error::OxenError;
@@ -146,15 +148,20 @@ mod tests {
             let commit = result.unwrap();
             assert!(commit.message.contains("Upload test ZIP"));
 
-            let bytes =
-                api::client::file::get_file(&remote_repo, branch_name, "images/image1.png").await;
+            let mut stream = api::client::file::get_file(
+                &remote_repo,
+                branch_name,
+                Path::new("images/image1.png"),
+                api::client::file::GetFileOpts::default(),
+            )
+            .await?;
+            let mut bytes = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
 
-            assert!(bytes.is_ok());
-            assert!(!bytes.as_ref().unwrap().is_empty());
-            assert_eq!(
-                bytes.as_ref().unwrap(),
-                &Bytes::from_static(b"fake png data 1")
-            );
+            assert!(!bytes.is_empty());
+            assert_eq!(bytes, Bytes::from_static(b"fake png data 1"));
 
             Ok(remote_repo)
         })
@@ -198,23 +205,33 @@ mod tests {
             let commit = result.unwrap();
             assert!(commit.message.contains("Upload test ZIP in empty repo"));
 
-            let bytes =
-                api::client::file::get_file(&remote_repo, branch_name, "images/image1.png").await;
+            let mut stream = api::client::file::get_file(
+                &remote_repo,
+                branch_name,
+                Path::new("images/image1.png"),
+                api::client::file::GetFileOpts::default(),
+            )
+            .await?;
+            let mut bytes = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
 
-            assert!(bytes.is_ok());
-            assert_eq!(
-                bytes.as_ref().unwrap(),
-                &Bytes::from_static(b"fake png data 1")
-            );
+            assert_eq!(bytes, Bytes::from_static(b"fake png data 1"));
 
-            let bytes_2 =
-                api::client::file::get_file(&remote_repo, branch_name, "images/image2.png").await;
+            let mut stream_2 = api::client::file::get_file(
+                &remote_repo,
+                branch_name,
+                Path::new("images/image2.png"),
+                api::client::file::GetFileOpts::default(),
+            )
+            .await?;
+            let mut bytes_2 = Vec::new();
+            while let Some(chunk) = stream_2.next().await {
+                bytes_2.extend_from_slice(&chunk?);
+            }
 
-            assert!(bytes_2.is_ok());
-            assert_eq!(
-                bytes_2.as_ref().unwrap(),
-                &Bytes::from_static(b"fake png data 2")
-            );
+            assert_eq!(bytes_2, Bytes::from_static(b"fake png data 2"));
 
             Ok(remote_repo)
         })

--- a/crates/liboxen/src/api/client/workspaces/files.rs
+++ b/crates/liboxen/src/api/client/workspaces/files.rs
@@ -1112,6 +1112,7 @@ mod tests {
 
     use std::path::Path;
     use tempfile::TempDir;
+    use tokio_stream::StreamExt;
     use uuid;
 
     #[test]
@@ -2094,8 +2095,17 @@ mod tests {
             assert!(new_file.is_some(), "File should exist at new path");
 
             // Verify the actual file content is accessible at the new path
-            let file_bytes =
-                api::client::file::get_file(&remote_repo, branch_name, new_path).await?;
+            let mut stream = api::client::file::get_file(
+                &remote_repo,
+                branch_name,
+                Path::new(new_path),
+                api::client::file::GetFileOpts::default(),
+            )
+            .await?;
+            let mut file_bytes = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                file_bytes.extend_from_slice(&chunk?);
+            }
             assert!(
                 !file_bytes.is_empty(),
                 "File content should not be empty at new path"

--- a/crates/liboxen/src/repositories/revisions.rs
+++ b/crates/liboxen/src/repositories/revisions.rs
@@ -1,8 +1,13 @@
 //! Revisions can either be commits by id or head commits on branches by name
 
+use std::path::Path;
+
+use crate::api;
+use crate::api::client::file::GetFileOpts;
 use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository};
 use crate::repositories;
+use crate::storage::BoxedByteStream;
 
 /// Get a commit object from a commit id or branch name
 /// Returns Ok(None) if the revision does not exist
@@ -17,4 +22,77 @@ pub fn get(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<Option<C
         .unwrap_or_else(|| revision.to_string());
     let commit = repositories::commits::get_by_id(repo, &commit_id)?;
     Ok(commit)
+}
+
+/// Streams the raw bytes of `path` as it existed at `revision`.
+///
+/// `revision` may be a branch name, a commit id, or `HEAD`. May make a network call to the
+/// configured `origin` remote when the file's bytes aren't available locally, so a remote must be
+/// set and reachable in that case. Errors if `revision` does not resolve to a commit, or if `path`
+/// is not a file in that commit.
+pub async fn get_version_stream_from_revision(
+    repo: &LocalRepository,
+    revision: &str,
+    path: impl AsRef<Path>,
+) -> Result<BoxedByteStream, OxenError> {
+    let path = path.as_ref();
+
+    let commit =
+        get(repo, revision)?.ok_or_else(|| OxenError::RevisionNotFound(revision.into()))?;
+    let file_node = repositories::tree::get_file_by_path(repo, &commit, path)?
+        .ok_or_else(|| OxenError::entry_does_not_exist_in_commit(path, &commit.id))?;
+    let hash = file_node.hash().to_string();
+
+    let version_store = repo.version_store();
+    if version_store.version_exists(&hash).await? {
+        return version_store.get_version_stream(&hash).await;
+    }
+
+    // The file is known in the merkle tree but its bytes aren't stored locally;
+    // stream them from the remote by the resolved commit id and path.
+    let remote_repo = api::client::repositories::get_default_remote(repo).await?;
+    api::client::file::get_file(&remote_repo, &commit.id, path, GetFileOpts::default()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::error::OxenError;
+    use crate::{repositories, test, util};
+    use tokio_stream::StreamExt;
+
+    #[tokio::test]
+    async fn test_get_version_stream_reads_committed_bytes_without_touching_worktree()
+    -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let relative_path = PathBuf::from("hello.txt");
+            let full_path = repo.path.join(&relative_path);
+
+            util::fs::write_to_path(&full_path, "head version")?;
+            repositories::add(&repo, &full_path).await?;
+            repositories::commit(&repo, "add hello")?;
+
+            // Modify the working tree so we can prove the read comes from the commit, not from
+            // disk.
+            util::fs::write_to_path(&full_path, "working version")?;
+
+            let mut stream = repositories::revisions::get_version_stream_from_revision(
+                &repo,
+                "HEAD",
+                &relative_path,
+            )
+            .await?;
+            let mut bytes = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
+
+            assert_eq!(String::from_utf8(bytes).unwrap(), "head version");
+            assert_eq!(util::fs::read_from_path(&full_path)?, "working version");
+
+            Ok(())
+        })
+        .await
+    }
 }

--- a/crates/liboxen/src/storage.rs
+++ b/crates/liboxen/src/storage.rs
@@ -5,5 +5,6 @@ pub mod version_store;
 pub use local::LocalVersionStore;
 pub use s3::{S3Opts, S3VersionStore};
 pub use version_store::{
-    LocalFilePath, StorageConfig, StorageKind, VersionLocation, VersionStore, create_version_store,
+    BoxedByteStream, LocalFilePath, StorageConfig, StorageKind, VersionLocation, VersionStore,
+    create_version_store,
 };

--- a/crates/liboxen/src/storage/local.rs
+++ b/crates/liboxen/src/storage/local.rs
@@ -6,7 +6,7 @@ use std::time::SystemTime;
 use crate::constants::{VERSION_CHUNK_FILE_NAME, VERSION_CHUNKS_DIR, VERSION_FILE_NAME};
 use crate::error::OxenError;
 use crate::model::MerkleHash;
-use crate::storage::version_store::{VersionLocation, VersionStore};
+use crate::storage::version_store::{BoxedByteStream, VersionLocation, VersionStore};
 use crate::util::fs::AtomicFile;
 use crate::util::{concurrency, hasher};
 use crate::view::versions::CleanCorruptedVersionsResult;
@@ -22,7 +22,6 @@ use tokio::io::AsyncReadExt;
 use tokio::io::BufReader;
 use tokio::sync::Semaphore;
 use tokio::task::spawn_blocking;
-use tokio_stream::Stream;
 use tokio_util::io::ReaderStream;
 
 /// Local filesystem implementation of version storage
@@ -154,11 +153,7 @@ impl VersionStore for LocalVersionStore {
         Ok(metadata.len())
     }
 
-    async fn get_version_stream(
-        &self,
-        hash: &str,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
-    {
+    async fn get_version_stream(&self, hash: &str) -> Result<BoxedByteStream, OxenError> {
         let path = self.version_path(hash);
         let file = File::open(&path).await?;
         let reader = BufReader::new(file);
@@ -171,8 +166,7 @@ impl VersionStore for LocalVersionStore {
         &self,
         orig_hash: &str,
         derived_filename: &str,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
-    {
+    ) -> Result<BoxedByteStream, OxenError> {
         let path = self.version_dir(orig_hash).join(derived_filename);
         let file = File::open(&path).await?;
         let reader = BufReader::new(file);

--- a/crates/liboxen/src/storage/s3.rs
+++ b/crates/liboxen/src/storage/s3.rs
@@ -16,7 +16,7 @@ use tokio::sync::OnceCell;
 use tokio_stream::Stream;
 use tokio_util::io::StreamReader;
 
-use super::version_store::{VersionLocation, VersionStore};
+use super::version_store::{BoxedByteStream, VersionLocation, VersionStore};
 use crate::constants::VERSION_FILE_NAME;
 use crate::util::fs::AtomicFile;
 use crate::util::hasher;
@@ -539,11 +539,7 @@ impl VersionStore for S3VersionStore {
         Ok(size)
     }
 
-    async fn get_version_stream(
-        &self,
-        hash: &str,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
-    {
+    async fn get_version_stream(&self, hash: &str) -> Result<BoxedByteStream, OxenError> {
         let client = self.client().await?;
         let key = self.generate_key(hash);
 
@@ -564,8 +560,7 @@ impl VersionStore for S3VersionStore {
         &self,
         orig_hash: &str,
         derived_filename: &str,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>
-    {
+    ) -> Result<BoxedByteStream, OxenError> {
         let client = self.client().await?;
         let key = format!("{}/{}", self.version_dir(orig_hash), derived_filename);
 

--- a/crates/liboxen/src/storage/version_store.rs
+++ b/crates/liboxen/src/storage/version_store.rs
@@ -19,6 +19,12 @@ use crate::storage::{LocalVersionStore, S3Opts, S3VersionStore};
 use crate::util;
 use crate::view::versions::CleanCorruptedVersionsResult;
 
+/// A boxed, `Send + Unpin` stream of byte chunks, each an `io::Result`.
+///
+/// The shared return type of the version store's streaming reads and the
+/// client-side file streamer.
+pub type BoxedByteStream = Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>;
+
 /// A local filesystem path to a version file.
 ///
 /// The path is guaranteed to be readable on the local filesystem, but callers MUST NOT assume it is
@@ -288,10 +294,7 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     ///
     /// # Arguments
     /// * `hash` - The content hash of the version to retrieve
-    async fn get_version_stream(
-        &self,
-        hash: &str,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>;
+    async fn get_version_stream(&self, hash: &str) -> Result<BoxedByteStream, OxenError>;
 
     /// Get the size in bytes of a derived file (e.g., resized image, video thumbnail).
     ///
@@ -318,7 +321,7 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         &self,
         orig_hash: &str,
         derived_filename: &str,
-    ) -> Result<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin>, OxenError>;
+    ) -> Result<BoxedByteStream, OxenError>;
 
     /// Check if a derived file exists
     ///

--- a/crates/oxen-cli/Cargo.toml
+++ b/crates/oxen-cli/Cargo.toml
@@ -37,6 +37,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/crates/oxen-cli/src/cmd.rs
+++ b/crates/oxen-cli/src/cmd.rs
@@ -8,6 +8,9 @@ pub use add::AddCmd;
 pub mod branch;
 pub use branch::BranchCmd;
 
+pub mod cat;
+pub use cat::CatCmd;
+
 pub mod checkout;
 pub use checkout::CheckoutCmd;
 

--- a/crates/oxen-cli/src/cmd/cat.rs
+++ b/crates/oxen-cli/src/cmd/cat.rs
@@ -22,7 +22,7 @@ impl RunCmd for CatCmd {
             .arg(
                 Arg::new("path")
                     .required(true)
-                    .help("Path to the file, relative to the repository root or current directory"),
+                    .help("Path to the file, relative to the current directory"),
             )
             .arg(
                 Arg::new("revision")

--- a/crates/oxen-cli/src/cmd/cat.rs
+++ b/crates/oxen-cli/src/cmd/cat.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use clap::{Arg, Command};
+use liboxen::model::LocalRepository;
+use liboxen::{repositories, util};
+use tokio::io::AsyncWriteExt;
+use tokio_stream::StreamExt;
+
+use crate::cmd::RunCmd;
+
+pub const NAME: &str = "cat";
+pub struct CatCmd;
+
+#[async_trait]
+impl RunCmd for CatCmd {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn args(&self) -> Command {
+        Command::new(NAME)
+            .about("Print the raw bytes of a file at a revision to stdout")
+            .arg(
+                Arg::new("path")
+                    .required(true)
+                    .help("Path to the file, relative to the repository root or current directory"),
+            )
+            .arg(
+                Arg::new("revision")
+                    .long("revision")
+                    .short('r')
+                    .help("The branch name or commit id to read from. Defaults to HEAD.")
+                    .default_value("HEAD")
+                    .action(clap::ArgAction::Set),
+            )
+    }
+
+    async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
+        let repository = LocalRepository::from_current_dir()?;
+        let path = args
+            .get_one::<String>("path")
+            .ok_or_else(|| anyhow::anyhow!("Must supply a path"))?;
+        let revision = args
+            .get_one::<String>("revision")
+            .ok_or_else(|| anyhow::anyhow!("Must supply a revision"))?;
+
+        // Resolve the user-supplied path to a repo-relative path. Joining an absolute path
+        // onto the current dir yields the absolute path, so this handles both absolute and
+        // current-dir-relative inputs. Don't canonicalize — the file need not exist in the
+        // working tree, only in the revision.
+        let current_dir = std::env::current_dir()?;
+        let repo_path = util::fs::path_relative_to_dir(current_dir.join(path), &repository.path)?;
+
+        let mut stream = repositories::revisions::get_version_stream_from_revision(
+            &repository,
+            revision,
+            repo_path,
+        )
+        .await?;
+
+        // Unbounded streamed write: use the large-buffer convention and flush explicitly, since
+        // `BufWriter`'s `Drop` does not flush.
+        let mut stdout = tokio::io::BufWriter::with_capacity(10 * 1024 * 1024, tokio::io::stdout());
+        while let Some(chunk) = stream.next().await {
+            stdout.write_all(&chunk?).await?;
+        }
+        stdout.flush().await?;
+
+        Ok(())
+    }
+}

--- a/crates/oxen-cli/src/main.rs
+++ b/crates/oxen-cli/src/main.rs
@@ -164,10 +164,11 @@ fn main_oxen_command() -> (Command, Runners) {
 }
 
 /// Every command that is used by the `oxen` CLI **MUST** be listed here!
-fn all_commands() -> [Box<dyn cmd::RunCmd>; 37] {
+fn all_commands() -> [Box<dyn cmd::RunCmd>; 38] {
     [
         Box::new(cmd::AddCmd),
         Box::new(cmd::BranchCmd),
+        Box::new(cmd::CatCmd),
         Box::new(cmd::CheckoutCmd),
         Box::new(cmd::CleanCmd),
         Box::new(cmd::CloneCmd),

--- a/crates/oxen-py/Cargo.toml
+++ b/crates/oxen-py/Cargo.toml
@@ -28,6 +28,7 @@ pyo3-async-runtimes = { workspace = true }
 pyo3-polars = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -1,3 +1,4 @@
+use liboxen::api::client::file::{GetFileOpts, get_file};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -10,6 +11,7 @@ use liboxen::model::{Remote, RemoteRepository};
 use liboxen::opts::{PaginateOpts, SortOpts};
 use liboxen::storage::StorageKind;
 use liboxen::{api, repositories};
+use tokio_stream::StreamExt;
 
 use std::borrow::Cow;
 use std::path::PathBuf;
@@ -253,10 +255,16 @@ impl PyRemoteRepo {
 
     fn get_file(&self, remote_path: PathBuf, revision: &str) -> Result<Cow<'_, [u8]>, PyOxenError> {
         let bytes = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::file::get_file(&self.repo, &revision, &remote_path).await
+            let mut stream =
+                get_file(&self.repo, revision, &remote_path, GetFileOpts::default()).await?;
+            let mut bytes = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
+            Ok::<_, OxenError>(bytes)
         })?;
 
-        Ok(bytes.to_vec().into())
+        Ok(bytes.into())
     }
 
     fn put_file(


### PR DESCRIPTION
Replaces #503 and satisfies a requested feature for a command similar to `git cat-file`, a generally-useful command to output the raw bytes of a file from a specific revision.

`oxen cat <path> -r <rev>` streams a file's bytes at a revision to stdout. It reads local-first from the version store and falls back to the configured remote when the bytes aren't stored locally. We check the merkle tree locally and only make a remote request if the file actually exists at that revision. `oxen cat` streams writes to stdout, so it handles files larger than memory.

Along the way, I did some refactoring. I collapsed `get_file`, `get_file_with_params`, `get_file_stream`, and `get_file_thumbnail` into one streaming entry point, `get_file(remote, revision, path, GetFileOpts) -> BoxedByteStream`, where `GetFileOpts` bundles the optional thumbnail/resize query parameters. Callers that still need the whole payload in memory drain the stream inline at the call site rather than through a shared helper, so each buffering site stays visible for a later move to full streaming.

I also added the `BoxedByteStream` alias in `storage::version_store`, shared by the version store's streaming reads and the client streamer, replacing the spelled-out `Box<dyn Stream<...>>` return type across the storage layer.