### PR TITLE
Min Version (4.2): simplify the merkle node types

### DIFF
--- a/crates/liboxen/src/core/v_latest/add.rs
+++ b/crates/liboxen/src/core/v_latest/add.rs
@@ -840,22 +840,19 @@ pub fn process_add_file(
     } else {
         (hash, None, hash)
     };
-    let file_node = FileNode::new(
-        repo,
-        FileNodeOpts {
-            name: relative_path_str.to_string(),
-            hash,
-            combined_hash,
-            metadata_hash,
-            num_bytes,
-            last_modified_seconds: mtime.unix_seconds(),
-            last_modified_nanoseconds: mtime.nanoseconds(),
-            data_type,
-            metadata,
-            mime_type: mime_type.clone(),
-            extension: file_extension.to_string(),
-        },
-    )?;
+    let file_node = FileNode::new(FileNodeOpts {
+        name: relative_path_str.to_string(),
+        hash,
+        combined_hash,
+        metadata_hash,
+        num_bytes,
+        last_modified_seconds: mtime.unix_seconds(),
+        last_modified_nanoseconds: mtime.nanoseconds(),
+        data_type,
+        metadata,
+        mime_type: mime_type.clone(),
+        extension: file_extension.to_string(),
+    })?;
 
     p_add_file_node_to_staged_db(staged_db, relative_path_str, status, &file_node, seen_dirs)
 }
@@ -939,22 +936,19 @@ pub fn process_add_file_with_staged_db_manager(
     } else {
         (hash, None, hash)
     };
-    let file_node = FileNode::new(
-        repo,
-        FileNodeOpts {
-            name: relative_path_str.to_string(),
-            hash,
-            combined_hash,
-            metadata_hash,
-            num_bytes,
-            last_modified_seconds: mtime.unix_seconds(),
-            last_modified_nanoseconds: mtime.nanoseconds(),
-            data_type,
-            metadata,
-            mime_type: mime_type.clone(),
-            extension: file_extension.to_string(),
-        },
-    )?;
+    let file_node = FileNode::new(FileNodeOpts {
+        name: relative_path_str.to_string(),
+        hash,
+        combined_hash,
+        metadata_hash,
+        num_bytes,
+        last_modified_seconds: mtime.unix_seconds(),
+        last_modified_nanoseconds: mtime.nanoseconds(),
+        data_type,
+        metadata,
+        mime_type: mime_type.clone(),
+        extension: file_extension.to_string(),
+    })?;
 
     add_file_node_to_staged_db(repo, relative_path_str, status, &file_node, seen_dirs)
 }
@@ -1132,22 +1126,19 @@ pub fn generate_file_node(
     } else {
         (hash, None, hash)
     };
-    let file_node = FileNode::new(
-        repo,
-        FileNodeOpts {
-            name: relative_path_str.to_string(),
-            hash,
-            combined_hash,
-            metadata_hash,
-            num_bytes,
-            last_modified_seconds: mtime.unix_seconds(),
-            last_modified_nanoseconds: mtime.nanoseconds(),
-            data_type,
-            metadata,
-            mime_type: mime_type.clone(),
-            extension: file_extension.to_string(),
-        },
-    )?;
+    let file_node = FileNode::new(FileNodeOpts {
+        name: relative_path_str.to_string(),
+        hash,
+        combined_hash,
+        metadata_hash,
+        num_bytes,
+        last_modified_seconds: mtime.unix_seconds(),
+        last_modified_nanoseconds: mtime.nanoseconds(),
+        data_type,
+        metadata,
+        mime_type: mime_type.clone(),
+        extension: file_extension.to_string(),
+    })?;
     Ok(Some(file_node))
 }
 

--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -277,17 +277,14 @@ pub fn create_empty_commit(
             },
         )?;
     let timestamp = OffsetDateTime::now_utc();
-    let commit_node = CommitNode::new(
-        repo,
-        CommitNodeOpts {
-            hash: new_commit.id.parse()?,
-            parent_ids: vec![existing_commit_id],
-            email: new_commit.email.clone(),
-            author: new_commit.author.clone(),
-            message: new_commit.message.clone(),
-            timestamp,
-        },
-    )?;
+    let commit_node = CommitNode::new(CommitNodeOpts {
+        hash: new_commit.id.parse()?,
+        parent_ids: vec![existing_commit_id],
+        email: new_commit.email.clone(),
+        author: new_commit.author.clone(),
+        message: new_commit.message.clone(),
+        timestamp,
+    })?;
 
     let parent_id = Some(existing_node.hash);
     let mut commit_db =
