### PR TITLE
CI: probe Windows runner for a Linux Docker engine (throwaway)

### DIFF
--- a/.github/workflows/windows_docker_probe.yml
+++ b/.github/workflows/windows_docker_probe.yml
@@ -1,0 +1,41 @@
+name: 🪟🐳 Windows Docker probe (throwaway)
+
+# Throwaway diagnostic: does the Windows CI runner expose a Linux Docker engine?
+# If it does, we can run the supported Linux oxen-server image as a test fixture
+# and keep the client push/pull suite on Windows against a supported server.
+# Delete this workflow (and its branch/PR) once the answer is recorded.
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-docker-probe:
+    name: Probe Linux-container support on the Windows runner
+    runs-on: windows-x64-8cpu-32ram-300ssd
+    defaults:
+      run:
+        shell: powershell
+    steps:
+      - name: Probe Docker / Linux-container support
+        continue-on-error: true
+        run: |
+          $ErrorActionPreference = 'Continue'
+          if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+            Write-Host "RESULT: docker CLI not installed on this runner"
+            exit 0
+          }
+          Write-Host "=== docker version ==="
+          docker version
+          Write-Host "=== docker info (OSType) ==="
+          $osType = (docker info --format '{{.OSType}}' 2>&1)
+          Write-Host "OSType = $osType"
+          Write-Host "=== attempt: run a linux/amd64 image (hello-world) ==="
+          docker run --rm hello-world
+          Write-Host "=== wsl status (a Linux engine usually rides on WSL2) ==="
+          wsl --status
+          Write-Host "RESULT: probe finished; read OSType and the hello-world result above"
+          exit 0


### PR DESCRIPTION
Determines whether our Windows CI runner (`windows-x64-8cpu-32ram-300ssd`) exposes a **Linux** Docker engine. The answer decides how we stop testing `oxen-server` on Windows now that it's no longer an officially supported server platform:

- **If a Linux engine is available**, we can run the supported Linux `oxen-server` image as a test fixture and keep the client push/pull suite running on Windows against a *supported* server — no per-test skips, no loss of client coverage.
- **If not** (the likely outcome — GitHub Actions service containers are Linux-runner-only, and Windows hosts default to Windows containers), we skip the server-dependent tests on Windows and keep only the local `liboxen` + CLI tests.

## What this PR does

Adds a self-contained, throwaway workflow (`.github/workflows/windows_docker_probe.yml`) with a single Windows job that:

- reports `docker version` and `docker info` `OSType`,
- attempts to run a `linux/amd64` image (`hello-world`),
- checks `wsl --status` (a Linux engine usually rides on WSL2).

It builds nothing and runs no tests, so it answers the question cheaply. The step is `continue-on-error` and exits 0 so the output is always visible.

Opened as a **draft** so the full `ci.yml` suite (which gates on `draft != true`) is skipped; only this probe runs.

## Next step

Read the probe output, record the answer, then close this PR and delete the branch/workflow.