### PR TITLE
Repo Integrity (1.11a): Push uploads files committed outside the fetched subtree

### DIFF
--- a/crates/liboxen/src/core/v_latest/push.rs
+++ b/crates/liboxen/src/core/v_latest/push.rs
@@ -288,7 +288,14 @@ async fn get_commit_missing_hashes(
     commits: &[Commit],
 ) -> Result<HashMap<MerkleHash, PushCommitInfo>, OxenError> {
     let mut base_hashes = HashSet::new();
-    let paths = &repo.subtree_paths().unwrap_or(vec![PathBuf::new()]);
+    // Walk the full local tree (root, unlimited depth) so the upload set covers every new object
+    // the commit references, including files committed outside a fetch-time subtree filter or
+    // below its depth. Subtrees that aren't present locally load empty and are skipped; objects
+    // already on the remote are pruned by `base_hashes`. Scoping the upload to `subtree_paths` /
+    // `depth` would silently drop those files and leave the advanced ref pointing at content the
+    // remote lacks.
+    let paths = &vec![PathBuf::new()];
+    let upload_walk_depth = -1;
 
     if let Some(ref commit) = latest_remote_commit {
         for path in paths {
@@ -300,7 +307,7 @@ async fn get_commit_missing_hashes(
                 None,
                 Some(&mut starting_node_hashes),
                 None,
-                repo.depth().unwrap_or(-1),
+                upload_walk_depth,
             )?
             else {
                 log::warn!("Could not get remote tree for path {path:?}");
@@ -340,7 +347,7 @@ async fn get_commit_missing_hashes(
                 Some(&base_hashes),
                 Some(&mut unique_hashes),
                 None,
-                repo.depth().unwrap_or(-1),
+                upload_walk_depth,
             )?
             else {
                 log::error!("push_commits commit node not found for commit: {commit}");

--- a/crates/liboxen/src/repositories/pull.rs
+++ b/crates/liboxen/src/repositories/pull.rs
@@ -1995,6 +1995,19 @@ mod tests {
                 assert!(repo.path.join("train").exists());
                 assert!(repo.path.join("dir1").join("newfile.txt").exists());
 
+                // The new file lives outside the cloned subtree; confirm the push actually
+                // uploaded it by fetching it back from the server (not just trusting the local
+                // copy), so a regression that drops out-of-subtree files would fail here.
+                let downloaded = repo.path.join("downloaded_newfile.txt");
+                api::client::entries::download_entry(
+                    &remote_repo,
+                    "dir1/newfile.txt",
+                    &downloaded,
+                    branch_name,
+                )
+                .await?;
+                assert_eq!(util::fs::read_from_path(&downloaded)?, "This is a new file");
+
                 Ok(())
             })
             .await?;


### PR DESCRIPTION
A push from a subtree or shallow (depth-limited) clone computed its upload set by walking only the fetch-time subtree paths and depth. A file committed outside that scope — a new directory added by a subtree clone, or a file deeper than the clone's depth — was silently left out of the upload, so the branch ref advanced to a commit referencing content the remote never received. The gap only surfaced later, when something tried to read that content.

The push now walks the full local tree (root, unlimited depth) when computing what to upload. Subtrees not present locally load empty and are skipped, and objects already on the remote are still pruned, so this adds no work for full clones and only covers the genuinely-new local objects a partial clone created.

ENG-1195. Prerequisite for the server-side reachable-objects check (1.11b, ENG-1184).