### PR TITLE
Bump to rust 1.96.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,9 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10502.0"
+version = "1.10504.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
+checksum = "0b9b997383221efd999a362448a0866c54b9a2cb7d4da8cd4903ead4df9f8eaa"
 dependencies = [
  "arrow",
  "cast",
@@ -4469,9 +4469,9 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10502.0"
+version = "1.10504.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
+checksum = "94e67523a40ee3da30411e00e243990b3760d91877202ab2f39c03ab34f8dbfc"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ dialoguer = "0.11.0"
 difference = "2.0.0"
 dirs = "5.0.1"
 dotenvy = "0.15.7"
-duckdb = { package = "duckdb", version = "=1.10502.0", default-features = false, features = ["serde_json"] }
+duckdb = { package = "duckdb", version = "=1.10504.0", default-features = false, features = ["serde_json"] }
 dunce = "1.0.4"
 env_logger = "0.11.3"
 filetime = "0.2.22"
@@ -89,7 +89,7 @@ itertools = "0.13.0"
 jsonwebtoken = "9.3.0"
 jwalk = "0.8.1"
 lazy_static = "1.4.0"
-libduckdb-sys = { version = "=1.10502.0" }
+libduckdb-sys = { version = "=1.10504.0" }
 # liboxen's `version` is kept in lockstep with `[workspace.package].version` by `bin/bump-version`.
 # `path` is used for local builds; `version` is used by `cargo publish` so oxen-cli and oxen-server
 # resolve liboxen from crates.io when published.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.96.1"


### PR DESCRIPTION
A [hotfix](https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/) release that fixes a few cargo issues and one compiler problem.

I also needed to update to the latest version of duckdb, since the latest GitHub Actions Windows Runner image broke something for duckdb C++ builds that duckdb fixed upstream.