### PR TITLE
Make `oxen info` honor the requested revision via `-r`/`--revision`

### DIFF
--- a/crates/liboxen/src/repositories/metadata.rs
+++ b/crates/liboxen/src/repositories/metadata.rs
@@ -3,11 +3,13 @@
 
 use crate::error::OxenError;
 use crate::model::entry::entry_data_type::EntryDataType;
+use crate::model::entry::metadata_entry::CLIMetadataEntry;
 use crate::model::merkle_tree::node::{DirNode, FileNode};
 use crate::model::metadata::MetadataDir;
 use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::parsed_resource::ParsedResourceView;
 use crate::model::{Commit, LocalRepository, MetadataEntry};
+use crate::repositories;
 use crate::util;
 
 use std::path::{Path, PathBuf};
@@ -98,6 +100,32 @@ pub fn from_dir_node(
 /// Returns metadata with latest commit information. Less efficient than get().
 pub use crate::core::v_latest::metadata::get_cli;
 
+/// Returns CLI metadata for `path` as it existed at `revision`, sourced from the merkle tree
+/// rather than the working-tree file. `revision` may be a branch name, a commit id, or `HEAD`.
+/// Errors if `revision` does not resolve to a commit, or if `path` is not a file in that commit.
+pub fn get_cli_at_revision(
+    repo: &LocalRepository,
+    path: impl AsRef<Path>,
+    revision: &str,
+) -> Result<CLIMetadataEntry, OxenError> {
+    let path = path.as_ref();
+    let commit = repositories::revisions::get(repo, revision)?
+        .ok_or_else(|| OxenError::RevisionNotFound(revision.into()))?;
+    let file_node = repositories::tree::get_file_by_path(repo, &commit, path)?
+        .ok_or_else(|| OxenError::entry_does_not_exist_in_commit(path, &commit.id))?;
+    let last_commit_id = file_node.last_commit_id().to_string();
+    let last_updated = repositories::commits::get_by_id(repo, &last_commit_id)?;
+    Ok(CLIMetadataEntry {
+        filename: file_node.name().to_string(),
+        last_updated,
+        hash: file_node.hash().to_string(),
+        size: file_node.num_bytes(),
+        data_type: file_node.data_type().clone(),
+        mime_type: file_node.mime_type().to_string(),
+        extension: file_node.extension().to_string(),
+    })
+}
+
 /// Returns the file size in bytes.
 pub fn get_file_size(path: impl AsRef<Path>) -> Result<u64, OxenError> {
     let metadata = util::fs::metadata(path.as_ref())?;
@@ -162,9 +190,12 @@ pub fn get_file_metadata(
 
 #[cfg(test)]
 mod tests {
+    use crate::error::OxenError;
     use crate::model::EntryDataType;
     use crate::repositories;
     use crate::test;
+    use crate::util;
+    use std::path::Path;
 
     #[tokio::test]
     async fn test_get_metadata_audio_flac() {
@@ -176,5 +207,32 @@ mod tests {
         assert_eq!(metadata.size, 37096);
         assert_eq!(metadata.data_type, EntryDataType::Audio);
         assert_eq!(metadata.mime_type, "audio/x-flac");
+    }
+
+    #[tokio::test]
+    async fn test_get_cli_at_revision_reads_committed_metadata_not_worktree()
+    -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let relative_path = Path::new("hello.txt");
+            let full_path = repo.path.join(relative_path);
+
+            util::fs::write_to_path(&full_path, "head version")?;
+            repositories::add(&repo, &full_path).await?;
+            repositories::commit(&repo, "add hello")?;
+
+            let committed =
+                repositories::metadata::get_cli_at_revision(&repo, relative_path, "HEAD")?;
+
+            // Change the working tree to prove the metadata comes from the commit, not disk.
+            util::fs::write_to_path(&full_path, "a longer working-tree version with new bytes")?;
+
+            let at_head =
+                repositories::metadata::get_cli_at_revision(&repo, relative_path, "HEAD")?;
+            assert_eq!(at_head.hash, committed.hash);
+            assert_eq!(at_head.size, "head version".len() as u64);
+
+            Ok(())
+        })
+        .await
     }
 }

--- a/crates/oxen-cli/src/cmd/cat.rs
+++ b/crates/oxen-cli/src/cmd/cat.rs
@@ -1,11 +1,13 @@
 use async_trait::async_trait;
 use clap::{Arg, Command};
 use liboxen::model::LocalRepository;
-use liboxen::{repositories, util};
+use liboxen::repositories;
+use std::path::Path;
 use tokio::io::AsyncWriteExt;
 use tokio_stream::StreamExt;
 
 use crate::cmd::RunCmd;
+use crate::helpers::path_relative_to_repo;
 
 pub const NAME: &str = "cat";
 pub struct CatCmd;
@@ -43,12 +45,7 @@ impl RunCmd for CatCmd {
             .get_one::<String>("revision")
             .ok_or_else(|| anyhow::anyhow!("Must supply a revision"))?;
 
-        // Resolve the user-supplied path to a repo-relative path. Joining an absolute path
-        // onto the current dir yields the absolute path, so this handles both absolute and
-        // current-dir-relative inputs. Don't canonicalize — the file need not exist in the
-        // working tree, only in the revision.
-        let current_dir = std::env::current_dir()?;
-        let repo_path = util::fs::path_relative_to_dir(current_dir.join(path), &repository.path)?;
+        let repo_path = path_relative_to_repo(&repository, Path::new(path))?;
 
         let mut stream = repositories::revisions::get_version_stream_from_revision(
             &repository,

--- a/crates/oxen-cli/src/cmd/info.rs
+++ b/crates/oxen-cli/src/cmd/info.rs
@@ -7,6 +7,7 @@ use liboxen::opts::InfoOpts;
 use liboxen::repositories;
 
 use crate::cmd::RunCmd;
+use crate::helpers::path_relative_to_repo;
 pub const NAME: &str = "info";
 pub struct InfoCmd;
 
@@ -64,11 +65,13 @@ impl RunCmd for InfoCmd {
 
         // Look up from the current dir for .oxen directory
         let repository = LocalRepository::from_current_dir()?;
-        // With a revision, read metadata from that commit's merkle tree; without one, describe
-        // the working-tree file on disk.
+        // With a revision, read metadata from that commit's merkle tree (which is keyed by
+        // repo-relative paths); without one, describe the working-tree file on disk at the path
+        // as given.
         let metadata = match &opts.revision {
             Some(revision) => {
-                repositories::metadata::get_cli_at_revision(&repository, &path, revision)?
+                let repo_path = path_relative_to_repo(&repository, &path)?;
+                repositories::metadata::get_cli_at_revision(&repository, &repo_path, revision)?
             }
             None => repositories::metadata::get_cli(&repository, &path, &path)?,
         };

--- a/crates/oxen-cli/src/cmd/info.rs
+++ b/crates/oxen-cli/src/cmd/info.rs
@@ -20,7 +20,13 @@ impl RunCmd for InfoCmd {
         Command::new(NAME)
             .about("Get metadata information about a file such as the oxen hash, data type, etc.")
             .arg(Arg::new("path").required(false))
-            .arg(Arg::new("revision").required(false))
+            .arg(
+                Arg::new("revision")
+                    .long("revision")
+                    .short('r')
+                    .help("Read metadata as of this branch or commit instead of the working tree.")
+                    .action(clap::ArgAction::Set),
+            )
             .arg(
                 Arg::new("verbose")
                     .long("verbose")
@@ -58,7 +64,14 @@ impl RunCmd for InfoCmd {
 
         // Look up from the current dir for .oxen directory
         let repository = LocalRepository::from_current_dir()?;
-        let metadata = repositories::metadata::get_cli(&repository, &path, &path)?;
+        // With a revision, read metadata from that commit's merkle tree; without one, describe
+        // the working-tree file on disk.
+        let metadata = match &opts.revision {
+            Some(revision) => {
+                repositories::metadata::get_cli_at_revision(&repository, &path, revision)?
+            }
+            None => repositories::metadata::get_cli(&repository, &path, &path)?,
+        };
 
         if opts.output_as_json {
             let json = serde_json::to_string(&metadata)?;

--- a/crates/oxen-cli/src/helpers.rs
+++ b/crates/oxen-cli/src/helpers.rs
@@ -9,7 +9,7 @@ use liboxen::util::oxen_version::OxenVersion;
 
 use colored::Colorize;
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 
 pub fn get_scheme_and_host_or_default() -> Result<(String, String), OxenError> {
@@ -112,5 +112,74 @@ pub fn check_repo_migration_needed(repo: &LocalRepository) -> Result<(), OxenErr
 /// Resolves a user-supplied path (current-dir-relative or absolute) to a repository-relative path.
 pub fn path_relative_to_repo(repo: &LocalRepository, path: &Path) -> Result<PathBuf, OxenError> {
     let current_dir = std::env::current_dir()?;
-    util::fs::path_relative_to_dir(current_dir.join(path), &repo.path)
+    path_relative_to_repo_from(&current_dir, &repo.path, path)
+}
+
+/// Maps `path` to a `repo_path`-relative path, resolving `.`/`..` against `current_dir`.
+fn path_relative_to_repo_from(
+    current_dir: &Path,
+    repo_path: &Path,
+    path: &Path,
+) -> Result<PathBuf, OxenError> {
+    let joined = current_dir.join(path);
+    // Resolve `.`/`..` lexically; canonicalizing would require the file to exist on disk.
+    let mut normalized = PathBuf::new();
+    for component in joined.components() {
+        match component {
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir => {}
+            component => normalized.push(component),
+        }
+    }
+    util::fs::path_relative_to_dir(normalized, repo_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::path_relative_to_repo_from;
+    use std::path::{Path, PathBuf};
+
+    fn assert_repo_relative(current_dir: &str, repo: &str, input: &str, expected: &str) {
+        let got =
+            path_relative_to_repo_from(Path::new(current_dir), Path::new(repo), Path::new(input))
+                .expect("path resolution should succeed for valid inputs");
+        assert_eq!(
+            got,
+            PathBuf::from(expected),
+            "cwd={current_dir} repo={repo} input={input}"
+        );
+    }
+
+    #[test]
+    fn maps_normal_relative_and_absolute_paths() {
+        // Relative input from the repo root.
+        assert_repo_relative("/repo", "/repo", "data.txt", "data.txt");
+        assert_repo_relative("/repo", "/repo", "a/b.txt", "a/b.txt");
+        // Relative input from a subdirectory picks up the subdirectory prefix.
+        assert_repo_relative("/repo/sub", "/repo", "data.txt", "sub/data.txt");
+        assert_repo_relative(
+            "/repo/sub",
+            "/repo",
+            "nested/data.txt",
+            "sub/nested/data.txt",
+        );
+        // Absolute input maps straight to repo-relative regardless of the current dir.
+        assert_repo_relative("/repo/sub", "/repo", "/repo/a/b.txt", "a/b.txt");
+    }
+
+    #[test]
+    fn resolves_dot_and_parent_dir_lexically() {
+        // `.` is a no-op.
+        assert_repo_relative("/repo/sub", "/repo", "./data.txt", "sub/data.txt");
+        // `..` climbs out of the current subdirectory.
+        assert_repo_relative("/repo/sub", "/repo", "../data.txt", "data.txt");
+        // Multiple `..`.
+        assert_repo_relative("/repo/a/b", "/repo", "../../data.txt", "data.txt");
+        // `..` mixed with normal segments.
+        assert_repo_relative("/repo/sub", "/repo", "../other/data.txt", "other/data.txt");
+        // `..` embedded in an absolute input.
+        assert_repo_relative("/repo/sub", "/repo", "/repo/sub/../data.txt", "data.txt");
+    }
 }

--- a/crates/oxen-cli/src/helpers.rs
+++ b/crates/oxen-cli/src/helpers.rs
@@ -4,10 +4,12 @@ use liboxen::config::AuthConfig;
 use liboxen::constants;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
+use liboxen::util;
 use liboxen::util::oxen_version::OxenVersion;
 
 use colored::Colorize;
 
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 pub fn get_scheme_and_host_or_default() -> Result<(String, String), OxenError> {
@@ -105,4 +107,10 @@ pub fn check_repo_migration_needed(repo: &LocalRepository) -> Result<(), OxenErr
     Err(OxenError::MigrationRequired(
         "Error: Migration required".to_string().into(),
     ))
+}
+
+/// Resolves a user-supplied path (current-dir-relative or absolute) to a repository-relative path.
+pub fn path_relative_to_repo(repo: &LocalRepository, path: &Path) -> Result<PathBuf, OxenError> {
+    let current_dir = std::env::current_dir()?;
+    util::fs::path_relative_to_dir(current_dir.join(path), &repo.path)
 }


### PR DESCRIPTION
(Stacked on #667)

`oxen info <path> <revision>` parsed a `revision` argument but never used it: metadata (hash, size, type) was computed from the working-tree file on disk and `last_updated` always came from HEAD, so the revision was silently ignored — and `info` returned wrong metadata, or failed outright, for a file whose committed bytes differ from the working tree or that isn't in the working tree at all.

Add `repositories::metadata::get_cli_at_revision`, which resolves the revision to a commit and reads the file's metadata from that commit's merkle-tree `FileNode` (hash, size, data type, mime type, extension, last-updated commit) instead of the on-disk file. `oxen info` routes through it when a revision is given and falls back to the working-tree path otherwise.

Change the revision from a silently-ignored positional argument to a `--revision`/`-r` flag, matching `oxen cat`, so `oxen info <path> -r <rev> --json` reports metadata for the same revision `oxen cat -r <rev>` streams. With no flag, `oxen info` still describes the working-tree file.

Closes ENG-1178