### PR TITLE
Cache Windows release with dependency tree

### DIFF
--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -122,8 +122,8 @@ jobs:
           # from-scratch build recompiles the whole graph every release. Restore
           # the previous run's compiled dependencies (and the registry, mtimes
           # intact) so cargo marks them Fresh and only workspace crates rebuild.
-          # Keyed on the third-party lockfile entries plus toolchain, so a
-          # workspace version bump alone does not rotate the key.
+          # The key hashes the third-party lockfile entries plus toolchain, so a
+          # workspace version bump alone keeps the same key.
           $depText = ((Get-Content Cargo.lock -Raw) -split '\[\[package\]\]' | Where-Object { $_ -match 'source = ' }) -join ''
           $rv = (cmd /c "rustc -V 2>nul") -join ''
           $sha = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes("$rv|$depText|v4"))).Replace("-","").Substring(0,32)
@@ -131,9 +131,21 @@ jobs:
           cmd /c "aws s3 cp s3://oxen-release-build-cache/deptree/$sha.tar C:\deptree.tar 2>nul"
           if (Test-Path C:\deptree.tar) {
             tar -xf C:\deptree.tar -C C:\
+            echo "DEPTREE_EXACT_HIT=1" >> $env:GITHUB_ENV
             Write-Host "DEPTREE restore hit ($sha)"
           } else {
-            Write-Host "DEPTREE restore miss ($sha)"
+            # A third-party dependency changed, so the exact key is gone. Restore
+            # the most recent tree anyway; cargo rebuilds only what the bump
+            # touched rather than the whole graph, and the save step writes a
+            # fresh tree under the new key so the next release hits exactly.
+            $latest = (aws s3 ls "s3://oxen-release-build-cache/deptree/" | Where-Object { $_ -match '\.tar$' } | Sort-Object | Select-Object -Last 1) -replace '.*\s',''
+            if ($latest) { cmd /c "aws s3 cp s3://oxen-release-build-cache/deptree/$latest C:\deptree.tar 2>nul" }
+            if (Test-Path C:\deptree.tar) {
+              tar -xf C:\deptree.tar -C C:\
+              Write-Host "DEPTREE restore miss ($sha), fell back to $latest"
+            } else {
+              Write-Host "DEPTREE restore miss ($sha), no tree to fall back to"
+            }
           }
           exit 0
 
@@ -157,10 +169,11 @@ jobs:
 
       - name: Save dependency build tree
         run: |
+          # Skip only on an exact-key hit. A fallback restore still has to write
+          # the tree under the current key so the next release hits exactly.
           # Saved after both builds so the tree covers the binaries' deps and the
-          # pyo3/maturin deps that only the wheel build pulls in; otherwise the
-          # wheel-only deps rebuild from scratch on every run.
-          if (Test-Path C:\deptree.tar) { Write-Host "DEPTREE cache already present"; exit 0 }
+          # pyo3/maturin deps that only the wheel build pulls in.
+          if ($env:DEPTREE_EXACT_HIT -eq "1") { Write-Host "DEPTREE exact hit, cache is current"; exit 0 }
           refreshenv
           $rel = "${{ github.workspace }}\target\release".Substring(3) -replace '\\','/'
           $list = @("$rel/.fingerprint", "$rel/deps", "$rel/build", "Users/Administrator/.cargo/registry/src", "Users/Administrator/.cargo/registry/cache")

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -180,9 +180,10 @@ jobs:
           }
 
       - name: Save dependency build tree
-        # Persist even when a build step failed, so a workspace bug doesn't throw
-        # away the dependency compiles this cache exists to reuse.
-        if: ${{ !cancelled() }}
+        # Only cache a tree from a fully successful build. A failed build can
+        # leave the tree incomplete, and saving it under the exact key would make
+        # later runs restore that partial tree and rebuild every time.
+        if: success()
         run: |
           # Skip only on an exact-key hit. A fallback restore still has to write
           # the tree under the current key so the next release hits exactly.

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -163,6 +163,7 @@ jobs:
         run: |
           refreshenv
           cargo build --workspace --exclude oxen-py --release
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Build Python wheels
         run: |

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -72,32 +72,11 @@ jobs:
         shell: powershell
 
     env:
