### PR TITLE
Cache release and wheel builds with sccache

### DIFF
--- a/.github/workflows/build_and_publish_test_pypi.yml
+++ b/.github/workflows/build_and_publish_test_pypi.yml
@@ -109,6 +109,8 @@ jobs:
     needs: [set_env, compute_version]
     uses: ./.github/workflows/build_wheels_macos.yml
     with:
+      AWS_ROLE: ${{ needs.set_env.outputs.aws_role }}
+      AWS_REGION: ${{ needs.set_env.outputs.aws_region }}
       PYTHON_VERSIONS: ${{ needs.set_env.outputs.python_versions }}
       CHECKOUT_REF: ${{ inputs.commit }}
       VERSION_OVERRIDE: ${{ needs.compute_version.outputs.version }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -93,7 +93,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
-      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_BUCKET: oxen-release-build-cache
       SCCACHE_REGION: us-west-1
       CARGO_INCREMENTAL: "0"
 

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -78,6 +78,7 @@ jobs:
           ec2-instance-type: ${{ env.EC2_INSTANCE_TYPE }}
           subnet-id: subnet-0e28805edbdad482f
           security-group-id: sg-09c8aa5830122d671
+          iam-role-name: github-runner-instance-profile
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"}
@@ -87,6 +88,14 @@ jobs:
     name: Build Python wheels
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
+
+    env:
+      RUSTC_WRAPPER: sccache
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_REGION: us-west-1
+      CARGO_INCREMENTAL: "0"
 
     steps:
       - name: Checkout
@@ -121,6 +130,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Build Python wheels
         run: |

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -39,7 +39,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
-      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_BUCKET: oxen-release-build-cache
       SCCACHE_REGION: us-west-1
       CARGO_INCREMENTAL: "0"
     steps:

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -15,6 +15,14 @@ on:
         description: "Version string to set in pyproject.toml (e.g. 0.44.1.dev0)"
         required: true
         type: string
+      AWS_ROLE:
+        description: "AWS role to assume"
+        required: true
+        type: string
+      AWS_REGION:
+        description: "AWS region"
+        required: true
+        type: string
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 10.13
@@ -27,11 +35,25 @@ jobs:
   build_wheels:
     name: Build Python wheels
     runs-on: macos-15-xlarge
+    env:
+      RUSTC_WRAPPER: sccache
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_REGION: us-west-1
+      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.CHECKOUT_REF }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ inputs.AWS_ROLE }}
+          role-duration-seconds: 3600
+          aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Patch version in pyproject.toml and Cargo.toml
         run: |
@@ -49,6 +71,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Build Python wheels
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
     uses: ./.github/workflows/release_macos.yml
     with:
       PYTHON_VERSIONS: ${{ needs.set_env.outputs.python_versions }}
+      AWS_ROLE: ${{ needs.set_env.outputs.aws_role }}
+      AWS_REGION: ${{ needs.set_env.outputs.aws_region }}
 
   release_windows_x86_64:
     name: Windows x86_64

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -75,6 +75,7 @@ jobs:
           ec2-instance-type: ${{ env.EC2_INSTANCE_TYPE }}
           subnet-id: subnet-0e28805edbdad482f
           security-group-id: sg-09c8aa5830122d671
+          iam-role-name: github-runner-instance-profile
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"}
@@ -84,6 +85,14 @@ jobs:
     name: Build Oxen CLI, Server, and Python wheels
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
+
+    env:
+      RUSTC_WRAPPER: sccache
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_REGION: us-west-1
+      CARGO_INCREMENTAL: "0"
 
     steps:
       - name: Checkout
@@ -110,6 +119,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       - name: Build oxen binaries
         run: |
           cargo build --workspace --exclude oxen-py --release
@@ -123,6 +135,10 @@ jobs:
           for version in ${{ inputs.PYTHON_VERSIONS }}; do
             uvx --from 'maturin[patchelf]' maturin build --release --interpreter /root/.local/bin/python${version}
           done
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Create tarballs with oxen binaries
         run: |

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -90,7 +90,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
-      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_BUCKET: oxen-release-build-cache
       SCCACHE_REGION: us-west-1
       CARGO_INCREMENTAL: "0"
 

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -31,7 +31,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
-      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_BUCKET: oxen-release-build-cache
       SCCACHE_REGION: us-west-1
       CARGO_INCREMENTAL: "0"
     steps:

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -7,6 +7,14 @@ on:
         description: "Python versions to build"
         required: true
         type: string
+      AWS_ROLE:
+        description: "AWS role to assume"
+        required: true
+        type: string
+      AWS_REGION:
+        description: "AWS region"
+        required: true
+        type: string
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 10.13
@@ -19,9 +27,23 @@ jobs:
   release_macos:
     name: Release Oxen MacOS
     runs-on: macos-15-xlarge
