### PR TITLE
Add package-backed CLI version flag

### DIFF
--- a/crates/oxen-cli/src/main.rs
+++ b/crates/oxen-cli/src/main.rs
@@ -20,6 +20,7 @@ mod helpers;
 // THE **ONLY** PUBLIC THING IN oxen-cli IS THE BINARY !!!
 
 const SHORT_ABOUT: &str = "🐂 is the AI and machine learning data management toolchain";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const LONG_ABOUT: &str = "
 🐂 is the AI and machine learning data management toolchain
@@ -137,7 +138,7 @@ async fn async_main() -> ExitCode {
 
 fn main_oxen_command() -> (Command, Runners) {
     let mut command = Command::new("oxen")
-        .version(liboxen::constants::OXEN_VERSION)
+        .version(VERSION)
         .about(SHORT_ABOUT)
         .long_about(LONG_ABOUT)
         .subcommand_required(true)
@@ -225,5 +226,24 @@ fn print_error(err: &anyhow::Error) {
         && let Some(hint) = oxen_error.hint()
     {
         eprintln!("  {} {}", "hint:".cyan().bold(), hint);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::error::ErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn version_flag_prints_package_version_and_succeeds() {
+        let (command, _) = main_oxen_command();
+        let error = command
+            .try_get_matches_from(["oxen", "--version"])
+            .expect_err("--version should exit before command dispatch");
+
+        assert_eq!(error.kind(), ErrorKind::DisplayVersion);
+        assert_eq!(error.exit_code(), 0);
+        assert_eq!(error.to_string(), format!("oxen {VERSION}\n"));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- source the `oxen --version` value directly from the CLI package manifest
- verify the flag prints the package version and exits successfully

## Testing
- pending focused Rust test
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://oxenai.slack.com/archives/C0BH4PSN84T/p1784055351585769?thread_ts=1784055351.585769&cid=C0BH4PSN84T)

<div><a href="https://cursor.com/agents/bc-038be2a0-0d2b-539c-8d33-18a0f298b0d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-038be2a0-0d2b-539c-8d33-18a0f298b0d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

