### PR TITLE
Repo Integrity (1.12): Make `push --revalidate` also repair missing blobs

### DIFF
--- a/crates/liboxen/src/core/v_latest/push.rs
+++ b/crates/liboxen/src/core/v_latest/push.rs
@@ -191,7 +191,7 @@ async fn revalidate_and_push_missing_files(
         clean_result.cleaned,
         humantime::format_duration(clean_result.elapsed)
     );
-    if clean_result.corrupted > clean_result.cleaned || clean_result.errors > clean_result.cleaned {
+    if clean_result.corrupted > clean_result.cleaned || clean_result.errors > 0 {
         println!(
             "🚧 This fix is not complete. Some files may still be corrupted. Please try running this command again."
         );

--- a/crates/liboxen/src/core/v_latest/push.rs
+++ b/crates/liboxen/src/core/v_latest/push.rs
@@ -173,7 +173,7 @@ async fn push_to_existing_branch(
     Ok(())
 }
 
-// delete corrupted version files and push again
+// Clean up any corrupted version files on the remote, then re-push whatever it's still missing.
 async fn revalidate_and_push_missing_files(
     repo: &LocalRepository,
     opts: &PushOpts,
@@ -184,31 +184,23 @@ async fn revalidate_and_push_missing_files(
     println!("🐂 revalidating the remote repo...");
     let response = api::client::versions::clean(remote_repo).await?;
     let clean_result = response.result;
-    if clean_result.corrupted > 0 {
+    println!(
+        "🔍 scanned {} files, found {} corrupted files, cleaned {} of them. Scanning took {}",
+        clean_result.scanned,
+        clean_result.corrupted,
+        clean_result.cleaned,
+        humantime::format_duration(clean_result.elapsed)
+    );
+    if clean_result.corrupted > clean_result.cleaned || clean_result.errors > clean_result.cleaned {
         println!(
-            "🔍 scanned {} files, found {} corrupted files, cleaned {} of them. Scanning took {}",
-            clean_result.scanned,
-            clean_result.corrupted,
-            clean_result.cleaned,
-            humantime::format_duration(clean_result.elapsed)
+            "🚧 This fix is not complete. Some files may still be corrupted. Please try running this command again."
         );
-        println!("🐂 pushing missing files...");
-        if clean_result.corrupted > clean_result.cleaned
-            || clean_result.errors > clean_result.cleaned
-        {
-            println!(
-                "🚧 This fix is not complete. Some files may still be corrupted. Please try running this command again."
-            );
-        }
-        return push_missing_files(repo, opts, remote_repo, latest_remote_commit, commits).await;
-    } else {
-        println!(
-            "🔍 scanned {} files, no corrupted files found. Scanning took {}",
-            clean_result.scanned,
-            humantime::format_duration(clean_result.elapsed)
-        );
-        Ok(())
     }
+
+    // Re-push regardless of the corrupted count: `clean` only turns corrupt-but-present blobs into
+    // absent ones, and a blob that was absent to begin with needs the same re-push.
+    println!("🐂 checking for missing files...");
+    push_missing_files(repo, opts, remote_repo, latest_remote_commit, commits).await
 }
 
 async fn push_missing_files(

--- a/crates/liboxen/src/repositories/push.rs
+++ b/crates/liboxen/src/repositories/push.rs
@@ -1680,4 +1680,63 @@ A: Checkout Oxen.ai
         })
         .await
     }
+
+    // `oxen push --revalidate` must re-push a blob the remote is simply MISSING, not only one that
+    // is corrupt-but-present. `versions::clean` reports zero corrupted for an absent blob, so the
+    // repair used to no-op on the common case.
+    #[tokio::test]
+    async fn test_revalidate_repushes_a_missing_blob() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async {
+            let mut repo = repo;
+
+            let path = repo.path.join("a.txt");
+            test::write_txt_file_to_path(&path, "alpha")?;
+            repositories::add(&repo, &path).await?;
+            let commit = repositories::commit(&repo, "add a.txt")?;
+
+            let remote = test::repo_remote_url_from(&repo.dirname());
+            command::config::set_remote(&mut repo, DEFAULT_REMOTE_NAME, &remote)?;
+            let remote_repo = test::create_remote_repo(&repo).await?;
+            repositories::push(&repo).await?;
+
+            // The server loses a.txt's blob — absent, not corrupt.
+            let hash = repositories::tree::get_node_by_path(&repo, &commit, "a.txt")?
+                .expect("a.txt in commit")
+                .file()?
+                .hash()
+                .to_string();
+            let sync_dir =
+                PathBuf::from(std::env::var("SYNC_DIR").expect("SYNC_DIR set by bin/test-rust"));
+            let server = repositories::get_by_namespace_and_name(
+                &sync_dir,
+                constants::DEFAULT_NAMESPACE,
+                repo.dirname(),
+                None,
+            )?
+            .expect("server repo exists");
+            server.version_store().delete_version(&hash).await?;
+            assert!(
+                !server.version_store().version_exists(&hash).await?,
+                "precondition: the blob should be gone from the server"
+            );
+
+            // clean finds nothing corrupt (the blob is absent), but revalidate must still re-push it.
+            let opts = PushOpts {
+                remote: DEFAULT_REMOTE_NAME.to_string(),
+                branch: DEFAULT_BRANCH_NAME.to_string(),
+                revalidate: true,
+                ..Default::default()
+            };
+            repositories::push::push_remote_branch(&repo, &opts).await?;
+
+            assert!(
+                server.version_store().version_exists(&hash).await?,
+                "revalidate must re-push the missing blob"
+            );
+
+            api::client::repositories::delete(&remote_repo).await?;
+            Ok(())
+        })
+        .await
+    }
 }

