### PR TITLE
Bump ffmpeg version

### DIFF
--- a/bin/install-ffmpeg
+++ b/bin/install-ffmpeg
@@ -39,7 +39,7 @@ if [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$want" ]; then
     exit 0
 fi
 
-tarball="ffmpeg-n${FFMPEG_VERSION}-${ff_arch}-lgpl-shared-${FFMPEG_BRANCH}.tar.xz"
+tarball="ffmpeg-n${FFMPEG_VERSION}${FFMPEG_BUILD_SUFFIX:-}-${ff_arch}-lgpl-shared-${FFMPEG_BRANCH}.tar.xz"
 url="https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_BTBN_TAG}/${tarball}"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT

--- a/tool-versions.env
+++ b/tool-versions.env
@@ -22,11 +22,16 @@ SHELLCHECK_VERSION=0.11.0
 # These pins are the single source read by bin/install-ffmpeg, which provisions FFmpeg for Linux
 # dev (bin/install-prereqs), the Dockerfiles, and the production-build CI. BtbN prunes old autobuild
 # releases over time; refresh the pin periodically, or mirror the asset to storage we control.
-FFMPEG_BTBN_TAG=autobuild-2026-06-23-13-52
+#
+# FFMPEG_BUILD_SUFFIX is the git-describe tail BtbN appends to the release-branch filenames once the
+# branch advances past its tag (e.g. `-22-g94138f6973` for 22 commits past n8.1.2). Leave it empty
+# when the branch tip sits exactly on the tag.
+FFMPEG_BTBN_TAG=autobuild-2026-07-08-13-30
 FFMPEG_VERSION=8.1.2
+FFMPEG_BUILD_SUFFIX=-22-g94138f6973
 FFMPEG_BRANCH=8.1
-FFMPEG_SHA256_LINUX_X86_64=8b1a22f1285a6ddb9a52abbc1a8abc0e4fa5076d038a2beaaacb1711a6442897
-FFMPEG_SHA256_LINUX_AARCH64=d4c9dd4dcd8b349f0204f7b3f31ecf5cc96b229167ac08e38c570605956838d2
+FFMPEG_SHA256_LINUX_X86_64=9d9de50c45777c84721719f281618e6e6ea387f02815a75d8eb97a2910c7e19f
+FFMPEG_SHA256_LINUX_AARCH64=8f6bd90024beb2bd2ee3bcae1e0f8c9a61f2bda41487cbc3fddfe55029b364d4
 
 # Python tools (installed via uvx / uv tool)
 RUFF_VERSION=0.15.13


### PR DESCRIPTION
We're building off of ffmpeg nightly builds, which are only stored for a limited amount of time before being taken down.

This PR bumps to the latest build.

I will be downloading and storing the builds we use somewhere and then in a followup PR I'll point CI to download from our durable storage.