### PR TITLE
Keep tree node unpacking from stalling the server

### DIFF
--- a/crates/liboxen/src/core/db/merkle_node/fs_merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/fs_merkle_node_store.rs
@@ -167,6 +167,30 @@ impl MerkleNodeStore for FsMerkleNodeStore {
         Ok(())
     }
 
+    fn write_nodes(
+        &self,
+        nodes: Vec<(MerkleHash, Bytes, Bytes)>,
+        overwrite_existing: bool,
+    ) -> Result<Vec<MerkleHash>, MerkleDbError> {
+        // Each node's two files sit under a path unique to its hash, so writes to different nodes
+        // never touch the same files. Each write pays filesystem latency (create, write, fsync,
+        // rename, done twice), which is time spent waiting on the disk. Running the batch across a
+        // rayon pool lets those waits overlap, so even a large unpack finishes in seconds.
+        // `write_node` is atomic on its own, so the only thing to coordinate is the first error.
+        use rayon::prelude::*;
+        let written = nodes
+            .into_par_iter()
+            .map(|(hash, node, children)| {
+                if !overwrite_existing && self.exists(&hash)? {
+                    return Ok(None);
+                }
+                self.write_node(&hash, node, children)?;
+                Ok(Some(hash))
+            })
+            .collect::<Result<Vec<_>, MerkleDbError>>()?;
+        Ok(written.into_iter().flatten().collect())
+    }
+
     fn delete(&self, hash: &MerkleHash) -> Result<(), MerkleDbError> {
         // Remove only this node's two files. A short hash whose suffix is empty stores its
         // files directly in the `{prefix}` shard alongside sibling suffix subdirs, so removing
@@ -299,6 +323,61 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         let store = FsMerkleNodeStore::new(dir.path());
         assert!(store.list_hashes()?.is_empty());
+        Ok(())
+    }
+
+    /// `write_nodes` persists a whole batch, returns exactly the hashes it newly wrote, and skips
+    /// nodes already present unless overwriting. This is the batch contract `extract_tar_under`
+    /// relies on, checked here over the filesystem backend's parallel write path.
+    #[test]
+    fn fs_write_nodes_batches_and_respects_existing() -> Result<(), OxenError> {
+        use std::collections::HashSet;
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let store = FsMerkleNodeStore::new(dir.path());
+
+        let a = MerkleHash::new(0xa);
+        let b = MerkleHash::new(0xb);
+        let batch = vec![
+            (
+                a,
+                Bytes::from_static(b"node-a"),
+                Bytes::from_static(b"kids-a"),
+            ),
+            (b, Bytes::from_static(b"node-b"), Bytes::new()),
+        ];
+
+        // A fresh batch writes every node and reports both hashes.
+        let written: HashSet<_> = store
+            .write_nodes(batch.clone(), false)?
+            .into_iter()
+            .collect();
+        assert_eq!(written, HashSet::from([a, b]));
+        assert_eq!(store.read_node(&a)?, Bytes::from_static(b"node-a"));
+        assert!(store.read_children(&b)?.is_empty());
+
+        // Re-running without overwrite writes nothing.
+        assert!(store.write_nodes(batch.clone(), false)?.is_empty());
+
+        // Overwriting must change the stored blobs, so read all four back and confirm the new
+        // bytes. b's children started empty.
+        let replacement = vec![
+            (
+                a,
+                Bytes::from_static(b"node-a2"),
+                Bytes::from_static(b"kids-a2"),
+            ),
+            (
+                b,
+                Bytes::from_static(b"node-b2"),
+                Bytes::from_static(b"kids-b2"),
+            ),
+        ];
+        let rewritten: HashSet<_> = store.write_nodes(replacement, true)?.into_iter().collect();
+        assert_eq!(rewritten, HashSet::from([a, b]));
+        assert_eq!(store.read_node(&a)?, Bytes::from_static(b"node-a2"));
+        assert_eq!(store.read_children(&a)?, Bytes::from_static(b"kids-a2"));
+        assert_eq!(store.read_node(&b)?, Bytes::from_static(b"node-b2"));
+        assert_eq!(store.read_children(&b)?, Bytes::from_static(b"kids-b2"));
         Ok(())
     }
 }

--- a/crates/liboxen/src/core/db/merkle_node/lmdb_merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/lmdb_merkle_node_store.rs
@@ -176,6 +176,31 @@ impl MerkleNodeStore for LmdbMerkleNodeStore {
         })
     }
 