+    env:
+      RUSTC_WRAPPER: sccache
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_REGION: us-west-1
+      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ inputs.AWS_ROLE }}
+          role-duration-seconds: 3600
+          aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Create release directory
         run: mkdir ${{ github.workspace }}/release
@@ -32,6 +54,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Build oxen binaries
         run: |
@@ -54,6 +79,10 @@ jobs:
             uvx maturin build --release --interpreter /Users/runner/.local/bin/python${version} --target aarch64-apple-darwin
             uvx maturin build --release --interpreter /Users/runner/.local/bin/python${version} --target x86_64-apple-darwin
           done
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Create tarballs with oxen binaries
         run: |

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -103,6 +103,7 @@ jobs:
           $versions = "${{ inputs.PYTHON_VERSIONS }}" -split ' '
           foreach ($version in $versions) {
               uvx maturin build --release --interpreter "C:\Users\Administrator\AppData\Roaming\uv\python\cpython-$version.*\python.exe"
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
       - name: Create zip with oxen binaries

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -85,10 +85,10 @@ jobs:
       # sccache wrapper and emits GCC-builtin calls that MSVC can't link;
       # its cmake path probes the toolchain correctly (and NASM is installed)
       AWS_LC_SYS_CMAKE_BUILDER: "1"
-      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_BUCKET: oxen-release-build-cache
       SCCACHE_REGION: us-west-1
       # vcpkg rebuilds FFmpeg from source on every ephemeral runner without this
-      VCPKG_BINARY_SOURCES: clear;x-aws,s3://oxen-ci-build-cache/vcpkg/,readwrite
+      VCPKG_BINARY_SOURCES: clear;x-aws,s3://oxen-release-build-cache/vcpkg/,readwrite
       # MSVC stamps wall-clock timestamps into linked PE files and .obj COFF
       # headers; sccache hashes proc-macro dlls (--extern) and staticlib members
       # into downstream Rust keys, so unstamped output churns those keys every
@@ -155,7 +155,7 @@ jobs:
           $keySrc = "$rv|$lock|-Clink-arg=/Brepro|v2"
           $sha = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($keySrc))).Replace("-","").Substring(0,32)
           echo "DEPTREE_KEY=$sha" >> $env:GITHUB_ENV
