### PR TITLE
Repo Integrity (1.9): Serialize change-tracking DB writes with a RwLock

### DIFF
--- a/crates/liboxen/src/core/db/data_frames/changes_db.rs
+++ b/crates/liboxen/src/core/db/data_frames/changes_db.rs
@@ -18,13 +18,15 @@
 //! This module keeps one shared handle per path in a global LRU cache, mirroring
 //! [`crate::core::staged::staged_db_manager`]. Every caller that touches the
 //! same change-tracking database in this process shares that one handle, so they
-//! never race on the file lock. RocksDB's `DB` is internally synchronized
-//! (`Send + Sync`, with `&self` reads and writes), so a shared `Arc<DB>` is safe
-//! to use concurrently — and, unlike a guard, it can be held across `.await`
-//! points in the async restore paths.
+//! never race on the file lock.
+//!
+//! Handles are `Arc<RwLock<DB>>`: compound writes take `.write()` across the full read-modify-write,
+//! readers take `.read()`. **Never hold a guard across `.await`** — the `Arc` may cross awaits,
+//! the guard must not. Eviction skips entries still held elsewhere; when every entry is pinned, new
+//! handles open uncached.
 
 use lru::LruCache;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rocksdb::DB;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
@@ -37,23 +39,24 @@ use crate::error::OxenError;
 const CHANGES_DB_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
 
 /// Global LRU cache of open change-tracking RocksDB handles, keyed by db path.
-static CHANGES_DB_INSTANCES: LazyLock<RwLock<LruCache<PathBuf, Arc<DB>>>> =
-    LazyLock::new(|| RwLock::new(LruCache::new(CHANGES_DB_CACHE_SIZE)));
+/// `Mutex` rather than `RwLock` because `LruCache::get` requires `&mut self` to
+/// bump recency, so every access is exclusive anyway.
+static CHANGES_DB_INSTANCES: LazyLock<Mutex<LruCache<PathBuf, Arc<RwLock<DB>>>>> =
+    LazyLock::new(|| Mutex::new(LruCache::new(CHANGES_DB_CACHE_SIZE)));
 
 /// Remove a single change-tracking db from the cache. The underlying handle is
 /// closed once the last outstanding `Arc` is dropped.
 pub fn remove_from_cache(db_path: impl AsRef<Path>) -> Result<(), OxenError> {
-    let mut instances = CHANGES_DB_INSTANCES.write();
+    let mut instances = CHANGES_DB_INSTANCES.lock();
     let _ = instances.pop(&db_path.as_ref().to_path_buf());
     Ok(())
 }
 
