### PR TITLE
Fix ENOTEMPTY on NFS in the `oxen download` path

### DIFF
--- a/crates/liboxen/src/api/client/entries.rs
+++ b/crates/liboxen/src/api/client/entries.rs
@@ -669,6 +669,11 @@ pub async fn download_large_entry(
         AtomicFile::new(&local_path_for_blocking)
             .with_hash(expected_hash)
             .stream(&mut combined)?;
+
+        // Close the chunk file handles before removing their directory. On NFS, unlinking a
+        // still-open file leaves a hidden .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
+        drop(combined);
+
         if tmp_dir_for_cleanup.exists() {
             std::fs::remove_dir_all(&tmp_dir_for_cleanup)?;
         }


### PR DESCRIPTION
On an NFS working directory, `oxen download` of a large file could abort with `Error: Directory not empty (os error 39)`, blocking the download. This is the same NFS failure fixed for clone/pull in #706, just in a different subcommand.