### PR TITLE
S3 (27.1): Delete a repository's version files when the repository is deleted

### DIFF
--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -279,22 +279,32 @@ pub async fn create(
     Ok(local_repo)
 }
 
-pub fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {
+pub async fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenError> {
     if !repo.path.exists() {
         let err = format!("Repository does not exist {:?}", repo.path);
         return Err(OxenError::basic_str(err));
     }
 
-    // Close DB instances before trying to delete the directory
-    merkle_tree::merkle_tree_node_cache::remove_from_cache(&repo.path)?;
-    core::staged::remove_from_cache_with_children(&repo.path)?;
-    core::refs::ref_manager::remove_from_cache(&repo.path)?;
-    // Drop cached DuckDB connections too. On NFS, unlinking a still-open file leaves a hidden
-    // .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
-    core::db::data_frames::df_db::remove_df_db_from_cache_with_children(&repo.path)?;
+    // Remove the stored version files first: for non-local backends (and local stores with a
+    // custom versions_path) they live outside the repo directory.
+    repo.version_store().destroy().await?;
 
-    log::debug!("Deleting repo directory: {repo:?}");
-    util::fs::remove_dir_all(&repo.path)?;
+    let path = repo.path.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), OxenError> {
+        // Close DB instances before trying to delete the directory
+        merkle_tree::merkle_tree_node_cache::remove_from_cache(&path)?;
+        core::staged::remove_from_cache_with_children(&path)?;
+        core::refs::ref_manager::remove_from_cache(&path)?;
+
+        // Drop cached DuckDB connections too. On NFS, unlinking a still-open file leaves a hidden
+        // .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
+        core::db::data_frames::df_db::remove_df_db_from_cache_with_children(&path)?;
+
+        log::debug!("Deleting repo directory: {path:?}");
+        util::fs::remove_dir_all(&path)?;
+        Ok(())
+    })
+    .await??;
     Ok(repo)
 }
 