@@ -342,34 +339,28 @@ pub fn create_initial_commit(
     let commit_id = commit_writer::compute_commit_id(&new_commit)?;
 
     // Create the commit node
-    let commit_node = CommitNode::new(
-        repo,
-        CommitNodeOpts {
-            hash: commit_id,
-            parent_ids: vec![],
-            email: user.email.clone(),
-            author: user.name.clone(),
-            message: message.to_string(),
-            timestamp,
-        },
-    )?;
+    let commit_node = CommitNode::new(CommitNodeOpts {
+        hash: commit_id,
+        parent_ids: vec![],
+        email: user.email.clone(),
+        author: user.name.clone(),
+        message: message.to_string(),
+        timestamp,
+    })?;
 
     // Create an empty root directory node
     let empty_dir_hash = MerkleHash::new(0); // Empty hash for empty directory
-    let dir_node = DirNode::new(
-        repo,
-        DirNodeOpts {
-            name: String::new(), // Root directory has empty name
-            hash: empty_dir_hash,
-            num_entries: 0,
-            num_bytes: 0,
-            last_commit_id: commit_id,
-            last_modified_seconds: timestamp.unix_timestamp(),
-            last_modified_nanoseconds: timestamp.nanosecond(),
-            data_type_counts: HashMap::new(),
-            data_type_sizes: HashMap::new(),
-        },
-    )?;
+    let dir_node = DirNode::new(DirNodeOpts {
+        name: String::new(), // Root directory has empty name
+        hash: empty_dir_hash,
+        num_entries: 0,
+        num_bytes: 0,
+        last_commit_id: commit_id,
+        last_modified_seconds: timestamp.unix_timestamp(),
+        last_modified_nanoseconds: timestamp.nanosecond(),
+        data_type_counts: HashMap::new(),
+        data_type_sizes: HashMap::new(),
+    })?;
 
     // Open the commit database and add the root directory
     let mut commit_db =
@@ -1076,17 +1067,14 @@ mod tests {
         let parent_hash: MerkleHash = parent.id.parse()?;
         let parent_node = repositories::tree::get_node_by_id_with_children(repo, &parent_hash)?
             .ok_or_else(|| OxenError::basic_str("parent node not found"))?;
-        let commit_node = CommitNode::new(
-            repo,
-            CommitNodeOpts {
-                hash,
-                parent_ids: vec![parent_hash],
-                email: new_commit.email.clone(),
-                author: new_commit.author.clone(),
-                message: new_commit.message.clone(),
-                timestamp,
-            },
-        )?;
+        let commit_node = CommitNode::new(CommitNodeOpts {
+            hash,
+            parent_ids: vec![parent_hash],
+            email: new_commit.email.clone(),
+            author: new_commit.author.clone(),
+            message: new_commit.message.clone(),
+            timestamp,
+        })?;
         let mut commit_db = MerkleNodeDB::open_read_write(
             repo.merkle_node_store(),
             &commit_node,

--- a/crates/liboxen/src/core/v_latest/merge.rs
+++ b/crates/liboxen/src/core/v_latest/merge.rs
@@ -1074,19 +1074,16 @@ fn create_empty_merge_commit(
     let base_commit_hash: MerkleHash = merge_commits.base.id.parse()?;
     let merge_commit_hash: MerkleHash = merge_commits.merge.id.parse()?;
 
-    let commit_node = CommitNode::new(
-        repo,
-        CommitNodeOpts {
-            hash: commit_id,
-            // CommitNode.parent_ids holds parent commit hashes (matches `create_empty_commit`
-            // in core/v_latest/commits.rs).
-            parent_ids: vec![base_commit_hash, merge_commit_hash],
-            email: author_email,
-            author: author_name,
-            message: merge_commits.commit_message(),
-            timestamp,
-        },
-    )?;
+    let commit_node = CommitNode::new(CommitNodeOpts {
+        hash: commit_id,
+        // CommitNode.parent_ids holds parent commit hashes (matches `create_empty_commit`
+        // in core/v_latest/commits.rs).
+        parent_ids: vec![base_commit_hash, merge_commit_hash],
+        email: author_email,
+        author: author_name,
+        message: merge_commits.commit_message(),
+        timestamp,
+    })?;
 
     // Open the new commit's MerkleNodeDB and add base's existing root DirNode as the only child.
     // Tree is content-addressed, so the new commit's tree equals base's tree without any tree

--- a/crates/liboxen/src/core/v_latest/model/merkle_tree/node/commit_node.rs
+++ b/crates/liboxen/src/core/v_latest/model/merkle_tree/node/commit_node.rs
@@ -1,10 +1,7 @@
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-use crate::{
-    core::versions::MinOxenVersion,
-    model::{MerkleHash, MerkleTreeNodeType, merkle_tree::node::commit_node::TCommitNode},
-};
+use crate::model::{MerkleHash, MerkleTreeNodeType, merkle_tree::node::commit_node::TCommitNode};
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct CommitNodeData {
@@ -18,10 +15,6 @@ pub struct CommitNodeData {
 }
 
 impl TCommitNode for CommitNodeData {
-    fn version(&self) -> MinOxenVersion {
-        MinOxenVersion::LATEST
-    }
-
     fn node_type(&self) -> &MerkleTreeNodeType {
         &self.node_type
     }

--- a/crates/liboxen/src/core/v_latest/model/merkle_tree/node/dir_node.rs
+++ b/crates/liboxen/src/core/v_latest/model/merkle_tree/node/dir_node.rs
@@ -5,7 +5,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::core::versions::MinOxenVersion;
 use crate::model::merkle_tree::node::dir_node::TDirNode;
 use crate::model::{MerkleHash, MerkleTreeNodeType};
 
@@ -35,10 +34,6 @@ pub struct DirNodeData {
 }
 
 impl TDirNode for DirNodeData {
-    fn version(&self) -> MinOxenVersion {
-        MinOxenVersion::LATEST
-    }
-
     fn node_type(&self) -> &MerkleTreeNodeType {
         &self.node_type
     }

--- a/crates/liboxen/src/core/v_latest/model/merkle_tree/node/file_node.rs
+++ b/crates/liboxen/src/core/v_latest/model/merkle_tree/node/file_node.rs
@@ -2,7 +2,6 @@
 //! that is stored in on disk
 //!
 
-use crate::core::versions::MinOxenVersion;
 use crate::model::merkle_tree::node::file_node::TFileNode;
 use crate::model::merkle_tree::node::file_node_types::{FileChunkType, FileStorageType};
 use crate::model::metadata::generic_metadata::GenericMetadata;
@@ -47,10 +46,6 @@ pub struct FileNodeData {
 }
 
 impl TFileNode for FileNodeData {
-    fn version(&self) -> MinOxenVersion {
-        MinOxenVersion::LATEST
-    }
-
     fn node_type(&self) -> &MerkleTreeNodeType {
         &self.node_type
     }

--- a/crates/liboxen/src/core/v_latest/model/merkle_tree/node/vnode.rs
+++ b/crates/liboxen/src/core/v_latest/model/merkle_tree/node/vnode.rs
@@ -2,7 +2,6 @@
 //! that is stored in on disk
 //!
 
-use crate::core::versions::MinOxenVersion;
 use crate::model::merkle_tree::node::vnode::TVNode;
 use crate::model::{MerkleHash, MerkleTreeNodeType};
 use serde::{Deserialize, Serialize};
@@ -15,10 +14,6 @@ pub struct VNodeData {
 }
 
 impl TVNode for VNodeData {
-    fn version(&self) -> MinOxenVersion {
-        MinOxenVersion::LATEST
-    }
-
     fn hash(&self) -> &MerkleHash {
         &self.hash
     }

--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -421,22 +421,19 @@ async fn compute_staged_merkle_tree_node(
     let file_extension = path.extension().unwrap_or_default().to_string_lossy();
     let relative_path = util::fs::path_relative_to_dir(path, &workspace.workspace_repo.path)?;
     let relative_path_str = relative_path.to_str().unwrap();
-    let file_node = FileNode::new(
-        &workspace.base_repo,
-        FileNodeOpts {
-            name: relative_path_str.to_string(),
-            hash,
-            combined_hash,
-            metadata_hash: Some(MerkleHash::new(metadata_hash)),
-            num_bytes,
-            last_modified_seconds: mtime.unix_seconds(),
-            last_modified_nanoseconds: mtime.nanoseconds(),
-            data_type,
-            metadata,
-            mime_type: mime_type.clone(),
-            extension: file_extension.to_string(),
-        },
-    )?;
+    let file_node = FileNode::new(FileNodeOpts {
+        name: relative_path_str.to_string(),
+        hash,
+        combined_hash,
+        metadata_hash: Some(MerkleHash::new(metadata_hash)),
+        num_bytes,
+        last_modified_seconds: mtime.unix_seconds(),
+        last_modified_nanoseconds: mtime.nanoseconds(),
+        data_type,
+        metadata,
+        mime_type: mime_type.clone(),
+        extension: file_extension.to_string(),
+    })?;
 
     Ok(StagedMerkleTreeNode {
         status,

--- a/crates/liboxen/src/model/merkle_tree/node/commit_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/commit_node.rs
@@ -5,14 +5,12 @@ use std::fmt;
 use time::OffsetDateTime;
 
 use crate::core::v_latest::model::merkle_tree::node::commit_node::CommitNodeData as CommitNodeDataV0_25_0;
-use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::{Commit, LocalRepository};
+use crate::model::Commit;
 use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode};
 
 pub trait TCommitNode {
     fn node_type(&self) -> &MerkleTreeNodeType;
-    fn version(&self) -> MinOxenVersion;
     fn hash(&self) -> &MerkleHash;
     fn parent_ids(&self) -> &Vec<MerkleHash>;
     fn message(&self) -> &str;
@@ -32,7 +30,6 @@ pub struct CommitNodeOpts {
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub enum ECommitNode {
-    // This is for backwards compatibility to load older versions from disk
     V0_25_0(CommitNodeDataV0_25_0),
 }
 
@@ -42,20 +39,18 @@ pub struct CommitNode {
 }
 
 impl CommitNode {
-    pub fn new(repo: &LocalRepository, opts: CommitNodeOpts) -> Result<CommitNode, OxenError> {
-        match repo.min_version() {
-            MinOxenVersion::LATEST => Ok(CommitNode {
-                node: ECommitNode::V0_25_0(CommitNodeDataV0_25_0 {
-                    hash: opts.hash,
-                    parent_ids: opts.parent_ids,
-                    email: opts.email,
-                    author: opts.author,
-                    message: opts.message,
-                    timestamp: opts.timestamp,
-                    node_type: MerkleTreeNodeType::Commit,
-                }),
+    pub fn new(opts: CommitNodeOpts) -> Result<CommitNode, OxenError> {
+        Ok(CommitNode {
+            node: ECommitNode::V0_25_0(CommitNodeDataV0_25_0 {
+                hash: opts.hash,
+                parent_ids: opts.parent_ids,
+                email: opts.email,
+                author: opts.author,
+                message: opts.message,
+                timestamp: opts.timestamp,
+                node_type: MerkleTreeNodeType::Commit,
             }),
-        }
+        })
     }
 
     pub fn from_commit(commit: Commit) -> CommitNode {
@@ -109,10 +104,6 @@ impl CommitNode {
         match self.node {
             ECommitNode::V0_25_0(ref commit) => commit,
         }
-    }
-
-    pub fn version(&self) -> MinOxenVersion {
-        self.node().version()
     }
 
     pub fn hash(&self) -> &MerkleHash {
@@ -192,8 +183,7 @@ impl fmt::Display for CommitNode {
             .join(",");
         write!(
             f,
-            "({}) \"{}\" -> {} {} parent_ids {:?}",
-            self.version(),
+            "\"{}\" -> {} {} parent_ids {:?}",
             self.message(),
             self.author(),
             self.email(),

--- a/crates/liboxen/src/model/merkle_tree/node/dir_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/dir_node.rs
@@ -5,15 +5,11 @@ use std::collections::HashMap;
 use std::fmt;
 
 use crate::core::v_latest::model::merkle_tree::node::dir_node::DirNodeData as DirNodeDataV0_25_0;
-use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::{
-    LocalRepository, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode,
-};
+use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode};
 use crate::view::DataTypeCount;
 
 pub trait TDirNode {
-    fn version(&self) -> MinOxenVersion;
     fn node_type(&self) -> &MerkleTreeNodeType;
     fn hash(&self) -> &MerkleHash;
     fn name(&self) -> &str;
@@ -55,23 +51,21 @@ pub struct DirNode {
 }
 
 impl DirNode {
-    pub fn new(repo: &LocalRepository, opts: DirNodeOpts) -> Result<Self, OxenError> {
-        match repo.min_version() {
-            MinOxenVersion::LATEST => Ok(Self {
-                node: EDirNode::V0_25_0(DirNodeDataV0_25_0 {
-                    node_type: MerkleTreeNodeType::Dir,
-                    name: opts.name,
-                    hash: opts.hash,
-                    num_entries: opts.num_entries,
-                    num_bytes: opts.num_bytes,
-                    last_commit_id: opts.last_commit_id,
-                    last_modified_seconds: opts.last_modified_seconds,
-                    last_modified_nanoseconds: opts.last_modified_nanoseconds,
-                    data_type_counts: opts.data_type_counts,
-                    data_type_sizes: opts.data_type_sizes,
-                }),
+    pub fn new(opts: DirNodeOpts) -> Result<Self, OxenError> {
+        Ok(Self {
+            node: EDirNode::V0_25_0(DirNodeDataV0_25_0 {
+                node_type: MerkleTreeNodeType::Dir,
+                name: opts.name,
+                hash: opts.hash,
+                num_entries: opts.num_entries,
+                num_bytes: opts.num_bytes,
+                last_commit_id: opts.last_commit_id,
+                last_modified_seconds: opts.last_modified_seconds,
+                last_modified_nanoseconds: opts.last_modified_nanoseconds,
+                data_type_counts: opts.data_type_counts,
+                data_type_sizes: opts.data_type_sizes,
             }),
-        }
+        })
     }
 
     pub fn get_opts(&self) -> DirNodeOpts {
@@ -109,10 +103,6 @@ impl DirNode {
 
     pub fn hash(&self) -> &MerkleHash {
         self.node().hash()
-    }
-
-    pub fn version(&self) -> MinOxenVersion {
-        self.node().version()
     }
 
     pub fn node_type(&self) -> &MerkleTreeNodeType {
@@ -224,7 +214,7 @@ impl TMerkleTreeNode for DirNode {}
 /// Debug is used for verbose multi-line output with println!("{:?}", node)
 impl fmt::Debug for DirNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "DirNode({})", self.version())?;
+        writeln!(f, "DirNode")?;
         writeln!(f, "\thash: {}", self.hash())?;
         writeln!(f, "\tname: {}", self.name())?;
         writeln!(

--- a/crates/liboxen/src/model/merkle_tree/node/file_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/file_node.rs
@@ -1,13 +1,11 @@
 //! Wrapper around the FileNodeData struct to support old versions of the file node
 
 use crate::core::v_latest::model::merkle_tree::node::file_node::FileNodeData as FileNodeDataV0_25_0;
-use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::file_node_types::{FileChunkType, FileStorageType};
 use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::{
-    EntryDataType, LocalRepository, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType,
-    TMerkleTreeNode,
+    EntryDataType, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -28,7 +26,6 @@ pub struct FileNodeOpts {
 }
 
 pub trait TFileNode {
-    fn version(&self) -> MinOxenVersion;
     fn node_type(&self) -> &MerkleTreeNodeType;
     fn hash(&self) -> &MerkleHash;
     fn name(&self) -> &str;
@@ -65,29 +62,27 @@ pub struct FileNode {
 }
 
 impl FileNode {
-    pub fn new(repo: &LocalRepository, opts: FileNodeOpts) -> Result<Self, OxenError> {
-        match repo.min_version() {
-            MinOxenVersion::LATEST => Ok(Self {
-                node: EFileNode::V0_25_0(FileNodeDataV0_25_0 {
-                    node_type: MerkleTreeNodeType::File,
-                    name: opts.name,
-                    hash: opts.hash,
-                    combined_hash: opts.combined_hash,
-                    metadata_hash: opts.metadata_hash,
-                    num_bytes: opts.num_bytes,
-                    last_commit_id: MerkleHash::new(0),
-                    last_modified_seconds: opts.last_modified_seconds,
-                    last_modified_nanoseconds: opts.last_modified_nanoseconds,
-                    data_type: opts.data_type,
-                    metadata: opts.metadata,
-                    mime_type: opts.mime_type,
-                    extension: opts.extension,
-                    chunk_hashes: vec![],
-                    chunk_type: FileChunkType::SingleFile,
-                    storage_backend: FileStorageType::Disk,
-                }),
+    pub fn new(opts: FileNodeOpts) -> Result<Self, OxenError> {
+        Ok(Self {
+            node: EFileNode::V0_25_0(FileNodeDataV0_25_0 {
+                node_type: MerkleTreeNodeType::File,
+                name: opts.name,
+                hash: opts.hash,
+                combined_hash: opts.combined_hash,
+                metadata_hash: opts.metadata_hash,
+                num_bytes: opts.num_bytes,
+                last_commit_id: MerkleHash::new(0),
+                last_modified_seconds: opts.last_modified_seconds,
+                last_modified_nanoseconds: opts.last_modified_nanoseconds,
+                data_type: opts.data_type,
+                metadata: opts.metadata,
+                mime_type: opts.mime_type,
+                extension: opts.extension,
+                chunk_hashes: vec![],
+                chunk_type: FileChunkType::SingleFile,
+                storage_backend: FileStorageType::Disk,
             }),
-        }
+        })
     }
 
     #[inline(always)]
@@ -119,10 +114,6 @@ impl FileNode {
 
     pub fn node_type(&self) -> &MerkleTreeNodeType {
         self.node().node_type()
-    }
-
-    pub fn version(&self) -> MinOxenVersion {
-        self.node().version()
     }
 
     pub fn hash(&self) -> &MerkleHash {
@@ -266,7 +257,7 @@ impl TMerkleTreeNode for FileNode {}
 /// Debug is used for verbose multi-line output with println!("{:?}", node)
 impl fmt::Debug for FileNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "FileNode({})", self.version())?;
+        writeln!(f, "FileNode")?;
         writeln!(f, "\thash: {}", self.hash())?;
         writeln!(f, "\tname: {}", self.name())?;
         writeln!(

--- a/crates/liboxen/src/model/merkle_tree/node/vnode.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/vnode.rs
@@ -6,16 +6,12 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use crate::core::v_latest::model::merkle_tree::node::vnode::VNodeData as VNodeImplV0_25_0;
-use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::{
-    LocalRepository, MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode,
-};
+use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode};
 
 pub trait TVNode {
     fn node_type(&self) -> &MerkleTreeNodeType;
     fn hash(&self) -> &MerkleHash;
-    fn version(&self) -> MinOxenVersion;
     fn num_entries(&self) -> u64;
     fn set_num_entries(&mut self, _: u64);
 }
@@ -36,16 +32,14 @@ pub struct VNode {
 }
 
 impl VNode {
-    pub fn new(repo: &LocalRepository, vnode_opts: VNodeOpts) -> Result<VNode, OxenError> {
-        match repo.min_version() {
-            MinOxenVersion::LATEST => Ok(Self {
-                node: EVNode::V0_25_0(VNodeImplV0_25_0 {
-                    hash: vnode_opts.hash,
-                    node_type: MerkleTreeNodeType::VNode,
-                    num_entries: vnode_opts.num_entries,
-                }),
+    pub fn new(vnode_opts: VNodeOpts) -> Result<VNode, OxenError> {
+        Ok(Self {
+            node: EVNode::V0_25_0(VNodeImplV0_25_0 {
+                hash: vnode_opts.hash,
+                node_type: MerkleTreeNodeType::VNode,
+                num_entries: vnode_opts.num_entries,
             }),
-        }
+        })
     }
 
     #[inline(always)]
@@ -72,10 +66,6 @@ impl VNode {
         match self.node {
             EVNode::V0_25_0(ref mut vnode) => vnode,
         }
-    }
-
-    pub fn version(&self) -> MinOxenVersion {
-        self.node().version()
     }
 
     pub fn hash(&self) -> &MerkleHash {

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -265,17 +265,14 @@ pub(crate) fn commit_dir_entries_with_parents(
         }
     }
 
-    let node = CommitNode::new(
-        repo,
-        CommitNodeOpts {
-            hash: commit_id,
-            parent_ids: parent_hashes,
-            email: new_commit.email.clone(),
-            author: new_commit.author.clone(),
-            message: message.to_string(),
-            timestamp,
-        },
-    )?;
+    let node = CommitNode::new(CommitNodeOpts {
+        hash: commit_id,
+        parent_ids: parent_hashes,
+        email: new_commit.email.clone(),
+        author: new_commit.author.clone(),
+        message: message.to_string(),
+        timestamp,
+    })?;
 
     let opts = db::key_val::opts::default();
     let commit_id_string = format!("{commit_id}").to_string();
@@ -349,21 +346,18 @@ pub fn commit_dir_entries_new(
 
     let commit_id = compute_commit_id(&new_commit)?;
 
-    let node = CommitNode::new(
-        repo,
-        CommitNodeOpts {
-            hash: commit_id,
-            parent_ids: new_commit
-                .parent_ids
-                .iter()
-                .map(|id: &String| id.parse().unwrap())
-                .collect(),
-            email: new_commit.email.clone(),
-            author: new_commit.author.clone(),
-            message: message.to_string(),
-            timestamp,
-        },
-    )?;
+    let node = CommitNode::new(CommitNodeOpts {
+        hash: commit_id,
+        parent_ids: new_commit
+            .parent_ids
+            .iter()
+            .map(|id: &String| id.parse().unwrap())
+            .collect(),
+        email: new_commit.email.clone(),
+        author: new_commit.author.clone(),
+        message: message.to_string(),
+        timestamp,
+    })?;
 
     let opts = db::key_val::opts::default();
     let commit_id_string = format!("{commit_id}").to_string();
@@ -462,17 +456,14 @@ pub fn commit_dir_entries(
     };
     let commit_id = compute_commit_id(&new_commit)?;
 
-    let node = CommitNode::new(
-        repo,
-        CommitNodeOpts {
-            hash: commit_id,
-            parent_ids,
-            email: new_commit.email.clone(),
-            author: new_commit.author.clone(),
-            message: message.to_string(),
-            timestamp,
-        },
-    )?;
+    let node = CommitNode::new(CommitNodeOpts {
+        hash: commit_id,
+        parent_ids,
+        email: new_commit.email.clone(),
+        author: new_commit.author.clone(),
+        message: message.to_string(),
+        timestamp,
+    })?;
 
     let opts = db::key_val::opts::default();
     let commit_id_string = format!("{commit_id}").to_string();
@@ -864,7 +855,7 @@ fn r_create_dir_node(
             hash: vnode.id,
             num_entries: vnode.entries.len() as u64,
         };
-        let vnode_obj = VNode::new(repo, opts)?;
+        let vnode_obj = VNode::new(opts)?;
         if let Some(dir_db) = maybe_dir_db {
             dir_db.add_child(&vnode_obj)?;
             *total_written += 1;
@@ -1159,20 +1150,17 @@ fn compute_dir_node(
         "Aggregated dir {path:?} [{hash}] num_bytes {num_bytes:?} num_entries {num_entries:?} data_type_counts {data_type_counts:?}"
     );
 
-    let node = DirNode::new(
-        repo,
-        DirNodeOpts {
-            name: file_name.to_owned(),
-            hash,
-            num_bytes,
-            num_entries,
-            last_commit_id: commit_id,
-            last_modified_seconds: 0,
-            last_modified_nanoseconds: 0,
-            data_type_counts,
-            data_type_sizes,
-        },
-    )?;
+    let node = DirNode::new(DirNodeOpts {
+        name: file_name.to_owned(),
+        hash,
+        num_bytes,
+        num_entries,
+        last_commit_id: commit_id,
+        last_modified_seconds: 0,
+        last_modified_nanoseconds: 0,
+        data_type_counts,
+        data_type_sizes,
+    })?;
     Ok(node)
 }
 

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1330,7 +1330,7 @@ pub fn write_tree(repo: &LocalRepository, node: &MerkleTreeNode) -> Result<(), O
     let EMerkleTreeNode::Commit(commit_node) = &node.node else {
         return Err(OxenError::basic_str("Expected commit node"));
     };
-    let commit_node = CommitNode::new(repo, commit_node.get_opts())?;
+    let commit_node = CommitNode::new(commit_node.get_opts())?;
     p_write_tree(repo, node, &commit_node)?;
     Ok(())
 }


### PR DESCRIPTION
Merkle node constructors no longer take a repository, and nodes no longer carry a version() accessor — both were vestiges of the multi-version dispatch that now only ever resolves to the current format. The single-variant node enums are left intact, so the on-disk node format is unchanged.

ENG-1252