### PR TITLE
Branch Comparison (2): Diff from merge base

### DIFF
--- a/crates/liboxen/src/repositories/diffs.rs
+++ b/crates/liboxen/src/repositories/diffs.rs
@@ -1505,6 +1505,78 @@ mod tests {
         .await
     }
 
+    // Diffing from the merge base (git three-dot base...head) excludes changes
+    // that landed on the base branch after the fork. Diffing from the base tip
+    // (two-dot) instead reports them as removals.
+    #[tokio::test]
+    async fn test_diff_entries_three_dot_excludes_base_changes() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            let shared = repo.path.join("shared.txt");
+            test::write_txt_file_to_path(&shared, "shared")?;
+            repositories::add(&repo, &shared).await?;
+            let fork = repositories::commit(&repo, "shared")?;
+
+            let main_branch = repositories::branches::current_branch(&repo)?
+                .expect("default branch exists after first commit");
+
+            // Feature branch adds its own file.
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let feature_file = repo.path.join("feature.txt");
+            test::write_txt_file_to_path(&feature_file, "feature")?;
+            repositories::add(&repo, &feature_file).await?;
+            let head = repositories::commit(&repo, "feature")?;
+
+            // Base branch advances past the fork with an unrelated file.
+            repositories::checkout(&repo, &main_branch.name).await?;
+            let main_side = repo.path.join("main_side.txt");
+            test::write_txt_file_to_path(&main_side, "main side")?;
+            repositories::add(&repo, &main_side).await?;
+            let base = repositories::commit(&repo, "main side")?;
+
+            let merge_base =
+                repositories::merge::lowest_common_ancestor_from_commits(&repo, &base, &head)?
+                    .expect("base and head share a merge base");
+            assert_eq!(merge_base.id, fork.id);
+
+            let two_dot = repositories::diffs::list_diff_entries(
+                &repo,
+                &base,
+                &head,
+                PathBuf::from(""),
+                PathBuf::from(""),
+                0,
+                100,
+            )
+            .await?;
+            let three_dot = repositories::diffs::list_diff_entries(
+                &repo,
+                &merge_base,
+                &head,
+                PathBuf::from(""),
+                PathBuf::from(""),
+                0,
+                100,
+            )
+            .await?;
+
+            assert!(
+                two_dot.counts.removed >= 1,
+                "two-dot keeps the base-side file"
+            );
+            assert_eq!(
+                three_dot.counts.removed, 0,
+                "three-dot drops the base-side file"
+            );
+            assert!(
+                three_dot.counts.added >= 1,
+                "three-dot still shows head's file"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
     #[tokio::test]
     async fn test_diff_entries_modify_one_tabular() -> Result<(), OxenError> {
         test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -35,6 +35,24 @@ use crate::params::{
     resolve_base_head,
 };
 
+/// The base a diff should range from. With `three_dot`, diff from the merge base
+/// (git `base...head`) so commits that landed on the base branch after the fork
+/// don't read as part of head's changes. Falls back to the given base when the
+/// two commits share no common ancestor.
+fn diff_base(
+    repository: &LocalRepository,
+    base: Commit,
+    head: &Commit,
+    three_dot: bool,
+) -> Result<Commit, OxenError> {
+    if !three_dot {
+        return Ok(base);
+    }
+    let merge_base =
+        repositories::merge::lowest_common_ancestor_from_commits(repository, &base, head)?;
+    Ok(merge_base.unwrap_or(base))
+}
+
 /// List commits between two revisions
 #[utoipa::path(
     get,
@@ -105,7 +123,8 @@ pub async fn commits(
         ("repo_name" = String, Path, description = "Name of the repository", example = "satellite-images"),
         ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
         ("page" = Option<usize>, Query, description = "Page number for pagination (starts at 1)"),
-        ("page_size" = Option<usize>, Query, description = "Page size for pagination")
+        ("page_size" = Option<usize>, Query, description = "Page size for pagination"),
+        ("three_dot" = Option<bool>, Query, description = "Diff from the merge base (base...head)")
     ),
     responses(
         (status = 200, description = "Entries found successfully", body = CompareEntriesResponse),
@@ -135,6 +154,12 @@ pub async fn entries(
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
+    let base_commit = diff_base(
+        &repository,
+        base_commit,
+        &head_commit,
+        query.three_dot.unwrap_or(false),
+    )?;
 
     let entries_diff = repositories::diffs::list_diff_entries(
         &repository,
@@ -189,13 +214,17 @@ pub async fn entries(
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "satellite-images"),
         ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
+        ("three_dot" = Option<bool>, Query, description = "Diff from the merge base (base...head)")
     ),
     responses(
         (status = 200, description = "Directory diff tree found successfully", body = DirTreeDiffResponse),
         (status = 404, description = "Repository or one of the revisions not found")
     )
 )]
-pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
+pub async fn dir_tree(
+    req: HttpRequest,
+    query: web::Query<PageNumQuery>,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
@@ -210,6 +239,12 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
+    let base_commit = diff_base(
+        &repository,
+        base_commit,
+        &head_commit,
+        query.three_dot.unwrap_or(false),
+    )?;
 
     let dir_diffs =
         repositories::diffs::list_changed_dirs(&repository, &base_commit, &head_commit)?;
@@ -237,7 +272,8 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
         ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
         ("dir" = String, Path, description = "The directory path to list entries for", example = "data/test"),
         ("page" = Option<usize>, Query, description = "Page number for pagination (starts at 1)"),
-        ("page_size" = Option<usize>, Query, description = "Page size for pagination")
+        ("page_size" = Option<usize>, Query, description = "Page size for pagination"),
+        ("three_dot" = Option<bool>, Query, description = "Diff from the merge base (base...head)")
     ),
     responses(
         (status = 200, description = "Entries found successfully", body = CompareEntriesResponse),
@@ -267,6 +303,12 @@ pub async fn dir_entries(
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
+    let base_commit = diff_base(
+        &repository,
+        base_commit,
+        &head_commit,
+        query.three_dot.unwrap_or(false),
+    )?;
     let dir = PathBuf::from(dir);
 
     let entries_diff = repositories::diffs::list_diff_entries(

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -31,8 +31,8 @@ use liboxen::{constants, repositories, util};
 
 use crate::helpers::get_repo;
 use crate::params::{
-    DFOptsQuery, PageNumQuery, app_data, df_opts_query, parse_base_head, path_param,
-    resolve_base_head,
+    DFOptsQuery, PageNumQuery, app_data, df_opts_query, parse_base_head, parse_base_head_three_dot,
+    path_param, resolve_base_head,
 };
 
 /// The base a diff should range from. With `three_dot`, diff from the merge base
@@ -121,10 +121,9 @@ pub async fn commits(
     params(
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "satellite-images"),
-        ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
+        ("base_head" = String, Path, description = "The base and head revisions separated by '..', or '...' to diff from the merge base", example = "main...feature/add-labels"),
         ("page" = Option<usize>, Query, description = "Page number for pagination (starts at 1)"),
-        ("page_size" = Option<usize>, Query, description = "Page size for pagination"),
-        ("three_dot" = Option<bool>, Query, description = "Diff from the merge base (base...head)")
+        ("page_size" = Option<usize>, Query, description = "Page size for pagination")
     ),
     responses(
         (status = 200, description = "Entries found successfully", body = CompareEntriesResponse),
@@ -148,18 +147,13 @@ pub async fn entries(
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
 
-    // Parse the base and head from the base..head string
-    let (base, head) = parse_base_head(&base_head)?;
+    // Parse the base and head from the base..head or base...head string
+    let (base, head, three_dot) = parse_base_head_three_dot(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = diff_base(
-        &repository,
-        base_commit,
-        &head_commit,
-        query.three_dot.unwrap_or(false),
-    )?;
+    let base_commit = diff_base(&repository, base_commit, &head_commit, three_dot)?;
 
     let entries_diff = repositories::diffs::list_diff_entries(
         &repository,
@@ -213,18 +207,14 @@ pub async fn entries(
     params(
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "satellite-images"),
-        ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
-        ("three_dot" = Option<bool>, Query, description = "Diff from the merge base (base...head)")
+        ("base_head" = String, Path, description = "The base and head revisions separated by '..', or '...' to diff from the merge base", example = "main...feature/add-labels")
     ),
     responses(
         (status = 200, description = "Directory diff tree found successfully", body = DirTreeDiffResponse),
         (status = 404, description = "Repository or one of the revisions not found")
     )
 )]
-pub async fn dir_tree(
-    req: HttpRequest,
-    query: web::Query<PageNumQuery>,
-) -> actix_web::Result<HttpResponse, OxenHttpError> {
+pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
@@ -233,18 +223,13 @@ pub async fn dir_tree(
     // Get the repository or return error
     let repository = get_repo(app_data, namespace, name)?;
 
-    // Parse the base and head from the base..head string
-    let (base, head) = parse_base_head(&base_head)?;
+    // Parse the base and head from the base..head or base...head string
+    let (base, head, three_dot) = parse_base_head_three_dot(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = diff_base(
-        &repository,
-        base_commit,
-        &head_commit,
-        query.three_dot.unwrap_or(false),
-    )?;
+    let base_commit = diff_base(&repository, base_commit, &head_commit, three_dot)?;
 
     let dir_diffs =
         repositories::diffs::list_changed_dirs(&repository, &base_commit, &head_commit)?;
@@ -269,11 +254,10 @@ pub async fn dir_tree(
     params(
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "satellite-images"),
-        ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
+        ("base_head" = String, Path, description = "The base and head revisions separated by '..', or '...' to diff from the merge base", example = "main...feature/add-labels"),
         ("dir" = String, Path, description = "The directory path to list entries for", example = "data/test"),
         ("page" = Option<usize>, Query, description = "Page number for pagination (starts at 1)"),
-        ("page_size" = Option<usize>, Query, description = "Page size for pagination"),
-        ("three_dot" = Option<bool>, Query, description = "Diff from the merge base (base...head)")
+        ("page_size" = Option<usize>, Query, description = "Page size for pagination")
     ),
     responses(
         (status = 200, description = "Entries found successfully", body = CompareEntriesResponse),
@@ -297,18 +281,13 @@ pub async fn dir_entries(
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
 
-    // Parse the base and head from the base..head string
-    let (base, head) = parse_base_head(&base_head)?;
+    // Parse the base and head from the base..head or base...head string
+    let (base, head, three_dot) = parse_base_head_three_dot(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = diff_base(
-        &repository,
-        base_commit,
-        &head_commit,
-        query.three_dot.unwrap_or(false),
-    )?;
+    let base_commit = diff_base(&repository, base_commit, &head_commit, three_dot)?;
     let dir = PathBuf::from(dir);
 
     let entries_diff = repositories::diffs::list_diff_entries(

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -143,7 +143,7 @@ pub async fn entries(
             &base_commit,
             &head_commit,
         )?
-        .unwrap_or(base_commit)
+        .ok_or_else(|| OxenError::basic_str("No merge base between the requested revisions"))?
     } else {
         base_commit
     };
@@ -230,7 +230,7 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
             &base_commit,
             &head_commit,
         )?
-        .unwrap_or(base_commit)
+        .ok_or_else(|| OxenError::basic_str("No merge base between the requested revisions"))?
     } else {
         base_commit
     };
@@ -299,7 +299,7 @@ pub async fn dir_entries(
             &base_commit,
             &head_commit,
         )?
-        .unwrap_or(base_commit)
+        .ok_or_else(|| OxenError::basic_str("No merge base between the requested revisions"))?
     } else {
         base_commit
     };

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -35,24 +35,6 @@ use crate::params::{
     path_param, resolve_base_head,
 };
 
-/// The base a diff should range from. With `three_dot`, diff from the merge base
-/// (git `base...head`) so commits that landed on the base branch after the fork
-/// don't read as part of head's changes. Falls back to the given base when the
-/// two commits share no common ancestor.
-fn diff_base(
-    repository: &LocalRepository,
-    base: Commit,
-    head: &Commit,
-    three_dot: bool,
-) -> Result<Commit, OxenError> {
-    if !three_dot {
-        return Ok(base);
-    }
-    let merge_base =
-        repositories::merge::lowest_common_ancestor_from_commits(repository, &base, head)?;
-    Ok(merge_base.unwrap_or(base))
-}
-
 /// List commits between two revisions
 #[utoipa::path(
     get,
@@ -153,7 +135,18 @@ pub async fn entries(
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = diff_base(&repository, base_commit, &head_commit, three_dot)?;
+    // Three dots (base...head) diff from the merge base, so commits that landed
+    // on the base branch after the fork don't read as part of head's changes.
+    let base_commit = if three_dot {
+        repositories::merge::lowest_common_ancestor_from_commits(
+            &repository,
+            &base_commit,
+            &head_commit,
+        )?
+        .unwrap_or(base_commit)
+    } else {
+        base_commit
+    };
 
     let entries_diff = repositories::diffs::list_diff_entries(
         &repository,
@@ -229,7 +222,18 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = diff_base(&repository, base_commit, &head_commit, three_dot)?;
+    // Three dots (base...head) diff from the merge base, so commits that landed
+    // on the base branch after the fork don't read as part of head's changes.
+    let base_commit = if three_dot {
+        repositories::merge::lowest_common_ancestor_from_commits(
+            &repository,
+            &base_commit,
+            &head_commit,
+        )?
+        .unwrap_or(base_commit)
+    } else {
+        base_commit
+    };
 
     let dir_diffs =
         repositories::diffs::list_changed_dirs(&repository, &base_commit, &head_commit)?;
@@ -287,7 +291,18 @@ pub async fn dir_entries(
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = diff_base(&repository, base_commit, &head_commit, three_dot)?;
+    // Three dots (base...head) diff from the merge base, so commits that landed
+    // on the base branch after the fork don't read as part of head's changes.
+    let base_commit = if three_dot {
+        repositories::merge::lowest_common_ancestor_from_commits(
+            &repository,
+            &base_commit,
+            &head_commit,
+        )?
+        .unwrap_or(base_commit)
+    } else {
+        base_commit
+    };
     let dir = PathBuf::from(dir);
 
     let entries_diff = repositories::diffs::list_diff_entries(

--- a/crates/oxen-server/src/params.rs
+++ b/crates/oxen-server/src/params.rs
@@ -140,6 +140,8 @@ pub fn parse_resource(
 }
 
 /// Split the base..head string into base and head strings
+// TODO: Incorporate the logic from parse_base_head_three_dot, update all call
+// sites, and remove the duplicate function.
 pub fn parse_base_head(base_head: impl AsRef<str>) -> Result<(String, String), OxenError> {
     let mut split = base_head.as_ref().split("..");
     if let (Some(base), Some(head)) = (split.next(), split.next()) {
@@ -147,6 +149,26 @@ pub fn parse_base_head(base_head: impl AsRef<str>) -> Result<(String, String), O
     } else {
         Err(OxenError::basic_str(
             "Could not parse commits. Format should be base..head",
+        ))
+    }
+}
+
+/// Split a `base..head` or `base...head` string into base, head, and whether it
+/// used three-dot syntax. Three dots select the merge base of base and head
+/// (git's `base...head`); two dots compare the two revisions directly.
+pub fn parse_base_head_three_dot(base_head: &str) -> Result<(String, String, bool), OxenError> {
+    // Check for the three-dot separator first, since it contains the two-dot one.
+    let (separator, three_dot) = if base_head.contains("...") {
+        ("...", true)
+    } else {
+        ("..", false)
+    };
+    let mut split = base_head.splitn(2, separator);
+    if let (Some(base), Some(head)) = (split.next(), split.next()) {
+        Ok((base.to_string(), head.to_string(), three_dot))
+    } else {
+        Err(OxenError::basic_str(
+            "Could not parse commits. Format should be base..head or base...head",
         ))
     }
 }
@@ -318,5 +340,29 @@ mod tests {
         // bumps it; test mode keeps the suite green.
         let req = request_with_user_agent("Oxen/0.60.0 (linux; tokio)");
         assert!(!client_must_use_multipart_staging(&req, true));
+    }
+
+    #[test]
+    fn test_parse_base_head_three_dot_two_dots() {
+        let (base, head, three_dot) = parse_base_head_three_dot("main..feature").unwrap();
+        assert_eq!(base, "main");
+        assert_eq!(head, "feature");
+        assert!(!three_dot);
+    }
+
+    #[test]
+    fn test_parse_base_head_three_dot_three_dots() {
+        let (base, head, three_dot) = parse_base_head_three_dot("main...feature").unwrap();
+        assert_eq!(base, "main");
+        assert_eq!(head, "feature");
+        assert!(three_dot);
+    }
+
+    #[test]
+    fn test_parse_base_head_three_dot_does_not_leak_dot_into_head() {
+        // The three-dot separator must be matched before the two-dot one, or the
+        // extra dot bleeds into head as ".feature".
+        let (_, head, _) = parse_base_head_three_dot("main...feature").unwrap();
+        assert_eq!(head, "feature");
     }
 }

--- a/crates/oxen-server/src/params/page_num_query.rs
+++ b/crates/oxen-server/src/params/page_num_query.rs
@@ -5,6 +5,8 @@ use utoipa::IntoParams;
 pub struct PageNumQuery {
     pub page: Option<usize>,
     pub page_size: Option<usize>,
+    /// Diff from the merge base (git `base...head`) rather than the base tip.
+    pub three_dot: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, IntoParams)]

--- a/crates/oxen-server/src/params/page_num_query.rs
+++ b/crates/oxen-server/src/params/page_num_query.rs
@@ -5,8 +5,6 @@ use utoipa::IntoParams;
 pub struct PageNumQuery {
     pub page: Option<usize>,
     pub page_size: Option<usize>,
-    /// Diff from the merge base (git `base...head`) rather than the base tip.
-    pub three_dot: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, IntoParams)]


### PR DESCRIPTION
A merge request should show exactly the changes it introduces, which requires knowing the commit graph, so the backend is the right place to work it out. Right now the frontend reconstructs it by choosing a base and diffing. This makes the diffs the frontend displays wrong.

This moves that job to the server. The entries, dir entries, and dir tree endpoints take a three_dot flag and find the common ancestor themselves, diffing from there (git base...head). It's opt in, so existing behavior is unchanged, and the frontend can stop doing merge base math.