### PR TITLE
Repo Integrity (1.11c): Reject a branch advance onto a commit the server can't fully serve

### DIFF
--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -612,6 +612,13 @@ pub enum OxenError {
         missing_nodes: usize,
         missing_versions: usize,
     },
+    /// A branch-ref advance was rejected because the new commit's directory-hash index
+    /// (`.oxen/history/<id>/dir_hashes`) is absent, so the server can't resolve the commit's tree
+    /// by path even when every referenced object is present. A full re-push repopulates it.
+    #[error(
+        "Commit {commit} is missing its directory index on the server, so its tree can't be served by path. Re-push the commit to repopulate the index."
+    )]
+    DirHashIndexMissing { commit: String },
 
     /// An `OxenResponse` arrived with `status == "warning"`: the request succeeded but
     /// the server attached an advisory message.
@@ -772,6 +779,9 @@ impl OxenError {
             | ReachableObjectsMissing { .. } => {
                 "If a content blob is missing on the server, run `oxen push --missing-files` from a clone with the full local history to repair it."
             }
+            DirHashIndexMissing { .. } => {
+                "Re-push the commit from a clone with the full local history to repopulate the server's directory index."
+            }
             UnsupportedRepoVersion(_) => {
                 "Use an older Oxen release to migrate this repository up to the current format, then retry with this CLI."
             }
@@ -834,6 +844,7 @@ impl OxenError {
             OxenError::HTTP(req_err) => req_err.status().is_some_and(is_fatal_http_status),
             OxenError::VersionsMissingOnServer { .. } => true,
             OxenError::ReachableObjectsMissing { .. } => true,
+            OxenError::DirHashIndexMissing { .. } => true,
             OxenError::VersionStoreDataMissing { .. } => true,
             OxenError::UnknownRemoteResponseStatus(_) => true,
             _ => false,

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -602,6 +602,17 @@ pub enum OxenError {
     #[error("{}", format_versions_missing_on_server(hashes))]
     VersionsMissingOnServer { hashes: Vec<String> },
 
+    /// A branch-ref advance was rejected because the new commit references merkle nodes or
+    /// version blobs that aren't present on the server. Only counts are carried — the recovery
+    /// path (`oxen push --missing-files`) re-derives which objects to re-push.
+    #[error(
+        "Commit references {missing_nodes} merkle node(s) and {missing_versions} version blob(s) the server is missing. Re-push the missing objects with `oxen push --missing-files`."
+    )]
+    ReachableObjectsMissing {
+        missing_nodes: usize,
+        missing_versions: usize,
+    },
+
     /// An `OxenResponse` arrived with `status == "warning"`: the request succeeded but
     /// the server attached an advisory message.
     #[error("Remote Warning: {0}")]
@@ -756,7 +767,9 @@ impl OxenError {
             WorkspaceStagedDbCorrupted { .. } => {
                 "Recreate the workspace: `oxen workspace delete <id>` then re-create it."
             }
-            DownloadBatchExhausted { .. } | VersionsMissingOnServer { .. } => {
+            DownloadBatchExhausted { .. }
+            | VersionsMissingOnServer { .. }
+            | ReachableObjectsMissing { .. } => {
                 "If a content blob is missing on the server, run `oxen push --missing-files` from a clone with the full local history to repair it."
             }
             UnsupportedRepoVersion(_) => {
@@ -820,6 +833,7 @@ impl OxenError {
             | OxenError::HttpDeserializeError { status, .. } => is_fatal_http_status(*status),
             OxenError::HTTP(req_err) => req_err.status().is_some_and(is_fatal_http_status),
             OxenError::VersionsMissingOnServer { .. } => true,
+            OxenError::ReachableObjectsMissing { .. } => true,
             OxenError::VersionStoreDataMissing { .. } => true,
             OxenError::UnknownRemoteResponseStatus(_) => true,
             _ => false,

--- a/crates/liboxen/src/repositories/branches.rs
+++ b/crates/liboxen/src/repositories/branches.rs
@@ -119,6 +119,45 @@ pub fn update(
     })
 }
 
+/// Return `Err(ReachableObjectsMissing)` unless every merkle node and version blob that `head`
+/// adds relative to `base` is present in this repository.
+///
+/// Server ref-advance paths call this before moving a ref, so it can never point at a commit whose
+/// content the server lacks. Local/CLI branch ops skip it — a local clone is the source of truth.
+pub async fn verify_reachable_objects(
+    repo: &LocalRepository,
+    base: Option<&Commit>,
+    head: &Commit,
+) -> Result<(), OxenError> {
+    let missing = repositories::tree::find_missing_added_objects(repo, base, head).await?;
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(OxenError::ReachableObjectsMissing {
+        missing_nodes: missing.nodes.len(),
+        missing_versions: missing.versions.len(),
+    })
+}
+
+/// Verify that advancing a ref to `commit_id` wouldn't point at a commit missing reachable
+/// objects, scoping the check to what it adds over `base_branch`'s head. A commit that doesn't
+/// exist yet is left for the ref-advance op to reject; a missing base branch checks the whole tree.
+pub async fn verify_advance_to(
+    repo: &LocalRepository,
+    commit_id: &str,
+    base_branch: &str,
+) -> Result<(), OxenError> {
+    let Some(head_commit) = repositories::commits::get_by_id(repo, commit_id)? else {
+        return Ok(());
+    };
+    let base_commit = get_by_name(repo, base_branch).ok().and_then(|branch| {
+        repositories::commits::get_by_id(repo, &branch.commit_id)
+            .ok()
+            .flatten()
+    });
+    verify_reachable_objects(repo, base_commit.as_ref(), &head_commit).await
+}
+
 /// Delete a local branch
 pub fn delete(repo: &LocalRepository, name: impl AsRef<str>) -> Result<Branch, OxenError> {
     let name = name.as_ref();
@@ -506,6 +545,122 @@ mod tests {
             let leftover_branches = repositories::branches::list(&repo)?;
             assert_eq!(og_branches.len(), leftover_branches.len());
 
+            Ok(())
+        })
+        .await
+    }
+
+    /// Open the server-side repository for a pushed remote so a test can mutate its on-disk
+    /// version store. `bin/test-rust` starts oxen-server against `$SYNC_DIR`, inherited by the
+    /// test process; repos live under `<SYNC_DIR>/<namespace>/<name>`.
+    fn server_repo(name: &str) -> Result<crate::model::LocalRepository, OxenError> {
+        let sync_dir =
+            std::path::PathBuf::from(std::env::var("SYNC_DIR").map_err(|_| {
+                OxenError::basic_str("SYNC_DIR not set; run tests via bin/test-rust")
+            })?);
+        repositories::get_by_namespace_and_name(
+            &sync_dir,
+            crate::constants::DEFAULT_NAMESPACE,
+            name,
+            None,
+        )?
+        .ok_or_else(|| OxenError::basic_str(format!("server repo not found for {name}")))
+    }
+
+    // Every server ref-advance path — branch update, new-branch create, and push-time merge —
+    // must refuse to point a ref at a commit whose newly-added blob is missing.
+    #[tokio::test]
+    async fn test_ref_advance_gates_reject_incomplete_commit() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async {
+            let mut repo = repo;
+
+            // commit1 is complete; commit2 adds b.txt.
+            let a_path = repo.path.join("a.txt");
+            test::write_txt_file_to_path(&a_path, "alpha")?;
+            repositories::add(&repo, &a_path).await?;
+            let commit1 = repositories::commit(&repo, "add a.txt")?;
+
+            let remote = test::repo_remote_url_from(&repo.dirname());
+            crate::command::config::set_remote(
+                &mut repo,
+                crate::constants::DEFAULT_REMOTE_NAME,
+                &remote,
+            )?;
+            let remote_repo = test::create_remote_repo(&repo).await?;
+            repositories::push(&repo).await?;
+
+            let b_path = repo.path.join("b.txt");
+            test::write_txt_file_to_path(&b_path, "beta")?;
+            repositories::add(&repo, &b_path).await?;
+            let commit2 = repositories::commit(&repo, "add b.txt")?;
+            repositories::push(&repo).await?;
+
+            // The server loses b.txt's blob — referenced only by commit2.
+            let b_hash = repositories::tree::get_node_by_path(&repo, &commit2, "b.txt")?
+                .expect("b.txt in commit2")
+                .file()?
+                .hash()
+                .to_string();
+            let server = server_repo(&repo.dirname())?;
+            server.version_store().delete_version(&b_hash).await?;
+
+            // Resetting back to the complete commit1 is allowed (it adds nothing missing).
+            crate::api::client::branches::update(&remote_repo, DEFAULT_BRANCH_NAME, &commit1)
+                .await?;
+            let head = crate::api::client::branches::get_by_name(&remote_repo, DEFAULT_BRANCH_NAME)
+                .await?
+                .expect("main exists");
+            assert_eq!(head.commit_id, commit1.id);
+
+            // update gate: re-advancing main to commit2 must be rejected.
+            let update_result =
+                crate::api::client::branches::update(&remote_repo, DEFAULT_BRANCH_NAME, &commit2)
+                    .await;
+            assert!(
+                update_result.is_err(),
+                "update onto a commit with a missing added blob must be rejected"
+            );
+            let head = crate::api::client::branches::get_by_name(&remote_repo, DEFAULT_BRANCH_NAME)
+                .await?
+                .expect("main exists");
+            assert_eq!(
+                head.commit_id, commit1.id,
+                "update must not advance main onto an incomplete commit"
+            );
+
+            // create gate: creating a new branch at commit2 (main is at the complete commit1) must
+            // be rejected, and the branch must not be created.
+            let create_result = crate::api::client::branches::create_from_commit(
+                &remote_repo,
+                "at-commit2",
+                &commit2,
+            )
+            .await;
+            assert!(
+                create_result.is_err(),
+                "creating a branch at a commit with a missing added blob must be rejected"
+            );
+            assert!(
+                crate::api::client::branches::get_by_name(&remote_repo, "at-commit2")
+                    .await?
+                    .is_none(),
+                "a rejected create must not leave the branch behind"
+            );
+
+            // merge gate: a push-time merge of commit2 into main (at commit1) must be rejected.
+            let merge_result = crate::api::client::branches::maybe_create_merge(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                &commit2.id,
+                &commit1.id,
+            )
+            .await;
+            assert!(
+                merge_result.is_err(),
+                "merging in a commit with a missing added blob must be rejected"
+            );
+
+            crate::api::client::repositories::delete(&remote_repo).await?;
             Ok(())
         })
         .await

--- a/crates/liboxen/src/repositories/branches.rs
+++ b/crates/liboxen/src/repositories/branches.rs
@@ -5,6 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::core::db::dir_hashes::dir_hashes_db::dir_hash_db_path;
 use crate::core::refs::with_ref_manager;
 use crate::core::v_latest::branches::OnConflict;
 use crate::error::OxenError;
@@ -119,24 +120,34 @@ pub fn update(
     })
 }
 
