### PR TITLE
Streamline Tests (12.5): weak-ref cache for dir_hashes_db

### DIFF
--- a/crates/liboxen/src/core/db/dir_hashes/dir_hashes_db.rs
+++ b/crates/liboxen/src/core/db/dir_hashes/dir_hashes_db.rs
@@ -4,31 +4,28 @@ use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository};
 use crate::util;
 
-use lru::LruCache;
+use parking_lot::{Mutex, RwLock};
 use rocksdb::{DBWithThreadMode, MultiThreaded};
 use std::collections::HashMap;
-use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock, Mutex, RwLock};
+use std::sync::{Arc, LazyLock, Weak};
 
-const DB_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
-
-/// Paired-lock cache for per-commit `dir_hash_db` RocksDB handles. The two fields solve
-/// disjoint problems — see each field. A single process-global instance ([`CACHE`]) is used;
-/// the public free functions below just delegate into it.
+/// Paired cache for per-commit `dir_hash_db` RocksDB handles. The two fields solve disjoint
+/// problems — see each field. A single process-global instance ([`CACHE`]) is used; the public
+/// free functions below just delegate into it.
 struct DirHashDbCache {
-    /// LRU of open RocksDB handles. Every access takes `.write()` briefly — `get` on a hit
-    /// (which bumps LRU recency and so requires `&mut`) or `put` on a miss. The inner
-    /// `Arc<DB>` lets the caller clone-and-release the lock quickly so the actual RocksDB
-    /// operation runs outside the cache lock.
-    handles: RwLock<LruCache<PathBuf, Arc<DBWithThreadMode<MultiThreaded>>>>,
+    /// Weak-ref registry of open read-only DB handles. The strong `Arc<DB>` lives only as long
+    /// as some [`with_reader`](DirHashDbCache::with_reader) call holds it; when the last caller
+    /// drops, RocksDB closes and the entry becomes a tombstone that the next opener prunes.
+    /// There is no capacity cap, so an in-use entry can never be evicted — every concurrent
+    /// reader of the same commit shares one handle instead of accumulating parallel RO opens.
+    handles: Mutex<HashMap<PathBuf, Weak<DBWithThreadMode<MultiThreaded>>>>,
 
-    /// Per-repo rebuild barriers. Readers of a repo's dir_hash_db hold `.read()` across
-    /// their whole operation; rebuilders take `.write()`. When the rebuilder gets the write
-    /// guard, every outstanding reader of *this repo* has released its cloned `Arc<DB>`,
-    /// so popping the cache entry drops the last reference and closes the RocksDB — which
-    /// Windows requires before `rename` on the directory will succeed. Rebuilds in other
-    /// repos are not blocked.
+    /// Per-repo rebuild barriers. Readers of a repo's dir_hash_db hold `.read()` across their
+    /// whole operation; rebuilders take `.write()`. When the rebuilder gets the write guard,
+    /// every outstanding reader of *this repo* has released its cloned `Arc<DB>`, so the
+    /// underlying RocksDB has already closed on that last drop — which Windows requires before
+    /// `rename` on the directory will succeed. Rebuilds in other repos are not blocked.
     ///
     /// Entries are never removed from the map; one entry per repo-path ever touched this
     /// process, ~40 bytes each, which is negligible for any realistic workload. The outer
@@ -37,27 +34,26 @@ struct DirHashDbCache {
 }
 
 static CACHE: LazyLock<DirHashDbCache> = LazyLock::new(|| DirHashDbCache {
-    handles: RwLock::new(LruCache::new(DB_CACHE_SIZE)),
+    handles: Mutex::new(HashMap::new()),
     rebuild_barriers: Mutex::new(HashMap::new()),
 });
 
 impl DirHashDbCache {
     /// Get or create the rebuild barrier for a repo, keyed by repo path.
-    fn barrier_for(&self, repo_path: &Path) -> Result<Arc<RwLock<()>>, OxenError> {
-        let mut map = self
-            .rebuild_barriers
-            .lock()
-            .map_err(|e| OxenError::LockPoisoned(format!("dir_hash_db barriers: {e}").into()))?;
-        Ok(map
-            .entry(repo_path.to_path_buf())
+    fn barrier_for(&self, repo_path: &Path) -> Arc<RwLock<()>> {
+        let mut map = self.rebuild_barriers.lock();
+        if let Some(barrier) = map.get(repo_path) {
+            return barrier.clone();
+        }
+        map.entry(repo_path.to_path_buf())
             .or_insert_with(|| Arc::new(RwLock::new(())))
-            .clone())
+            .clone()
     }
 
     /// Run `operation` against the cached RocksDB for a commit, opening it read-only on first
-    /// access. Holds this repo's rebuild barrier as a reader across the closure so an
-    /// in-flight rebuilder of *this repo* waits for the operation (and its cloned `Arc<DB>`)
-    /// to finish before proceeding. Rebuilds in other repos are unaffected.
+    /// access. Holds this repo's rebuild barrier as a reader across the closure so an in-flight
+    /// rebuilder of *this repo* waits for the operation (and its cloned `Arc<DB>`) to finish
+    /// before proceeding. Rebuilds in other repos are unaffected.
     fn with_reader<F, T>(
         &self,
         repository: &LocalRepository,
@@ -67,95 +63,71 @@ impl DirHashDbCache {
     where
         F: FnOnce(&DBWithThreadMode<MultiThreaded>) -> Result<T, OxenError>,
     {
-        let barrier = self.barrier_for(&repository.path)?;
-        let _barrier_guard = barrier
-            .read()
-            .map_err(|e| OxenError::LockPoisoned(format!("dir_hash_db access: {e}").into()))?;
+        let barrier = self.barrier_for(&repository.path);
+        let _barrier_guard = barrier.read();
 
-        let dir_hashes_db = {
-            let dir_hashes_db_dir = dir_hash_db_path_from_commit_id(repository, commit_id);
-
-            // `get` rather than `peek` so cache hits bump the entry's LRU recency. That needs
-            // `&mut` on the cache, hence `.write()` for every access (hit or miss). The clone
-            // is cheap and the write guard drops before `operation` runs, so the actual
-            // RocksDB work happens outside the cache lock.
-            let mut cache_w = self
-                .handles
-                .write()
-                .map_err(|e| OxenError::LockPoisoned(format!("dir_hash_db LRU: {e}").into()))?;
-
-            if let Some(db) = cache_w.get(&dir_hashes_db_dir) {
-                Arc::clone(db)
-            } else {
-                if !dir_hashes_db_dir.exists() {
-                    return Err(OxenError::path_does_not_exist(&dir_hashes_db_dir));
-                }
-
-                let opts = db::key_val::opts::default();
-                let dir_hashes_db: DBWithThreadMode<MultiThreaded> =
-                    DBWithThreadMode::open_for_read_only(&opts, &dir_hashes_db_dir, false)?;
-
-                let db = Arc::new(dir_hashes_db);
-                cache_w.put(dir_hashes_db_dir, db.clone());
-                db
-            }
-        };
-
+        let dir_hashes_db_dir = dir_hash_db_path_from_commit_id(repository, commit_id);
+        let dir_hashes_db = self.open_reader(&dir_hashes_db_dir)?;
         operation(&dir_hashes_db)
     }
 
-    /// Take this repo's rebuild barrier exclusively, pop the cache entry for `commit_id`,
-    /// and run `operation`. The write-guard wait ensures no reader of *this repo* holds a
-    /// cloned `Arc<DB>`, so popping drops the last reference and closes the RocksDB —
-    /// releasing the OS file handles that would otherwise prevent `rename` from succeeding
-    /// on Windows. Readers and rebuilders of other repos are unaffected.
-    fn with_entry_evicted<F, R>(
+    /// Return the shared read-only handle for `dir_hashes_db_dir`, opening it on first access.
+    /// The dir must already exist — dir_hashes are written when a commit is created, and readers
+    /// error out (rather than materialize an empty dir) if the target commit has none on disk.
+    fn open_reader(
+        &self,
+        dir_hashes_db_dir: &Path,
+    ) -> Result<Arc<DBWithThreadMode<MultiThreaded>>, OxenError> {
+        let mut handles = self.handles.lock();
+        if let Some(strong) = lookup_live(&handles, dir_hashes_db_dir) {
+            return Ok(strong);
+        }
+        if !dir_hashes_db_dir.exists() {
+            return Err(OxenError::path_does_not_exist(dir_hashes_db_dir));
+        }
+        let opts = db::key_val::opts::default();
+        let db = Arc::new(DBWithThreadMode::<MultiThreaded>::open_for_read_only(
+            &opts,
+            dir_hashes_db_dir,
+            false,
+        )?);
+        handles.insert(dir_hashes_db_dir.to_path_buf(), Arc::downgrade(&db));
+        handles.retain(|_, weak| weak.strong_count() > 0);
+        Ok(db)
+    }
+
+    /// Take this repo's rebuild barrier exclusively, then run `operation`. The write-guard wait
+    /// ensures no reader of *this repo* holds a cloned `Arc<DB>`; without any strong reference,
+    /// the underlying RocksDB has already closed, so the OS file handles blocking `rename` on
+    /// Windows are released. The closure is free to rename or replace the directory; the next
+    /// reader reopens on cache miss. Readers and rebuilders of other repos are not blocked.
+    fn with_exclusive_access<F, R>(
         &self,
         repo: &LocalRepository,
-        commit_id: &str,
         operation: F,
     ) -> Result<R, OxenError>
     where
         F: FnOnce() -> Result<R, OxenError>,
     {
-        let barrier = self.barrier_for(&repo.path)?;
-        let _barrier_guard = barrier
-            .write()
-            .map_err(|e| OxenError::LockPoisoned(format!("dir_hash_db access: {e}").into()))?;
-
-        let path = dir_hash_db_path_from_commit_id(repo, commit_id);
-        {
-            let mut handles = self
-                .handles
-                .write()
-                .map_err(|e| OxenError::LockPoisoned(format!("dir_hash_db LRU: {e}").into()))?;
-            handles.pop(&path);
-        }
-
+        let barrier = self.barrier_for(&repo.path);
+        let _barrier_guard = barrier.write();
         operation()
     }
 
-    /// Remove any cached handles whose on-disk path starts with `prefix`. Takes only the LRU's
-    /// write lock — does not take `rebuild_barrier`. Callers that need the rebuild guarantee
-    /// should go through [`Self::with_entry_evicted`] instead.
-    fn evict_prefix(&self, prefix: &Path) -> Result<(), OxenError> {
-        let mut instances = self
-            .handles
-            .write()
-            .map_err(|e| OxenError::LockPoisoned(format!("dir_hash_db LRU: {e}").into()))?;
-
-        let dbs_to_remove = instances
-            .iter()
-            .filter(|(key, _)| key.starts_with(prefix))
-            .map(|(key, _)| key.clone())
-            .collect::<Vec<_>>();
-
-        for db in dbs_to_remove {
-            let _ = instances.pop(&db);
-        }
-
-        Ok(())
+    /// Remove tombstone entries under `prefix` from the registry. Live entries (someone still
+    /// holds the `Arc`) are unaffected; the DB closes when the last strong reference drops.
+    fn evict_prefix(&self, prefix: &Path) {
+        self.handles
+            .lock()
+            .retain(|key, _| !key.starts_with(prefix));
     }
+}
+
+fn lookup_live(
+    handles: &HashMap<PathBuf, Weak<DBWithThreadMode<MultiThreaded>>>,
+    dir_hashes_db_dir: &Path,
+) -> Option<Arc<DBWithThreadMode<MultiThreaded>>> {
+    handles.get(dir_hashes_db_dir)?.upgrade()
 }
 
 // Commit db is the directories per commit
@@ -177,10 +149,11 @@ pub fn dir_hash_db_path_from_commit_id(
         .join(DIR_HASHES_DIR)
 }
 
-/// Removes all dir_hashes DB instances from cache whose path starts with the given prefix.
-/// Used in test cleanup to release file handles before directory deletion.
+/// Removes tombstone entries under `db_path_prefix` from the registry. Live entries are
+/// unaffected; the DB closes when the last strong reference drops. Used in test cleanup.
 pub fn remove_from_cache_with_children(db_path_prefix: impl AsRef<Path>) -> Result<(), OxenError> {
-    CACHE.evict_prefix(db_path_prefix.as_ref())
+    CACHE.evict_prefix(db_path_prefix.as_ref());
+    Ok(())
 }
 
 pub fn with_dir_hash_db_manager<F, T>(
@@ -194,21 +167,11 @@ where
     CACHE.with_reader(repository, commit_id, operation)
 }
 
-/// Run `operation` with `commit_id`'s entry evicted from the dir_hash_db cache.
-///
-/// The repo's rebuild barrier is taken exclusively so no concurrent reader of this repo
-/// holds a cloned `Arc<DB>`; popping the cache entry then drops the last reference, closing
-/// the RocksDB and releasing OS file handles on the directory. The closure is free to rename
-/// or replace the directory (on Windows this requires no process hold files inside it open).
-/// The next reader after release reopens the DB on cache miss. Readers and rebuilders of
-/// other repos are not blocked.
-pub fn with_entry_evicted<F, R>(
-    repo: &LocalRepository,
-    commit_id: &str,
-    operation: F,
-) -> Result<R, OxenError>
+/// Run `operation` under exclusive access to `repo`'s dir_hash_dbs — no reader of this repo can
+/// hold an `Arc<DB>` for the duration. See [`DirHashDbCache::with_exclusive_access`].
+pub fn with_exclusive_access<F, R>(repo: &LocalRepository, operation: F) -> Result<R, OxenError>
 where
     F: FnOnce() -> Result<R, OxenError>,
 {
-    CACHE.with_entry_evicted(repo, commit_id, operation)
+    CACHE.with_exclusive_access(repo, operation)
 }

--- a/crates/liboxen/src/repositories/fsck.rs
+++ b/crates/liboxen/src/repositories/fsck.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 
 use crate::core::db;
 use crate::core::db::dir_hashes::dir_hashes_db::{
-    dir_hash_db_path_from_commit_id, with_entry_evicted,
+    dir_hash_db_path_from_commit_id, with_exclusive_access,
 };
 use crate::core::db::key_val::str_val_db;
 use crate::error::OxenError;
@@ -50,10 +50,10 @@ pub struct RebuildDirHashesStats {
 /// writer.
 ///
 /// Strategy: build the new database in a sibling temp directory, then hand off to
-/// [`with_entry_evicted`] for the swap. That helper takes the per-path cache slot
-/// for writing (waiting for in-flight readers to drop their guards), drops the cached RocksDB
-/// handle — which on Windows is required before the directory can be renamed — runs our
-/// rename dance, and releases the lock.
+/// [`with_exclusive_access`] for the swap. That helper takes the per-repo write barrier —
+/// waiting for in-flight readers to drop their `Arc<DB>`, which is what actually closes the
+/// RocksDB and releases the OS file handles Windows needs before rename — runs our rename
+/// dance, and releases the barrier.
 pub fn rebuild_dir_hash_db(
     repo: &LocalRepository,
     commit: &Commit,
@@ -102,10 +102,11 @@ pub fn rebuild_dir_hash_db(
         // Drop the handle before renaming so RocksDB releases file locks.
     }
 
-    // 2. Swap under the slot's write lock. The cached RocksDB handle is closed inside this
-    //    helper so Windows will permit the renames; the helper also reopens afterwards.
+    // 2. Swap under the per-repo write barrier. In-flight readers finish and drop their
+    //    `Arc<DB>` before we enter the closure, so the RocksDB handle is already closed and
+    //    Windows will permit the renames; the next reader after the closure exits reopens.
     let swap_db_path = db_path.clone();
-    with_entry_evicted(repo, &commit.id, move || {
+    with_exclusive_access(repo, move || {
         let had_existing = swap_db_path.exists();
         if had_existing {
             util::fs::rename(&swap_db_path, &old_path)?;


### PR DESCRIPTION
Last of the five RocksDB caches with the same LRU-eviction pathology the earlier weak-ref refactors (#713, #715, #718, and #719). `dir_hashes_db` opens read-only for regular usage, so this one looks slightly different, though still pretty similar.

Callers of `with_dir_hash_db_manager` now always see the same shared handle for the life of any concurrent reader of the same commit. Idle handles close as soon as the last reader drops.

 The exclusive-access helper is renamed from `with_entry_evicted` to `with_exclusive_access`. 

RO opens don't take the per-directory `LOCK` file, because you can have multiple read-only opens of the same file, so the retry loop the earlier refactors carry isn't needed here.