-      RUSTC_WRAPPER: sccache
-      # cc-rs (duckdb/rocksdb/zstd bundled builds) intercepts via CC/CXX;
-      # cmake-driven builds (aws-lc) need the launcher vars plus a generator
-      # that honors them (Visual Studio generators ignore launchers).
-      CC: sccache cl
-      CXX: sccache cl
-      CMAKE_C_COMPILER_LAUNCHER: sccache
-      CMAKE_CXX_COMPILER_LAUNCHER: sccache
-      CMAKE_GENERATOR: Ninja
-      # aws-lc-sys's cc builder misdetects the compiler family behind the
-      # sccache wrapper and emits GCC-builtin calls that MSVC can't link;
-      # its cmake path probes the toolchain correctly (and NASM is installed)
-      AWS_LC_SYS_CMAKE_BUILDER: "1"
-      SCCACHE_BUCKET: oxen-release-build-cache
-      SCCACHE_REGION: us-west-1
-      # vcpkg rebuilds FFmpeg from source on every ephemeral runner without this
-      VCPKG_BINARY_SOURCES: clear;x-aws,s3://oxen-release-build-cache/vcpkg/,readwrite
-      # MSVC stamps wall-clock timestamps into linked PE files and .obj COFF
-      # headers; sccache hashes proc-macro dlls (--extern) and staticlib members
-      # into downstream Rust keys, so unstamped output churns those keys every
-      # run. /Brepro zeroes the timestamps.
-      RUSTFLAGS: -Clink-arg=/Brepro
-      CFLAGS: /Brepro
-      CXXFLAGS: /Brepro
       CARGO_INCREMENTAL: "0"
-      SCCACHE_IDLE_TIMEOUT: "0"
+      # FFmpeg builds from source (~10 min) on a bare runner; the binary cache
+      # restores it in seconds. The vcpkg checkout is pinned below so its ABI
+      # hash stays stable and the cache actually hits across releases.
+      VCPKG_BINARY_SOURCES: clear;x-aws,s3://oxen-release-build-cache/vcpkg/,readwrite
 
     steps:
       - name: Checkout
@@ -108,54 +87,46 @@ jobs:
       - name: Create release directory
         run: mkdir ${{ github.workspace }}\release
 
-      - name: Disable Windows Defender for build (ephemeral runner)
+      - name: Exclude build paths from Windows Defender
         run: |
           try {
-            # Same configuration GitHub applies to its hosted runner images
-            Set-MpPreference -DisableRealtimeMonitoring $true -DisableArchiveScanning $true -DisableBehaviorMonitoring $true -DisableIOAVProtection $true -DisableScriptScanning $true -MAPSReporting 0 -PUAProtection 0 -ScanAvgCPULoadFactor 5
             Set-MpPreference -ExclusionPath @("C:\Windows\System32\actions-runner", "C:\Users\Administrator\.cargo", "C:\Users\Administrator\.rustup", "C:\vcpkg", "C:\ProgramData\chocolatey", "$env:TEMP")
-            Set-MpPreference -ExclusionProcess @("rustc.exe", "cargo.exe", "sccache.exe", "cl.exe", "link.exe", "cmake.exe", "ninja.exe", "python.exe", "git.exe")
-            $s = Get-MpComputerStatus
-            Write-Host "Defender: RealTimeProtection=$($s.RealTimeProtectionEnabled) TamperProtected=$($s.IsTamperProtected)"
+            Set-MpPreference -ExclusionProcess @("rustc.exe", "cargo.exe", "cl.exe", "link.exe", "cmake.exe", "python.exe", "git.exe")
+            Write-Host "Defender exclusions applied"
           } catch {
             Write-Host "Defender configuration unavailable: $_"
           }
 
       - name: Install dependencies
         run: |
-          choco install -y cmake llvm uv rustup.install ninja nasm
+          choco install -y cmake llvm uv rustup.install nasm
           if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
             choco install -y awscli
