### PR TITLE
Streamline Tests (12.7): Preload DuckDB JSON extension

### DIFF
--- a/crates/liboxen/src/core/df.rs
+++ b/crates/liboxen/src/core/df.rs
@@ -1,6 +1,7 @@
 //! Functions to manipulate DataFrames
 //!
 
+pub mod duckdb_setup;
 pub mod filter;
 pub mod pretty_print;
 pub mod sql;

--- a/crates/liboxen/src/core/df/duckdb_setup.rs
+++ b/crates/liboxen/src/core/df/duckdb_setup.rs
@@ -1,0 +1,20 @@
+//! One-shot DuckDB extension installation.
+
+use crate::error::OxenError;
+
+/// Install the JSON extension into DuckDB's user extensions directory so subsequent
+/// connections load it without triggering the autoload flow.
+///
+/// Call once at startup before any parallel DuckDB use. Concurrent first-use autoloads
+/// race on the extension file's temp→final rename (`Could not move file: Access is
+/// denied` on Windows, comparable timing hazards elsewhere); preinstalling closes that
+/// window.
+pub fn preload_extensions() -> Result<(), OxenError> {
+    let conn = duckdb::Connection::open_in_memory().map_err(|e| {
+        OxenError::basic_str(format!(
+            "failed to open in-memory DuckDB connection for extension preload: {e}"
+        ))
+    })?;
+    conn.execute_batch("INSTALL json;")
+        .map_err(|e| OxenError::basic_str(format!("failed to install DuckDB json extension: {e}")))
+}

--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -600,6 +600,16 @@ async fn start(
         );
     }
 
+    // Install DuckDB extensions before actix hands out any request threads. oxen-server
+    // is a single-instance deploy, so every restart drains pent-up client retries into a
+    // burst of concurrent first-use requests; two of them triggering autoload at once
+    // race on the extension file's temp→final rename (`Could not move file: Access is
+    // denied` on Windows, similar timing hazards elsewhere).
+    match liboxen::core::df::duckdb_setup::preload_extensions() {
+        Ok(()) => log::info!("DuckDB extensions preloaded"),
+        Err(e) => log::error!("Failed to preload DuckDB extensions: {e}"),
+    }
+
     let data = app_data::OxenAppData {
         path: PathBuf::from(sync_dir),
         config,


### PR DESCRIPTION
## Summary

Eliminates a Windows-only concurrent-startup race where DuckDB's first-use autoload of the JSON extension fails with `Could not move file: Access is denied`. 

`oxen-server` now runs a single `INSTALL json` against an in-memory connection during startup, so the extension is already resident on disk by the time real connections open it — no first-use race is possible.