-          cmd /c "aws s3 cp s3://oxen-ci-build-cache/deptree/$sha.tar C:\deptree.tar 2>nul"
+          cmd /c "aws s3 cp s3://oxen-release-build-cache/deptree/$sha.tar C:\deptree.tar 2>nul"
           if (Test-Path C:\deptree.tar) {
             tar -xf C:\deptree.tar -C C:\
             Write-Host "DEPTREE restore hit ($sha)"
@@ -196,7 +196,7 @@ jobs:
           $list = @("$rel/.fingerprint", "$rel/deps", "$rel/build", "Users/Administrator/.cargo/registry/src", "Users/Administrator/.cargo/registry/cache")
           $list | Set-Content C:\deptree-list.txt
           tar -cf C:\deptree-out.tar -C C:\ -T C:\deptree-list.txt
-          aws s3 cp C:\deptree-out.tar s3://oxen-ci-build-cache/deptree/$env:DEPTREE_KEY.tar
+          aws s3 cp C:\deptree-out.tar s3://oxen-release-build-cache/deptree/$env:DEPTREE_KEY.tar
           Write-Host "DEPTREE saved ($env:DEPTREE_KEY)"
 
       - name: Build Python wheels

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -57,6 +57,7 @@ jobs:
           startup-timeout-minutes: 10
           subnet-id: subnet-0e28805edbdad482f
           security-group-id: sg-09c8aa5830122d671
+          iam-role-name: github-runner-instance-profile
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"}
@@ -70,6 +71,34 @@ jobs:
       run:
         shell: powershell
 
+    env:
+      RUSTC_WRAPPER: sccache
+      # cc-rs (duckdb/rocksdb/zstd bundled builds) intercepts via CC/CXX;
+      # cmake-driven builds (aws-lc) need the launcher vars plus a generator
+      # that honors them (Visual Studio generators ignore launchers).
+      CC: sccache cl
+      CXX: sccache cl
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      CMAKE_GENERATOR: Ninja
+      # aws-lc-sys's cc builder misdetects the compiler family behind the
+      # sccache wrapper and emits GCC-builtin calls that MSVC can't link;
+      # its cmake path probes the toolchain correctly (and NASM is installed)
+      AWS_LC_SYS_CMAKE_BUILDER: "1"
+      SCCACHE_BUCKET: oxen-ci-build-cache
+      SCCACHE_REGION: us-west-1
+      # vcpkg rebuilds FFmpeg from source on every ephemeral runner without this
+      VCPKG_BINARY_SOURCES: clear;x-aws,s3://oxen-ci-build-cache/vcpkg/,readwrite
+      # MSVC stamps wall-clock timestamps into linked PE files and .obj COFF
+      # headers; sccache hashes proc-macro dlls (--extern) and staticlib members
+      # into downstream Rust keys, so unstamped output churns those keys every
+      # run. /Brepro zeroes the timestamps.
+      RUSTFLAGS: -Clink-arg=/Brepro
+      CFLAGS: /Brepro
+      CXXFLAGS: /Brepro
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_IDLE_TIMEOUT: "0"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -77,9 +106,32 @@ jobs:
       - name: Create release directory
         run: mkdir ${{ github.workspace }}\release
 
+      - name: Disable Windows Defender for build (ephemeral runner)
+        run: |
+          try {
+            # Same configuration GitHub applies to its hosted runner images
+            Set-MpPreference -DisableRealtimeMonitoring $true -DisableArchiveScanning $true -DisableBehaviorMonitoring $true -DisableIOAVProtection $true -DisableScriptScanning $true -MAPSReporting 0 -PUAProtection 0 -ScanAvgCPULoadFactor 5
+            Set-MpPreference -ExclusionPath @("C:\Windows\System32\actions-runner", "C:\Users\Administrator\.cargo", "C:\Users\Administrator\.rustup", "C:\vcpkg", "C:\ProgramData\chocolatey", "$env:TEMP")
+            Set-MpPreference -ExclusionProcess @("rustc.exe", "cargo.exe", "sccache.exe", "cl.exe", "link.exe", "cmake.exe", "ninja.exe", "python.exe", "git.exe")
+            $s = Get-MpComputerStatus
+            Write-Host "Defender: RealTimeProtection=$($s.RealTimeProtectionEnabled) TamperProtected=$($s.IsTamperProtected)"
+          } catch {
+            Write-Host "Defender configuration unavailable: $_"
+          }
+
       - name: Install dependencies
         run: |
-          choco install -y cmake llvm uv rustup.install
+          choco install -y cmake llvm uv rustup.install ninja nasm
+          if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
+            choco install -y awscli
+            # choco appends to the machine PATH; this process needs it now for vcpkg's x-aws
+            $env:Path = "C:\Program Files\Amazon\AWSCLIV2;$env:Path"
+          }
+          aws --version
+          # Install sccache 0.16 to a machine-PATH dir so it survives refreshenv
+          Invoke-WebRequest -Uri "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-pc-windows-msvc.zip" -OutFile C:\sccache.zip
+          Expand-Archive -Path C:\sccache.zip -DestinationPath C:\sccache-dl -Force
+          Copy-Item C:\sccache-dl\sccache-v0.16.0-x86_64-pc-windows-msvc\sccache.exe C:\ProgramData\chocolatey\bin\sccache.exe -Force
           # Install vcpkg for FFmpeg development libraries
           git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
           cd C:\vcpkg
@@ -88,14 +140,81 @@ jobs:
           # Set VCPKG_ROOT for cargo to find FFmpeg libraries
           echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
 
+      - name: Restore dependency build tree
+        run: |
+          refreshenv
+          # Proc-macro dlls never link byte-identically across runs (PE content
+          # varies even with /Brepro), and sccache hashes them into every direct
+          # consumer's key, so those consumers and everything above them miss
+          # every run. Restoring the dependency slice of target\release plus the
+          # registry trees (mtimes preserved, so cargo's staleness math holds)
+          # makes cargo reuse the previous run's dlls verbatim; workspace crates
+          # stay dirty via fresh checkout mtimes and rebuild as usual.
+          $lock = (Get-FileHash Cargo.lock -Algorithm SHA256).Hash
+          $rv = (cmd /c "rustc -V 2>nul") -join ''
+          $keySrc = "$rv|$lock|-Clink-arg=/Brepro|v2"
+          $sha = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($keySrc))).Replace("-","").Substring(0,32)
+          echo "DEPTREE_KEY=$sha" >> $env:GITHUB_ENV
+          cmd /c "aws s3 cp s3://oxen-ci-build-cache/deptree/$sha.tar C:\deptree.tar 2>nul"
+          if (Test-Path C:\deptree.tar) {
+            tar -xf C:\deptree.tar -C C:\
+            Write-Host "DEPTREE restore hit ($sha)"
+          } else {
+            Write-Host "DEPTREE restore miss ($sha)"
+          }
+          exit 0
+
       - name: Build oxen binaries
         run: |
           refreshenv
