### PR TITLE
Run nextest on Linux/Windows, cargo test on macOS

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+[profile.default]
+retries = 2
+failure-output = "immediate-final"
+fail-fast = { max-fail = 10 }
+leak-timeout = "1s"
+
+[profile.ci]
+# Do not cancel the test run on the first failure
+fail-fast = false
+retries = 2
+failure-output = "immediate-final"
+leak-timeout = "1s"

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -140,17 +140,33 @@ jobs:
           .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
           copy user_config.toml data\test\config\user_config.toml
 
-      - name: Run oxen rust tests (Linux/macOS)
-        if: matrix.platform != 'windows'
+      # macOS runs `cargo test`: a single test process amortizes per-test startup and wins there.
+      # Linux and Windows run nextest, whose process-per-test isolation avoids the shared-process
+      # lock/global-state contention that makes one `cargo test` process ~1.5-2.3x slower on those
+      # runners (measured on this branch's CI).
+      - name: Install nextest runner (Linux/Windows)
+        if: matrix.platform != 'macos'
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        with:
+          tool: nextest@0.9.114
+
+      - name: Run oxen rust tests (macOS, cargo test)
+        if: matrix.platform == 'macos'
         run: |
           ./target/debug/oxen-server start --test &
           cargo test --workspace --no-fail-fast
 
-      - name: Run oxen rust tests (Windows)
+      - name: Run oxen rust tests (Linux, nextest)
+        if: matrix.platform == 'linux'
+        run: |
+          ./target/debug/oxen-server start --test &
+          cargo nextest run --workspace --profile ci
+
+      - name: Run oxen rust tests (Windows, nextest)
         if: matrix.platform == 'windows'
         run: |
           Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start","--test"
-          cargo test --workspace --no-fail-fast
+          cargo nextest run --workspace --profile ci
 
   python-test:
     name: Python Tests

--- a/crates/liboxen/src/core/db/data_frames/df_db.rs
+++ b/crates/liboxen/src/core/db/data_frames/df_db.rs
@@ -1233,12 +1233,11 @@ mod tests {
 
             flush_all_df_db_connections();
 
-            // Cache must be drained — every Arc removed, every connection dropped.
-            assert_eq!(
-                DF_DB_INSTANCES.read().len(),
-                0,
-                "cache should be empty after flush"
-            );
+            // Don't assert the global cache length here. Under `cargo test` this process is shared
+            // with other df_db tests that populate `DF_DB_INSTANCES` in parallel (they sit on
+            // different serial keys), so its length isn't this test's to observe. A sibling can
+            // insert between the flush and the read. That the flush dropped our own connection is
+            // proven below, where the reopen only succeeds because the file lock was released.
 
             // Reopen WITHOUT going through recovery (no stale-WAL handling needed
             // because flush already CHECKPOINTed): data must still be present.


### PR DESCRIPTION
The switch from nextest to cargo test is faster on macOS but slower on Linux and much slower on Windows, or so it appears from CI.

"Run oxen rust tests" step, same base commit:

| | cargo test | nextest |
|--|--:|--:|
| macOS | ~238s | ~333s |
| Linux | ~250s | ~162s |
| Windows | ~412s | ~176s |

Windows gets ~2.1x parallelism in one shared process against ~5x under nextest. The process-wide singletons (`DF_DB_INSTANCES`, the RocksDB and merkle caches, the DuckDB extension store) contend under Windows' mandatory file locking. Per-test processes don't.

So cargo test runs on macOS and local dev, nextest on Linux and Windows. Critical path drops from ~412s to ~238s.

Also drops the flush test's `DF_DB_INSTANCES.len() == 0` assertion, which reads process-global state that parallel df_db tests mutate.