### PR TITLE
S3 (26.2): RemoteRepository always reports its storage backend

### DIFF
--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -24,7 +24,7 @@ static MTIME_TOLERANCE_CACHE: LazyLock<Mutex<HashMap<PathBuf, Duration>>> =
 
 /// In-process model of a local working tree (CLI) or a server-side repo directory.
 /// Not part of any API wire shape — `RepositoryView` is what crosses the wire. Held by
-/// `Workspace` and `LocalRepositoryWithEntries`, both of which are likewise in-process.
+/// `Workspace`, which is likewise in-process.
 #[derive(Debug, Clone)]
 pub struct LocalRepository {
     pub path: PathBuf,
@@ -56,11 +56,6 @@ pub struct LocalRepository {
     /// The backend `merkle_node_store` resolved to. Persisted as `merkle_node_backend` in
     /// `config.toml` by [`save`](Self::save) so the choice is the authoritative record on the next load.
     merkle_node_backend: MerkleNodeBackend,
-}
-
-#[derive(Debug, Clone)]
-pub struct LocalRepositoryWithEntries {
-    pub local_repo: LocalRepository,
 }
 
 impl LocalRepository {

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -5,7 +5,7 @@ use crate::core::db::merkle_node::{MerkleNodeBackend, MerkleNodeStore, create_me
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
-use crate::model::{MetadataEntry, Remote, RemoteRepository};
+use crate::model::{Remote, RemoteRepository};
 use crate::storage::{S3Opts, StorageConfig, VersionStore, create_version_store};
 use crate::util;
 use crate::util::fs::AtomicFile;
@@ -61,7 +61,6 @@ pub struct LocalRepository {
 #[derive(Debug, Clone)]
 pub struct LocalRepositoryWithEntries {
     pub local_repo: LocalRepository,
-    pub entries: Option<Vec<MetadataEntry>>,
 }
 
 impl LocalRepository {

--- a/crates/liboxen/src/model/repository/remote_repository.rs
+++ b/crates/liboxen/src/model/repository/remote_repository.rs
@@ -1,5 +1,6 @@
 use crate::api;
 use crate::core::versions::MinOxenVersion;
+use crate::storage::StorageKind;
 use crate::view::RepositoryView;
 use crate::view::repository::RepositoryCreationView;
 use crate::{error::OxenError, model::Remote};
@@ -13,6 +14,8 @@ pub struct RemoteRepository {
     pub remote: Remote,
     pub min_version: Option<String>,
     pub is_empty: bool,
+    /// The server's version-store backend for this repo (local filesystem or S3).
+    pub storage_kind: StorageKind,
 }
 
 impl RemoteRepository {
@@ -23,6 +26,7 @@ impl RemoteRepository {
             remote: remote.clone(),
             min_version: repository.min_version.clone(),
             is_empty: repository.is_empty,
+            storage_kind: repository.storage_kind,
         }
     }
 
@@ -36,6 +40,7 @@ impl RemoteRepository {
             remote: remote.clone(),
             min_version: repository.min_version.clone(),
             is_empty: true,
+            storage_kind: repository.storage_kind,
         }
     }
 

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -10,11 +10,9 @@ use crate::core::refs::with_ref_manager;
 use crate::error::OxenError;
 use crate::model::Commit;
 use crate::model::LocalRepository;
-use crate::model::MetadataEntry;
 use crate::model::file::FileContents;
 use crate::model::merkle_tree;
 use crate::model::repository::local_repository::LocalRepositoryWithEntries;
-use crate::repositories;
 use crate::storage::S3Opts;
 use crate::util;
 use jwalk::WalkDir;
@@ -249,7 +247,6 @@ pub async fn create(
     })?;
 
     // If the user supplied files, add and commit them
-    let mut commit: Option<Commit> = None;
     if let Some(files) = &new_repo.files {
         let user = &files[0].user;
         // Add the files
@@ -275,44 +272,12 @@ pub async fn create(
             add(&local_repo, &full_path).await?;
         }
 
-        commit = Some(core::v_latest::commits::commit_with_user(
-            &local_repo,
-            "Initial commit",
-            user,
-        )?);
-        branches::create(
-            &local_repo,
-            constants::DEFAULT_BRANCH_NAME,
-            &commit.as_ref().unwrap().id,
-        )?;
+        let commit =
+            core::v_latest::commits::commit_with_user(&local_repo, "Initial commit", user)?;
+        branches::create(&local_repo, constants::DEFAULT_BRANCH_NAME, &commit.id)?;
     }
 
-    let metadata_entries: Option<Vec<MetadataEntry>> = if let Some(files) = &new_repo.files {
-        let entries: Vec<MetadataEntry> = files
-            .iter()
-            .filter_map(|file| {
-                repositories::entries::get_meta_entry(
-                    &local_repo,
-                    commit.as_ref().unwrap(),
-                    &file.path,
-                )
-                .ok()
-            })
-            .collect();
-
-        if entries.is_empty() {
-            None
-        } else {
-            Some(entries)
-        }
-    } else {
-        None
-    };
-
-    Ok(LocalRepositoryWithEntries {
-        local_repo,
-        entries: metadata_entries,
-    })
+    Ok(LocalRepositoryWithEntries { local_repo })
 }
 
 pub fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -12,7 +12,6 @@ use crate::model::Commit;
 use crate::model::LocalRepository;
 use crate::model::file::FileContents;
 use crate::model::merkle_tree;
-use crate::model::repository::local_repository::LocalRepositoryWithEntries;
 use crate::storage::S3Opts;
 use crate::util;
 use jwalk::WalkDir;
@@ -191,7 +190,7 @@ pub async fn create(
     root_dir: &Path,
     new_repo: RepoNew,
     server_s3_opts: Option<&S3Opts>,
-) -> Result<LocalRepositoryWithEntries, OxenError> {
+) -> Result<LocalRepository, OxenError> {
     // Validate repo name
     if !is_valid_repo_name(&new_repo.name) {
         return Err(OxenError::InvalidRepoName(new_repo.name.into()));
@@ -277,7 +276,7 @@ pub async fn create(
         branches::create(&local_repo, constants::DEFAULT_BRANCH_NAME, &commit.id)?;
     }
 
-    Ok(LocalRepositoryWithEntries { local_repo })
+    Ok(local_repo)
 }
 
 pub fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {

--- a/crates/liboxen/src/view/repository.rs
+++ b/crates/liboxen/src/view/repository.rs
@@ -1,6 +1,7 @@
 use super::{DataTypeCount, StatusMessage};
 use crate::model::parsed_resource::ParsedResourceView;
-use crate::model::{Commit, EntryDataType, MetadataEntry};
+use crate::model::{Commit, EntryDataType};
+use crate::storage::StorageKind;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -10,6 +11,7 @@ use utoipa::ToSchema;
         "namespace": "ox",
         "name": "ImageNet-1k",
         "is_empty": false,
+        "storage_kind": "s3",
     })
 )]
 pub struct RepositoryView {
@@ -17,6 +19,7 @@ pub struct RepositoryView {
     pub name: String,
     pub min_version: Option<String>,
     pub is_empty: bool,
+    pub storage_kind: StorageKind,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -45,6 +48,7 @@ pub struct RepositoryListView {
             "email": "ox@example.com",
             "timestamp": "2025-01-01T10:00:00Z"
         },
+        "storage_kind": "s3",
     })
 )]
 pub struct RepositoryCreationView {
@@ -52,6 +56,7 @@ pub struct RepositoryCreationView {
     pub name: String,
     pub latest_commit: Option<Commit>,
     pub min_version: Option<String>,
+    pub storage_kind: StorageKind,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -59,22 +64,21 @@ pub struct RepositoryCreationView {
     example = json!({
         "namespace": "bessie",
         "name": "my-corn-pics",
+        "is_empty": false,
+        "storage_kind": "s3",
         "size": 1073741824,
         "data_types": [
             { "data_type": "image", "count": 1000 },
             { "data_type": "tabular", "count": 5 }
         ],
-        "is_empty": false,
         "branch_count": 3,
     })
 )]
 pub struct RepositoryDataTypesView {
-    pub namespace: String,
-    pub name: String,
+    #[serde(flatten)]
+    pub repository: RepositoryView,
     pub size: u64,
     pub data_types: Vec<DataTypeCount>,
-    pub min_version: Option<String>,
-    pub is_empty: bool,
     #[serde(default)]
     pub branch_count: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -116,21 +120,12 @@ pub struct RepositoryResponse {
                 "timestamp": "2025-01-01T10:00:00Z"
             },
         },
-        "metadata_entries": [
-            {
-                "path": "data/images/cow.jpg",
-                "data_type": "image",
-                "content_hash": "a1b2c3d4e5f678902e41",
-                "file_size": 1024000,
-            }
-        ],
     })
 )]
 pub struct RepositoryCreationResponse {
     pub status: String,
     pub status_message: String,
     pub repository: RepositoryCreationView,
-    pub metadata_entries: Option<Vec<MetadataEntry>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
@@ -230,4 +225,106 @@ pub struct DataTypeView {
 pub struct RepositoryStatsView {
     pub data_size: u64,
     pub data_types: Vec<DataTypeView>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_types_view_serializes_flat_with_storage_kind() {
+        let view = RepositoryDataTypesView {
+            repository: RepositoryView {
+                namespace: "ox".to_string(),
+                name: "test".to_string(),
+                min_version: Some("0.0.0".to_string()),
+                is_empty: false,
+                storage_kind: StorageKind::S3,
+            },
+            size: 42,
+            data_types: vec![],
+            branch_count: 1,
+            default_resource: None,
+        };
+        let json = serde_json::to_value(&view).expect("view should serialize");
+        // Flattened: the identity fields (including storage_kind) sit at the top level, not
+        // nested under a "repository" key.
+        assert_eq!(json["namespace"], "ox");
+        assert_eq!(json["storage_kind"], "s3");
+        assert_eq!(json["size"], 42);
+        assert!(json.get("repository").is_none());
+    }
+
+    #[test]
+    fn repository_view_reads_storage_kind_from_flattened_payload() {
+        // The client parses the (flattened) show-endpoint payload as a RepositoryView.
+        let payload = serde_json::json!({
+            "namespace": "ox",
+            "name": "test",
+            "min_version": "0.0.0",
+            "is_empty": false,
+            "storage_kind": "local",
+            "size": 42,
+            "data_types": [],
+            "branch_count": 1,
+        });
+        let view: RepositoryView =
+            serde_json::from_value(payload).expect("payload should deserialize");
+        assert_eq!(view.storage_kind, StorageKind::Local);
+    }
+
+    #[test]
+    fn repository_view_requires_storage_kind() {
+        // A response missing storage_kind must fail to deserialize rather than defaulting.
+        let payload = serde_json::json!({
+            "namespace": "ox",
+            "name": "test",
+            "is_empty": false,
+        });
+        let result = serde_json::from_value::<RepositoryView>(payload);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn creation_view_serializes_and_requires_storage_kind() {
+        let view = RepositoryCreationView {
+            namespace: "ox".to_string(),
+            name: "test".to_string(),
+            latest_commit: None,
+            min_version: Some("0.0.0".to_string()),
+            storage_kind: StorageKind::S3,
+        };
+        let json = serde_json::to_value(&view).expect("view should serialize");
+        assert_eq!(json["storage_kind"], "s3");
+
+        // A create response missing storage_kind must fail rather than defaulting.
+        let missing = serde_json::json!({ "namespace": "ox", "name": "test" });
+        assert!(serde_json::from_value::<RepositoryCreationView>(missing).is_err());
+    }
+
+    #[test]
+    fn data_types_view_round_trips_through_flatten() {
+        // Guards against the serde `flatten` + integer-field deserialization footgun: a struct
+        // that both flattens another struct and carries numeric fields (`size`, `branch_count`).
+        let view = RepositoryDataTypesView {
+            repository: RepositoryView {
+                namespace: "ox".to_string(),
+                name: "test".to_string(),
+                min_version: Some("0.0.0".to_string()),
+                is_empty: false,
+                storage_kind: StorageKind::S3,
+            },
+            size: 1_073_741_824,
+            data_types: vec![],
+            branch_count: 3,
+            default_resource: None,
+        };
+        let json = serde_json::to_string(&view).expect("view should serialize");
+        let back: RepositoryDataTypesView =
+            serde_json::from_str(&json).expect("view should round-trip through the flatten");
+        assert_eq!(back.repository.storage_kind, StorageKind::S3);
+        assert_eq!(back.repository.namespace, "ox");
+        assert_eq!(back.size, 1_073_741_824);
+        assert_eq!(back.branch_count, 3);
+    }
 }

--- a/crates/oxen-py/src/py_remote_data_frame.rs
+++ b/crates/oxen-py/src/py_remote_data_frame.rs
@@ -34,7 +34,7 @@ impl PyRemoteDataFrame {
             opts.slice = Some("0..1".to_string());
 
             let response = api::client::data_frames::get(
-                &self.repo.repo,
+                self.repo.repo()?,
                 revision,
                 &self.path,
                 DFOpts::empty(),
@@ -58,7 +58,8 @@ impl PyRemoteDataFrame {
             opts.slice = Some(format!("{}..{}", row, row + 1));
 
             let response =
-                api::client::data_frames::get(&self.repo.repo, revision, &self.path, opts).await?;
+                api::client::data_frames::get(self.repo.repo()?, revision, &self.path, opts)
+                    .await?;
 
             // convert view to json string
             match serde_json::to_string(&response.data_frame.view.data) {
@@ -92,7 +93,8 @@ impl PyRemoteDataFrame {
             }
 
             let response =
-                api::client::data_frames::get(&self.repo.repo, revision, &self.path, opts).await?;
+                api::client::data_frames::get(self.repo.repo()?, revision, &self.path, opts)
+                    .await?;
 
             // convert view to json string
             match serde_json::to_string(&response.data_frame.view.data) {

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -216,6 +216,10 @@ impl PyRemoteRepo {
             })?;
 
         self.repo = Some(result);
+        // A non-empty create points the handle at the initial commit on the default branch. An
+        // empty create leaves the handle untouched: `revision` is the branch future operations
+        // target (the constructor defaults it to "main" before the branch exists), so clearing
+        // it would break follow-up calls like `log()` once the first commit lands.
         if let Some(branch) = default_branch {
             self.revision = Some(branch.name);
             self.commit_id = Some(branch.commit_id);

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -190,7 +190,7 @@ impl PyRemoteRepo {
                 let user = config.to_user();
                 let files: Vec<FileNew> = vec![FileNew {
                     path: PathBuf::from("README.md"),
-                    contents: FileContents::Text(format!("# {}\n", &self.name)),
+                    contents: FileContents::Text(format!("# {}\n", self.name)),
                     user: user.clone(),
                 }];
                 let mut repo =

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -7,7 +7,7 @@ use liboxen::config::UserConfig;
 use liboxen::error::OxenError;
 use liboxen::model::commit::NewCommitBody;
 use liboxen::model::file::{FileContents, FileNew};
-use liboxen::model::{Remote, RemoteRepository, User};
+use liboxen::model::{RemoteRepository, User};
 use liboxen::opts::{PaginateOpts, SortOpts};
 use liboxen::storage::StorageKind;
 use liboxen::{api, repositories};
@@ -30,16 +30,33 @@ use crate::py_workspace::PyWorkspaceResponse;
 #[derive(Clone)]
 #[pyclass]
 pub struct PyRemoteRepo {
-    pub repo: RemoteRepository,
+    // Identity of the repo this handle points at, known even before it exists on the server.
+    pub namespace: String,
+    pub name: String,
+    pub url: String,
     #[pyo3(get)]
     pub host: String,
     #[pyo3(get)]
     pub scheme: String,
+    // The server's repo metadata; None until the repo exists (fetched on construction or create).
+    pub repo: Option<RemoteRepository>,
     // revision and commit_id are Option's in case you call .create(empty=True)
     #[pyo3(get)]
     pub revision: Option<String>,
     #[pyo3(get)]
     pub commit_id: Option<String>,
+}
+
+impl PyRemoteRepo {
+    /// The server metadata for this repo, erroring if the repo does not exist on the server yet.
+    pub(crate) fn repo(&self) -> Result<&RemoteRepository, OxenError> {
+        self.repo.as_ref().ok_or_else(|| {
+            OxenError::internal_error(format!(
+                "Remote repository {}/{} does not exist",
+                self.namespace, self.name
+            ))
+        })
+    }
 }
 
 #[pymethods]
@@ -52,8 +69,8 @@ impl PyRemoteRepo {
         revision: &str,
         scheme: &str,
     ) -> Result<Self, PyOxenError> {
-        let (namespace, repo_name) = match repo.split_once('/') {
-            Some((namespace, repo_name)) => (namespace.to_string(), repo_name.to_string()),
+        let (namespace, name) = match repo.split_once('/') {
+            Some((namespace, name)) => (namespace.to_string(), name.to_string()),
             None => {
                 return Err(OxenError::basic_str(format!(
                     "Invalid repo name, must be in format namespace/repo_name. Got {repo}"
@@ -62,29 +79,41 @@ impl PyRemoteRepo {
             }
         };
 
-        let remote_repo = RemoteRepository {
-            namespace: namespace.to_owned(),
-            name: repo_name.to_owned(),
-            remote: Remote {
-                url: liboxen::api::endpoint::remote_url_from_namespace_name_scheme(
-                    &host, &namespace, &repo_name, scheme,
-                ),
-                name: String::from(liboxen::constants::DEFAULT_REMOTE_NAME),
-            },
-            is_empty: false,
-            min_version: Some(liboxen::constants::MIN_OXEN_VERSION.to_string()),
-        };
+        let url = liboxen::api::endpoint::remote_url_from_namespace_name_scheme(
+            &host, &namespace, &name, scheme,
+        );
 
-        let parsed_revision = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            liboxen::api::client::revisions::get(&remote_repo, revision).await
-        })?;
+        // Fetch the server's metadata; a repo that does not exist yet (awaiting `create`) leaves
+        // it None. Any other error -- including a server too old to report storage_kind -- fails.
+        let (remote_repo, commit_id) =
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                let remote_repo = match api::client::repositories::get_by_name_host_and_scheme(
+                    &repo, &host, scheme,
+                )
+                .await
+                {
+                    Ok(remote_repo) => Some(remote_repo),
+                    Err(OxenError::RemoteRepoNotFound(_)) => None,
+                    Err(err) => return Err(err),
+                };
+                let commit_id = match &remote_repo {
+                    Some(remote_repo) => api::client::revisions::get(remote_repo, revision)
+                        .await?
+                        .and_then(|parsed| parsed.commit.map(|commit| commit.id)),
+                    None => None,
+                };
+                Ok::<_, OxenError>((remote_repo, commit_id))
+            })?;
 
         Ok(Self {
-            repo: remote_repo,
+            namespace,
+            name,
+            url,
             scheme: scheme.to_string(),
             host,
+            repo: remote_repo,
             revision: Some(revision.to_string()),
-            commit_id: parsed_revision.map(|r| r.commit.unwrap().id),
+            commit_id,
         })
     }
 
@@ -103,15 +132,15 @@ impl PyRemoteRepo {
     }
 
     fn url(&self) -> &str {
-        self.repo.url()
+        &self.url
     }
 
     fn namespace(&self) -> &str {
-        &self.repo.namespace
+        &self.namespace
     }
 
     fn name(&self) -> &str {
-        &self.repo.name
+        &self.name
     }
 
     fn set_revision(&mut self, new_revision: String) {
@@ -124,7 +153,7 @@ impl PyRemoteRepo {
 
     fn list_workspaces(&self) -> Result<Vec<PyWorkspaceResponse>, PyOxenError> {
         let workspaces = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::workspaces::list(&self.repo).await })?;
+            .block_on(async { api::client::workspaces::list(self.repo()?).await })?;
         Ok(workspaces
             .iter()
             .map(|w| PyWorkspaceResponse {
@@ -148,8 +177,8 @@ impl PyRemoteRepo {
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             if empty {
                 let mut repo = RepoNew::from_namespace_name_host(
-                    self.repo.namespace.clone(),
-                    self.repo.name.clone(),
+                    self.namespace.clone(),
+                    self.name.clone(),
                     self.host.clone(),
                     storage_kind,
                 );
@@ -161,11 +190,11 @@ impl PyRemoteRepo {
                 let user = config.to_user();
                 let files: Vec<FileNew> = vec![FileNew {
                     path: PathBuf::from("README.md"),
-                    contents: FileContents::Text(format!("# {}\n", self.repo.name)),
+                    contents: FileContents::Text(format!("# {}\n", &self.name)),
                     user: user.clone(),
                 }];
                 let mut repo =
-                    RepoNew::from_files(&self.repo.namespace, &self.repo.name, files, storage_kind);
+                    RepoNew::from_files(&self.namespace, &self.name, files, storage_kind);
                 repo.host = Some(self.host.clone());
                 repo.is_public = Some(is_public);
                 repo.scheme = Some(self.scheme.clone());
@@ -173,27 +202,42 @@ impl PyRemoteRepo {
             }
         })?;
 
-        self.repo = result;
+        self.repo = Some(result);
 
         Ok(PyRemoteRepo {
-            repo: self.repo.clone(),
+            namespace: self.namespace.clone(),
+            name: self.name.clone(),
+            url: self.url.clone(),
             host: self.host.clone(),
             scheme: self.scheme.clone(),
+            repo: self.repo.clone(),
             revision: self.revision.clone(),
             commit_id: self.commit_id.clone(),
         })
     }
 
     fn exists(&self) -> Result<bool, PyOxenError> {
-        let exists = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::repositories::exists(&self.repo).await })?;
+        let name = format!("{}/{}", self.namespace, self.name);
+        let exists = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+            match api::client::repositories::get_by_name_host_and_scheme(
+                &name,
+                &self.host,
+                &self.scheme,
+            )
+            .await
+            {
+                Ok(_) => Ok(true),
+                Err(OxenError::RemoteRepoNotFound(_)) => Ok(false),
+                Err(err) => Err(err),
+            }
+        })?;
 
         Ok(exists)
     }
 
     fn delete(&self) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::repositories::delete(&self.repo).await })?;
+            .block_on(async { api::client::repositories::delete(self.repo()?).await })?;
 
         Ok(())
     }
@@ -206,9 +250,9 @@ impl PyRemoteRepo {
     ) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             if !revision.is_empty() {
-                repositories::download(&self.repo, &remote_path, &local_path, revision).await
+                repositories::download(self.repo()?, &remote_path, &local_path, revision).await
             } else if let Some(revision) = &self.revision {
-                repositories::download(&self.repo, &remote_path, &local_path, &revision).await
+                repositories::download(self.repo()?, &remote_path, &local_path, &revision).await
             } else {
                 Err(OxenError::basic_str(
                     "Invalid Revision: Cannot download without a version.",
@@ -228,7 +272,7 @@ impl PyRemoteRepo {
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             if !revision.is_empty() {
                 api::client::export::download_dir_as_zip(
-                    &self.repo,
+                    self.repo()?,
                     revision,
                     &directory,
                     &local_path,
@@ -236,7 +280,7 @@ impl PyRemoteRepo {
                 .await
             } else if let Some(revision) = &self.revision {
                 api::client::export::download_dir_as_zip(
-                    &self.repo,
+                    self.repo()?,
                     revision,
                     &directory,
                     &local_path,
@@ -256,7 +300,7 @@ impl PyRemoteRepo {
     fn get_file(&self, remote_path: PathBuf, revision: &str) -> Result<Cow<'_, [u8]>, PyOxenError> {
         let bytes = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             let mut stream =
-                get_file(&self.repo, revision, &remote_path, GetFileOpts::default()).await?;
+                get_file(self.repo()?, revision, &remote_path, GetFileOpts::default()).await?;
             let mut bytes = Vec::new();
             while let Some(chunk) = stream.next().await {
                 bytes.extend_from_slice(&chunk?);
@@ -283,7 +327,7 @@ impl PyRemoteRepo {
         };
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::file::put_file(
-                &self.repo,
+                self.repo()?,
                 &branch,
                 &directory,
                 &local_path,
@@ -310,7 +354,7 @@ impl PyRemoteRepo {
         });
 
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::file::delete_file(&self.repo, &branch, &file_path, commit_body).await
+            api::client::file::delete_file(self.repo()?, &branch, &file_path, commit_body).await
         })?;
 
         Ok(())
@@ -331,13 +375,20 @@ impl PyRemoteRepo {
 
         let paginated_commits = if let Some(path) = path {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-                api::client::commits::list_commits_for_path(&self.repo, revision, path, &page_opts)
-                    .await
+                api::client::commits::list_commits_for_path(
+                    self.repo()?,
+                    revision,
+                    path,
+                    &page_opts,
+                )
+                .await
             })?
         } else {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 api::client::commits::list_commit_history_paginated(
-                    &self.repo, revision, &page_opts,
+                    self.repo()?,
+                    revision,
+                    &page_opts,
                 )
                 .await
             })?
@@ -348,7 +399,7 @@ impl PyRemoteRepo {
 
     fn list_branches(&self) -> Result<Vec<PyBranch>, PyOxenError> {
         let branches = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::branches::list(&self.repo).await })?;
+            .block_on(async { api::client::branches::list(self.repo()?).await })?;
         Ok(branches
             .iter()
             .map(|b| PyBranch::new(b.name.clone(), b.commit_id.clone()))
@@ -373,7 +424,7 @@ impl PyRemoteRepo {
 
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::dir::list_with_opts(
-                &self.repo,
+                self.repo()?,
                 revision,
                 &path,
                 page_num,
@@ -390,7 +441,7 @@ impl PyRemoteRepo {
 
     fn file_exists(&self, path: PathBuf, revision: &str) -> Result<bool, PyOxenError> {
         let exists = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            match api::client::metadata::get_file(&self.repo, &revision, &path).await {
+            match api::client::metadata::get_file(self.repo()?, &revision, &path).await {
                 Ok(Some(_)) => Ok(true),
                 Ok(None) => Ok(false),
                 Err(e) => Err(e),
@@ -407,7 +458,7 @@ impl PyRemoteRepo {
         revision: &str,
     ) -> PyResult<bool> {
         match pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::metadata::get_file(&self.repo, &revision, &remote_path).await
+            api::client::metadata::get_file(self.repo()?, &revision, &remote_path).await
         }) {
             Ok(Some(remote_metadata)) => {
                 let remote_hash = remote_metadata.entry.hash();
@@ -431,7 +482,7 @@ impl PyRemoteRepo {
         };
 
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::metadata::get_file(&self.repo, &revision, &path).await
+            api::client::metadata::get_file(self.repo()?, &revision, &path).await
         })?;
 
         Ok(result.map(|e| PyEntry::from(e.entry)))
@@ -441,8 +492,8 @@ impl PyRemoteRepo {
         log::info!("Get branch... {branch_name}");
 
         let branch = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            log::info!("From repo... {}", self.repo.remote.url);
-            api::client::branches::get_by_name(&self.repo, &branch_name).await
+            log::info!("From repo... {}", self.url);
+            api::client::branches::get_by_name(self.repo()?, &branch_name).await
         });
 
         match branch {
@@ -452,8 +503,9 @@ impl PyRemoteRepo {
     }
 
     fn branch_exists(&self, branch_name: String) -> PyResult<bool> {
-        let branch = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::branches::get_by_name(&self.repo, &branch_name).await });
+        let branch = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+            api::client::branches::get_by_name(self.repo()?, &branch_name).await
+        });
 
         match branch {
             Ok(Some(_)) => Ok(true),
@@ -464,7 +516,7 @@ impl PyRemoteRepo {
 
     fn get_commit(&self, commit_id: String) -> PyResult<PyCommit> {
         let commit = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::commits::get_by_id(&self.repo, &commit_id).await });
+            .block_on(async { api::client::commits::get_by_id(self.repo()?, &commit_id).await });
         match commit {
             Ok(Some(commit)) => Ok(PyCommit { commit }),
             _ => Err(PyValueError::new_err("could not get commit id {commit_id}")),
@@ -479,7 +531,7 @@ impl PyRemoteRepo {
         };
 
         let branch = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::branches::create_from_commit_id(&self.repo, &new_name, &commit_id).await
+            api::client::branches::create_from_commit_id(self.repo()?, &new_name, &commit_id).await
         });
 
         match branch {
@@ -490,7 +542,7 @@ impl PyRemoteRepo {
 
     fn delete_branch(&self, branch_name: String) -> PyResult<()> {
         let result = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::branches::delete(&self.repo, &branch_name).await });
+            .block_on(async { api::client::branches::delete(self.repo()?, &branch_name).await });
 
         match result {
             Ok(_) => Ok(()),
@@ -508,7 +560,7 @@ impl PyRemoteRepo {
     ) -> Result<PyCommit, PyOxenError> {
         let author: User = user.into();
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::merger::merge(&self.repo, &base_branch, &head_branch, &author).await
+            api::client::merger::merge(self.repo()?, &base_branch, &head_branch, &author).await
         })?;
 
         // Make sure to advance internal commit id
@@ -525,7 +577,7 @@ impl PyRemoteRepo {
         head_branch: String,
     ) -> Result<PyMergeable, PyOxenError> {
         let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::merger::mergeable(&self.repo, &base_branch, &head_branch).await
+            api::client::merger::mergeable(self.repo()?, &base_branch, &head_branch).await
         })?;
 
         Ok(result.into())
@@ -555,7 +607,7 @@ impl PyRemoteRepo {
 
     fn diff_file(&self, base: &str, head: &str, path: &str) -> Result<PyDiffEntry, PyOxenError> {
         let diff = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::diff::diff_entries(&self.repo, &base, &head, path).await
+            api::client::diff::diff_entries(self.repo()?, &base, &head, path).await
         })?;
 
         Ok(diff.into())

--- a/crates/oxen-py/src/py_remote_repo.rs
+++ b/crates/oxen-py/src/py_remote_repo.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 
 use liboxen::api::requests::RepoNew;
 use liboxen::config::UserConfig;
+use liboxen::constants::DEFAULT_BRANCH_NAME;
 use liboxen::error::OxenError;
 use liboxen::model::commit::NewCommitBody;
 use liboxen::model::file::{FileContents, FileNew};
@@ -174,35 +175,51 @@ impl PyRemoteRepo {
         let storage_kind = storage_backend
             .map(|s| StorageKind::from_str(&s))
             .transpose()?;
-        let result = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            if empty {
-                let mut repo = RepoNew::from_namespace_name_host(
-                    self.namespace.clone(),
-                    self.name.clone(),
-                    self.host.clone(),
-                    storage_kind,
-                );
-                repo.is_public = Some(is_public);
-                repo.scheme = Some(self.scheme.clone());
-                api::client::repositories::create_empty(repo).await
-            } else {
-                let config = UserConfig::get()?;
-                let user = config.to_user();
-                let files: Vec<FileNew> = vec![FileNew {
-                    path: PathBuf::from("README.md"),
-                    contents: FileContents::Text(format!("# {}\n", self.name)),
-                    user: user.clone(),
-                }];
-                let mut repo =
-                    RepoNew::from_files(&self.namespace, &self.name, files, storage_kind);
-                repo.host = Some(self.host.clone());
-                repo.is_public = Some(is_public);
-                repo.scheme = Some(self.scheme.clone());
-                api::client::repositories::create(repo).await
-            }
-        })?;
+        let (result, default_branch) =
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                if empty {
+                    let mut repo = RepoNew::from_namespace_name_host(
+                        self.namespace.clone(),
+                        self.name.clone(),
+                        self.host.clone(),
+                        storage_kind,
+                    );
+                    repo.is_public = Some(is_public);
+                    repo.scheme = Some(self.scheme.clone());
+                    let repo = api::client::repositories::create_empty(repo).await?;
+                    Ok::<_, OxenError>((repo, None))
+                } else {
+                    let config = UserConfig::get()?;
+                    let user = config.to_user();
+                    let files: Vec<FileNew> = vec![FileNew {
+                        path: PathBuf::from("README.md"),
+                        contents: FileContents::Text(format!("# {}\n", self.name)),
+                        user: user.clone(),
+                    }];
+                    let mut repo =
+                        RepoNew::from_files(&self.namespace, &self.name, files, storage_kind);
+                    repo.host = Some(self.host.clone());
+                    repo.is_public = Some(is_public);
+                    repo.scheme = Some(self.scheme.clone());
+                    let repo = api::client::repositories::create(repo).await?;
+                    // The non-empty create makes an initial commit; look up the default branch so
+                    // the handle reflects it.
+                    let branch =
+                        api::client::branches::get_by_name(&repo, DEFAULT_BRANCH_NAME).await?;
+                    let branch = branch.ok_or_else(|| {
+                        OxenError::internal_error(format!(
+                            "Branch {DEFAULT_BRANCH_NAME} not found after repository creation"
+                        ))
+                    })?;
+                    Ok((repo, Some(branch)))
+                }
+            })?;
 
         self.repo = Some(result);
+        if let Some(branch) = default_branch {
+            self.revision = Some(branch.name);
+            self.commit_id = Some(branch.commit_id);
+        }
 
         Ok(PyRemoteRepo {
             namespace: self.namespace.clone(),

--- a/crates/oxen-py/src/py_workspace.rs
+++ b/crates/oxen-py/src/py_workspace.rs
@@ -60,7 +60,7 @@ impl PyWorkspace {
 
         // Get the workspace by name
         let workspace = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::workspaces::get(&repo.repo, &workspace_identifier).await
+            api::client::workspaces::get(repo.repo()?, &workspace_identifier).await
         })?;
 
         if let Some(workspace) = workspace {
@@ -75,7 +75,7 @@ impl PyWorkspace {
 
         let workspace = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::create_with_path(
-                &repo.repo,
+                repo.repo()?,
                 &branch_name,
                 &workspace_id,
                 Path::new(&path.unwrap_or("/".to_string())),
@@ -120,7 +120,7 @@ impl PyWorkspace {
     fn status(&self, path: PathBuf) -> Result<PyStagedData, PyOxenError> {
         let remote_status = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::changes::list(
-                &self.repo.repo,
+                self.repo.repo()?,
                 &self.get_identifier(),
                 &path,
                 liboxen::constants::DEFAULT_PAGE_NUM,
@@ -136,7 +136,7 @@ impl PyWorkspace {
     fn add(&self, src: Vec<PathBuf>, dst: String) -> Result<Vec<PyErrorFileInfo>, PyOxenError> {
         let errors = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::files::add(
-                &self.repo.repo,
+                self.repo.repo()?,
                 &self.get_identifier(),
                 &dst,
                 src,
@@ -154,7 +154,7 @@ impl PyWorkspace {
     ) -> Result<Vec<PyErrorFileInfo>, PyOxenError> {
         let errors = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::files::add_files(
-                &self.repo.repo,
+                self.repo.repo()?,
                 &self.get_identifier(),
                 base_dir,
                 src,
@@ -166,14 +166,15 @@ impl PyWorkspace {
 
     fn rm(&self, path: PathBuf) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-            api::client::workspaces::files::rm(&self.repo.repo, &self.id, path).await
+            api::client::workspaces::files::rm(self.repo.repo()?, &self.id, path).await
         })?;
         Ok(())
     }
 
     fn delete(&self) -> Result<(), PyOxenError> {
-        pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(async { api::client::workspaces::delete(&self.repo.repo, &self.id).await })?;
+        pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+            api::client::workspaces::delete(self.repo.repo()?, &self.id).await
+        })?;
         Ok(())
     }
 
@@ -193,7 +194,7 @@ impl PyWorkspace {
         let workspace_id = self.get_identifier();
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             let commit = api::client::workspaces::commit(
-                &self.repo.repo,
+                self.repo.repo()?,
                 &branch_name,
                 &workspace_id,
                 &commit,

--- a/crates/oxen-py/src/py_workspace_data_frame.rs
+++ b/crates/oxen-py/src/py_workspace_data_frame.rs
@@ -18,9 +18,9 @@ pub fn is_indexed(
     workspace_id: String,
     path: PathBuf,
 ) -> Result<bool, PyOxenError> {
-    let repo = workspace.repo.repo;
+    let repo = workspace.repo.repo()?;
     let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-        api::client::workspaces::data_frames::is_indexed(&repo, &workspace_id, &path).await
+        api::client::workspaces::data_frames::is_indexed(repo, &workspace_id, &path).await
     })?;
     Ok(data)
 }
@@ -31,9 +31,9 @@ pub fn index(
     workspace_id: String,
     path: PathBuf,
 ) -> Result<(), PyOxenError> {
-    let repo = workspace.repo.repo;
+    let repo = workspace.repo.repo()?;
     pyo3_async_runtimes::tokio::get_runtime().block_on(async {
-        api::client::workspaces::data_frames::index(&repo, &workspace_id, &path).await
+        api::client::workspaces::data_frames::index(repo, &workspace_id, &path).await
     })?;
     Ok(())
 }
@@ -97,7 +97,7 @@ impl PyWorkspaceDataFrame {
         // Fetch the first page so that it is
         // quick to look up size and other pagination params
 
-        let df = _get(&workspace.repo.repo, &workspace_id, &path)?;
+        let df = _get(workspace.repo.repo()?, &workspace_id, &path)?;
         Ok(Self {
             workspace,
             path,
@@ -106,7 +106,7 @@ impl PyWorkspaceDataFrame {
     }
 
     fn size(&mut self) -> Result<(usize, usize), PyOxenError> {
-        let df = _get(&self.workspace.repo.repo, &self.workspace.id, &self.path)?;
+        let df = _get(self.workspace.repo.repo()?, &self.workspace.id, &self.path)?;
         let size = &df.view.size;
         let width = size.width;
         let height = df.view.pagination.total_entries;
@@ -115,7 +115,7 @@ impl PyWorkspaceDataFrame {
     }
 
     fn get_columns(&self) -> Result<Vec<PyColumn>, PyOxenError> {
-        let df = _get(&self.workspace.repo.repo, &self.workspace.id, &self.path)?;
+        let df = _get(self.workspace.repo.repo()?, &self.workspace.id, &self.path)?;
         let columns = &df.view.schema.fields;
         let columns = columns
             .iter()
@@ -138,7 +138,7 @@ impl PyWorkspaceDataFrame {
     pub fn is_indexed(&self) -> Result<bool, PyOxenError> {
         let is_indexed = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::is_indexed(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
             )
@@ -150,7 +150,7 @@ impl PyWorkspaceDataFrame {
     pub fn index(&self) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::index(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
             )
@@ -167,7 +167,7 @@ impl PyWorkspaceDataFrame {
 
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::get(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 &opts,
@@ -190,7 +190,7 @@ impl PyWorkspaceDataFrame {
 
         match pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::get(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 &opts,
@@ -212,7 +212,7 @@ impl PyWorkspaceDataFrame {
     fn is_nearest_neighbors_enabled(&self, column: String) -> Result<bool, PyOxenError> {
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::embeddings::get(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
             )
@@ -230,7 +230,7 @@ impl PyWorkspaceDataFrame {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             let use_background_thread = false;
             api::client::workspaces::data_frames::embeddings::index(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 &column,
@@ -254,7 +254,7 @@ impl PyWorkspaceDataFrame {
                 page_size,
             };
             api::client::workspaces::data_frames::embeddings::neighbors(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 &column,
@@ -287,7 +287,7 @@ impl PyWorkspaceDataFrame {
 
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::get(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 &opts,
@@ -309,7 +309,7 @@ impl PyWorkspaceDataFrame {
             opts.sql = Some(format!("SELECT * FROM df LIMIT 1 OFFSET {row}"));
 
             let response = api::client::workspaces::data_frames::get(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 &opts,
@@ -330,7 +330,7 @@ impl PyWorkspaceDataFrame {
     fn get_row_by_id(&self, id: String) -> Result<String, PyOxenError> {
         let data = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::rows::get(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 id.as_str(),
@@ -353,7 +353,7 @@ impl PyWorkspaceDataFrame {
 
         let (_, Some(row_id)) = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::rows::add(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &workspace_id,
                 &self.path,
                 data.to_string(),
@@ -374,7 +374,7 @@ impl PyWorkspaceDataFrame {
 
         let view = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::rows::update(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 id.as_str(),
@@ -391,7 +391,7 @@ impl PyWorkspaceDataFrame {
     fn delete_row(&self, id: String) -> Result<(), PyOxenError> {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::rows::delete(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 id.as_str(),
@@ -410,7 +410,7 @@ impl PyWorkspaceDataFrame {
 
             let data = data.to_string();
             api::client::workspaces::data_frames::columns::create(
-                &self.workspace.repo.repo,
+                self.workspace.repo.repo()?,
                 &self.workspace.id,
                 &self.path,
                 data,
@@ -421,7 +421,7 @@ impl PyWorkspaceDataFrame {
     }
 
     fn restore(&self) -> Result<(), PyOxenError> {
-        let repo = &self.workspace.repo.repo;
+        let repo = self.workspace.repo.repo()?;
 
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             api::client::workspaces::data_frames::restore(repo, &self.workspace.id, &self.path)
@@ -433,7 +433,7 @@ impl PyWorkspaceDataFrame {
 
     fn commit(&self, branch: &str, message: &str) -> Result<PyCommit, PyOxenError> {
         let user = UserConfig::get()?;
-        let repo = &self.workspace.repo.repo;
+        let repo = self.workspace.repo.repo()?;
 
         let commit = NewCommitBody {
             message: message.to_string(),

--- a/crates/oxen-py/src/remote.rs
+++ b/crates/oxen-py/src/remote.rs
@@ -36,9 +36,12 @@ pub fn get_repo(
     };
 
     Ok(Some(PyRemoteRepo {
-        repo: remote_repo.clone(),
+        namespace: remote_repo.namespace.clone(),
+        name: remote_repo.name.clone(),
+        url: remote_repo.url().to_string(),
         host: host.clone(),
         scheme: scheme.to_string(),
+        repo: Some(remote_repo),
         revision: Some(branch_name.to_string()),
         commit_id: revision.commit.map(|r| r.id),
     }))
@@ -85,9 +88,12 @@ pub fn create_repo(
 
             let repo = liboxen::api::client::repositories::create_empty(repo).await?;
             Ok(PyRemoteRepo {
-                repo: repo.clone(),
+                namespace: repo.namespace.clone(),
+                name: repo.name.clone(),
+                url: repo.url().to_string(),
                 host: host.clone(),
                 scheme: scheme.to_string(),
+                repo: Some(repo),
                 // Empty repo does not have a revision or commit_id
                 revision: None,
                 commit_id: None,
@@ -114,9 +120,12 @@ pub fn create_repo(
                 .unwrap();
 
             Ok(PyRemoteRepo {
-                repo: repo.clone(),
+                namespace: repo.namespace.clone(),
+                name: repo.name.clone(),
+                url: repo.url().to_string(),
                 host: host.clone(),
                 scheme: scheme.to_string(),
+                repo: Some(repo),
                 revision: Some(DEFAULT_BRANCH_NAME.to_string()),
                 commit_id: Some(branch.commit_id),
             })

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -125,12 +125,15 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
         status: STATUS_SUCCESS.to_string(),
         status_message: MSG_RESOURCE_FOUND.to_string(),
         repository: RepositoryDataTypesView {
-            namespace,
-            name,
+            repository: RepositoryView {
+                namespace,
+                name,
+                min_version: Some(repository.min_version().to_string()),
+                is_empty: repositories::is_empty(&repository)?,
+                storage_kind: repository.storage_config().kind,
+            },
             size,
             data_types,
-            min_version: Some(repository.min_version().to_string()),
-            is_empty: repositories::is_empty(&repository)?,
             branch_count,
             default_resource,
         },
@@ -334,8 +337,8 @@ async fn handle_json_creation(
                     latest_commit: Some(latest_commit.clone()),
                     name: repo_new_clone.name.clone(),
                     min_version: Some(repo.local_repo.min_version().to_string()),
+                    storage_kind: repo.local_repo.storage_config().kind,
                 },
-                metadata_entries: None,
             })),
             Err(OxenError::NoCommitsFound) => {
                 Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
@@ -346,8 +349,8 @@ async fn handle_json_creation(
                         latest_commit: None,
                         name: repo_new_clone.name.clone(),
                         min_version: Some(repo.local_repo.min_version().to_string()),
+                        storage_kind: repo.local_repo.storage_config().kind,
                     },
-                    metadata_entries: None,
                 }))
             }
             Err(err) => {
@@ -472,8 +475,8 @@ async fn handle_multipart_creation(
                     latest_commit: Some(latest_commit),
                     name: repo_data_clone.name,
                     min_version: Some(repo.local_repo.min_version().to_string()),
+                    storage_kind: repo.local_repo.storage_config().kind,
                 },
-                metadata_entries: repo.entries,
             })),
             Err(OxenError::NoCommitsFound) => {
                 Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
@@ -484,8 +487,8 @@ async fn handle_multipart_creation(
                         latest_commit: None,
                         name: repo_data_clone.name,
                         min_version: Some(repo.local_repo.min_version().to_string()),
+                        storage_kind: repo.local_repo.storage_config().kind,
                     },
-                    metadata_entries: repo.entries,
                 }))
             }
             Err(err) => {
@@ -608,6 +611,7 @@ pub async fn transfer_namespace(
             name,
             min_version: Some(repo.min_version().to_string()),
             is_empty: repositories::is_empty(&repo)?,
+            storage_kind: repo.storage_config().kind,
         },
     }))
 }

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -301,7 +301,7 @@ pub async fn create(
                 println!("Failed to parse JSON: {e:?}");
                 OxenHttpError::BadRequest("Invalid JSON".into())
             })?;
-            return handle_json_creation(app_data, json_data).await;
+            return create_repo_response(app_data, json_data).await;
         } else {
             content_type
                 .to_str()
@@ -314,53 +314,6 @@ pub async fn create(
         }
     }
     Err(OxenHttpError::BadRequest("Unsupported Content-Type".into()))
-}
-
-async fn handle_json_creation(
-    app_data: &OxenAppData,
-    data: RepoNew,
-) -> actix_web::Result<HttpResponse, OxenHttpError> {
-    let data = {
-        let mut data = data;
-        data.storage_kind = Some(app_data.config.storage.resolve(data.storage_kind)?);
-        data
-    };
-
-    let repo_new_clone = data.clone();
-    match repositories::create(&app_data.path, data, app_data.config.storage.s3()).await {
-        Ok(repo) => match repositories::commits::latest_commit(&repo.local_repo) {
-            Ok(latest_commit) => Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
-                status: STATUS_SUCCESS.to_string(),
-                status_message: MSG_RESOURCE_FOUND.to_string(),
-                repository: RepositoryCreationView {
-                    namespace: repo_new_clone.namespace.clone(),
-                    latest_commit: Some(latest_commit.clone()),
-                    name: repo_new_clone.name.clone(),
-                    min_version: Some(repo.local_repo.min_version().to_string()),
-                    storage_kind: repo.local_repo.storage_config().kind,
-                },
-            })),
-            Err(OxenError::NoCommitsFound) => {
-                Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
-                    status: STATUS_SUCCESS.to_string(),
-                    status_message: MSG_RESOURCE_FOUND.to_string(),
-                    repository: RepositoryCreationView {
-                        namespace: repo_new_clone.namespace.clone(),
-                        latest_commit: None,
-                        name: repo_new_clone.name.clone(),
-                        min_version: Some(repo.local_repo.min_version().to_string()),
-                        storage_kind: repo.local_repo.storage_config().kind,
-                    },
-                }))
-            }
-            Err(err) => {
-                log::error!("Err repositories::commits::latest_commit: {err:?}");
-                Ok(HttpResponse::InternalServerError()
-                    .json(StatusMessage::error("Failed to get latest commit.")))
-            }
-        },
-        Err(err) => Ok(map_create_error_to_response(err)),
-    }
 }
 
 async fn handle_multipart_creation(
@@ -458,45 +411,46 @@ async fn handle_multipart_creation(
         };
 
         repo_data.files = if !files.is_empty() { Some(files) } else { None };
-        repo_data.storage_kind = Some(app_data.config.storage.resolve(repo_data.storage_kind)?);
         repo_data
     };
 
-    let repo_data_clone = repo_data.clone();
-
     // Create repository
-    match repositories::create(&app_data.path, repo_data, app_data.config.storage.s3()).await {
-        Ok(repo) => match repositories::commits::latest_commit(&repo.local_repo) {
-            Ok(latest_commit) => Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
+    create_repo_response(app_data, repo_data).await
+}
+
+/// Create the repository from a [`RepoNew`] and build the response that both creation routes
+/// (JSON and multipart) send back. `data.storage_kind` is resolved against the server's storage
+/// policy (`None` selects the server default).
+async fn create_repo_response(
+    app_data: &OxenAppData,
+    mut data: RepoNew,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    data.storage_kind = Some(app_data.config.storage.resolve(data.storage_kind)?);
+    let namespace = data.namespace.clone();
+    let name = data.name.clone();
+    match repositories::create(&app_data.path, data, app_data.config.storage.s3()).await {
+        Ok(repo) => {
+            let latest_commit = match repositories::commits::latest_commit(&repo.local_repo) {
+                Ok(commit) => Some(commit),
+                Err(OxenError::NoCommitsFound) => None,
+                Err(err) => {
+                    log::error!("Err repositories::commits::latest_commit: {err:?}");
+                    return Ok(HttpResponse::InternalServerError()
+                        .json(StatusMessage::error("Failed to get latest commit.")));
+                }
+            };
+            Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                 status: STATUS_SUCCESS.to_string(),
                 status_message: MSG_RESOURCE_FOUND.to_string(),
                 repository: RepositoryCreationView {
-                    namespace: repo_data_clone.namespace,
-                    latest_commit: Some(latest_commit),
-                    name: repo_data_clone.name,
+                    namespace,
+                    name,
+                    latest_commit,
                     min_version: Some(repo.local_repo.min_version().to_string()),
                     storage_kind: repo.local_repo.storage_config().kind,
                 },
-            })),
-            Err(OxenError::NoCommitsFound) => {
-                Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
-                    status: STATUS_SUCCESS.to_string(),
-                    status_message: MSG_RESOURCE_FOUND.to_string(),
-                    repository: RepositoryCreationView {
-                        namespace: repo_data_clone.namespace,
-                        latest_commit: None,
-                        name: repo_data_clone.name,
-                        min_version: Some(repo.local_repo.min_version().to_string()),
-                        storage_kind: repo.local_repo.storage_config().kind,
-                    },
-                }))
-            }
-            Err(err) => {
-                log::error!("Err repositories::commits::latest_commit: {err:?}");
-                Ok(HttpResponse::InternalServerError()
-                    .json(StatusMessage::error("Failed to get latest commit.")))
-            }
-        },
+            }))
+        }
         Err(err) => Ok(map_create_error_to_response(err)),
     }
 }

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -430,7 +430,7 @@ async fn create_repo_response(
     let name = data.name.clone();
     match repositories::create(&app_data.path, data, app_data.config.storage.s3()).await {
         Ok(repo) => {
-            let latest_commit = match repositories::commits::latest_commit(&repo.local_repo) {
+            let latest_commit = match repositories::commits::latest_commit(&repo) {
                 Ok(commit) => Some(commit),
                 Err(OxenError::NoCommitsFound) => None,
                 Err(err) => {
@@ -446,8 +446,8 @@ async fn create_repo_response(
                     namespace,
                     name,
                     latest_commit,
-                    min_version: Some(repo.local_repo.min_version().to_string()),
-                    storage_kind: repo.local_repo.storage_config().kind,
+                    min_version: Some(repo.min_version().to_string()),
+                    storage_kind: repo.storage_config().kind,
                 },
             }))
         }

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -430,13 +430,14 @@ async fn create_repo_response(
     let name = data.name.clone();
     match repositories::create(&app_data.path, data, app_data.config.storage.s3()).await {
         Ok(repo) => {
+            // The repository exists by this point, so a failed lookup only degrades the
+            // response's latest_commit to None rather than failing the creation.
             let latest_commit = match repositories::commits::latest_commit(&repo) {
                 Ok(commit) => Some(commit),
                 Err(OxenError::NoCommitsFound) => None,
                 Err(err) => {
                     log::error!("Err repositories::commits::latest_commit: {err:?}");
-                    return Ok(HttpResponse::InternalServerError()
-                        .json(StatusMessage::error("Failed to get latest commit.")));
+                    None
                 }
             };
             Ok(HttpResponse::Ok().json(RepositoryCreationResponse {


### PR DESCRIPTION
The client's RemoteRepository now has a definite storage backend (local or s3).

This required some tweaks to the Python binding: RemoteRepo built a placeholder RemoteRepository before the repo was known to exist. The binding now tracks its own identity (namespace/name/url) and fetches the real repository on construction, so the core type never has to stand in for "not yet known".