### PR TITLE
Fix paths pushed by Windows CLI

### DIFF
--- a/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
@@ -36,7 +36,11 @@ impl CommitMerkleTree {
                         let key = str::from_utf8(&key)?;
                         let value = str::from_utf8(&value)?;
                         let hash = value.parse()?;
-                        dir_hashes.insert(PathBuf::from(key), hash);
+                        // Heal legacy keys written with backslashes by a Windows client: repo
+                        // paths are slash-separated, and a backslash key never matches the
+                        // slash-based path a lookup asks for.
+                        dir_hashes
+                            .insert(PathBuf::from(crate::util::fs::linux_path_str(key)), hash);
                     }
                     _ => {
                         return Err(OxenError::basic_str(
@@ -1211,6 +1215,69 @@ mod tests {
     use crate::repositories;
 
     use test::add_n_files_m_dirs;
+
+    /// A Windows client writes `dir_hashes` keys with backslash separators. The Linux server
+    /// then can't match a nested directory's slash-based lookup path, so its folder listing
+    /// returns "Resource not found". The loader must normalize backslash keys back to slashes.
+    /// `test_load_dir_nodes` can't catch this: on Windows both separators collapse in `PathBuf`,
+    /// so the assertion passes there too. The break only shows up cross-platform, which is what
+    /// this test forces by injecting a backslash key and reading it on the host running the test.
+    #[tokio::test]
+    async fn test_dir_hashes_heal_windows_backslash_keys() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|dir| async move {
+            let repo = repositories::init::init_with_version(dir, MinOxenVersion::LATEST)?;
+
+            let child_dir = repo.path.join("assets").join("characters");
+            crate::util::fs::create_dir_all(&child_dir)?;
+            test::write_txt_file_to_path(child_dir.join("a.txt"), "hi")?;
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commits::commit(&repo, "seed nested dir")?;
+
+            let nested = PathBuf::from("assets/characters");
+            let healthy = CommitMerkleTree::dir_hashes(&repo, &commit)?;
+            let hash = *healthy
+                .get(&nested)
+                .expect("nested dir should be in a healthy dir_hashes");
+
+            // Rewrite the slash key as a backslash key, mimicking a Windows-authored index.
+            let db_path =
+                crate::core::db::dir_hashes::dir_hashes_db::dir_hash_db_path_from_commit_id(
+                    &repo, &commit.id,
+                );
+            crate::core::db::dir_hashes::dir_hashes_db::remove_from_cache_with_children(&db_path)?;
+            {
+                let opts = crate::core::db::key_val::opts::default();
+                let db: rocksdb::DBWithThreadMode<rocksdb::SingleThreaded> =
+                    rocksdb::DBWithThreadMode::open(&opts, &db_path)?;
+                crate::core::db::key_val::str_val_db::delete(&db, "assets/characters")?;
+                crate::core::db::key_val::str_val_db::put(
+                    &db,
+                    "assets\\characters",
+                    &hash.to_string(),
+                )?;
+            }
+            crate::core::db::dir_hashes::dir_hashes_db::remove_from_cache_with_children(&db_path)?;
+
+            let healed = CommitMerkleTree::dir_hashes(&repo, &commit)?;
+            assert!(
+                healed.contains_key(&nested),
+                "backslash key should load as the slash path {nested:?}"
+            );
+            assert!(
+                !healed.keys().any(|k| k.to_string_lossy().contains('\\')),
+                "no backslash keys should survive the load"
+            );
+
+            // The browsing endpoint resolves the nested dir again.
+            assert!(
+                repositories::tree::get_dir_with_children(&repo, &commit, &nested, None)?.is_some(),
+                "get_dir_with_children should resolve {nested:?} after the heal"
+            );
+
+            Ok(())
+        })
+        .await
+    }
 
     #[tokio::test]
     async fn test_load_dir_nodes() -> Result<(), OxenError> {

--- a/crates/liboxen/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
@@ -256,7 +256,9 @@ impl CommitMerkleTree {
                     let key = str::from_utf8(&key)?;
                     let value = str::from_utf8(&value)?;
                     let hash = value.parse()?;
-                    dir_hashes.insert(PathBuf::from(key), hash);
+                    // Heal legacy backslash keys from Windows clients: repo paths are
+                    // slash-separated, so a backslash key never matches a lookup.
+                    dir_hashes.insert(PathBuf::from(crate::util::fs::linux_path_str(key)), hash);
                 }
                 _ => {
                     return Err(OxenError::basic_str(

--- a/crates/liboxen/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_old/v0_19_0/index/commit_merkle_tree.rs
@@ -617,6 +617,64 @@ mod tests {
 
     use test::add_n_files_m_dirs;
 
+    /// The v0.19.0 reader must heal legacy backslash keys the same way `v_latest` does; these
+    /// older repos are the ones most likely to carry keys written by a pre-fix Windows client.
+    /// See the matching `v_latest` test for why this can only be reproduced by injecting a
+    /// backslash key and reading it back on a slash-separated host.
+    #[tokio::test]
+    async fn test_dir_hashes_heal_windows_backslash_keys_v0_19_0() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|dir| async move {
+            let repo = repositories::init::init_with_version(dir, MinOxenVersion::V0_19_0)?;
+
+            let child_dir = repo.path.join("assets").join("characters");
+            crate::util::fs::create_dir_all(&child_dir)?;
+            test::write_txt_file_to_path(child_dir.join("a.txt"), "hi")?;
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commits::commit(&repo, "seed nested dir")?;
+
+            let nested = PathBuf::from("assets/characters");
+            let healthy = CommitMerkleTree::dir_hashes(&repo, &commit)?;
+            let hash = *healthy
+                .get(&nested)
+                .expect("nested dir should be in a healthy dir_hashes");
+
+            let db_path =
+                crate::core::db::dir_hashes::dir_hashes_db::dir_hash_db_path_from_commit_id(
+                    &repo, &commit.id,
+                );
+            crate::core::db::dir_hashes::dir_hashes_db::remove_from_cache_with_children(&db_path)?;
+            {
+                let opts = crate::core::db::key_val::opts::default();
+                let db: rocksdb::DBWithThreadMode<rocksdb::SingleThreaded> =
+                    rocksdb::DBWithThreadMode::open(&opts, &db_path)?;
+                crate::core::db::key_val::str_val_db::delete(&db, "assets/characters")?;
+                crate::core::db::key_val::str_val_db::put(
+                    &db,
+                    "assets\\characters",
+                    &hash.to_string(),
+                )?;
+            }
+            crate::core::db::dir_hashes::dir_hashes_db::remove_from_cache_with_children(&db_path)?;
+
+            let healed = CommitMerkleTree::dir_hashes(&repo, &commit)?;
+            assert!(
+                healed.contains_key(&nested),
+                "backslash key should load as the slash path {nested:?}"
+            );
+            assert!(
+                !healed.keys().any(|k| k.to_string_lossy().contains('\\')),
+                "no backslash keys should survive the load"
+            );
+            assert!(
+                repositories::tree::get_dir_with_children(&repo, &commit, &nested, None)?.is_some(),
+                "get_dir_with_children should resolve {nested:?} after the heal"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
     #[tokio::test]
     async fn test_load_dir_nodes_v0_19_0() -> Result<(), OxenError> {
         test::run_empty_dir_test_async(|dir| async move {

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -42,13 +42,22 @@ use crate::model::merkle_tree::node::MerkleTreeNode;
 use crate::model::merkle_tree::node::{CommitNode, DirNode};
 
 /// Persist path→hash entries into a commit's dir_hash_db.
+///
+/// Repo paths are logical and always slash-separated, so keys are written with forward
+/// slashes regardless of the host OS. A Windows client renders `PathBuf` with backslashes,
+/// and a backslash-keyed nested directory never matches the slash-based path the server
+/// looks it up by, so its folder listing returns "Resource not found".
 fn put_dir_hashes(
     dir_hash_db: &DBWithThreadMode<SingleThreaded>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
 ) -> Result<(), OxenError> {
     for (path, hash) in dir_hashes {
         match path.to_str() {
-            Some(path_str) => str_val_db::put(dir_hash_db, path_str, &hash.to_string())?,
+            Some(path_str) => str_val_db::put(
+                dir_hash_db,
+                util::fs::to_unix_str(path_str),
+                &hash.to_string(),
+            )?,
             None => log::error!("Failed to convert path to string: {path:?}"),
         }
     }
@@ -815,9 +824,9 @@ fn cache_invalidate_dir_hash_db<'a>(
                 let child_path = PathBuf::from(dir_node.name());
                 // `child_path` already contains the full relative path
                 // (e.g., "annotations/train"), so use it directly as the key
-                let path_str = child_path.to_string_lossy();
+                let path_str = util::fs::to_unix_str(&child_path);
                 log::debug!("deleting removed dir hash: {path_str}");
-                str_val_db::delete(dir_hash_db, path_str)?;
+                str_val_db::delete(dir_hash_db, &path_str)?;
             }
         }
     }

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -43,10 +43,9 @@ use crate::model::merkle_tree::node::{CommitNode, DirNode};
 
 /// Persist path→hash entries into a commit's dir_hash_db.
 ///
-/// Repo paths are logical and always slash-separated, so keys are written with forward
-/// slashes regardless of the host OS. A Windows client renders `PathBuf` with backslashes,
-/// and a backslash-keyed nested directory never matches the slash-based path the server
-/// looks it up by, so its folder listing returns "Resource not found".
+/// Keys are canonicalized to forward slashes so a directory is looked up by the same path on
+/// every platform, keeping a Windows client (which writes `\` separators into `PathBuf`) and
+/// a Linux server agreeing on directory keys.
 fn put_dir_hashes(
     dir_hash_db: &DBWithThreadMode<SingleThreaded>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -41,6 +41,20 @@ use crate::{repositories, util};
 use crate::model::merkle_tree::node::MerkleTreeNode;
 use crate::model::merkle_tree::node::{CommitNode, DirNode};
 
+/// Persist path→hash entries into a commit's dir_hash_db.
+fn put_dir_hashes(
+    dir_hash_db: &DBWithThreadMode<SingleThreaded>,
+    dir_hashes: &HashMap<PathBuf, MerkleHash>,
+) -> Result<(), OxenError> {
+    for (path, hash) in dir_hashes {
+        match path.to_str() {
+            Some(path_str) => str_val_db::put(dir_hash_db, path_str, &hash.to_string())?,
+            None => log::error!("Failed to convert path to string: {path:?}"),
+        }
+    }
+    Ok(())
+}
+
 #[derive(Clone)]
 pub struct EntryVNode {
     pub id: MerkleHash,
@@ -261,13 +275,7 @@ pub(crate) fn commit_dir_entries_with_parents(
         None => (HashMap::new(), None),
     };
 
-    for (path, hash) in &dir_hashes {
-        if let Some(path_str) = path.to_str() {
-            str_val_db::put(&dir_hash_db, path_str, &hash.to_string())?;
-        } else {
-            log::error!("Failed to convert path to string: {path:?}");
-        }
-    }
+    put_dir_hashes(&dir_hash_db, &dir_hashes)?;
 
     let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, parent_id)?;
     write_commit_entries(
@@ -355,13 +363,7 @@ pub fn commit_dir_entries_new(
         None => (HashMap::new(), None),
     };
 
-    for (path, hash) in &dir_hashes {
-        if let Some(path_str) = path.to_str() {
-            str_val_db::put(&dir_hash_db, path_str, &hash.to_string())?;
-        } else {
-            log::error!("Failed to convert path to string: {path:?}");
-        }
-    }
+    put_dir_hashes(&dir_hash_db, &dir_hashes)?;
 
     let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, parent_id)?;
 
@@ -467,13 +469,7 @@ pub fn commit_dir_entries(
         None => HashMap::new(),
     };
 
-    for (path, hash) in &dir_hashes {
-        if let Some(path_str) = path.to_str() {
-            str_val_db::put(&dir_hash_db, path_str, &hash.to_owned().to_string())?;
-        } else {
-            log::error!("Failed to convert path to string: {path:?}");
-        }
-    }
+    put_dir_hashes(&dir_hash_db, &dir_hashes)?;
 
     let mut commit_db = MerkleNodeDB::open_read_write(repo.merkle_node_store(), &node, None)?;
     write_commit_entries(

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -41,24 +41,33 @@ use crate::{repositories, util};
 use crate::model::merkle_tree::node::MerkleTreeNode;
 use crate::model::merkle_tree::node::{CommitNode, DirNode};
 
-/// Persist path→hash entries into a commit's dir_hash_db.
+/// Persist one path→hash entry into a commit's dir_hash_db.
 ///
 /// Keys are canonicalized to forward slashes so a directory is looked up by the same path on
 /// every platform, keeping a Windows client (which writes `\` separators into `PathBuf`) and
 /// a Linux server agreeing on directory keys.
+fn put_dir_hash(
+    dir_hash_db: &DBWithThreadMode<SingleThreaded>,
+    path: &Path,
+    hash: &MerkleHash,
+) -> Result<(), OxenError> {
+    match path.to_str() {
+        Some(path_str) => str_val_db::put(
+            dir_hash_db,
+            util::fs::to_unix_str(path_str),
+            &hash.to_string(),
+        )?,
+        None => log::error!("Failed to convert path to string: {path:?}"),
+    }
+    Ok(())
+}
+
 fn put_dir_hashes(
     dir_hash_db: &DBWithThreadMode<SingleThreaded>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
 ) -> Result<(), OxenError> {
     for (path, hash) in dir_hashes {
-        match path.to_str() {
-            Some(path_str) => str_val_db::put(
-                dir_hash_db,
-                util::fs::to_unix_str(path_str),
-                &hash.to_string(),
-            )?,
-            None => log::error!("Failed to convert path to string: {path:?}"),
-        }
+        put_dir_hash(dir_hash_db, path, hash)?;
     }
     Ok(())
 }
@@ -780,11 +789,7 @@ fn write_commit_entries(
     commit_db.add_child(&dir_node)?;
     total_written += 1;
 
-    str_val_db::put(
-        dir_hash_db,
-        root_path.to_str().unwrap(),
-        &dir_node.hash().to_string(),
-    )?;
+    put_dir_hash(dir_hash_db, &root_path, dir_node.hash())?;
     let dir_db =
         MerkleNodeDB::open_read_write(repo.merkle_node_store(), &dir_node, Some(commit_id))?;
     let mut maybe_dir_db = Some(dir_db);
@@ -935,11 +940,7 @@ fn r_create_dir_node(
                         dir_node
                     };
 
-                    str_val_db::put(
-                        dir_hash_db,
-                        dir_path.to_str().unwrap(),
-                        &dir_node.hash().to_string(),
-                    )?;
+                    put_dir_hash(dir_hash_db, &dir_path, dir_node.hash())?;
                 }
                 EMerkleTreeNode::File(file_node) => {
                     let mut file_node = file_node.clone();


### PR DESCRIPTION
Nested folders on repos pushed from a Windows client returned "Resource not found" in the web browser and the dir API.

The commit writer stores each directory path as a key in a `dir_hashes` lookup, and on Windows it wrote those keys with backslash separators. That db is taken at face value by the server, and a Linux server looking up `a/b/c` never matched the stored `a\b\c`.

Our pre existing tests only run the client and server on the same OS, so they always agree on separators. It would be useful to run more tests cross platform.

Writes now canonicalize keys to forward slashes. I also made the loader heal existing backslash keys on read, so existing repos and old clients with this problem will now work.
