### PR TITLE
Min Version (4.1): split the client-protocol floor out of MIN_OXEN_VERSION

### DIFF
--- a/crates/liboxen/src/constants.rs
+++ b/crates/liboxen/src/constants.rs
@@ -215,6 +215,10 @@ pub const DEFAULT_PAGE_NUM: usize = 1;
 /// Minimum allowable oxen version to push or pull data
 pub const MIN_OXEN_VERSION: MinOxenVersion = MinOxenVersion::LATEST;
 
+/// Minimum client (CLI) version the server accepts on the wire. A standalone client-protocol
+/// floor, independent of any repo/node format version.
+pub const MIN_OXEN_CLIENT_VERSION: &str = "0.36.0";
+
 /// Filepath used to track repo and server-level migration status
 pub const LAST_MIGRATION_FILE: &str = "last_migration.txt";
 

--- a/crates/oxen-server/src/controllers/oxen_version.rs
+++ b/crates/oxen-server/src/controllers/oxen_version.rs
@@ -1,6 +1,6 @@
 use crate::params::{app_data, path_param};
 use actix_web::{HttpRequest, HttpResponse};
-use liboxen::constants::MIN_OXEN_VERSION;
+use liboxen::constants::MIN_OXEN_CLIENT_VERSION;
 use liboxen::repositories;
 use liboxen::view::StatusMessage;
 use liboxen::view::oxen_version::OxenVersionResponse;
@@ -24,7 +24,7 @@ pub async fn index(_req: HttpRequest) -> HttpResponse {
 pub async fn min_version(_req: HttpRequest) -> HttpResponse {
     let response = OxenVersionResponse {
         status: StatusMessage::resource_found(),
-        version: MIN_OXEN_VERSION.to_string(),
+        version: MIN_OXEN_CLIENT_VERSION.to_string(),
     };
     HttpResponse::Ok().json(response)
 }

--- a/crates/oxen-server/src/params.rs
+++ b/crates/oxen-server/src/params.rs
@@ -59,7 +59,7 @@ pub fn app_data(req: &HttpRequest) -> Result<&OxenAppData, OxenHttpError> {
 
     if user_cli_is_out_of_date(user_agent_str) {
         return Err(OxenHttpError::UpdateRequired(
-            constants::MIN_OXEN_VERSION.as_str().into(),
+            constants::MIN_OXEN_CLIENT_VERSION.into(),
         ));
     }
 
@@ -222,7 +222,7 @@ fn user_cli_is_out_of_date(user_agent: &str) -> bool {
         return true;
     };
 
-    let min_oxen_version = match OxenVersion::from_str(constants::MIN_OXEN_VERSION.as_str()) {
+    let min_oxen_version = match OxenVersion::from_str(constants::MIN_OXEN_CLIENT_VERSION) {
         Ok(v) => v,
         Err(_) => return true,
     };


### PR DESCRIPTION
The version the server gates incoming clients against is now a standalone `MIN_OXEN_CLIENT_VERSION` constant, independent of the repo-format version. The client gate and the /api/min_version endpoint read it directly, so removing the repo-format `MIN_OXEN_VERSION` in a later substep no longer threatens the gate.