### PR TITLE
Bump to Rust 1.97.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"
+
+[target.aarch64-apple-darwin]
+# Suppress compact unwind linker warnings on macOS for aarch64 -- they're harmless
+rustflags = ["-C", "link-args=-Wl,-no_compact_unwind"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"

--- a/bin/install-prereqs
+++ b/bin/install-prereqs
@@ -202,7 +202,7 @@ install_cargo_tool() {
     fi
 }
 
-install_cargo_tool bacon          bacon          "$BACON_VERSION"
+install_cargo_tool bacon          bacon          "$BACON_VERSION"        "--locked"
 install_cargo_tool cargo-machete  cargo-machete  "$CARGO_MACHETE_VERSION"
 install_cargo_tool cargo-llvm-cov cargo-llvm-cov "$CARGO_LLVM_COV_VERSION"
 install_cargo_tool cargo-sort     cargo-sort     "$CARGO_SORT_VERSION"

--- a/crates/liboxen/src/core/df/tabular.rs
+++ b/crates/liboxen/src/core/df/tabular.rs
@@ -1101,7 +1101,7 @@ async fn _read_lazy_df_with_extension(
             return Err(OxenError::entry_does_not_exist(&path));
         }
 
-        log::debug!("Reading df with extension {:?} {:?}", &extension, &path);
+        log::debug!("Reading df with extension {:?} {:?}", extension, path);
 
         match extension.as_str() {
             "ndjson" | "jsonl" => read_df_jsonl(&path),

--- a/crates/liboxen/src/core/v_latest/branches.rs
+++ b/crates/liboxen/src/core/v_latest/branches.rs
@@ -274,7 +274,7 @@ pub async fn checkout_subtrees(
             for file_to_restore in results.files_to_restore {
                 log::debug!("file_to_restore: {:?}", file_to_restore.file_node);
                 // In remote-mode repos, only restore files that are present in version store
-                let file_hash = format!("{}", &file_to_restore.file_node.hash());
+                let file_hash = format!("{}", file_to_restore.file_node.hash());
                 if version_store.version_exists(&file_hash).await? {
                     restore::restore_file(
                         repo,

--- a/crates/liboxen/src/core/v_latest/fetch.rs
+++ b/crates/liboxen/src/core/v_latest/fetch.rs
@@ -915,7 +915,7 @@ async fn download_large_entries(
     );
     let mut handles = vec![];
     let tmp_dir = util::fs::oxen_hidden_dir(dst).join("tmp").join("pulled");
-    log::debug!("Backing up pulls to tmp dir: {:?}", &tmp_dir);
+    log::debug!("Backing up pulls to tmp dir: {:?}", tmp_dir);
     for worker in 0..worker_count {
         let queue = queue.clone();
         let progress_bar = Arc::clone(progress_bar);

--- a/crates/liboxen/src/core/v_latest/merge.rs
+++ b/crates/liboxen/src/core/v_latest/merge.rs
@@ -1141,7 +1141,7 @@ pub fn lowest_common_ancestor_from_commits(
     let mut has_common_ancestor = false;
     let mut min_depth = usize::MAX;
     let mut lca: Commit = commit_depths_from_head.keys().next().unwrap().clone();
-    for (commit, _) in commit_depths_from_merge.iter() {
+    for commit in commit_depths_from_merge.keys() {
         if let Some(depth) = commit_depths_from_head.get(commit) {
             has_common_ancestor = true;
 

--- a/crates/liboxen/src/core/v_latest/push.rs
+++ b/crates/liboxen/src/core/v_latest/push.rs
@@ -148,7 +148,7 @@ async fn push_to_existing_branch(
                 // Force push: push the full history and update the branch pointer
                 log::info!(
                     "Force pushing branch '{}' to {}",
-                    &remote_branch.name,
+                    remote_branch.name,
                     commit.id
                 );
                 let latest_remote_commit = find_latest_remote_commit(repo, remote_repo).await?;

--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -86,7 +86,7 @@ async fn commit_inner(
         }
         Err(e) => return Err(e),
     };
-    log::debug!("commit looking up branch: {:#?}", &branch);
+    log::debug!("commit looking up branch: {:#?}", branch);
 
     let staged_db_path = util::fs::oxen_hidden_dir(&workspace.workspace_repo.path).join(STAGED_DIR);
 

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames/rows.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames/rows.rs
@@ -251,7 +251,7 @@ pub async fn prepare_modified_or_removed_row(
 
     log::debug!(
         "prepare_modified_or_removed_row() commit_merkle_tree: {:?}",
-        &commit_merkle_tree.hash.to_string()
+        commit_merkle_tree.hash.to_string()
     );
 
     // let scan_rows = 10000 as usize;

--- a/crates/liboxen/src/core/v_latest/workspaces/files.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/files.rs
@@ -744,7 +744,7 @@ async fn fetch_file(
             log::debug!("file::import add file ✅ success! staged file {path:?}");
         }
     } else {
-        log::debug!("file::import add file {:?}", &filepath);
+        log::debug!("file::import add file {:?}", filepath);
         let path = repositories::workspaces::files::add(workspace, &save_path).await?;
         log::debug!("file::import add file ✅ success! staged file {path:?}");
     }

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -755,10 +755,9 @@ impl OxenError {
                 if req_err.is_connect() || req_err.is_timeout() {
                     "Check your internet connection and that the remote host is reachable."
                 } else if req_err.is_status() {
-                    if let Some(status) = req_err.status() {
+                    {
+                        let status = req_err.status()?;
                         return Some(format!("Server returned HTTP {status}."));
-                    } else {
-                        return None;
                     }
                 } else {
                     "Check your internet connection and remote configuration with `oxen remote -v`."

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -987,7 +987,7 @@ fn get_children(
     let dir_path = dir_path.as_ref().to_path_buf();
     let mut children = vec![];
 
-    for (path, _) in entries.iter() {
+    for path in entries.keys() {
         if path.starts_with(&dir_path) {
             children.push(path.clone());
         }

--- a/crates/liboxen/src/repositories/remote_mode/commit.rs
+++ b/crates/liboxen/src/repositories/remote_mode/commit.rs
@@ -176,7 +176,7 @@ mod tests {
                     .await?;
                     status.print();
 
-                    let commit_message = format!("Adding {}", &filename);
+                    let commit_message = format!("Adding {}", filename);
                     let commit_body =
                         NewCommitBody::from_config(&UserConfig::get()?, &commit_message);
 

--- a/crates/liboxen/src/repositories/rm.rs
+++ b/crates/liboxen/src/repositories/rm.rs
@@ -1008,7 +1008,7 @@ mod tests {
             status.print();
 
             assert_eq!(status.staged_files.len(), og_num_files);
-            for (_, staged_entry) in status.staged_files.iter() {
+            for staged_entry in status.staged_files.values() {
                 assert_eq!(staged_entry.status, StagedEntryStatus::Removed);
             }
 
@@ -1043,7 +1043,7 @@ mod tests {
             status.print();
 
             assert_eq!(status.staged_files.len(), og_num_files);
-            for (_, staged_entry) in status.staged_files.iter() {
+            for staged_entry in status.staged_files.values() {
                 assert_eq!(staged_entry.status, StagedEntryStatus::Removed);
             }
 
@@ -1070,7 +1070,7 @@ mod tests {
             status.print();
 
             assert_eq!(status.staged_files.len(), og_num_files);
-            for (_, staged_entry) in status.staged_files.iter() {
+            for staged_entry in status.staged_files.values() {
                 assert_eq!(staged_entry.status, StagedEntryStatus::Removed);
             }
 

--- a/crates/liboxen/src/repositories/workspaces/data_frames/embeddings.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames/embeddings.rs
@@ -371,7 +371,7 @@ pub fn nearest_neighbors(
             let sql = format!("{base_sql} LIMIT {limit} OFFSET {offset}");
 
             // Print just the first 50 characters of the query
-            log::debug!("Executing similarity query: {}", &sql);
+            log::debug!("Executing similarity query: {}", sql);
 
             let result_set: Vec<RecordBatch> = conn.prepare(&sql)?.query_arrow([])?.collect();
             Ok((result_set, schema))

--- a/crates/liboxen/src/test.rs
+++ b/crates/liboxen/src/test.rs
@@ -844,7 +844,7 @@ where
     };
     let files: Vec<FileNew> = vec![FileNew {
         path: PathBuf::from("README.md"),
-        contents: FileContents::Text(format!("# {}\n", &name)),
+        contents: FileContents::Text(format!("# {}\n", name)),
         user: user.clone(),
     }];
     let mut repo = RepoNew::from_files(namespace, &name, files, None);

--- a/crates/oxen-cli/src/cmd/branch.rs
+++ b/crates/oxen-cli/src/cmd/branch.rs
@@ -92,7 +92,7 @@ impl RunCmd for BranchCmd {
 
         // Parse Args
         if let Some((cmd, _)) = args.subcommand() {
-            return Err(UnknownSubcommand {
+            Err(UnknownSubcommand {
                 parent: "branch",
                 name: cmd.to_string(),
             })?;
@@ -237,7 +237,7 @@ impl BranchCmd {
 
         let branches = api::client::branches::list(&remote_repo).await?;
         for branch in branches.iter() {
-            println!("{}\t{}", &remote.name, branch.name);
+            println!("{}\t{}", remote.name, branch.name);
         }
         Ok(())
     }

--- a/crates/oxen-cli/src/cmd/migrate.rs
+++ b/crates/oxen-cli/src/cmd/migrate.rs
@@ -109,7 +109,7 @@ impl RunCmd for MigrateCmd {
                     for (repo_path, error) in errored {
                         println!("\t[FAIL] \"{}\" due to: {error}", repo_path.display());
                     }
-                    return Err(OxenError::MigrationFailed)?;
+                    Err(OxenError::MigrationFailed)?;
                 }
             } else {
                 let mr = try_apply_migration(

--- a/crates/oxen-cli/src/cmd/workspace/df/get.rs
+++ b/crates/oxen-cli/src/cmd/workspace/df/get.rs
@@ -126,7 +126,7 @@ impl RunCmd for WorkspaceDFGetCmd {
                 }
             }
             Err(e) => {
-                return Err(e)?;
+                Err(e)?;
             }
         }
 

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -161,7 +161,7 @@ impl PyRemoteRepo {
                 let user = config.to_user();
                 let files: Vec<FileNew> = vec![FileNew {
                     path: PathBuf::from("README.md"),
-                    contents: FileContents::Text(format!("# {}\n", &self.repo.name)),
+                    contents: FileContents::Text(format!("# {}\n", self.repo.name)),
                     user: user.clone(),
                 }];
                 let mut repo =

--- a/crates/oxen-server/src/controllers/branches.rs
+++ b/crates/oxen-server/src/controllers/branches.rs
@@ -444,7 +444,7 @@ pub async fn list_entry_versions(
             match maybe_schema {
                 Some(schema) => Some(schema.hash),
                 None => {
-                    log::error!("Could not get schema for tabular file {:?}", &path);
+                    log::error!("Could not get schema for tabular file {:?}", path);
                     None
                 }
             }

--- a/crates/oxen-server/src/controllers/commits.rs
+++ b/crates/oxen-server/src/controllers/commits.rs
@@ -376,7 +376,7 @@ pub async fn mark_commits_as_synced(
     // until we delete this endpoint entirely in the near future as part of ENG-994
     log::debug!(
         "mark_commits_as_synced received {} commit hashes (no-op)",
-        &hashes.len()
+        hashes.len()
     );
     Ok(HttpResponse::Ok().json(MerkleHashesResponse {
         status: StatusMessage::resource_found(),

--- a/crates/oxen-server/src/controllers/file.rs
+++ b/crates/oxen-server/src/controllers/file.rs
@@ -333,9 +333,8 @@ pub async fn put(
     let commit_body = NewCommitBody {
         author: name.unwrap_or_default(),
         email: email.unwrap_or_default(),
-        message: message.unwrap_or_else(|| {
-            format!("Auto-commit files to {}", &resource.path.to_string_lossy())
-        }),
+        message: message
+            .unwrap_or_else(|| format!("Auto-commit files to {}", resource.path.to_string_lossy())),
     };
 
     let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;
@@ -407,7 +406,7 @@ pub async fn delete(
         email: email.clone().unwrap_or("".to_string()),
         message: message
             .clone()
-            .unwrap_or(format!("Remove {}", &path.to_string_lossy())),
+            .unwrap_or(format!("Remove {}", path.to_string_lossy())),
     };
 
     let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;

--- a/crates/oxen-server/src/controllers/import.rs
+++ b/crates/oxen-server/src/controllers/import.rs
@@ -196,7 +196,7 @@ pub async fn import(
         author: user.name,
         email: user.email,
         message: message
-            .unwrap_or_else(|| format!("Import files to {}", &resource.path.to_string_lossy())),
+            .unwrap_or_else(|| format!("Import files to {}", resource.path.to_string_lossy())),
     };
 
     let commit = repositories::workspaces::commit(&workspace, &commit_body, branch.name).await?;

--- a/crates/oxen-server/src/controllers/versions.rs
+++ b/crates/oxen-server/src/controllers/versions.rs
@@ -296,7 +296,7 @@ pub async fn stream_versions_tar_gz(
                     }
                     log::info!(
                         "Successfully appended data to tarball for hash: {}",
-                        &file_hash
+                        file_hash
                     );
                 }
                 Err(e) => {
@@ -445,7 +445,7 @@ pub async fn stream_versions_zip(
                         break;
                     }
 
-                    log::info!("Successfully appended data to zip for hash: {}", &hash);
+                    log::info!("Successfully appended data to zip for hash: {}", hash);
                 }
                 Err(e) => {
                     log::error!("Failed to get version {hash}: {e}");

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -87,7 +87,7 @@ pub async fn get(
     };
 
     let path = path_param(&req, "path")?.to_string();
-    log::debug!("got workspace file path {:?}", &path);
+    log::debug!("got workspace file path {:?}", path);
 
     // First, look for the file in the workspace staged_db
     let staged_db_manager = get_staged_db_manager(&workspace.workspace_repo)?;
@@ -545,7 +545,7 @@ pub async fn save_parts(
                     Ok(Err(e)) => {
                         log::error!(
                             "Failed to decompress data for file {}: {:?}",
-                            &upload_filename,
+                            upload_filename,
                             e
                         );
                         record_error_file(
@@ -559,7 +559,7 @@ pub async fn save_parts(
                     Err(e) => {
                         log::error!(
                             "Failed to execute blocking decompression task for file {}: {}",
-                            &upload_filename,
+                            upload_filename,
                             e
                         );
                         record_error_file(
@@ -581,12 +581,12 @@ pub async fn save_parts(
                         hash: upload_filehash.to_string(),
                         path: upload_filename.into(),
                     });
-                    log::info!("Successfully stored version for hash: {}", &upload_filehash);
+                    log::info!("Successfully stored version for hash: {}", upload_filehash);
                 }
                 Err(e) => {
                     log::error!(
                         "Failed to store version for hash {}: {}",
-                        &upload_filehash,
+                        upload_filehash,
                         e
                     );
                     record_error_file(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.0"


### PR DESCRIPTION
- Bump to Rust 1.97.0
- Fix harmless linker warning by adding config to `.cargo/config.toml` to ignore it
- Bump deep dependency `ethnum` from `1.5.2` to `1.5.3` to resolve undefined behavior which Rust 1.97.0 doesn't allow
- Everything else is just fixes for new clippy lints