-            # choco appends to the machine PATH; this process needs it now for vcpkg's x-aws
+            # choco appends to the machine PATH; this process needs it now for the s3 caches
             $env:Path = "C:\Program Files\Amazon\AWSCLIV2;$env:Path"
           }
           aws --version
-          # Install sccache 0.16 to a machine-PATH dir so it survives refreshenv
-          Invoke-WebRequest -Uri "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-pc-windows-msvc.zip" -OutFile C:\sccache.zip
-          Expand-Archive -Path C:\sccache.zip -DestinationPath C:\sccache-dl -Force
-          Copy-Item C:\sccache-dl\sccache-v0.16.0-x86_64-pc-windows-msvc\sccache.exe C:\ProgramData\chocolatey\bin\sccache.exe -Force
-          # Install vcpkg for FFmpeg development libraries
-          git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+          # Pin vcpkg so the FFmpeg binary-cache ABI hash is stable across runs;
+          # an unpinned HEAD rotates the key and the cache never hits.
+          git clone --depth 1 --branch 2026.06.24 https://github.com/microsoft/vcpkg.git C:\vcpkg
           cd C:\vcpkg
           .\bootstrap-vcpkg.bat
           .\vcpkg.exe install ffmpeg:x64-windows
-          # Set VCPKG_ROOT for cargo to find FFmpeg libraries
           echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
 
       - name: Restore dependency build tree
         run: |
           refreshenv
-          # Proc-macro dlls never link byte-identically across runs (PE content
-          # varies even with /Brepro), and sccache hashes them into every direct
-          # consumer's key, so those consumers and everything above them miss
-          # every run. Restoring the dependency slice of target\release plus the
-          # registry trees (mtimes preserved, so cargo's staleness math holds)
-          # makes cargo reuse the previous run's dlls verbatim; workspace crates
-          # stay dirty via fresh checkout mtimes and rebuild as usual.
-          $lock = (Get-FileHash Cargo.lock -Algorithm SHA256).Hash
+          # Windows proc-macro dlls never link byte-identically across runs, and
+          # a version bump rewrites every downstream crate's fingerprint, so a
+          # from-scratch build recompiles the whole graph every release. Restore
+          # the previous run's compiled dependencies (and the registry, mtimes
+          # intact) so cargo marks them Fresh and only workspace crates rebuild.
+          # Keyed on the third-party lockfile entries plus toolchain, so a
+          # workspace version bump alone does not rotate the key.
+          $depText = ((Get-Content Cargo.lock -Raw) -split '\[\[package\]\]' | Where-Object { $_ -match 'source = ' }) -join ''
           $rv = (cmd /c "rustc -V 2>nul") -join ''