+          # cc-rs only self-locates MSVC when CC is unset; with CC="sccache cl"
+          # the dev shell must put cl.exe (+ INCLUDE/LIB) in the environment
+          $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64'
+          $env:RUSTC_WRAPPER = "sccache"
+          $env:RUSTFLAGS = "-Clink-arg=/Brepro"
+          $env:CC = "sccache cl"
+          $env:CXX = "sccache cl"
+          $env:CFLAGS = "/Brepro"
+          $env:CXXFLAGS = "/Brepro"
+          $env:CMAKE_C_COMPILER_LAUNCHER = "sccache"
+          $env:CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
+          $env:CMAKE_GENERATOR = "Ninja"
+          $env:AWS_LC_SYS_CMAKE_BUILDER = "1"
+          cmd /c "sccache --start-server"
           cargo build --workspace --exclude oxen-py --release
+          $cargoExit = $LASTEXITCODE
+          sccache --show-stats
+          exit $cargoExit
+
+      - name: Save dependency build tree
+        run: |
+          if (Test-Path C:\deptree.tar) { Write-Host "DEPTREE cache already present"; exit 0 }
+          refreshenv
+          $rel = "${{ github.workspace }}\target\release".Substring(3) -replace '\\','/'
+          $list = @("$rel/.fingerprint", "$rel/deps", "$rel/build", "Users/Administrator/.cargo/registry/src", "Users/Administrator/.cargo/registry/cache")
+          $list | Set-Content C:\deptree-list.txt
+          tar -cf C:\deptree-out.tar -C C:\ -T C:\deptree-list.txt
+          aws s3 cp C:\deptree-out.tar s3://oxen-ci-build-cache/deptree/$env:DEPTREE_KEY.tar
+          Write-Host "DEPTREE saved ($env:DEPTREE_KEY)"
 
       - name: Build Python wheels
         run: |
           refreshenv
+          $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64'
+          $env:RUSTC_WRAPPER = "sccache"
+          $env:RUSTFLAGS = "-Clink-arg=/Brepro"
+          $env:CC = "sccache cl"
+          $env:CXX = "sccache cl"
+          $env:CFLAGS = "/Brepro"
+          $env:CXXFLAGS = "/Brepro"
+          $env:CMAKE_C_COMPILER_LAUNCHER = "sccache"
+          $env:CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
+          $env:CMAKE_GENERATOR = "Ninja"
+          $env:AWS_LC_SYS_CMAKE_BUILDER = "1"
           uv python install ${{ inputs.PYTHON_VERSIONS }}
 
           cd ${{ github.workspace }}\oxen-python
@@ -105,6 +224,12 @@ jobs:
               uvx maturin build --release --interpreter "C:\Users\Administrator\AppData\Roaming\uv\python\cpython-$version.*\python.exe"
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
+
+      - name: sccache stats
+        if: always()
+        run: |
+          refreshenv
+          sccache --show-stats
 
       - name: Create zip with oxen binaries
         run: |


### PR DESCRIPTION
CI rebuilds the rust graph and c/c++ from scratch on every release build, which is slow. This uses sccache for Linux and macOS release builsd and wheel builders.

We use the GH actions cache for CI, but it evicts after 7 days and if we used it for releases it would fight our CI for space. We use an s3 bucket here so we don't have to worry about that and so that the cache persists.

The bundled c/c++ stays cached across releases because it doesnt change between them.

~~I ran into some issues dealing with windows so i'll tackle it later.~~

### Windows

I got windows working, it was a real pain compared to linux and macos.

* sccache doesn't pick up the c/c++ compiler automatically on windows like it does on linux
* ffmpeg was getting rebuilt from source on every run
* Windows bulids proc macro dlls slightly differently every time which made sccache think everything using them had changed and then it would reocmpile half of the entire graph

That last one is fixed by saving the built dependencies to s3 and restoring them between runs.

I also had to turn off Defender during builds, since it was slowing things down, but this is already what GitHub does on its own runners and it shouldn't be an issue.

Also, we had a bug when building the windows wheels where maturin errors would be ignored, but I also fixed that.

### Final measurements

| Build | Before | After | Δ |
|---|---|---|---|
| Linux x86_64 release | 27m38s | 17m02s | -38% |
| Linux arm64 release | 27m35s | 19m05s | -31% |
| macOS release (both arches) | 52m52s | 31m31s | -40% |
| Windows release | 53m31s | 30m18s | -43% |
| Linux x86_64 wheels | 55m25s | 7m45s | -86% |
| Linux arm64 wheels | 64m53s | 9m43s | -85% |
| macOS wheels | 104m30s | 13m59s | -87% |