-/// Remove every cached change-tracking db whose path lives under `prefix`.
-/// Mainly used for test cleanup so handles are released before the temp
-/// directory is deleted.
+/// Remove every cached change-tracking db whose path lives under `prefix`. Mainly used for test
+/// cleanup so handles are released before the temp directory is deleted.
 pub fn remove_from_cache_with_children(prefix: impl AsRef<Path>) -> Result<(), OxenError> {
     let prefix = prefix.as_ref();
-    let mut instances = CHANGES_DB_INSTANCES.write();
+    let mut instances = CHANGES_DB_INSTANCES.lock();
     let to_remove: Vec<PathBuf> = instances
         .iter()
         .map(|(key, _)| key.clone())
@@ -69,7 +72,7 @@ pub fn remove_from_cache_with_children(prefix: impl AsRef<Path>) -> Result<(), O
 /// caching it on first use. The db directory is created if it does not exist,
 /// so this is the right entry point for write paths (recording row/column
 /// changes) that always need a db to write into.
-pub fn get_changes_db(db_path: &Path) -> Result<Arc<DB>, DataFrameError> {
+pub fn get_changes_db(db_path: &Path) -> Result<Arc<RwLock<DB>>, DataFrameError> {
     if let Some(db) = lookup_cached(db_path) {
         return Ok(db);
     }
@@ -80,31 +83,31 @@ pub fn get_changes_db(db_path: &Path) -> Result<Arc<DB>, DataFrameError> {
 /// on disk instead of creating it. Use for read paths (diffs, view decoration)
 /// so that merely reading a data frame never materializes an empty
 /// change-tracking db on disk.
-pub fn try_get_changes_db(db_path: &Path) -> Result<Option<Arc<DB>>, DataFrameError> {
+pub fn try_get_changes_db(db_path: &Path) -> Result<Option<Arc<RwLock<DB>>>, DataFrameError> {
     if let Some(db) = lookup_cached(db_path) {
         return Ok(Some(db));
     }
-    // Don't create a db just to read from it.
-    if !db_path.exists() {
+    // `CURRENT` exists once RocksDB has initialized the db
+    if !db_path.join("CURRENT").exists() {
         return Ok(None);
     }
     open_and_cache(db_path).map(Some)
 }
 
-/// Fast path: hand back an existing handle under a short-lived read lock.
-fn lookup_cached(db_path: &Path) -> Option<Arc<DB>> {
-    let cache_r = CHANGES_DB_INSTANCES.read();
-    cache_r.peek(&db_path.to_path_buf()).cloned()
+/// Look up a cached handle, bumping its LRU recency on a hit.
+fn lookup_cached(db_path: &Path) -> Option<Arc<RwLock<DB>>> {
+    let mut cache = CHANGES_DB_INSTANCES.lock();
+    cache.get(&db_path.to_path_buf()).cloned()
 }
 
-/// Slow path: open the db under the cache write lock and store the handle.
-/// Re-checks the cache first, since another thread may have opened the same
-/// path while we waited for the write lock.
-fn open_and_cache(db_path: &Path) -> Result<Arc<DB>, DataFrameError> {
+/// Slow path: open the db under the cache lock, evict an unreferenced LRU entry to make room, and
+/// cache the new handle. Returns the new handle uncached (with a warning) if every cached entry
+/// is still in use.
+fn open_and_cache(db_path: &Path) -> Result<Arc<RwLock<DB>>, DataFrameError> {
     let key = db_path.to_path_buf();
 
-    let mut cache_w = CHANGES_DB_INSTANCES.write();
-    if let Some(db) = cache_w.get(&key) {
+    let mut cache = CHANGES_DB_INSTANCES.lock();
+    if let Some(db) = cache.get(&key) {
         return Ok(db.clone());
     }
 
@@ -112,10 +115,40 @@ fn open_and_cache(db_path: &Path) -> Result<Arc<DB>, DataFrameError> {
         std::fs::create_dir_all(db_path).map_err(DataFrameError::FailCreateDfDbDir)?;
     }
 
+    let can_cache = make_room_for_new_entry(&mut cache);
+
     let opts = db::key_val::opts::default();
-    let db = Arc::new(DB::open(&opts, dunce::simplified(db_path))?);
-    cache_w.put(key, db.clone());
-    Ok(db)
+    let handle = Arc::new(RwLock::new(DB::open(&opts, dunce::simplified(db_path))?));
+    if can_cache {
+        cache.put(key, handle.clone());
+    }
+    Ok(handle)
+}
+
+/// Returns `true` if a new entry can be cached: either the cache had room, or an unreferenced
+/// LRU entry was evicted. Returns `false` when every cached entry is still held.
+fn make_room_for_new_entry(cache: &mut LruCache<PathBuf, Arc<RwLock<DB>>>) -> bool {
+    if cache.len() < cache.cap().get() {
+        return true;
+    }
+    let victim = cache
+        .iter()
+        .rev()
+        .find_map(|(k, v)| (Arc::strong_count(v) == 1).then(|| k.clone()));
+    match victim {
+        Some(key) => {
+            cache.pop(&key);
+            true
+        }
+        None => {
+            log::warn!(
+                "changes_db cache is at capacity ({}) with every entry still in use; \
+                 opening a new handle uncached",
+                cache.cap().get()
+            );
+            false
+        }
+    }
 }
 
 #[cfg(test)]
@@ -165,8 +198,8 @@ mod tests {
                     .map(|i| {
                         let db_path = db_path.clone();
                         scope.spawn(move || -> Result<(), OxenError> {
-                            let db = get_changes_db(&db_path)?;
-                            db.put(format!("key-{i}"), format!("val-{i}"))?;
+                            let handle = get_changes_db(&db_path)?;
+                            handle.write().put(format!("key-{i}"), format!("val-{i}"))?;
                             Ok(())
                         })
                     })
@@ -180,11 +213,13 @@ mod tests {
             });
 
             // Every concurrent write is visible through the shared handle.
-            let db = get_changes_db(&db_path)?;
+            let handle = get_changes_db(&db_path)?;
+            let db = handle.read();
             for i in 0..NUM_THREADS {
                 let value = db.get(format!("key-{i}"))?;
                 assert_eq!(value.as_deref(), Some(format!("val-{i}").as_bytes()));
             }
+            drop(db);
 
             remove_from_cache(&db_path)?;
             Ok(())
@@ -203,10 +238,126 @@ mod tests {
                 "try_get_changes_db must not create the db directory on a read miss"
             );
 
+            // An empty leftover directory (no `CURRENT` file) is treated as
+            // missing — a stray dir must not be promoted into a live db.
+            std::fs::create_dir_all(&db_path)?;
+            assert!(try_get_changes_db(&db_path)?.is_none());
+            assert!(
+                !db_path.join("CURRENT").exists(),
+                "try_get_changes_db must not initialize an empty leftover directory"
+            );
+
             // Once a writer creates it, the reader sees the same handle/data.
-            get_changes_db(&db_path)?.put("k", "v")?;
-            let db = try_get_changes_db(&db_path)?.expect("db exists after write");
-            assert_eq!(db.get("k")?.as_deref(), Some(b"v".as_ref()));
+            get_changes_db(&db_path)?.write().put("k", "v")?;
+            let handle = try_get_changes_db(&db_path)?.expect("db exists after write");
+            assert_eq!(handle.read().get("k")?.as_deref(), Some(b"v".as_ref()));
+
+            remove_from_cache(&db_path)?;
+            Ok(())
+        })
+    }
+
+    /// When every cached entry is still in use, an additional open returns a working handle
+    /// without installing it in the cache.
+    #[test]
+    fn test_open_uncached_when_cache_is_fully_pinned() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|data_dir| {
+            // Pin every cache slot by holding `CHANGES_DB_CACHE_SIZE` Arcs.
+            let mut pinned = Vec::with_capacity(CHANGES_DB_CACHE_SIZE.get());
+            for i in 0..CHANGES_DB_CACHE_SIZE.get() {
+                pinned.push(get_changes_db(&data_dir.join(format!("pinned-{i}")))?);
+            }
+
+            // One more open finds no evictable slot and returns uncached.
+            let extra_path = data_dir.join("extra");
+            let extra = get_changes_db(&extra_path)?;
+            extra.write().put("k", "v")?;
+
+            // The uncached handle reads back through itself.
+            assert_eq!(extra.read().get("k")?.as_deref(), Some(b"v".as_ref()));
+
+            // The next opener for `extra_path` does not find it in the cache: it opens a
+            // *different* Arc (which only succeeds because the current `extra` Arc still holds
+            // the RocksDB lock — so we drop it first to make room).
+            drop(extra);
+            let reopened = get_changes_db(&extra_path)?;
+            // The data persisted to disk and the new handle sees it.
+            assert_eq!(reopened.read().get("k")?.as_deref(), Some(b"v".as_ref()));
+
+            drop(reopened);
+            drop(pinned);
+            remove_from_cache_with_children(data_dir)?;
+            Ok(())
+        })
+    }
+
+    /// Reopening a path whose handle is still held returns the same cached `Arc`, even after enough
+    /// distinct opens to fill the cache twice over.
+    #[test]
+    fn test_eviction_skips_still_held_entries() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|data_dir| {
+            let held_path = data_dir.join("held");
+            let held = get_changes_db(&held_path)?;
+            held.write().put("k", "v")?;
+
+            // Fill the cache twice over with immediately-dropped handles to pressure eviction.
+            let pressure = CHANGES_DB_CACHE_SIZE.get() * 2;
+            for i in 0..pressure {
+                let other = get_changes_db(&data_dir.join(format!("other-{i}")))?;
+                drop(other);
+            }
+
+            let reopened = get_changes_db(&held_path)?;
+            assert!(
+                Arc::ptr_eq(&held, &reopened),
+                "the held handle must survive eviction pressure",
+            );
+            assert_eq!(reopened.read().get("k")?.as_deref(), Some(b"v".as_ref()));
+
+            drop(held);
+            drop(reopened);
+            remove_from_cache_with_children(data_dir)?;
+            Ok(())
+        })
+    }
+
+    /// Concurrent compound writes (delete + put) for the same key serialize: the final value
+    /// matches exactly one writer, with no torn state visible.
+    #[test]
+    fn test_concurrent_compound_writes_serialize() -> Result<(), OxenError> {
+        const NUM_THREADS: usize = 16;
+
+        test::run_empty_dir_test(|data_dir| {
+            let db_path = data_dir.join("row_changes");
+            let handle = get_changes_db(&db_path)?;
+
+            thread::scope(|scope| {
+                let workers: Vec<_> = (0..NUM_THREADS)
+                    .map(|i| {
+                        let handle = handle.clone();
+                        scope.spawn(move || -> Result<(), OxenError> {
+                            // Compound delete-then-put under one write guard.
+                            let db = handle.write();
+                            db.delete("shared")?;
+                            db.put("shared", format!("value-{i}"))?;
+                            Ok(())
+                        })
+                    })
+                    .collect();
+                for w in workers {
+                    w.join().expect("worker panicked").expect("compound write");
+                }
+            });
+
+            // Exactly one writer's value persists.
+            let db = handle.read();
+            let value = db.get("shared")?.expect("some writer's value persisted");
+            let value = std::str::from_utf8(&value).expect("utf8");
+            assert!(
+                (0..NUM_THREADS).any(|i| value == format!("value-{i}")),
+                "stored value should match one of the writers, got {value:?}",
+            );
+            drop(db);
 
             remove_from_cache(&db_path)?;
             Ok(())

--- a/crates/liboxen/src/core/db/data_frames/columns.rs
+++ b/crates/liboxen/src/core/db/data_frames/columns.rs
@@ -67,7 +67,10 @@ pub fn record_column_change(
     column_before: Option<ColumnChange>,
     column_after: Option<ColumnChange>,
 ) -> Result<(), DataFrameError> {
-    let db = changes_db::get_changes_db(column_changes_path)?;
+    let handle = changes_db::get_changes_db(column_changes_path)?;
+
+    // One write guard across the lookup-revert-write compound. Must not cross `.await`.
+    let db = handle.write();
 
     if operation == "deleted"
         && let Some(column) = &column_before
@@ -183,4 +186,111 @@ pub fn polar_update_column(
     let result_set: Vec<RecordBatch> = conn.prepare(&sql_query)?.query_arrow([])?.collect();
 
     df_db::record_batches_to_polars_df(result_set)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::OxenError;
+    use crate::test;
+
+    /// Concurrent `record_column_change` calls on the same column serialize: the final state
+    /// matches exactly one writer's complete record (or is empty after an added-then-deleted
+    /// collapse), with no mixed fields.
+    #[test]
+    fn test_concurrent_record_column_change_same_column_serializes() -> Result<(), OxenError> {
+        const NUM_THREADS: usize = 16;
+        const COLUMN: &str = "shared-col";
+
+        test::run_empty_dir_test(|data_dir| {
+            let column_changes_path = data_dir.join("column_changes");
+            let _bootstrap = changes_db::get_changes_db(&column_changes_path)?;
+
+            std::thread::scope(|scope| {
+                let workers: Vec<_> = (0..NUM_THREADS)
+                    .map(|i| {
+                        let column_changes_path = column_changes_path.clone();
+                        scope.spawn(move || -> Result<(), DataFrameError> {
+                            // Mix add/delete to exercise the early-return
+                            // (added-then-deleted collapse) branch under
+                            // contention alongside the normal write path.
+                            if i % 2 == 0 {
+                                record_column_change(
+                                    &column_changes_path,
+                                    "added".to_string(),
+                                    None,
+                                    Some(ColumnChange {
+                                        column_name: COLUMN.to_string(),
+                                        column_data_type: Some(format!("type-{i}")),
+                                    }),
+                                )
+                            } else {
+                                record_column_change(
+                                    &column_changes_path,
+                                    "deleted".to_string(),
+                                    Some(ColumnChange {
+                                        column_name: COLUMN.to_string(),
+                                        column_data_type: Some(format!("type-{i}")),
+                                    }),
+                                    None,
+                                )
+                            }
+                        })
+                    })
+                    .collect();
+                for w in workers {
+                    w.join()
+                        .expect("worker panicked")
+                        .expect("record_column_change must not race itself");
+                }
+            });
+
+            // After all threads finish, the stored entry (if any) must be a
+            // self-consistent record from a single writer — never a mix of
+            // fields from different writers.
+            let handle = changes_db::get_changes_db(&column_changes_path)?;
+            let stored = column_changes_db::get_data_frame_column_change(&handle.read(), COLUMN)?;
+            if let Some(change) = stored {
+                match change.operation.as_str() {
+                    "added" => {
+                        assert!(
+                            change.column_before.is_none(),
+                            "added record must have no column_before, got {:?}",
+                            change.column_before,
+                        );
+                        let after = change.column_after.expect("added has column_after");
+                        assert_eq!(after.column_name, COLUMN);
+                        let dt = after.column_data_type.expect("added has data type");
+                        assert!(
+                            (0..NUM_THREADS)
+                                .step_by(2)
+                                .any(|i| dt == format!("type-{i}")),
+                            "stored type must match an add-writer, got {dt:?}",
+                        );
+                    }
+                    "deleted" => {
+                        assert!(
+                            change.column_after.is_none(),
+                            "deleted record must have no column_after, got {:?}",
+                            change.column_after,
+                        );
+                        let before = change.column_before.expect("deleted has column_before");
+                        assert_eq!(before.column_name, COLUMN);
+                        let dt = before.column_data_type.expect("deleted has data type");
+                        assert!(
+                            (1..NUM_THREADS)
+                                .step_by(2)
+                                .any(|i| dt == format!("type-{i}")),
+                            "stored type must match a delete-writer, got {dt:?}",
+                        );
+                    }
+                    other => panic!("unexpected operation: {other:?}"),
+                }
+            }
+            drop(handle);
+
+            changes_db::remove_from_cache(&column_changes_path)?;
+            Ok(())
+        })
+    }
 }

--- a/crates/liboxen/src/core/db/data_frames/rows.rs
+++ b/crates/liboxen/src/core/db/data_frames/rows.rs
@@ -388,10 +388,11 @@ pub fn record_row_change(
         new_value,
     };
 
-    let db = changes_db::get_changes_db(row_changes_path)?;
+    let handle = changes_db::get_changes_db(row_changes_path)?;
 
+    // One write guard across the revert-then-put compound. Must not cross `.await`.
+    let db = handle.write();
     maybe_revert_row_changes(&db, row_id.to_owned())?;
-
     row_changes_db::write_data_frame_row_change(&change, &db)
 }
 
@@ -439,4 +440,65 @@ fn needs_explicit_cast(sql_type: &str) -> bool {
     // List columns end with `[]` (e.g. INTEGER[], VARCHAR[]); fixed-size arrays / embeddings end with `[N]`.
     // Structs are stored as JSON (which already accepts string binds), but cast for symmetry / clarity.
     sql_type.ends_with(']') || sql_type == "JSON"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::OxenError;
+    use crate::test;
+
+    /// Concurrent `record_row_change` calls for the same `row_id` serialize: the final stored value
+    /// matches exactly one writer, with no torn state.
+    #[test]
+    fn test_concurrent_record_row_change_same_row_id_serializes() -> Result<(), OxenError> {
+        const NUM_THREADS: usize = 16;
+
+        test::run_empty_dir_test(|data_dir| {
+            let row_changes_path = data_dir.join("row_changes");
+            // Pre-open so all worker threads share the same cached handle.
+            let _bootstrap = changes_db::get_changes_db(&row_changes_path)?;
+
+            std::thread::scope(|scope| {
+                let workers: Vec<_> = (0..NUM_THREADS)
+                    .map(|i| {
+                        let row_changes_path = row_changes_path.clone();
+                        scope.spawn(move || -> Result<(), OxenError> {
+                            record_row_change(
+                                &row_changes_path,
+                                "shared-row".to_string(),
+                                "modified".to_string(),
+                                Value::String(format!("value-{i}")),
+                                None,
+                            )?;
+                            Ok(())
+                        })
+                    })
+                    .collect();
+                for w in workers {
+                    w.join()
+                        .expect("worker panicked")
+                        .expect("record_row_change must not race itself");
+                }
+            });
+
+            // Exactly one writer's change is stored (last-writer-wins on the
+            // atomic compound); no torn intermediate is visible.
+            let handle = changes_db::get_changes_db(&row_changes_path)?;
+            let stored = row_changes_db::get_data_frame_row_change(&handle.read(), "shared-row")?
+                .expect("a writer's change is present");
+            let value = match stored.value {
+                Value::String(s) => s,
+                other => panic!("unexpected stored value: {other:?}"),
+            };
+            assert!(
+                (0..NUM_THREADS).any(|i| value == format!("value-{i}")),
+                "stored value should match one of the writers, got {value:?}",
+            );
+            drop(handle);
+
+            changes_db::remove_from_cache(&row_changes_path)?;
+            Ok(())
+        })
+    }
 }

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -184,9 +184,16 @@ pub async fn restore(
         file_path,
     )?;
 
-    let maybe_change =
-        column_changes_db::get_data_frame_column_change(&handle.read(), &column_to_restore.name)?;
-    if let Some(change) = maybe_change {
+    // Hold one write guard from the change lookup through the DuckDB mutation and revert, so a
+    // concurrent `record_column_change` can't replace the entry between read and revert. Drop the
+    // guard before any `.await`.
+    let result = {
+        let db = handle.write();
+        let change = column_changes_db::get_data_frame_column_change(&db, &column_to_restore.name)?
+            .ok_or_else(|| {
+                DataFrameError::ColumnNameNotFound(column_to_restore.name.to_string())
+            })?;
+
         match change.operation.as_str() {
             "added" => {
                 log::debug!("restore_column() column is added, deleting");
@@ -207,7 +214,7 @@ pub async fn restore(
                     manager.with_conn(|conn| columns::delete_column(conn, &column_to_delete))
                 })?;
                 columns::revert_column_changes(
-                    &handle.write(),
+                    &db,
                     &change
                         .column_after
                         .ok_or_else(|| {
@@ -218,8 +225,7 @@ pub async fn restore(
                         })?
                         .column_name,
                 )?;
-                repositories::workspaces::files::add(workspace, file_path).await?;
-                Ok(result)
+                result
             }
             "deleted" => {
                 log::debug!("restore_column() column was removed, adding it back");
@@ -252,7 +258,7 @@ pub async fn restore(
                     manager.with_conn(|conn| columns::add_column(conn, &new_column))
                 })?;
                 columns::revert_column_changes(
-                    &handle.write(),
+                    &db,
                     &change
                         .column_before
                         .ok_or_else(|| {
@@ -263,8 +269,7 @@ pub async fn restore(
                         })?
                         .column_name,
                 )?;
-                repositories::workspaces::files::add(workspace, file_path).await?;
-                Ok(result)
+                result
             }
             "modified" => {
                 log::debug!("restore_column() column was modified, reverting changes");
@@ -314,7 +319,7 @@ pub async fn restore(
                     })
                 })?;
                 columns::revert_column_changes(
-                    &handle.write(),
+                    &db,
                     &change
                         .column_after
                         .clone()
@@ -352,18 +357,18 @@ pub async fn restore(
                         })?
                         .column_name,
                 )?;
-                repositories::workspaces::files::add(workspace, file_path).await?;
-                Ok(result)
+                result
             }
-            _ => Err(OxenError::UnsupportedOperation(
-                change.operation.clone().into(),
-            )),
+            _ => {
+                return Err(OxenError::UnsupportedOperation(
+                    change.operation.clone().into(),
+                ));
+            }
         }
-    } else {
-        Err(DataFrameError::ColumnNameNotFound(
-            column_to_restore.name.to_string(),
-        ))?
-    }
+    };
+
+    repositories::workspaces::files::add(workspace, file_path).await?;
+    Ok(result)
 }
 
 pub fn add_column_metadata(

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -173,7 +173,8 @@ pub async fn restore(
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
 
-    let db = changes_db::get_changes_db(&column_changes_path)?;
+    // Arc may cross `.await`; the guards taken below must not.
+    let handle = changes_db::get_changes_db(&column_changes_path)?;
 
     log::debug!("restore_column() got db_path: {db_path:?}");
 
@@ -183,9 +184,9 @@ pub async fn restore(
         file_path,
     )?;
 
-    if let Some(change) =
-        column_changes_db::get_data_frame_column_change(&db, &column_to_restore.name)?
-    {
+    let maybe_change =
+        column_changes_db::get_data_frame_column_change(&handle.read(), &column_to_restore.name)?;
+    if let Some(change) = maybe_change {
         match change.operation.as_str() {
             "added" => {
                 log::debug!("restore_column() column is added, deleting");
@@ -206,7 +207,7 @@ pub async fn restore(
                     manager.with_conn(|conn| columns::delete_column(conn, &column_to_delete))
                 })?;
                 columns::revert_column_changes(
-                    &db,
+                    &handle.write(),
                     &change
                         .column_after
                         .ok_or_else(|| {
@@ -251,7 +252,7 @@ pub async fn restore(
                     manager.with_conn(|conn| columns::add_column(conn, &new_column))
                 })?;
                 columns::revert_column_changes(
-                    &db,
+                    &handle.write(),
                     &change
                         .column_before
                         .ok_or_else(|| {
@@ -313,7 +314,7 @@ pub async fn restore(
                     })
                 })?;
                 columns::revert_column_changes(
-                    &db,
+                    &handle.write(),
                     &change
                         .column_after
                         .clone()

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -289,7 +289,8 @@ pub async fn restore_row_in_db(
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path.as_ref());
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, path.as_ref());
-    let db = changes_db::get_changes_db(&column_changes_path)?;
+    // Arc may cross `.await`; the guards taken below must not.
+    let handle = changes_db::get_changes_db(&column_changes_path)?;
 
     // Get the row by id
     let row =
@@ -305,7 +306,7 @@ pub async fn restore_row_in_db(
         StagedRowStatus::Added => {
             // Row is added, just delete it
             log::debug!("restore_row() row is added, deleting");
-            rows::revert_row_changes(&db, row_id.to_owned())?;
+            rows::revert_row_changes(&handle.write(), row_id.to_owned())?;
             with_df_db_manager(&db_path, |manager| {
                 manager.with_conn(|conn| rows::delete_row(conn, row_id))
             })?
@@ -321,7 +322,7 @@ pub async fn restore_row_in_db(
             )
             .await?;
             log::debug!("restore_row() insert_row: {insert_row:?}");
-            rows::revert_row_changes(&db, row_id.to_owned())?;
+            rows::revert_row_changes(&handle.write(), row_id.to_owned())?;
             log::debug!("restore_row() after revert");
             with_df_db_manager(&db_path, |manager| {
                 manager.with_conn(|conn| rows::modify_row(conn, &mut insert_row, row_id))

--- a/crates/liboxen/src/repositories/workspaces/data_frames/columns.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames/columns.rs
@@ -90,8 +90,9 @@ pub fn get_column_diff(
 ) -> Result<Vec<DataFrameColumnChange>, DataFrameError> {
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path);
+    // No change-tracking db on disk means no edits are staged: empty diff.
     match changes_db::try_get_changes_db(&column_changes_path)? {
-        Some(db) => get_all_data_frame_column_changes(&db),
+        Some(handle) => get_all_data_frame_column_changes(&handle.read()),
         None => Ok(Vec::new()),
     }
 }
@@ -103,9 +104,11 @@ pub fn decorate_fields_with_column_diffs(
 ) -> Result<(), OxenError> {
     let column_changes_path =
         repositories::workspaces::data_frames::column_changes_path(workspace, file_path.as_ref());
-    let Some(db) = changes_db::try_get_changes_db(&column_changes_path)? else {
+    let Some(handle) = changes_db::try_get_changes_db(&column_changes_path)? else {
         return Ok(());
     };
+    // The function is sync — hold one read guard across both iterations.
+    let db = handle.read();
 
     df_views
         .source

--- a/crates/liboxen/src/repositories/workspaces/data_frames/rows.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames/rows.rs
@@ -38,8 +38,9 @@ pub fn get_row_diff(
 ) -> Result<Vec<DataFrameRowChange>, DataFrameError> {
     let row_changes_path =
         repositories::workspaces::data_frames::row_changes_path(workspace, file_path);
+    // No change-tracking db on disk means no edits are staged: empty diff.
     match changes_db::try_get_changes_db(&row_changes_path)? {
-        Some(db) => get_all_data_frame_row_changes(&db),
+        Some(handle) => get_all_data_frame_row_changes(&handle.read()),
         None => Ok(Vec::new()),
     }
 }


### PR DESCRIPTION
1. Two concurrent edits to the same workspace data frame could interleave their revert-then-write sequences and leave the data frame in a state where neither writer's intent was fully recorded. Make those sequences atomic per (workspace, file) so the recorded diff always reflects what one of the writers actually did.

2. Also close a latent cache hazard: the LRU could evict a handle that another task still held, dropping the cache's `Arc` and racing the RocksDB file lock against the next opener. Eviction now skips entries that are still in use, falling back to an uncached open with a warning when the cache is fully pinned. The read-only open path no longer materializes a half-created on-disk DB from a leftover empty directory.
