### PR TITLE
Fix ENOTEMPTY on NFS when combining downloaded file chunks

### DIFF
--- a/crates/liboxen/src/storage/local.rs
+++ b/crates/liboxen/src/storage/local.rs
@@ -368,6 +368,10 @@ impl VersionStore for LocalVersionStore {
                 .with_hash(expected_hash)
                 .stream(&mut combined)?;
 
+            // Close the chunk file handles before removing their directory. On NFS, unlinking a
+            // still-open file leaves a hidden .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
+            drop(combined);
+
             if chunks_dir.exists() {
                 std::fs::remove_dir_all(&chunks_dir)?;
             }
@@ -793,6 +797,37 @@ mod tests {
         // Get and verify the data
         let retrieved = store.get_version_chunk(&hash, offset, size).await.unwrap();
         assert_eq!(retrieved, data);
+    }
+
+    #[tokio::test]
+    async fn test_combine_version_chunks_reassembles_and_removes_chunks_dir() {
+        let (_temp_dir, store) = setup().await;
+        let data = b"chunk-zero-byteschunk-one-bytes";
+        let hash = hasher::hash_buffer(data);
+
+        // Split into two chunks stored at their byte offsets.
+        let split = 16;
+        store
+            .store_version_chunk(&hash, 0, Bytes::copy_from_slice(&data[..split]))
+            .await
+            .unwrap();
+        store
+            .store_version_chunk(&hash, split as u64, Bytes::copy_from_slice(&data[split..]))
+            .await
+            .unwrap();
+
+        let chunks_dir = store.version_chunks_dir(&hash);
+        assert!(chunks_dir.exists());
+
+        store.combine_version_chunks(&hash).await.unwrap();
+
+        // The reassembled version file matches the original bytes...
+        let version_path = store.version_path(&hash);
+        assert!(version_path.exists());
+        assert_eq!(store.get_version(&hash).await.unwrap(), data);
+
+        // ...and the chunks directory is removed.
+        assert!(!chunks_dir.exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
On an NFS-backed working directory (and probably on NTFS on Windows), `oxen clone` / `oxen pull` could fail with `Error: Directory not empty (os error 39)` while reassembling a large file from its downloaded chunks, aborting the whole operation. Retrying, `pull --missing-files`, `restore`, and `fsck` don't recover it: each attempt re-enters the same reassembly step and fails identically, leaving the repository effectively unclonable.

When combining chunks, the chunk files were still held open as chained readers at the moment their directory was removed. On NFS, unlinking a file that a process still has open triggers a rename to a hidden `.nfsXXXX` file rather than a real delete, so the follow-up `remove_dir_all` finds the directory non-empty and fails with `ENOTEMPTY`. This PR drops the readers to close the handles before removing the chunks directory. Local filesystems on linux/macOS unlink an open file cleanly, which is why this only surfaced on NFS.

I'm investigating adding some CI for NFS, specifically, to catch these sorts of issues in the future. I think the test I added covering chunk reassembly and cleanup would have caught this particular problem on NTFS on our existing Windows CI.