-/// Return `Err(ReachableObjectsMissing)` unless every merkle node and version blob that `head`
-/// adds relative to `base` is present in this repository.
+/// Reject the ref advance unless the server can fully serve `head`: every merkle node and version
+/// blob it adds relative to `base` is present (else `ReachableObjectsMissing`), and its
+/// directory-hash index — needed to resolve the tree by path — exists (else `DirHashIndexMissing`).
 ///
-/// Server ref-advance paths call this before moving a ref, so it can never point at a commit whose
-/// content the server lacks. Local/CLI branch ops skip it — a local clone is the source of truth.
+/// Server ref-advance paths call this before moving a ref, so it can never point at a commit the
+/// server can't serve. Local/CLI branch ops skip it — a local clone is the source of truth.
 pub async fn verify_reachable_objects(
     repo: &LocalRepository,
     base: Option<&Commit>,
     head: &Commit,
 ) -> Result<(), OxenError> {
     let missing = repositories::tree::find_missing_added_objects(repo, base, head).await?;
-    if missing.is_empty() {
-        return Ok(());
+    if !missing.is_empty() {
+        return Err(OxenError::ReachableObjectsMissing {
+            missing_nodes: missing.nodes.len(),
+            missing_versions: missing.versions.len(),
+        });
     }
-    Err(OxenError::ReachableObjectsMissing {
-        missing_nodes: missing.nodes.len(),
-        missing_versions: missing.versions.len(),
-    })
+
+    // Path-based serving also needs the commit's dir-hashes index — require it even when every
+    // referenced object is present.
+    if !dir_hash_db_path(repo, head).exists() {
+        return Err(OxenError::DirHashIndexMissing {
+            commit: head.id.clone(),
+        });
+    }
+
+    Ok(())
 }
 
 /// Verify that advancing a ref to `commit_id` wouldn't point at a commit missing reachable
@@ -658,6 +669,66 @@ mod tests {
             assert!(
                 merge_result.is_err(),
                 "merging in a commit with a missing added blob must be rejected"
+            );
+
+            crate::api::client::repositories::delete(&remote_repo).await?;
+            Ok(())
+        })
+        .await
+    }
+
+    // The gate also refuses a commit whose objects are all present but whose dir-hashes index is
+    // missing — the tree can't be served by path without it. The check lives in the shared
+    // `verify_reachable_objects`, so exercising the update gate covers all three ref-advance paths.
+    #[tokio::test]
+    async fn test_ref_advance_gate_requires_dir_hashes() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async {
+            let mut repo = repo;
+
+            let a_path = repo.path.join("a.txt");
+            test::write_txt_file_to_path(&a_path, "alpha")?;
+            repositories::add(&repo, &a_path).await?;
+            let commit1 = repositories::commit(&repo, "add a.txt")?;
+
+            let remote = test::repo_remote_url_from(&repo.dirname());
+            crate::command::config::set_remote(
+                &mut repo,
+                crate::constants::DEFAULT_REMOTE_NAME,
+                &remote,
+            )?;
+            let remote_repo = test::create_remote_repo(&repo).await?;
+            repositories::push(&repo).await?;
+
+            // commit2 is pushed complete: every node and blob it adds is on the server.
+            let b_path = repo.path.join("b.txt");
+            test::write_txt_file_to_path(&b_path, "beta")?;
+            repositories::add(&repo, &b_path).await?;
+            let commit2 = repositories::commit(&repo, "add b.txt")?;
+            repositories::push(&repo).await?;
+
+            // Reset main to commit1, then remove commit2's dir-hashes index on the server.
+            crate::api::client::branches::update(&remote_repo, DEFAULT_BRANCH_NAME, &commit1)
+                .await?;
+            let server = server_repo(&repo.dirname())?;
+            let dir_hashes =
+                crate::core::db::dir_hashes::dir_hashes_db::dir_hash_db_path(&server, &commit2);
+            util::fs::remove_dir_all(&dir_hashes)?;
+
+            // Re-advancing main to commit2 must be rejected even though its objects are all
+            // present, and main must stay at commit1.
+            let result =
+                crate::api::client::branches::update(&remote_repo, DEFAULT_BRANCH_NAME, &commit2)
+                    .await;
+            assert!(
+                result.is_err(),
+                "advance onto a commit missing its dir-hashes index must be rejected"
+            );
+            let head = crate::api::client::branches::get_by_name(&remote_repo, DEFAULT_BRANCH_NAME)
+                .await?
+                .expect("main exists");
+            assert_eq!(
+                head.commit_id, commit1.id,
+                "a rejected advance must not move main"
             );
 
             crate::api::client::repositories::delete(&remote_repo).await?;

--- a/crates/liboxen/src/repositories/branches.rs
+++ b/crates/liboxen/src/repositories/branches.rs
@@ -161,11 +161,12 @@ pub async fn verify_advance_to(
     let Some(head_commit) = repositories::commits::get_by_id(repo, commit_id)? else {
         return Ok(());
     };
-    let base_commit = get_by_name(repo, base_branch).ok().and_then(|branch| {
-        repositories::commits::get_by_id(repo, &branch.commit_id)
-            .ok()
-            .flatten()
-    });
+    // Only an absent base branch falls back to a whole-tree check; real lookup errors surface.
+    let base_commit = match get_by_name(repo, base_branch) {
+        Ok(branch) => repositories::commits::get_by_id(repo, &branch.commit_id)?,
+        Err(OxenError::BranchNotFound(_)) => None,
+        Err(e) => return Err(e),
+    };
     verify_reachable_objects(repo, base_commit.as_ref(), &head_commit).await
 }
 

--- a/crates/liboxen/src/repositories/branches.rs
+++ b/crates/liboxen/src/repositories/branches.rs
@@ -124,8 +124,9 @@ pub fn update(
 /// blob it adds relative to `base` is present (else `ReachableObjectsMissing`), and its
 /// directory-hash index — needed to resolve the tree by path — exists (else `DirHashIndexMissing`).
 ///
-/// Server ref-advance paths call this before moving a ref, so it can never point at a commit the
-/// server can't serve. Local/CLI branch ops skip it — a local clone is the source of truth.
+/// Server ref-advance paths that move onto a client-supplied commit call this first, so a ref can
+/// never point at a commit the server can't serve. Local/CLI branch ops skip it — a local clone is
+/// the source of truth.
 pub async fn verify_reachable_objects(
     repo: &LocalRepository,
     base: Option<&Commit>,
@@ -730,6 +731,72 @@ mod tests {
             assert_eq!(
                 head.commit_id, commit1.id,
                 "a rejected advance must not move main"
+            );
+
+            crate::api::client::repositories::delete(&remote_repo).await?;
+            Ok(())
+        })
+        .await
+    }
+
+    // Creating a branch *from another branch* is a ref advance too: it must refuse when the source
+    // branch's head commit is missing an added blob, just like commit-based creation.
+    #[tokio::test]
+    async fn test_ref_advance_gate_rejects_create_from_incomplete_branch() -> Result<(), OxenError>
+    {
+        test::run_empty_local_repo_test_async(|repo| async {
+            let mut repo = repo;
+
+            let a_path = repo.path.join("a.txt");
+            test::write_txt_file_to_path(&a_path, "alpha")?;
+            repositories::add(&repo, &a_path).await?;
+            let commit1 = repositories::commit(&repo, "add a.txt")?;
+
+            let remote = test::repo_remote_url_from(&repo.dirname());
+            crate::command::config::set_remote(
+                &mut repo,
+                crate::constants::DEFAULT_REMOTE_NAME,
+                &remote,
+            )?;
+            let remote_repo = test::create_remote_repo(&repo).await?;
+            repositories::push(&repo).await?;
+
+            let b_path = repo.path.join("b.txt");
+            test::write_txt_file_to_path(&b_path, "beta")?;
+            repositories::add(&repo, &b_path).await?;
+            let commit2 = repositories::commit(&repo, "add b.txt")?;
+            repositories::push(&repo).await?;
+
+            // "src" points at the complete commit2; then main resets to commit1 so the gate below
+            // diffs commit2 against commit1 and actually inspects b.txt.
+            crate::api::client::branches::create_from_branch(&remote_repo, "src", DEFAULT_BRANCH_NAME)
+                .await?;
+            crate::api::client::branches::update(&remote_repo, DEFAULT_BRANCH_NAME, &commit1)
+                .await?;
+
+            // The server loses b.txt's blob — referenced only by commit2 (src's head).
+            let b_hash = repositories::tree::get_node_by_path(&repo, &commit2, "b.txt")?
+                .expect("b.txt in commit2")
+                .file()?
+                .hash()
+                .to_string();
+            let server = server_repo(&repo.dirname())?;
+            server.version_store().delete_version(&b_hash).await?;
+
+            // Creating a branch from "src" (head = the now-incomplete commit2) must be rejected, and
+            // the new branch must not be created.
+            let result =
+                crate::api::client::branches::create_from_branch(&remote_repo, "derived", "src")
+                    .await;
+            assert!(
+                result.is_err(),
+                "create-from-branch off a source whose head is missing an added blob must be rejected"
+            );
+            assert!(
+                crate::api::client::branches::get_by_name(&remote_repo, "derived")
+                    .await?
+                    .is_none(),
+                "a rejected create-from-branch must not leave the branch behind"
             );
 
             crate::api::client::repositories::delete(&remote_repo).await?;

--- a/crates/oxen-server/src/controllers/branches.rs
+++ b/crates/oxen-server/src/controllers/branches.rs
@@ -161,7 +161,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let data: Result<BranchNewFromCommitId, serde_json::Error> = serde_json::from_str(&body);
     if let Ok(data) = data {
         log::debug!("Create from commit!");
-        return create_from_commit(&repo, &data);
+        return create_from_commit(&repo, &data).await;
     }
 
     Ok(HttpResponse::BadRequest().json(StatusMessage::error("Invalid request body")))
@@ -194,10 +194,19 @@ fn create_from_branch(
     }))
 }
 
-fn create_from_commit(
+async fn create_from_commit(
     repo: &LocalRepository,
     data: &BranchNewFromCommitId,
 ) -> Result<HttpResponse, OxenHttpError> {
+    // Verify the new branch's commit before pointing a ref at it, scoping the check to what it
+    // adds over the default branch.
+    repositories::branches::verify_advance_to(
+        repo,
+        &data.commit_id,
+        constants::DEFAULT_BRANCH_NAME,
+    )
+    .await?;
+
     let new_branch = repositories::branches::create(repo, &data.new_name, &data.commit_id)?;
 
     Ok(HttpResponse::Ok().json(BranchResponse {
@@ -275,7 +284,11 @@ pub async fn update(
     let data: Result<BranchUpdate, serde_json::Error> = serde_json::from_str(&body);
     let data = data.map_err(|err| OxenHttpError::BadRequest(format!("{err:?}").into()))?;
 
-    let branch = repositories::branches::update(&repository, branch_name, data.commit_id)?;
+    // Don't advance the ref onto a commit whose newly-added objects aren't all present. Scope the
+    // check to what changed since the branch's current head.
+    repositories::branches::verify_advance_to(&repository, &data.commit_id, &branch_name).await?;
+
+    let branch = repositories::branches::update(&repository, &branch_name, data.commit_id)?;
 
     Ok(HttpResponse::Ok().json(BranchResponse {
         status: StatusMessage::resource_updated(),
@@ -330,6 +343,16 @@ pub async fn maybe_create_merge(
         .ok_or_else(|| OxenError::resource_not_found(&current_commit_id))?;
 
     log::debug!("maybe_create_merge got client head commit {incoming_commit_id:?}");
+
+    // Validate the incoming commit's added objects before merging it in, so the merge can't build
+    // a head missing reachable objects. Scope the check to what the client added over the
+    // current server head.
+    repositories::branches::verify_reachable_objects(
+        &repository,
+        Some(&current_commit),
+        &incoming_commit,
+    )
+    .await?;
 
     let merge_commit = match repositories::merge::merge_commit_into_base_on_branch(
         &repository,

--- a/crates/oxen-server/src/controllers/branches.rs
+++ b/crates/oxen-server/src/controllers/branches.rs
@@ -154,7 +154,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let data: Result<BranchNewFromBranchName, serde_json::Error> = serde_json::from_str(&body);
     if let Ok(data) = data {
         log::debug!("Create from branch!");
-        return create_from_branch(&repo, &data);
+        return create_from_branch(&repo, &data).await;
     }
 
     // Try to deserialize the body into a BranchNewFromCommitId
@@ -167,7 +167,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     Ok(HttpResponse::BadRequest().json(StatusMessage::error("Invalid request body")))
 }
 
-fn create_from_branch(
+async fn create_from_branch(
     repo: &LocalRepository,
     data: &BranchNewFromBranchName,
 ) -> Result<HttpResponse, OxenHttpError> {
@@ -185,6 +185,15 @@ fn create_from_branch(
 
     let from_branch = repositories::branches::get_by_name(repo, &data.from_name)
         .map_err(|_| OxenHttpError::NotFound)?;
+
+    // Verify the source branch's head before pointing a new ref at it, scoping the check to what it
+    // adds over the default branch.
+    repositories::branches::verify_advance_to(
+        repo,
+        &from_branch.commit_id,
+        constants::DEFAULT_BRANCH_NAME,
+    )
+    .await?;
 
     let new_branch = repositories::branches::create(repo, &data.new_name, from_branch.commit_id)?;
 

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -653,6 +653,28 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::NotFound().json(error_json)
                     }
+                    OxenError::ReachableObjectsMissing {
+                        missing_nodes,
+                        missing_versions,
+                    } => {
+                        log::warn!(
+                            "Refusing branch advance: commit references missing reachable objects ({missing_nodes} node(s), {missing_versions} blob(s))"
+                        );
+                        let error_json = json!({
+                            "error": {
+                                "type": "reachable_objects_missing",
+                                "title": "Commit references objects missing on server",
+                                "detail": format!(
+                                    "Refusing to advance the branch: the commit references {missing_nodes} merkle node(s) and {missing_versions} version blob(s) the server is missing. Re-push the missing objects with `oxen push --missing-files`."
+                                ),
+                                "missing_node_count": missing_nodes,
+                                "missing_version_count": missing_versions,
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
                     err => {
                         // Surface the error's message so unmapped variants return a real reason
                         // instead of a bare "internal_server_error" that lives only in the logs.

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -675,6 +675,24 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
+                    OxenError::DirHashIndexMissing { commit } => {
+                        log::warn!(
+                            "Refusing branch advance: commit {commit} is missing its directory index"
+                        );
+                        let error_json = json!({
+                            "error": {
+                                "type": "dir_hash_index_missing",
+                                "title": "Commit directory index missing on server",
+                                "detail": format!(
+                                    "Refusing to advance the branch: commit {commit} is missing its directory index on the server, so its tree can't be served by path. Re-push the commit to repopulate it."
+                                ),
+                                "commit": commit,
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
                     err => {
                         // Surface the error's message so unmapped variants return a real reason
                         // instead of a bare "internal_server_error" that lives only in the logs.


### PR DESCRIPTION
The server advanced a branch ref after checking only that the commit's metadata existed. Nothing verified that the merkle nodes and version blobs the commit references are present. A partial or interrupted push could move a ref onto a commit whose content the server lacks, and the gap stayed invisible until a later clone or pull failed on the missing object.

The server now verifies, before advancing a ref, that every object the commit adds relative to its base is present, and rejects the advance with an error reporting how many merkle nodes and version blobs are missing so the client can re-push the gap; the branch stays at its prior commit. This covers all three ref-advancing paths: fast-forward/force update, new-branch creation, and push-time merge.

ENG-1184