### PR TITLE
Upgrade video thumbnailing from FFmpeg 7 to 8

### DIFF
--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -37,10 +37,14 @@ jobs:
           cache-all-crates: true
           cache-on-failure: true
 
-      - name: Install FFmpeg dev libraries
+      - name: Install FFmpeg 8
+        # Install FFmpeg 8 (the `production` feature enables `ffmpeg`) and point pkg-config
+        # at it for the build and clippy steps below.
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev pkg-config
+          sudo apt-get install -y clang pkg-config
+          bash bin/install-ffmpeg
+          echo "PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
 
       - name: Build with production features
         run: cargo build --workspace --features production

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,17 +275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags 2.11.0",
  "cexpr",
@@ -1605,16 +1594,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.11.0",
  "cexpr",
@@ -1680,7 +1669,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.4.2",
+ "constant_time_eq",
  "cpufeatures",
 ]
 
@@ -2050,16 +2039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,7 +2046,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.9",
+ "libloading",
 ]
 
 [[package]]
@@ -2270,26 +2249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,12 +2291,6 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "constant_time_eq"
@@ -3183,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "7.1.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
+checksum = "f7c4bd5ab1ac61f29c634df1175d350ded29cf74c3c6d4f7030431a5ae3c7d5d"
 dependencies = [
  "bitflags 2.11.0",
  "ffmpeg-sys-next",
@@ -3194,11 +3147,11 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "7.1.3"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
+checksum = "a314bc0e022a33a99567ed4bd2576bd58ffd8fcff7891c29194cfecc26a62547"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen 0.72.1",
  "cc",
  "libc",
  "num_cpus",
@@ -3222,12 +3175,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -4193,15 +4140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4505,16 +4443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4612,7 +4540,6 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
- "thumbnails",
  "time",
  "tokio",
  "tokio-stream",
@@ -4626,6 +4553,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
+ "video-rs",
  "walkdir",
  "xxhash-rust",
  "zip 2.4.2",
@@ -4821,16 +4749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
-dependencies = [
- "byteorder",
- "crc",
-]
-
-[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,12 +4777,6 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
-
-[[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -5104,9 +5016,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -5656,42 +5568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "pdfium-render"
-version = "0.8.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6553f6604a52b3203db7b4e9d51eb4dd193cf455af9e56d40cab6575b547b679"
-dependencies = [
- "bitflags 2.11.0",
- "bytemuck",
- "bytes",
- "chrono",
- "console_error_panic_hook",
- "console_log",
- "image",
- "itertools 0.14.0",
- "js-sys",
- "libloading 0.9.0",
- "log",
- "maybe-owned",
- "once_cell",
- "utf16string",
- "vecmath",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5706,17 +5582,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
-]
 
 [[package]]
 name = "phf"
@@ -5820,12 +5685,6 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
-
-[[package]]
-name = "piston-float"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
 
 [[package]]
 name = "pkcs8"
@@ -8527,22 +8386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thumbnails"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252ed8a0ffd9ed2d28e06cf629c7d7fe6e58375f344e7f2a73d7a6879e0958d0"
-dependencies = [
- "anyhow",
- "image",
- "ndarray",
- "pdfium-render",
- "tempfile",
- "tree_magic_mini",
- "video-rs",
- "zip 2.4.2",
-]
-
-[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9014,17 +8857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_magic_mini"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
-dependencies = [
- "memchr",
- "nom 8.0.0",
- "petgraph",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9125,15 +8957,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf16string"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b62a1e85e12d5d712bf47a85f426b73d303e2d00a90de5f3004df3596e9d216"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "utf8_iter"
@@ -9242,15 +9065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vecmath"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
-dependencies = [
- "piston-float",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9258,9 +9072,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video-rs"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859aad7261bac267f90f9635ec9addba3b4bcb4bbb2edb03fec3e6b765657bee"
+checksum = "2633ec4c2a8aeb7c0e970f75ba99122a75841e9f7b34d5225366d0e61a870a8c"
 dependencies = [
  "ffmpeg-next",
  "ndarray",
@@ -10177,20 +9991,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"
@@ -10231,28 +10031,15 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
- "aes",
  "arbitrary",
- "bzip2",
- "constant_time_eq 0.3.1",
  "crc32fast",
  "crossbeam-utils",
- "deflate64",
  "displaydoc",
  "flate2",
- "getrandom 0.3.4",
- "hmac 0.12.1",
  "indexmap 2.13.0",
- "lzma-rs",
  "memchr",
- "pbkdf2",
- "sha1 0.10.6",
  "thiserror 2.0.18",
- "time",
- "xz2",
- "zeroize",
  "zopfli",
- "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,6 @@ sysinfo = "0.33.0"
 tar = "0.4.44"
 tempfile = "3.8.0"
 thiserror = "2.0.18"
-thumbnails = "0.2.1"
 time = { version = "0.3.28", features = ["serde", "formatting"] }
 tokio = { version = "1.32.0", features = ["full", "tracing"] }
 tokio-console = "0.1.13"
@@ -161,6 +160,7 @@ urlencoding = "2.1.3"
 utoipa = { version = "5", features = ["time"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
+video-rs = { version = "0.11", features = ["ndarray"] }
 walkdir = "2.5.0"
 xxhash-rust = { version = "0.8.7", features = ["xxh3"] }
 zip = { version = "2.4.1", default-features = false, features = ["deflate"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,20 @@ FROM rust:1.94-bookworm AS builder
 USER root
 RUN apt-get update
 RUN apt-get install -y apt-utils
-RUN apt-get install -y clang libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libavutil-dev openssl libssl-dev pkg-config
+RUN apt-get install -y clang openssl libssl-dev pkg-config
 
 RUN apt-get update \
-    && apt-get -y install curl build-essential clang cmake pkg-config libjpeg-turbo-progs libpng-dev \
+    && apt-get -y install curl ca-certificates xz-utils build-essential clang cmake pkg-config libjpeg-turbo-progs libpng-dev \
     && rm -rfv /var/lib/apt/lists/*
+
+# FFmpeg 8 for the `ffmpeg` video-thumbnail feature, installed via the shared helper. Pins live in
+# tool-versions.env, the single source of truth shared with Linux dev (bin/install-prereqs) and CI.
+ARG TARGETARCH
+COPY bin/install-ffmpeg tool-versions.env /tmp/ffmpeg-install/
+RUN FFMPEG_ARCH="$TARGETARCH" TOOL_VERSIONS_FILE=/tmp/ffmpeg-install/tool-versions.env \
+    bash /tmp/ffmpeg-install/install-ffmpeg \
+    && rm -rf /tmp/ffmpeg-install
+ENV PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 
 # ENV MAGICK_VERSION 7.1
 
@@ -56,8 +65,12 @@ RUN cargo build --workspace --exclude oxen-py --release --features liboxen/ffmpe
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update \
-    && apt-get install -y openssl libavutil-dev libavformat-dev libavdevice-dev \
+    && apt-get install -y openssl \
     && rm -rfv /var/lib/apt/lists/*
+
+# FFmpeg 8 shared libraries for the `ffmpeg` video-thumbnail feature (see builder stage).
+COPY --from=builder /opt/ffmpeg/lib /opt/ffmpeg/lib
+RUN echo /opt/ffmpeg/lib > /etc/ld.so.conf.d/ffmpeg.conf && ldconfig
 
 WORKDIR /oxen-server
 COPY --from=builder /usr/src/oxen-server/target/release/oxen /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM rust:1.94-bookworm AS builder
 USER root
 RUN apt-get update
 RUN apt-get install -y apt-utils
-RUN apt-get install -y clang openssl libssl-dev pkg-config
+RUN apt-get install -y --no-install-recommends clang openssl libssl-dev pkg-config
 
 RUN apt-get update \
-    && apt-get -y install curl ca-certificates xz-utils build-essential clang cmake pkg-config libjpeg-turbo-progs libpng-dev \
+    && apt-get -y install --no-install-recommends curl ca-certificates xz-utils build-essential clang cmake pkg-config libjpeg-turbo-progs libpng-dev \
     && rm -rfv /var/lib/apt/lists/*
 
 # FFmpeg 8 for the `ffmpeg` video-thumbnail feature, installed via the shared helper. Pins live in
@@ -65,7 +65,7 @@ RUN cargo build --workspace --exclude oxen-py --release --features liboxen/ffmpe
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update \
-    && apt-get install -y openssl \
+    && apt-get install -y --no-install-recommends openssl \
     && rm -rfv /var/lib/apt/lists/*
 
 # FFmpeg 8 shared libraries for the `ffmpeg` video-thumbnail feature (see builder stage).

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,14 +6,21 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libssl-dev \
-    libavcodec-dev \
-    libavformat-dev \
-    libavfilter-dev \
-    libavdevice-dev \
-    libavutil-dev \
+    curl \
+    ca-certificates \
+    xz-utils \
     libjpeg-turbo-progs \
     libpng-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# FFmpeg 8 for the `ffmpeg` video-thumbnail feature, installed via the shared helper. Pins live in
+# tool-versions.env, the single source of truth shared with Linux dev (bin/install-prereqs) and CI.
+ARG TARGETARCH
+COPY bin/install-ffmpeg tool-versions.env /tmp/ffmpeg-install/
+RUN FFMPEG_ARCH="$TARGETARCH" TOOL_VERSIONS_FILE=/tmp/ffmpeg-install/tool-versions.env \
+    bash /tmp/ffmpeg-install/install-ffmpeg \
+    && rm -rf /tmp/ffmpeg-install
+ENV PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 
 RUN cargo install cargo-chef
 
@@ -40,11 +47,11 @@ RUN apt-get update \
     && apt-get install -y \
     openssl \
     ca-certificates \
-    libavutil-dev \
-    libavformat-dev \
-    libavdevice-dev \
-    libavfilter-dev \
     && rm -rfv /var/lib/apt/lists/*
+
+# FFmpeg 8 shared libraries for the `ffmpeg` video-thumbnail feature (see base stage).
+COPY --from=builder /opt/ffmpeg/lib /opt/ffmpeg/lib
+RUN echo /opt/ffmpeg/lib > /etc/ld.so.conf.d/ffmpeg.conf && ldconfig
 
 WORKDIR /oxen-server
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM rust:1.94-bookworm AS base
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     lld \
     cmake \
@@ -44,7 +44,7 @@ RUN cargo build -p oxen-server --features liboxen/ffmpeg,liboxen/perf-logging
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get install -y --no-install-recommends \
     openssl \
     ca-certificates \
     && rm -rfv /var/lib/apt/lists/*

--- a/bin/install-ffmpeg
+++ b/bin/install-ffmpeg
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# install-ffmpeg
+#
+# Install a pinned FFmpeg 8 (LGPL shared build from BtbN/FFmpeg-Builds) under a prefix and register
+# its libraries with ldconfig. Shared by bin/install-prereqs, the production-build CI workflow, and
+# the Dockerfiles, which all provision FFmpeg from this one place. Pins live in tool-versions.env.
+#
+# BtbN prunes old autobuild releases over time; refresh the pin in tool-versions.env periodically,
+# or mirror the asset to storage we control.
+#
+# Usage: install-ffmpeg [PREFIX]            (PREFIX defaults to /opt/ffmpeg)
+#   TOOL_VERSIONS_FILE   path to tool-versions.env (default: alongside this script's repo root)
+#   FFMPEG_ARCH          target arch override: amd64|arm64|x86_64|aarch64 (default: uname -m)
+# Privileged steps run with sudo when not already root.
+set -euo pipefail
+
+PREFIX="${1:-/opt/ffmpeg}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOOL_VERSIONS_FILE="${TOOL_VERSIONS_FILE:-$SCRIPT_DIR/../tool-versions.env}"
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOL_VERSIONS_FILE"
+
+case "${FFMPEG_ARCH:-$(uname -m)}" in
+    amd64 | x86_64)  ff_arch="linux64";    ff_sha="$FFMPEG_SHA256_LINUX_X86_64" ;;
+    arm64 | aarch64) ff_arch="linuxarm64"; ff_sha="$FFMPEG_SHA256_LINUX_AARCH64" ;;
+    *) echo "Unsupported architecture for FFmpeg install: ${FFMPEG_ARCH:-$(uname -m)}" >&2; exit 1 ;;
+esac
+
+as_root() {
+    if [ "$(id -u)" -eq 0 ]; then "$@"; else sudo "$@"; fi
+}
+
+stamp="$PREFIX/.oxen-ffmpeg-version"
+want="${FFMPEG_VERSION}+${FFMPEG_BTBN_TAG}"
+if [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$want" ]; then
+    echo "FFmpeg ${FFMPEG_VERSION} already installed at $PREFIX"
+    exit 0
+fi
+
+tarball="ffmpeg-n${FFMPEG_VERSION}-${ff_arch}-lgpl-shared-${FFMPEG_BRANCH}.tar.xz"
+url="https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_BTBN_TAG}/${tarball}"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+echo "Downloading FFmpeg ${FFMPEG_VERSION} (${ff_arch}) from ${url}..."
+curl -fsSL "$url" -o "$tmp_dir/ffmpeg.tar.xz"
+echo "${ff_sha}  $tmp_dir/ffmpeg.tar.xz" | sha256sum -c -
+
+# Replace any prior install before extracting; no library from an older pin is left behind.
+as_root rm -rf "$PREFIX"
+as_root mkdir -p "$PREFIX"
+as_root tar -xJf "$tmp_dir/ffmpeg.tar.xz" -C "$PREFIX" --strip-components=1
+
+echo "$PREFIX/lib" | as_root tee /etc/ld.so.conf.d/oxen-ffmpeg.conf >/dev/null
+as_root ldconfig
+echo "$want" | as_root tee "$stamp" >/dev/null
+echo "FFmpeg ${FFMPEG_VERSION} installed at $PREFIX"

--- a/bin/install-prereqs
+++ b/bin/install-prereqs
@@ -77,7 +77,7 @@ if [ "$PLATFORM" = "macos" ]; then
         ok "Homebrew already installed"
     fi
 
-    brew install cmake pkg-config ffmpeg@7 imagemagick
+    brew install cmake pkg-config ffmpeg imagemagick
 
 elif [ "$PLATFORM" = "linux" ]; then
     if ! command_exists apt-get || ! command_exists dpkg; then
@@ -95,11 +95,7 @@ elif [ "$PLATFORM" = "linux" ]; then
     dpkg -s clang               &>/dev/null || NEEDED_PKGS+=(clang)
     dpkg -s libclang-dev        &>/dev/null || NEEDED_PKGS+=(libclang-dev)
     dpkg -s curl                &>/dev/null || NEEDED_PKGS+=(curl)
-    dpkg -s libavcodec-dev      &>/dev/null || NEEDED_PKGS+=(libavcodec-dev)
-    dpkg -s libavformat-dev     &>/dev/null || NEEDED_PKGS+=(libavformat-dev)
-    dpkg -s libavutil-dev       &>/dev/null || NEEDED_PKGS+=(libavutil-dev)
-    dpkg -s libavfilter-dev     &>/dev/null || NEEDED_PKGS+=(libavfilter-dev)
-    dpkg -s libavdevice-dev     &>/dev/null || NEEDED_PKGS+=(libavdevice-dev)
+    dpkg -s xz-utils            &>/dev/null || NEEDED_PKGS+=(xz-utils)
     dpkg -s libjpeg-turbo-progs &>/dev/null || NEEDED_PKGS+=(libjpeg-turbo-progs)
 
     if [ ${#NEEDED_PKGS[@]} -gt 0 ]; then
@@ -109,6 +105,10 @@ elif [ "$PLATFORM" = "linux" ]; then
     else
         ok "All system packages already installed"
     fi
+
+    # Install FFmpeg 8 for the `ffmpeg` feature via the shared helper; bin/test-rust points
+    # pkg-config at this prefix.
+    "$SCRIPT_DIR/install-ffmpeg"
 fi
 
 ###############################################################################
@@ -317,6 +317,13 @@ info "All prerequisites installed successfully!"
 info "You can now build the project:"
 info "  cargo build --workspace"
 info "  cd oxen-python && uv sync --verbose"
+
+# bin/test-rust --ffmpeg wires up PKG_CONFIG_PATH itself; a bare ffmpeg-feature build needs it set.
+if [ "$PLATFORM" = "linux" ]; then
+    echo ""
+    info "To build the 'ffmpeg' feature outside bin/test-rust, point pkg-config at /opt/ffmpeg:"
+    info "  export PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig:\$PKG_CONFIG_PATH"
+fi
 
 # Print shell configuration hints for any tools we freshly installed.
 if $INSTALLED_CARGO || $INSTALLED_BREW || $INSTALLED_UV; then

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -44,8 +44,8 @@ set -euo pipefail
 if [ -n "$FEATURE_ARGS" ] && [ "$(uname)" = "Linux" ]; then
     if [ -d /opt/ffmpeg/lib/pkgconfig ]; then
         export PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-    elif ! pkg-config --exists libavutil 2>/dev/null; then
-        echo "ERROR: --ffmpeg needs FFmpeg 8 dev libraries, but none were found."
+    elif ! pkg-config --atleast-version=60 libavutil 2>/dev/null; then
+        echo "ERROR: --ffmpeg needs FFmpeg 8 dev libraries (libavutil >= 60), not found."
         echo "       Run bin/install-prereqs to install them under /opt/ffmpeg"
         echo "       (apt's FFmpeg is too old for ffmpeg-sys-next 8)."
         exit 1

--- a/bin/test-rust
+++ b/bin/test-rust
@@ -39,13 +39,16 @@ done
 
 set -euo pipefail
 
-# On macOS, ffmpeg@7 is keg-only, so Homebrew does not symlink its pkgconfig dir onto the
-# default pkg-config search path. ffmpeg-sys-next locates libav* via pkg-config, so without
-# this the `ffmpeg` feature build fails with "system library libavutil was not found".
-if [[ "$FEATURE_ARGS" == *ffmpeg* ]] && [ "$(uname)" = "Darwin" ] && command -v brew &>/dev/null; then
-    FFMPEG_PREFIX="$(brew --prefix ffmpeg@7 2>/dev/null)"
-    if [ -n "$FFMPEG_PREFIX" ] && [ -d "$FFMPEG_PREFIX/lib/pkgconfig" ]; then
-        export PKG_CONFIG_PATH="$FFMPEG_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+# On Linux the `ffmpeg` feature links FFmpeg 8 from /opt/ffmpeg (installed by bin/install-prereqs);
+# point pkg-config at it. macOS gets FFmpeg 8 from Homebrew, already on the default pkg-config path.
+if [ -n "$FEATURE_ARGS" ] && [ "$(uname)" = "Linux" ]; then
+    if [ -d /opt/ffmpeg/lib/pkgconfig ]; then
+        export PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+    elif ! pkg-config --exists libavutil 2>/dev/null; then
+        echo "ERROR: --ffmpeg needs FFmpeg 8 dev libraries, but none were found."
+        echo "       Run bin/install-prereqs to install them under /opt/ffmpeg"
+        echo "       (apt's FFmpeg is too old for ffmpeg-sys-next 8)."
+        exit 1
     fi
 fi
 

--- a/crates/liboxen/Cargo.toml
+++ b/crates/liboxen/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/lib.rs"
 [features]
 default = ["duckdb/bundled"]
 docs = ["duckdb"]
-ffmpeg = ["thumbnails"]
+ffmpeg = ["dep:video-rs"]
 metrics = ["dep:metrics"]
 otel = [
     "dep:opentelemetry",
@@ -123,7 +123,6 @@ sysinfo = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-thumbnails = { workspace = true, optional = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
@@ -137,6 +136,7 @@ url = { workspace = true }
 urlencoding = { workspace = true }
 utoipa = { workspace = true }
 uuid = { workspace = true }
+video-rs = { workspace = true, optional = true }
 walkdir = { workspace = true }
 xxhash-rust = { workspace = true }
 zip = { workspace = true }

--- a/crates/liboxen/README.md
+++ b/crates/liboxen/README.md
@@ -358,15 +358,21 @@ Which would then store the benchmark under `target/criterion/add`
 
 ## Enable ffmpeg
 
-To enable thumbnailing for videos, you will have to build with ffmpeg enabled
+To enable thumbnailing for videos, you will have to build with ffmpeg enabled. This needs FFmpeg 8
+libraries on the host.
+
+On macOS, install them with Homebrew:
 
 ```bash
-brew install ffmpeg@7
+brew install ffmpeg
 cargo build --workspace --all-features
 ```
 
-Or for a specific crate:
+On Linux, run `bin/install-prereqs` — apt ships an older FFmpeg, so it installs a pinned FFmpeg 8
+build under `/opt/ffmpeg`. Build the feature through `bin/test-rust --ffmpeg` (which points
+pkg-config at that prefix), or set `PKG_CONFIG_PATH` yourself:
 
 ```bash
+export PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig:$PKG_CONFIG_PATH
 cargo build -p oxen-server --features liboxen/ffmpeg
 ```

--- a/crates/liboxen/src/util/fs.rs
+++ b/crates/liboxen/src/util/fs.rs
@@ -39,9 +39,11 @@ use crate::storage::version_store::VersionStore;
 use crate::view::health::DiskUsage;
 use crate::{constants, repositories, util};
 use filetime::FileTime;
+#[cfg(feature = "ffmpeg")]
+use image::{DynamicImage, ImageBuffer, Rgb};
 use image::{ImageFormat, ImageReader};
 #[cfg(feature = "ffmpeg")]
-use thumbnails::Thumbnailer;
+use video_rs::decode::Decoder;
 
 // Deprecated
 pub fn oxen_hidden_dir(repo_path: impl AsRef<Path>) -> PathBuf {
@@ -1462,8 +1464,20 @@ pub async fn resize_cache_image_version_store(
     Ok((stream, content_length))
 }
 
-/// Generate a video thumbnail using thumbnails crate.
-/// This function extracts a frame from the video and saves it as an image thumbnail.
+/// Initialize the FFmpeg/libav globals once per process for video decoding.
+#[cfg(feature = "ffmpeg")]
+fn ensure_video_decoding_initialized() -> Result<(), OxenError> {
+    static INIT: OnceLock<()> = OnceLock::new();
+    if INIT.get().is_none() {
+        video_rs::init().map_err(|e| {
+            OxenError::internal_error(format!("Failed to initialize video decoding: {e}"))
+        })?;
+        let _ = INIT.set(());
+    }
+    Ok(())
+}
+
+/// Generate a video's JPEG thumbnail with video-rs (FFmpeg) and store it in the version store.
 #[cfg(feature = "ffmpeg")]
 async fn generate_video_thumbnail_version_store(
     version_store: Arc<dyn VersionStore>,
@@ -1482,14 +1496,13 @@ async fn generate_video_thumbnail_version_store(
         return Ok(());
     }
 
-    // The thumbnails crate reads from a filesystem path, so materialize the video file. The guard
+    // video-rs decodes from a filesystem path, so materialize the video file. The guard
     // `version_file` is held on the async side (its drop runs after the blocking generation below)
     // so a materialized S3 temp outlives the read; the closure takes a plain path copy.
     let version_file = version_store.materialize(video_hash, dir).await?;
     let version_path = version_file.to_pathbuf();
 
-    // Determine output dimensions
-    // The thumbnails crate maintains aspect ratio, so we use max dimensions
+    // Output dimensions bound the thumbnail; `DynamicImage::thumbnail` preserves aspect ratio.
     let (output_width, output_height) = match (thumbnail.width, thumbnail.height) {
         (Some(w), Some(h)) => (w, h),
         (Some(w), None) => (w, w), // Use width for both if only width specified
@@ -1497,25 +1510,34 @@ async fn generate_video_thumbnail_version_store(
         (None, None) => (320, 240),
     };
 
-    // Note: The thumbnails crate doesn't support timestamp selection directly.
-    // It extracts from the beginning of the video.
-    // If timestamp support is needed, we may need to use ffmpeg directly or another approach.
-    let _timestamp = thumbnail.timestamp.unwrap_or(1.0);
-
-    // Run blocking ffmpeg thumbnail generation on a separate thread
+    // The thumbnail is taken from the first decoded frame; thumbnail.timestamp is not yet honored.
     let buf = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, OxenError> {
-        // Create thumbnailer with specified dimensions
-        let thumbnailer = Thumbnailer::new(output_width, output_height);
+        ensure_video_decoding_initialized()?;
 
-        // Generate thumbnail from video file
-        let thumb_image = thumbnailer
-            .get(&version_path)
-            .map_err(|e| OxenError::basic_str(format!("Failed to generate thumbnail: {e}.")))?;
+        let mut decoder = Decoder::new(version_path.as_path()).map_err(|e| {
+            OxenError::internal_error(format!("Failed to open video for thumbnailing: {e}"))
+        })?;
+
+        let (width, height) = decoder.size();
+        let (_timestamp, frame) = decoder
+            .decode()
+            .map_err(|e| OxenError::internal_error(format!("Failed to decode video frame: {e}")))?;
+
+        // video-rs hands back an RGB frame as a contiguous (height, width, 3) ndarray.
+        let pixels = frame
+            .as_slice()
+            .ok_or_else(|| OxenError::internal_error("Decoded video frame was not contiguous"))?;
+        let img: ImageBuffer<Rgb<u8>, Vec<u8>> =
+            ImageBuffer::from_raw(width, height, pixels.to_vec()).ok_or_else(|| {
+                OxenError::internal_error("Failed to build image buffer from video frame")
+            })?;
+
+        let thumb = DynamicImage::ImageRgb8(img).thumbnail(output_width, output_height);
 
         let mut buf = Vec::new();
-        thumb_image
+        thumb
             .write_to(&mut Cursor::new(&mut buf), image::ImageFormat::Jpeg)
-            .map_err(|e| OxenError::basic_str(format!("Failed to encode thumbnail: {e}")))?;
+            .map_err(|e| OxenError::internal_error(format!("Failed to encode thumbnail: {e}")))?;
         Ok(buf)
     })
     .await??;

--- a/crates/liboxen/src/util/fs.rs
+++ b/crates/liboxen/src/util/fs.rs
@@ -1467,14 +1467,10 @@ pub async fn resize_cache_image_version_store(
 /// Initialize the FFmpeg/libav globals once per process for video decoding.
 #[cfg(feature = "ffmpeg")]
 fn ensure_video_decoding_initialized() -> Result<(), OxenError> {
-    static INIT: OnceLock<()> = OnceLock::new();
-    if INIT.get().is_none() {
-        video_rs::init().map_err(|e| {
-            OxenError::internal_error(format!("Failed to initialize video decoding: {e}"))
-        })?;
-        let _ = INIT.set(());
-    }
-    Ok(())
+    static INIT: OnceLock<Result<(), String>> = OnceLock::new();
+    INIT.get_or_init(|| video_rs::init().map_err(|e| e.to_string()))
+        .clone()
+        .map_err(|e| OxenError::internal_error(format!("Failed to initialize video decoding: {e}")))
 }
 
 /// Generate a video's JPEG thumbnail with video-rs (FFmpeg) and store it in the version store.

--- a/tool-versions.env
+++ b/tool-versions.env
@@ -18,5 +18,15 @@ CARGO_NEXTEST_VERSION=0.9.136
 # Shell tools
 SHELLCHECK_VERSION=0.11.0
 
+# FFmpeg (prebuilt LGPL shared build from BtbN/FFmpeg-Builds, for the `ffmpeg` feature on Linux).
+# These pins are the single source read by bin/install-ffmpeg, which provisions FFmpeg for Linux
+# dev (bin/install-prereqs), the Dockerfiles, and the production-build CI. BtbN prunes old autobuild
+# releases over time; refresh the pin periodically, or mirror the asset to storage we control.
+FFMPEG_BTBN_TAG=autobuild-2026-06-23-13-52
+FFMPEG_VERSION=8.1.2
+FFMPEG_BRANCH=8.1
+FFMPEG_SHA256_LINUX_X86_64=8b1a22f1285a6ddb9a52abbc1a8abc0e4fa5076d038a2beaaacb1711a6442897
+FFMPEG_SHA256_LINUX_AARCH64=d4c9dd4dcd8b349f0204f7b3f31ecf5cc96b229167ac08e38c570605956838d2
+
 # Python tools (installed via uvx / uv tool)
 RUFF_VERSION=0.15.13


### PR DESCRIPTION
Video thumbnail generation (the `ffmpeg` feature) now builds and links against FFmpeg 8 instead of FFmpeg 7. This unpins us from an unmaintained dependency, drops a stack of transitive libraries we never used, and fixes local `--ffmpeg` builds that broke whenever only the keg-only Homebrew `ffmpeg@7` was installed.

The FFmpeg 7 pin came in entirely through the `thumbnails` crate (last released 0.2.1), which capped `video-rs` at a version targeting FFmpeg 7 and pulled in unused pdfium/zip/ MIME-sniffing dependencies. It is replaced with a direct dependency on `video-rs` 0.11. Thumbnail behavior is unchanged: the first decoded frame is resized and stored as a JPEG.

FFmpeg 8 is now provisioned for every build path from one place. apt ships an FFmpeg too old for ffmpeg-sys-next 8, so a pinned LGPL prebuilt is used instead, with its pins (release tag + per-arch SHA256s) living solely in tool-versions.env:

- macOS dev gets Homebrew's `ffmpeg` (v8), already on the default pkg-config path.
- Linux dev, both Dockerfiles, and the production-build CI install via the shared bin/install-ffmpeg helper and point pkg-config at /opt/ffmpeg.

ENG-1164