-          $keySrc = "$rv|$lock|-Clink-arg=/Brepro|v2"
-          $sha = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($keySrc))).Replace("-","").Substring(0,32)
+          $sha = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes("$rv|$depText|v4"))).Replace("-","").Substring(0,32)
           echo "DEPTREE_KEY=$sha" >> $env:GITHUB_ENV
           cmd /c "aws s3 cp s3://oxen-release-build-cache/deptree/$sha.tar C:\deptree.tar 2>nul"
           if (Test-Path C:\deptree.tar) {
@@ -169,54 +140,11 @@ jobs:
       - name: Build oxen binaries
         run: |
           refreshenv
-          # cc-rs only self-locates MSVC when CC is unset; with CC="sccache cl"
-          # the dev shell must put cl.exe (+ INCLUDE/LIB) in the environment
-          $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64'
-          $env:RUSTC_WRAPPER = "sccache"
-          $env:RUSTFLAGS = "-Clink-arg=/Brepro"
-          $env:CC = "sccache cl"
-          $env:CXX = "sccache cl"
-          $env:CFLAGS = "/Brepro"
-          $env:CXXFLAGS = "/Brepro"
-          $env:CMAKE_C_COMPILER_LAUNCHER = "sccache"
-          $env:CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
-          $env:CMAKE_GENERATOR = "Ninja"
-          $env:AWS_LC_SYS_CMAKE_BUILDER = "1"
-          cmd /c "sccache --start-server"
           cargo build --workspace --exclude oxen-py --release
-          $cargoExit = $LASTEXITCODE
-          sccache --show-stats
-          exit $cargoExit
-
-      - name: Save dependency build tree
-        run: |
-          if (Test-Path C:\deptree.tar) { Write-Host "DEPTREE cache already present"; exit 0 }
-          refreshenv
-          $rel = "${{ github.workspace }}\target\release".Substring(3) -replace '\\','/'
-          $list = @("$rel/.fingerprint", "$rel/deps", "$rel/build", "Users/Administrator/.cargo/registry/src", "Users/Administrator/.cargo/registry/cache")
-          $list | Set-Content C:\deptree-list.txt
-          tar -cf C:\deptree-out.tar -C C:\ -T C:\deptree-list.txt
-          aws s3 cp C:\deptree-out.tar s3://oxen-release-build-cache/deptree/$env:DEPTREE_KEY.tar
-          Write-Host "DEPTREE saved ($env:DEPTREE_KEY)"
 
       - name: Build Python wheels
         run: |
           refreshenv
-          $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64'
-          $env:RUSTC_WRAPPER = "sccache"
-          $env:RUSTFLAGS = "-Clink-arg=/Brepro"
-          $env:CC = "sccache cl"
-          $env:CXX = "sccache cl"
-          $env:CFLAGS = "/Brepro"
-          $env:CXXFLAGS = "/Brepro"
-          $env:CMAKE_C_COMPILER_LAUNCHER = "sccache"
-          $env:CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
-          $env:CMAKE_GENERATOR = "Ninja"
-          $env:AWS_LC_SYS_CMAKE_BUILDER = "1"
           uv python install ${{ inputs.PYTHON_VERSIONS }}
 
           cd ${{ github.workspace }}\oxen-python
@@ -227,11 +155,19 @@ jobs:
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
-      - name: sccache stats
-        if: always()
+      - name: Save dependency build tree
         run: |
+          # Saved after both builds so the tree covers the binaries' deps and the
+          # pyo3/maturin deps that only the wheel build pulls in; otherwise the
+          # wheel-only deps rebuild from scratch on every run.
+          if (Test-Path C:\deptree.tar) { Write-Host "DEPTREE cache already present"; exit 0 }
           refreshenv
-          sccache --show-stats
+          $rel = "${{ github.workspace }}\target\release".Substring(3) -replace '\\','/'
+          $list = @("$rel/.fingerprint", "$rel/deps", "$rel/build", "Users/Administrator/.cargo/registry/src", "Users/Administrator/.cargo/registry/cache")
+          $list | Set-Content C:\deptree-list.txt
+          tar -cf C:\deptree-out.tar -C C:\ -T C:\deptree-list.txt
+          aws s3 cp C:\deptree-out.tar s3://oxen-release-build-cache/deptree/$env:DEPTREE_KEY.tar
+          Write-Host "DEPTREE saved ($env:DEPTREE_KEY)"
 
       - name: Create zip with oxen binaries
         run: |

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -73,9 +73,9 @@ jobs:
 
     env:
       CARGO_INCREMENTAL: "0"
-      # FFmpeg builds from source (~10 min) on a bare runner; the binary cache
-      # restores it in seconds. The vcpkg checkout is pinned below so its ABI
-      # hash stays stable and the cache actually hits across releases.
+      # FFmpeg is slow to build from source on a bare runner, so the binary
+      # cache restores it in seconds. The vcpkg checkout is pinned below so its
+      # ABI hash stays stable and the cache hits across releases.
       VCPKG_BINARY_SOURCES: clear;x-aws,s3://oxen-release-build-cache/vcpkg/,readwrite
 
     steps:
@@ -108,13 +108,13 @@ jobs:
           if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
             choco install -y awscli
             if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { exit $LASTEXITCODE }
-            # choco appends to the machine PATH; this process needs it now for the s3 caches
+            # choco appends to the machine PATH, so this process needs it added now for the s3 caches
             $env:Path = "C:\Program Files\Amazon\AWSCLIV2;$env:Path"
           }
           aws --version
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          # Pin vcpkg so the FFmpeg binary-cache ABI hash is stable across runs;
-          # an unpinned HEAD rotates the key and the cache never hits.
+          # Pin vcpkg so the FFmpeg binary-cache ABI hash stays stable across
+          # runs. An unpinned HEAD rotates the key and the cache never hits.
           git clone --depth 1 --branch 2026.06.24 https://github.com/microsoft/vcpkg.git C:\vcpkg
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cd C:\vcpkg
@@ -145,8 +145,8 @@ jobs:
             Write-Host "DEPTREE restore hit ($sha)"
           } else {
             # A third-party dependency changed, so the exact key is gone. Restore
-            # the most recent tree anyway; cargo rebuilds only what the bump
-            # touched rather than the whole graph, and the save step writes a
+            # the most recent tree anyway, so cargo reuses the unchanged deps and
+            # rebuilds only what the bump touched. The save step then writes a
             # fresh tree under the new key so the next release hits exactly.
             $latest = (aws s3 ls "s3://oxen-release-build-cache/deptree/" | Where-Object { $_ -match '\.tar$' } | Sort-Object | Select-Object -Last 1) -replace '.*\s',''
             if ($latest) { cmd /c "aws s3 cp s3://oxen-release-build-cache/deptree/$latest C:\deptree.tar 2>nul" }

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -99,19 +99,29 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # PowerShell doesn't stop on a failed native command, so a failed
+          # install would be masked by the next command and only surface later
+          # as a confusing build error. Check each critical command. choco
+          # returns 3010 to mean "installed, reboot pending", which is success.
           choco install -y cmake llvm uv rustup.install nasm
+          if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { exit $LASTEXITCODE }
           if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
             choco install -y awscli
+            if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { exit $LASTEXITCODE }
             # choco appends to the machine PATH; this process needs it now for the s3 caches
             $env:Path = "C:\Program Files\Amazon\AWSCLIV2;$env:Path"
           }
           aws --version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Pin vcpkg so the FFmpeg binary-cache ABI hash is stable across runs;
           # an unpinned HEAD rotates the key and the cache never hits.
           git clone --depth 1 --branch 2026.06.24 https://github.com/microsoft/vcpkg.git C:\vcpkg
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cd C:\vcpkg
           .\bootstrap-vcpkg.bat
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           .\vcpkg.exe install ffmpeg:x64-windows
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
 
       - name: Restore dependency build tree

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -168,6 +168,7 @@ jobs:
         run: |
           refreshenv
           uv python install ${{ inputs.PYTHON_VERSIONS }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           cd ${{ github.workspace }}\oxen-python
 
@@ -178,6 +179,9 @@ jobs:
           }
 
       - name: Save dependency build tree