+    fn write_nodes(
+        &self,
+        nodes: Vec<(MerkleHash, Bytes, Bytes)>,
+        overwrite_existing: bool,
+    ) -> Result<Vec<MerkleHash>, MerkleDbError> {
+        // The whole batch commits in one transaction, so LMDB fsyncs once for it. That single
+        // fsync keeps a large unpack fast, even at tens of thousands of nodes. A node counts as
+        // present only when both of its keys are there, matching `exists`, so if a node key ever
+        // lost its children key, this writes it again.
+        self.write(|db, txn| {
+            let mut written = Vec::new();
+            for (hash, node, children) in &nodes {
+                let present = db.contains(txn, &Self::key(hash, NODE_TAG))?
+                    && db.contains(txn, &Self::key(hash, CHILDREN_TAG))?;
+                if !overwrite_existing && present {
+                    continue;
+                }
+                db.put(txn, &Self::key(hash, NODE_TAG), node.as_ref())?;
+                db.put(txn, &Self::key(hash, CHILDREN_TAG), children.as_ref())?;
+                written.push(*hash);
+            }
+            Ok(written)
+        })
+    }
+
     fn delete(&self, hash: &MerkleHash) -> Result<(), MerkleDbError> {
         self.write(|db, txn| {
             db.delete(txn, &Self::key(hash, NODE_TAG))?;
@@ -286,6 +311,91 @@ mod tests {
         assert_eq!(fs.read_children(&hash)?, lmdb.read_children(&hash)?);
         assert_eq!(fs.node_byte_sizes(&hash)?, lmdb.node_byte_sizes(&hash)?);
         assert_eq!(fs.list_hashes()?, lmdb.list_hashes()?);
+        Ok(())
+    }
+
+    /// `write_nodes` commits the whole batch in one transaction, returns exactly the hashes it newly
+    /// wrote, and skips nodes already present unless overwriting. This is the same batch contract the
+    /// filesystem backend satisfies, checked here over LMDB's single transaction path.
+    #[test]
+    fn lmdb_write_nodes_batches_and_respects_existing() -> Result<(), OxenError> {
+        use std::collections::HashSet;
+        let (_dir, store) = test_store();
+
+        let a = MerkleHash::new(0xa);
+        let b = MerkleHash::new(0xb);
+        let batch = vec![
+            (
+                a,
+                Bytes::from_static(b"node-a"),
+                Bytes::from_static(b"kids-a"),
+            ),
+            (b, Bytes::from_static(b"node-b"), Bytes::new()),
+        ];
+
+        // A fresh batch writes every node and reports both hashes.
+        let written: HashSet<_> = store
+            .write_nodes(batch.clone(), false)?
+            .into_iter()
+            .collect();
+        assert_eq!(written, HashSet::from([a, b]));
+        assert_eq!(store.read_node(&a)?, Bytes::from_static(b"node-a"));
+        assert!(store.read_children(&b)?.is_empty());
+
+        // Re-running without overwrite writes nothing.
+        assert!(store.write_nodes(batch.clone(), false)?.is_empty());
+
+        // Overwriting must change the stored blobs, so read all four back and confirm the new
+        // bytes. b's children started empty.
+        let replacement = vec![
+            (
+                a,
+                Bytes::from_static(b"node-a2"),
+                Bytes::from_static(b"kids-a2"),
+            ),
+            (
+                b,
+                Bytes::from_static(b"node-b2"),
+                Bytes::from_static(b"kids-b2"),
+            ),
+        ];
+        let rewritten: HashSet<_> = store.write_nodes(replacement, true)?.into_iter().collect();
+        assert_eq!(rewritten, HashSet::from([a, b]));
+        assert_eq!(store.read_node(&a)?, Bytes::from_static(b"node-a2"));
+        assert_eq!(store.read_children(&a)?, Bytes::from_static(b"kids-a2"));
+        assert_eq!(store.read_node(&b)?, Bytes::from_static(b"node-b2"));
+        assert_eq!(store.read_children(&b)?, Bytes::from_static(b"kids-b2"));
+        Ok(())
+    }
+
+    /// A record with its node key but no children key counts as absent, so `write_nodes` writes it
+    /// even when `overwrite_existing` is false. Only corruption produces that state, since
+    /// `write_node` writes both keys in one transaction. This test guards the presence check that
+    /// requires both keys.
+    #[test]
+    fn lmdb_write_nodes_rewrites_a_half_written_node() -> Result<(), OxenError> {
+        let (_dir, store) = test_store();
+        let hash = MerkleHash::new(0xc);
+
+        // Plant a broken record with the node key present and no children key.
+        store.write(|db, txn| -> Result<(), MerkleDbError> {
+            db.put(txn, &LmdbMerkleNodeStore::key(&hash, NODE_TAG), b"stale")?;
+            Ok(())
+        })?;
+        assert!(
+            !store.exists(&hash)?,
+            "a node missing its children key is not present"
+        );
+
+        // With overwrite off, `write_nodes` does not skip the broken record. It writes both blobs.
+        let batch = vec![(
+            hash,
+            Bytes::from_static(b"node-c"),
+            Bytes::from_static(b"kids-c"),
+        )];
+        assert_eq!(store.write_nodes(batch, false)?, vec![hash]);
+        assert_eq!(store.read_node(&hash)?, Bytes::from_static(b"node-c"));
+        assert_eq!(store.read_children(&hash)?, Bytes::from_static(b"kids-c"));
         Ok(())
     }
 }

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -112,24 +112,13 @@ pub(crate) trait MerkleNodeStore: Debug + Send + Sync {
     ///
     /// Unpacking a commit's tree writes one node for every directory and vnode. A large repo has
     /// tens of thousands of them, and writing them one at a time means tens of thousands of
-    /// separate trips to the store. Each backend has a faster way to write a whole batch, so this
-    /// hands it the batch and lets it use that way. The filesystem backend writes the files at once
-    /// across threads. The LMDB backend commits the batch in a single transaction. The default is
-    /// the plain serial loop that any backend can fall back on.
+    /// separate trips to the store. Each backend implements batching: the filesystem backend writes
+    /// files in parallel across threads; the LMDB backend commits the batch in a single transaction.
     fn write_nodes(
         &self,
         nodes: Vec<(MerkleHash, Bytes, Bytes)>,
         overwrite_existing: bool,
-    ) -> Result<Vec<MerkleHash>, MerkleDbError> {
-        let mut written = Vec::with_capacity(nodes.len());
-        for (hash, node, children) in nodes {
-            if overwrite_existing || !self.exists(&hash)? {
-                self.write_node(&hash, node, children)?;
-                written.push(hash);
-            }
-        }
-        Ok(written)
-    }
+    ) -> Result<Vec<MerkleHash>, MerkleDbError>;
 
     /// Remove the node for `hash` (both blobs). Idempotent: deleting an absent node is `Ok`.
     fn delete(&self, hash: &MerkleHash) -> Result<(), MerkleDbError>;

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -107,6 +107,30 @@ pub(crate) trait MerkleNodeStore: Debug + Send + Sync {
         children: Bytes,
     ) -> Result<(), MerkleDbError>;
 
+    /// Persist many nodes at once and return the hashes actually written. With `overwrite_existing`
+    /// false, a node already present is left untouched and kept out of the returned set.
+    ///
+    /// Unpacking a commit's tree writes one node for every directory and vnode. A large repo has
+    /// tens of thousands of them, and writing them one at a time means tens of thousands of
+    /// separate trips to the store. Each backend has a faster way to write a whole batch, so this
+    /// hands it the batch and lets it use that way. The filesystem backend writes the files at once
+    /// across threads. The LMDB backend commits the batch in a single transaction. The default is
+    /// the plain serial loop that any backend can fall back on.
+    fn write_nodes(
+        &self,
+        nodes: Vec<(MerkleHash, Bytes, Bytes)>,
+        overwrite_existing: bool,
+    ) -> Result<Vec<MerkleHash>, MerkleDbError> {
+        let mut written = Vec::with_capacity(nodes.len());
+        for (hash, node, children) in nodes {
+            if overwrite_existing || !self.exists(&hash)? {
+                self.write_node(&hash, node, children)?;
+                written.push(hash);
+            }
+        }
+        Ok(written)
+    }
+
     /// Remove the node for `hash` (both blobs). Idempotent: deleting an absent node is `Ok`.
     fn delete(&self, hash: &MerkleHash) -> Result<(), MerkleDbError>;
 

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1046,6 +1046,14 @@ fn extract_tar_under<R: Read>(
     // and exhaust memory before the post-loop completeness check runs.
     let mut pending: Option<(MerkleHash, Option<Bytes>, Option<Bytes>)> = None;
 
+    // Completed nodes collect here and flush to the store in batches. Batching lets each backend
+    // write a whole group at once. The filesystem writes the files across threads, and LMDB commits
+    // them in one transaction. Capping each batch by total bytes keeps peak memory flat, so even a
+    // node with a large `children` blob flushes promptly.
+    const FLUSH_THRESHOLD_BYTES: usize = 64 * 1024 * 1024;
+    let mut batch: Vec<(MerkleHash, Bytes, Bytes)> = Vec::new();
+    let mut batch_bytes: usize = 0;
+
     let decoder = GzDecoder::new(reader);
     let mut archive = Archive::new(decoder);
     let entries = archive.entries().map_err(MerkleDbError::CannotReadMerkle)?;
@@ -1154,12 +1162,21 @@ fn extract_tar_under<R: Read>(
         };
         pending = None;
 
-        // Persist the node as a unit through the store.
-        if overwrite_existing || !store.exists(&hash)? {
-            store.write_node(&hash, node, children)?;
-            installed.insert(hash);
+        // Buffer the completed node and flush once the batch grows past the threshold. The store
+        // decides what was newly installed (skipping nodes already present unless overwriting), so
+        // only its returned hashes join `installed`.
+        batch_bytes += node.len() + children.len();
+        batch.push((hash, node, children));
+        if batch_bytes >= FLUSH_THRESHOLD_BYTES {
+            installed.extend(store.write_nodes(std::mem::take(&mut batch), overwrite_existing)?);
+            batch_bytes = 0;
         }
     }
+
+    // Flush whatever is left in the final batch. A truncated archive still keeps every complete
+    // node it contained, so a later retry starts from there, and the partial node at the very end
+    // is rejected below.
+    installed.extend(store.write_nodes(batch, overwrite_existing)?);
 
     // EOF validation: a well-formed archive pairs every `node` blob with its `children` blob and
     // clears `pending` as each pair completes. A leftover entry means the archive was truncated

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1048,9 +1048,12 @@ fn extract_tar_under<R: Read>(
 
     // Completed nodes collect here and flush to the store in batches. Batching lets each backend
     // write a whole group at once. The filesystem writes the files across threads, and LMDB commits
-    // them in one transaction. Capping each batch by total bytes keeps peak memory flat, so even a
-    // node with a large `children` blob flushes promptly.
+    // them in one transaction. Each batch is capped by total bytes and by node count, so peak memory
+    // stays flat whether a batch holds a few large nodes or many tiny ones. The count cap matters
+    // because empty blobs add nothing to the byte total, so a hostile archive of empty nodes would
+    // otherwise grow the batch without bound.
     const FLUSH_THRESHOLD_BYTES: usize = 64 * 1024 * 1024;
+    const FLUSH_THRESHOLD_NODES: usize = 100_000;
     let mut batch: Vec<(MerkleHash, Bytes, Bytes)> = Vec::new();
     let mut batch_bytes: usize = 0;
 
@@ -1167,7 +1170,7 @@ fn extract_tar_under<R: Read>(
         // only its returned hashes join `installed`.
         batch_bytes += node.len() + children.len();
         batch.push((hash, node, children));
-        if batch_bytes >= FLUSH_THRESHOLD_BYTES {
+        if batch_bytes >= FLUSH_THRESHOLD_BYTES || batch.len() >= FLUSH_THRESHOLD_NODES {
             installed.extend(store.write_nodes(std::mem::take(&mut batch), overwrite_existing)?);
             batch_bytes = 0;
         }

--- a/crates/oxen-server/src/controllers/tree.rs
+++ b/crates/oxen-server/src/controllers/tree.rs
@@ -182,13 +182,16 @@ pub async fn create_nodes(
     while let Some(item) = body.next().await {
         bytes.extend_from_slice(&item.map_err(|_| OxenHttpError::FailedToReadRequestPayload)?);
     }
+    let bytes = bytes.freeze();
 
-    log::debug!(
-        "create_node decompressing {} bytes",
-        ByteSize::b(bytes.len() as u64)
-    );
+    log::debug!("create_nodes unpacking {}", ByteSize::b(bytes.len() as u64));
 
-    let _hashes = repositories::tree::unpack_nodes(&repository, &bytes[..])?;
+    // Unpacking decompresses the archive and writes every node to the store. That is blocking CPU
+    // and disk work, and it takes longer the bigger the tree is. Run it on the blocking pool so a
+    // large tree never stalls the async workers that serve every other request this server handles.
+    tokio::task::spawn_blocking(move || repositories::tree::unpack_nodes(&repository, &bytes[..]))
+        .await
+        .map_err(|e| OxenError::basic_str(format!("create_nodes unpack task panicked: {e}")))??;
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_found()))
 }


### PR DESCRIPTION
When you push, the server unpacks the commit's tree one node at a time, on the same threads it uses to handle network traffic. A big repo has tens of thousands of nodes, so a single unpack can take minutes and hold one of those threads the whole time, and while it does, that thread can't serve the other connections it's juggling.

That's synchronous filesystem and DB work running on the async workers, which should go in spawn_blocking. This moves it there, so a slow unpack can't tie up the threads that serve requests.

I also made it write nodes in bulk rather than one at a time: the file backend writes a batch in parallel, and the LMDB backend commits a batch in one transaction. That was about 30% faster in local testing, though I don't know how it translates to the server.