### PR TITLE
Stop persisting checkout credentials

### DIFF
--- a/.github/workflows/build_and_publish_test_pypi.yml
+++ b/.github/workflows/build_and_publish_test_pypi.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.commit }}
           sparse-checkout: oxen-python/pyproject.toml
           sparse-checkout-cone-mode: false

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.branch }}
 
       - name: Set release version

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.CHECKOUT_REF }}
 
       - name: Patch version in pyproject.toml and Cargo.toml

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.CHECKOUT_REF }}
 
       - name: Patch version in pyproject.toml and Cargo.toml

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.CHECKOUT_REF }}
 
       - name: Patch version in pyproject.toml and Cargo.toml

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Free up disk space
         uses: ./.github/actions/free-disk-space

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Free up disk space
         if: matrix.platform == 'linux'
@@ -182,6 +184,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Free up disk space
         if: matrix.platform == 'linux'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Free up disk space
         uses: ./.github/actions/free-disk-space
       - name: Package and verify crates

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -96,6 +96,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Get build metadata
         id: metadata

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -88,6 +88,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Create release directory
         run: mkdir ${{ github.workspace }}/release

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Create release directory
         run: mkdir ${{ github.workspace }}/release

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Create release directory
         run: mkdir ${{ github.workspace }}\release


### PR DESCRIPTION
Actions/checkout leaves the GITHUB_TOKEN in .git/config by default.

Sets persist-credentials: false on all checkouts except bump-version and the homebrew formula push, since those are the only ones that actually need it.