+        # Persist even when a build step failed, so a workspace bug doesn't throw
+        # away the dependency compiles this cache exists to reuse.
+        if: ${{ !cancelled() }}
         run: |
           # Skip only on an exact-key hit. A fallback restore still has to write
           # the tree under the current key so the next release hits exactly.


### PR DESCRIPTION
Caching already works well on Linux and macOS, but the windows build has been resistant and so far my approaches have failed to make a difference.

Windows releases rebuild the whole dependency graph and the bundled c/c++ from scratch every run. I tried using sccache to fix that, but it gets 0 hits in release builds. The crates that change miss the cache anyway and the rest already comes back from the dep tree cache. So sccache was actually slowing us down.

Further, the dep tree cache wasn't properly working. It hashed the whole Cargo.lock, and every release bumps the workspace crate versions in there, so the cache always missed. Locally I was rerunning against the same commit, which is why it looked like it was working before. Now it only hashes the third party entries, so a version bump keeps the same key. When a dependency does change and the key misses, it falls back to the most recent tree, so cargo still only rebuilds what the bump touched.

Ffmpeg had a similar problem. We cloned vcpkg at HEAD so its binary cache key drifted, and ffmpeg rebuilt from source every run. Pinning vcpkg fixes it.

So to sum it up, this drops sccache on windows, along with all the setup it needed, and leans on the dep tree cache alone. I did some trial runs and it looks like windows release went from 59 to 35 min, but we will have to see how it works out under real usage.
