### PR TITLE
Fix NFS/DuckDB bug when deleting/clearing workspaces or deleting a repo

### DIFF
--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -325,6 +325,9 @@ pub fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {
     merkle_tree::merkle_tree_node_cache::remove_from_cache(&repo.path)?;
     core::staged::remove_from_cache_with_children(&repo.path)?;
     core::refs::ref_manager::remove_from_cache(&repo.path)?;
+    // Drop cached DuckDB connections too. On NFS, unlinking a still-open file leaves a hidden
+    // .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
+    core::db::data_frames::df_db::remove_df_db_from_cache_with_children(&repo.path)?;
 
     log::debug!("Deleting repo directory: {repo:?}");
     util::fs::remove_dir_all(&repo.path)?;

--- a/crates/liboxen/src/repositories/workspaces.rs
+++ b/crates/liboxen/src/repositories/workspaces.rs
@@ -1,6 +1,7 @@
 use crate::config::RepositoryConfig;
 use crate::constants::{OXEN_HIDDEN_DIR, REPO_CONFIG_FILENAME};
 use crate::core;
+use crate::core::db::data_frames::df_db;
 use crate::core::staged::staged_db_manager::get_staged_db_manager;
 use crate::core::workspaces::workspace_name_index;
 use crate::error::OxenError;
@@ -448,6 +449,9 @@ pub fn delete(workspace: &Workspace) -> Result<(), OxenError> {
     // Clean up caches before deleting the workspace
     merkle_tree::merkle_tree_node_cache::remove_from_cache(&workspace.workspace_repo.path)?;
     core::staged::remove_from_cache(&workspace.workspace_repo.path)?;
+    // Drop cached DuckDB connections rooted in this workspace before removing the dir. On NFS,
+    // unlinking a still-open file leaves a hidden .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
+    df_db::remove_df_db_from_cache_with_children(&workspace_dir)?;
     match util::fs::remove_dir_all(&workspace_dir) {
         Ok(_) => log::debug!("workspace::delete removed workspace dir: {workspace_dir:?}"),
         Err(e) => log::error!("workspace::delete error removing workspace dir: {e:?}"),

--- a/crates/liboxen/src/repositories/workspaces.rs
+++ b/crates/liboxen/src/repositories/workspaces.rs
@@ -468,6 +468,9 @@ pub fn clear(repo: &LocalRepository) -> Result<(), OxenError> {
 
     // Evict the name index DB handle from cache before removing the directory
     workspace_name_index::remove_from_cache(repo);
+    // Drop cached DuckDB connections under any workspace before removing the dir. On NFS,
+    // unlinking a still-open file leaves a hidden .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
+    df_db::remove_df_db_from_cache_with_children(&workspaces_dir)?;
 
     util::fs::remove_dir_all(&workspaces_dir)?;
     Ok(())


### PR DESCRIPTION
Fix an `ENOTEMPTY` error that occurrs when deleting a workspace on NFS. We need to close a workspace's DuckDB connections before deleting the workspace.

We found this bug with our new NFS CI job.