### PR TITLE
Remove the 10-minute client timeout

### DIFF
--- a/crates/liboxen/src/api/client.rs
+++ b/crates/liboxen/src/api/client.rs
@@ -4,7 +4,6 @@
 use crate::config::AuthConfig;
 use crate::config::RuntimeConfig;
 use crate::config::runtime_config::runtime::Runtime;
-use crate::constants;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
 use crate::view::OxenResponse;
@@ -14,7 +13,6 @@ use reqwest::retry;
 use reqwest::{Client, ClientBuilder, header};
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
-use std::time;
 
 pub mod branches;
 pub mod commits;
@@ -90,9 +88,7 @@ fn new_for_host(host: String, should_add_user_agent: bool) -> Result<Client, Oxe
 
     // Slow path: build outside the write lock so concurrent first-time callers
     // for *different* hosts don't serialize on one mutex.
-    let client = builder_for_host(host, should_add_user_agent)?
-        .timeout(time::Duration::from_secs(constants::timeout()))
-        .build()?;
+    let client = builder_for_host(host, should_add_user_agent)?.build()?;
 
     // Double-check under the write lock; another thread may have inserted while we built.
     let mut cache = CLIENT_CACHE

--- a/crates/liboxen/src/api/client/tree.rs
+++ b/crates/liboxen/src/api/client/tree.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time;
 use tokio_util::io::{ReaderStream, StreamReader, SyncIoBridge};
 
 use crate::api;
@@ -116,9 +115,7 @@ pub async fn create_nodes(
 
     let uri = "/tree/nodes".to_string();
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
-    let client = client::builder_for_url(&url)?
-        .timeout(time::Duration::from_secs(120))
-        .build()?;
+    let client = client::builder_for_url(&url)?.build()?;
     log::debug!("uploading {n} nodes to {url}");
 
     let res = client
@@ -375,9 +372,7 @@ async fn node_download_request(
 ) -> Result<(), OxenError> {
     let url = url.as_ref();
 
-    let client = client::builder_for_url(url)?
-        .timeout(time::Duration::from_secs(12000))
-        .build()?;
+    let client = client::builder_for_url(url)?.build()?;
     log::debug!("node_download_request sending request {url}");
     let res = client.get(url).send().await?;
     let res = client::handle_non_json_response(url, res).await?;

--- a/crates/liboxen/src/constants.rs
+++ b/crates/liboxen/src/constants.rs
@@ -202,8 +202,6 @@ pub const NUM_HTTP_RETRIES: u64 = 1;
 pub const NUM_HTTP_RETRIES: u64 = 5;
 /// Number of workers
 pub const DEFAULT_NUM_WORKERS: usize = 8;
-/// Default timeout for HTTP requests
-pub const DEFAULT_TIMEOUT_SECS: u64 = 600;
 /// Default vnode size
 pub const DEFAULT_VNODE_SIZE: u64 = 10_000;
 
@@ -237,22 +235,6 @@ pub fn max_retries() -> usize {
     } else {
         // Environment variable not set, use default
         NUM_HTTP_RETRIES.try_into().unwrap()
-    }
-}
-
-// Parse the timeout for http requests from environment variable
-pub fn timeout() -> u64 {
-    if let Ok(timeout) = std::env::var("OXEN_TIMEOUT_SECS") {
-        // If the environment variable is set, use that
-        if let Ok(timeout) = timeout.parse::<u64>() {
-            timeout
-        } else {
-            // If parsing failed, fall back to default
-            DEFAULT_TIMEOUT_SECS
-        }
-    } else {
-        // Environment variable not set, use default
-        DEFAULT_TIMEOUT_SECS
     }
 }
 


### PR DESCRIPTION
All client requests had a 10-minute timeout. That's unnecessary. Some operations take longer than 10 minutes, and we make the server--which should always either complete or have it's own timeouts. No need for a client timeout at this point.