### PR TITLE
Align CodeRabbit config with Hub

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,35 +1,70 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-#
-# IMPORTANT: CodeRabbit reads this file from the BASE branch (e.g. main),
-# not from the PR branch. Merge this into your default branch first,
-# then open new PRs to see the changes take effect.
-
-language: "en-US"
-
 reviews:
-  # We want to generate a PR summary, but...
+  # more strict review profile
+  profile: "assertive"
+
+  # put high level summary in its own comment
+  # instead of editing your pr description
   high_level_summary: true
-
-  # don't edit the PR description.
-  # Instead, put it in CodeRabbit's own walkthrough comment.
   high_level_summary_in_walkthrough: true
-
-  # Clear the placeholder so that even if "@coderabbitai summary"
-  # appears in the PR description, CodeRabbit won't inject into it.
   high_level_summary_placeholder: ""
 
-  # Prevent CodeRabbit from auto-generating PR titles.
+  # also never auto edit titles
   auto_title_placeholder: ""
 
-  # Re-review on every push so the walkthrough comment stays current.
-  auto_review:
-    enabled: true
-    auto_incremental_review: true
-    # Review PRs against any base branch
-    base_branches:
-      - ".*"
+  # the pr-review channel takes care of this
+  suggested_reviewers: false
 
-  # Disable the docstring-coverage pre-merge check — it reports a misleading 0% for this repo.
+  # rust and python, no docstring coverage gate
   pre_merge_checks:
     docstrings:
       mode: "off"
+
+  # and disable the docstring generation checkbox
+  finishing_touches:
+    docstrings:
+      enabled: false
+
+  path_instructions:
+    - path: "**"
+      instructions: |
+        Do not comment about failing CI, it's already clear and visible.
+        Public repo: flag references to private Oxen repos or internal-only systems in user-facing text.
+    - path: "crates/liboxen/**"
+      instructions: |
+        Core library. New business logic belongs here before CLI/server wrappers.
+        Production code: no .unwrap()/.expect(); return OxenError. All disk writes via AtomicFile (util/fs.rs).
+        IO follows docs/async_policy.md: sync fs/DB inside spawn_blocking; no DB transactions across .await.
+        Symlinks: metadata.is_dir() not path.is_dir(); skip symlinks, never follow them.
+    - path: "crates/oxen-server/**"
+      instructions: |
+        Map inspectable OxenError variants to specific OxenHttpError; others to InternalServerError.
+        Server API operations must not touch a local checkout on disk.
+        New endpoints that supersede old ones: add alongside, register in docs/deprecations.md, remove later.
+    - path: "crates/oxen-cli/**"
+      instructions: |
+        Thin wrapper over liboxen. User-visible command/flag/output changes may need docs.oxen.ai updates (separate docs repo).
+    - path: "crates/oxen-py/**"
+      instructions: |
+        PyO3 bindings. Public API changes likely need matching oxen-python/ updates and bin/test-rust -p.
+    - path: "oxen-python/**"
+      instructions: |
+        Python package and pytest suite. Cross-check Rust binding changes in crates/oxen-py/.
+        Run bin/test-rust -p, not raw pytest without the script's server/build setup.
+    - path: "docs/**"
+      instructions: |
+        Policy docs (async_policy.md, deprecations.md, github_actions_pinning.md) are authoritative.
+    - path: ".github/workflows/**"
+      instructions: |
+        Actions are pinned by trust tier per docs/github_actions_pinning.md: version tags for first-party/high-trust orgs, full commit SHA with `# vX.Y.Z` comment for third-party.
+
+  # auto review new commits
+  # auto review draft PRs
+  # auto review against any base branch
+  # don't pause reviews on active PRs (default pauses after 5 commits)
+  auto_review:
+    enabled: true
+    drafts: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
+    base_branches:
+      - ".*"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,34 +28,6 @@ reviews:
     - path: "**"
       instructions: |
         Do not comment about failing CI, it's already clear and visible.
-        Public repo: flag references to private Oxen repos or internal-only systems in user-facing text.
-    - path: "crates/liboxen/**"
-      instructions: |
-        Core library. New business logic belongs here before CLI/server wrappers.
-        Production code: no .unwrap()/.expect(); return OxenError. All disk writes via AtomicFile (util/fs.rs).
-        IO follows docs/async_policy.md: sync fs/DB inside spawn_blocking; no DB transactions across .await.
-        Symlinks: metadata.is_dir() not path.is_dir(); skip symlinks, never follow them.
-    - path: "crates/oxen-server/**"
-      instructions: |
-        Map inspectable OxenError variants to specific OxenHttpError; others to InternalServerError.
-        Server API operations must not touch a local checkout on disk.
-        New endpoints that supersede old ones: add alongside, register in docs/deprecations.md, remove later.
-    - path: "crates/oxen-cli/**"
-      instructions: |
-        Thin wrapper over liboxen. User-visible command/flag/output changes may need docs.oxen.ai updates (separate docs repo).
-    - path: "crates/oxen-py/**"
-      instructions: |
-        PyO3 bindings. Public API changes likely need matching oxen-python/ updates and bin/test-rust -p.
-    - path: "oxen-python/**"
-      instructions: |
-        Python package and pytest suite. Cross-check Rust binding changes in crates/oxen-py/.
-        Run bin/test-rust -p, not raw pytest without the script's server/build setup.
-    - path: "docs/**"
-      instructions: |
-        Policy docs (async_policy.md, deprecations.md, github_actions_pinning.md) are authoritative.
-    - path: ".github/workflows/**"
-      instructions: |
-        Actions are pinned by trust tier per docs/github_actions_pinning.md: version tags for first-party/high-trust orgs, full commit SHA with `# vX.Y.Z` comment for third-party.
 
   # auto review new commits
   # auto review draft PRs


### PR DESCRIPTION
Rewrites `.coderabbit.yaml` to match OxenHub and oxen-model-backend: assertive profile, draft PR review, docstring checks off. Conventions stay in `.claude/CLAUDE.md`.