--- a/crates/oxen-cli/src/cmd/push.rs
+++ b/crates/oxen-cli/src/cmd/push.rs
@@ -47,6 +47,9 @@ impl RunCmd for PushCmd {
                     .num_args(0..=1)
                     .value_name("COMMIT_ID")
                     .default_missing_value("true")
+                    // Whole-store clean + a commit-scoped re-push would delete corrupt files
+                    // everywhere but only re-push one commit's — leaving others missing.
+                    .conflicts_with("revalidate")
             )
             .arg(
                 Arg::new("revalidate")

--- a/crates/oxen-cli/src/cmd/push.rs
+++ b/crates/oxen-cli/src/cmd/push.rs
@@ -43,7 +43,7 @@ impl RunCmd for PushCmd {
             .arg(
                 Arg::new("missing-files")
                     .long("missing-files")
-                    .help("Push files missing from server (useful in case of a failed push). Optionally specify a commit id to push files from.")
+                    .help("Re-upload files the remote is missing — a fast repair after a failed push. Detects absence only, not corrupt-but-present files (use --revalidate for that). Optionally give a commit id to scope which files are pushed.")
                     .num_args(0..=1)
                     .value_name("COMMIT_ID")
                     .default_missing_value("true")
@@ -51,7 +51,7 @@ impl RunCmd for PushCmd {
             .arg(
                 Arg::new("revalidate")
                     .long("revalidate")
-                    .help("Revalidate file hashes on remote and push any missing files.")
+                    .help("Full integrity repair: re-hash every file on the remote, delete any that are corrupt, then re-upload all missing files. Slower than --missing-files but also fixes corruption, not just absence.")
                     .action(clap::ArgAction::SetTrue)
             )
             .arg(


### PR DESCRIPTION
`oxen push --revalidate` only re-uploaded files when the server's integrity scan reported corrupt-but-present blobs. A blob that was simply absent was never counted as corrupted, so the the command wouldn't push those files.

It now re-pushes whatever the remote reports as missing or corrupted. Also, the pre-push message no longer claims to be "pushing missing files" before the server negotiation has determined that there are any.

ENG-1185.