### PR TITLE
Make workspace data frame indexing atomic and self-healing

### DIFF
--- a/crates/liboxen/src/core/db/data_frames/df_db.rs
+++ b/crates/liboxen/src/core/db/data_frames/df_db.rs
@@ -312,6 +312,24 @@ pub fn table_exists(conn: &duckdb::Connection, table_name: &str) -> Result<bool,
     Ok(exists)
 }
 
+/// Returns true only if `table_name` exists and contains every Oxen tracking
+/// column (`OXEN_COLS`). A table missing any of them is only partially indexed:
+/// the workspace read path projects the tracking columns, so a query against
+/// such a table fails to bind. Callers use this to treat a partial table as not
+/// indexed and rebuild it rather than serving an unqueryable one.
+pub fn table_is_fully_indexed(
+    conn: &duckdb::Connection,
+    table_name: &str,
+) -> Result<bool, duckdb::Error> {
+    if !table_exists(conn, table_name)? {
+        return Ok(false);
+    }
+    let schema = get_schema(conn, table_name)?;
+    Ok(OXEN_COLS
+        .iter()
+        .all(|col| schema.fields.iter().any(|field| field.name == *col)))
+}
+
 /// Create a table from a set of oxen fields with data types.
 fn p_create_table_if_not_exists(
     conn: &duckdb::Connection,

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -1,6 +1,7 @@
 use duckdb::Connection;
 
 use crate::constants::{DIFF_HASH_COL, DIFF_STATUS_COL, EXCLUDE_OXEN_COLS, TABLE_NAME};
+use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::df_db;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
 use crate::core::staged::get_staged_db_manager;
@@ -72,10 +73,25 @@ pub fn get_queryable_data_frame_workspace_from_file_node(
             let workspace_file_db_path =
                 repositories::workspaces::data_frames::duckdb_path(&workspace, path);
 
-            // Check if the DuckDB file exists in the workspace's directory
+            // Only treat this as the queryable workspace if its DuckDB table is
+            // fully indexed (all OXEN_COLS present). A missing file, or a partial
+            // table left by an interrupted index, is treated as not indexed so the
+            // caller rebuilds rather than serving a table the read path can't bind.
             if workspace_file_db_path.exists() {
-                // The file exists in this non-editable workspace, and the commit IDs match
-                return Ok(workspace);
+                let fully_indexed = match with_df_db_manager(&workspace_file_db_path, |manager| {
+                    manager.with_conn(|conn| Ok(df_db::table_is_fully_indexed(conn, TABLE_NAME)?))
+                }) {
+                    Ok(fully_indexed) => fully_indexed,
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to check index completeness for {workspace_file_db_path:?}: {e}"
+                        );
+                        false
+                    }
+                };
+                if fully_indexed {
+                    return Ok(workspace);
+                }
             }
         }
     }
@@ -168,13 +184,35 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     tokio::task::spawn_blocking(move || {
         with_df_db_manager(&db_path, |manager| {
             manager.with_conn(|conn| {
+                // Drop any prior table (possibly partial or stale) and commit that
+                // drop before the rebuild, so a failed rebuild leaves no table at
+                // all rather than rolling back to a partial one.
                 if df_db::table_exists(conn, TABLE_NAME)? {
                     df_db::drop_table(conn, TABLE_NAME)?;
                 }
 
-                df_db::index_file_with_id(&version_path, conn, &extension)?;
-                add_row_status_cols(conn)?;
-                Ok(())
+                // A workspace data frame is only queryable once every OXEN_COLS
+                // tracking column is present, so build the table inside a
+                // transaction and publish it only on success. On any failure, roll
+                // back (and drop defensively) so the read path never sees a table
+                // that is missing tracking columns.
+                conn.execute_batch("BEGIN TRANSACTION")?;
+                let build = (|| -> Result<(), DataFrameError> {
+                    df_db::index_file_with_id(&version_path, conn, &extension)?;
+                    add_row_status_cols(conn)?;
+                    Ok(())
+                })();
+                match build {
+                    Ok(()) => {
+                        conn.execute_batch("COMMIT")?;
+                        Ok(())
+                    }
+                    Err(e) => {
+                        let _ = conn.execute_batch("ROLLBACK");
+                        let _ = df_db::drop_table(conn, TABLE_NAME);
+                        Err(e)
+                    }
+                }
             })
         })
     })

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -45,9 +45,11 @@ pub fn is_indexed(workspace: &Workspace, path: &Path) -> Result<bool, DataFrameE
 
     with_df_db_manager(&db_path, |manager| {
         manager.with_conn(|conn| {
-            let table_exists = df_db::table_exists(conn, TABLE_NAME)?;
-            log::debug!("dataset_is_indexed() got table_exists: {table_exists:?}");
-            Ok(table_exists)
+            // A partially-indexed table (missing some OXEN_COLS) can't be queried,
+            // so report it as not indexed and let callers rebuild it.
+            let fully_indexed = df_db::table_is_fully_indexed(conn, TABLE_NAME)?;
+            log::debug!("dataset_is_indexed() got fully_indexed: {fully_indexed:?}");
+            Ok(fully_indexed)
         })
     })
 }
@@ -581,6 +583,57 @@ mod tests {
                 }
                 _ => panic!("Expected tabular diff result"),
             }
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_partial_index_reads_as_not_indexed_and_reindex_repairs() -> Result<(), OxenError>
+    {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-partial-index")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+
+            // A normal index produces a fully-indexed, queryable table.
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+            assert!(workspaces::data_frames::is_indexed(&workspace, &file_path)?);
+
+            // Simulate the partial-index corruption an interrupted index leaves
+            // behind: a table that is missing one of the tracking columns.
+            let db_path = workspaces::data_frames::duckdb_path(&workspace, &file_path);
+            super::with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| {
+                    conn.execute(
+                        &format!(
+                            "ALTER TABLE \"{}\" DROP COLUMN \"{}\"",
+                            crate::constants::TABLE_NAME,
+                            crate::constants::DIFF_STATUS_COL
+                        ),
+                        [],
+                    )?;
+                    Ok(())
+                })
+            })?;
+
+            // A partial table must read as NOT indexed so callers rebuild it
+            // instead of serving a table the read path cannot bind.
+            assert!(!workspaces::data_frames::is_indexed(
+                &workspace, &file_path
+            )?);
+
+            // Re-indexing repairs the table back to fully indexed.
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+            assert!(workspaces::data_frames::is_indexed(&workspace, &file_path)?);
 
             Ok(())
         })


### PR DESCRIPTION
Build the DuckDB table inside a transaction so a failed or interrupted index leaves no partial table behind, and treat a table missing any OXEN_COLS as not indexed so callers rebuild it instead of querying a table the read path cannot bind.