@@ -311,6 +321,52 @@ mod tests {
     use crate::util;
     use std::path::{Path, PathBuf};
     use time::OffsetDateTime;
+
+    #[tokio::test]
+    async fn test_delete_removes_custom_versions_path_outside_repo() -> Result<(), OxenError> {
+        use crate::config::RepositoryConfig;
+        use crate::storage::{StorageConfig, StorageKind};
+        use bytes::Bytes;
+
+        test::run_empty_dir_test_async(|dir| async move {
+            // A local store whose versions root lives OUTSIDE the repo directory: deleting
+            // the repo directory alone would leak it.
+            let repo_path = dir.join("repo");
+            let custom_root = dir.join("custom-versions");
+            util::fs::create_dir_all(util::fs::oxen_hidden_dir(&repo_path))?;
+
+            let repo = LocalRepository::new(
+                &repo_path,
+                RepositoryConfig {
+                    storage: Some(StorageConfig {
+                        kind: StorageKind::Local,
+                        versions_path: Some(custom_root.clone()),
+                    }),
+                    ..Default::default()
+                },
+            )?;
+            repo.save()?;
+
+            let data = b"leak check";
+            let hash = util::hasher::hash_buffer(data);
+
+            let store = repo.version_store();
+            store.init().await?;
+            store.store_version(&hash, Bytes::from_static(data)).await?;
+            assert!(store.version_exists(&hash).await?);
+            assert!(custom_root.exists());
+
+            repositories::delete(&repo).await?;
+
+            assert!(
+                !custom_root.exists(),
+                "custom versions root must be removed"
+            );
+            assert!(!repo_path.exists(), "repo directory must be removed");
+            Ok(())
+        })
+        .await
+    }
 
     #[tokio::test]
     async fn test_local_repository_api_create_empty_with_commit() -> Result<(), OxenError> {

--- a/crates/liboxen/src/storage/local.rs
+++ b/crates/liboxen/src/storage/local.rs
@@ -238,6 +238,15 @@ impl VersionStore for LocalVersionStore {
         Ok(())
     }
 
+    async fn destroy(&self) -> Result<(), OxenError> {
+        // The versions root may live outside the repo directory (custom `versions_path`), so it
+        // must be removed explicitly rather than relying on the repo-directory removal.
+        if self.root_path.exists() {
+            fs::remove_dir_all(&self.root_path).await?;
+        }
+        Ok(())
+    }
+
     async fn list_versions(&self) -> Result<Vec<String>, OxenError> {
         let mut versions = Vec::new();
 

--- a/crates/liboxen/src/storage/s3.rs
+++ b/crates/liboxen/src/storage/s3.rs
@@ -741,6 +741,22 @@ impl VersionStore for S3VersionStore {
         self.delete_objects(keys).await
     }
 
+    async fn destroy(&self) -> Result<(), OxenError> {
+        // A store's prefix scopes it to one repository; an empty prefix would make this
+        // delete every object in the bucket.
+        if self.prefix.is_empty() {
+            return Err(OxenError::internal_error(
+                "refusing to destroy an S3 version store with an empty prefix",
+            ));
+        }
+        // The trailing slash keeps the listing from matching sibling repos whose prefix
+        // starts with this one (e.g. `ns/repo` vs `ns/repo2`).
+        let keys = self
+            .list_objects_with_prefix(&format!("{}/", self.prefix))
+            .await?;
+        self.delete_objects(keys).await
+    }
+
     async fn list_versions(&self) -> Result<Vec<String>, OxenError> {
         // Each version is stored at `{self.prefix}/{hash}/...`. To enumerate the hashes
         // without reading every leaf object, ask S3 for the common prefixes under
@@ -1090,6 +1106,74 @@ mod tests {
     async fn test_check_bucket_accessible_succeeds() {
         let (store, _tmp, _server) = setup().await;
         store.check_bucket_accessible().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_destroy_removes_only_this_stores_objects() {
+        let (addr, _tmp, _server) = spawn_s3s().await;
+        let client = Arc::new(build_test_client(addr));
+        client
+            .create_bucket()
+            .bucket("test-bucket")
+            .send()
+            .await
+            .unwrap();
+
+        let store = S3VersionStore::new_with_client(
+            Arc::clone(&client),
+            "test-bucket".to_string(),
+            "us-west-1".to_string(),
+            "ns/repo".to_string(),
+            Some(format!("http://{addr}")),
+        );
+        // A sibling repo whose prefix extends this store's prefix must survive the destroy.
+        let sibling = S3VersionStore::new_with_client(
+            client,
+            "test-bucket".to_string(),
+            "us-west-1".to_string(),
+            "ns/repo2".to_string(),
+            Some(format!("http://{addr}")),
+        );
+
+        store
+            .store_version("aaaa1111", Bytes::from_static(b"one"))
+            .await
+            .unwrap();
+        store
+            .store_version_chunk("bbbb2222", 0, Bytes::from_static(b"chunk"))
+            .await
+            .unwrap();
+        sibling
+            .store_version("cccc3333", Bytes::from_static(b"sibling"))
+            .await
+            .unwrap();
+
+        store.destroy().await.unwrap();
+
+        assert!(store.list_versions().await.unwrap().is_empty());
+        assert!(!store.version_exists("aaaa1111").await.unwrap());
+        assert!(sibling.version_exists("cccc3333").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_destroy_refuses_empty_prefix() {
+        let (addr, _tmp, _server) = spawn_s3s().await;
+        let client = Arc::new(build_test_client(addr));
+        client
+            .create_bucket()
+            .bucket("test-bucket")
+            .send()
+            .await
+            .unwrap();
+
+        let store = S3VersionStore::new_with_client(
+            client,
+            "test-bucket".to_string(),
+            "us-west-1".to_string(),
+            String::new(),
+            Some(format!("http://{addr}")),
+        );
+        assert!(store.destroy().await.is_err());
     }
 
     #[tokio::test]

--- a/crates/liboxen/src/storage/version_store.rs
+++ b/crates/liboxen/src/storage/version_store.rs
@@ -463,6 +463,10 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// * `hash` - The content hash of the version to delete
     async fn delete_version(&self, hash: &str) -> Result<(), OxenError>;
 
+    /// Delete every version file this store holds, including chunks and derived versions.
+    /// After this call the store is empty. Call when the repository itself is being deleted.
+    async fn destroy(&self) -> Result<(), OxenError>;
+
     /// List all versions.
     ///
     /// Results are returned as hash strings, sorted in UTF-8 byte order (equivalent to

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -504,10 +504,13 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
         return Ok(HttpResponse::NotFound().json(StatusMessage::resource_not_found()));
     };
 
-    // Delete in a background thread because it could take awhile
-    std::thread::spawn(move || match repositories::delete(&repository) {
-        Ok(_) => log::info!("Deleted repo: {namespace}/{name}"),
-        Err(err) => log::error!("Err deleting repo: {err}"),
+    // Delete in a background task because it could take awhile; the blocking directory
+    // removal runs inside delete's own spawn_blocking.
+    tokio::spawn(async move {
+        match repositories::delete(&repository).await {
+            Ok(_) => log::info!("Deleted repo: {namespace}/{name}"),
+            Err(err) => log::error!("Err deleting repo: {err}"),
+        }
     });
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_deleted()))


### PR DESCRIPTION
Deleting a repository now removes its stored version files, not just the repository directory, so a delete can no longer leak storage. The default in-directory path was reclaimed incidentally by the directory removal, so the hosted product wasn't affected. The new S3-backed version storage under testing leaked, leaving the objects in the bucket forever. A local repo (or self-hosted server) would leak when configured with a custom `versions_path` outside the repository directory.

Version store cleanup runs before the directory is removed, and a failure there aborts the delete with the repository left intact, so the operation can be retried rather than leaving a half-deleted repository behind.

ENG-1266