### PR TITLE
Repo Integrity (1.13): Fail `push --missing-files` fast 

### DIFF
--- a/crates/liboxen/src/core/v_latest/push.rs
+++ b/crates/liboxen/src/core/v_latest/push.rs
@@ -252,15 +252,30 @@ async fn list_and_push_missing_files(
         return Ok(());
     }
 
-    if let Some(commit_entry) = missing_files.first() {
-        let version_store = repo.version_store();
-        if !version_store.version_exists(&commit_entry.hash).await? {
-            return Err(OxenError::CannotPushShallowClone {
-                commit_id: head_commit.id.clone(),
-                commit_message: head_commit.message.clone(),
-                help: "To repair the remote, re-run this command from a clone that has the full history.".to_string(),
-            });
-        }
+    // Fail fast if any file the push will upload is absent from this clone — before uploading any.
+    let hashes: Vec<String> = missing_files.iter().map(|e| e.hash.clone()).collect();
+    let locally_absent = repo.version_store().find_missing_versions(&hashes).await?;
+    if !locally_absent.is_empty() {
+        let listed = locally_absent
+            .iter()
+            .take(10)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let extra = locally_absent.len().saturating_sub(10);
+        let listed = if extra > 0 {
+            format!("{listed}, and {extra} more")
+        } else {
+            listed
+        };
+        return Err(OxenError::CannotPushShallowClone {
+            commit_id: head_commit.id.clone(),
+            commit_message: head_commit.message.clone(),
+            help: format!(
+                "{} of the files to upload are absent from this clone ({listed}). Re-run this command from a clone that has the full history.",
+                locally_absent.len()
+            ),
+        });
     }
 
     let total_bytes = missing_files.iter().map(|e| e.num_bytes).sum();

--- a/crates/liboxen/src/repositories/push.rs
+++ b/crates/liboxen/src/repositories/push.rs
@@ -1739,4 +1739,82 @@ A: Checkout Oxen.ai
         })
         .await
     }
+
+    // `--missing-files` from a clone missing some of the files the remote needs must fail fast with
+    // CannotPushShallowClone and upload nothing — not partially upload and then error mid-stream.
+    #[tokio::test]
+    async fn test_missing_files_fails_fast_on_shallow_clone() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async {
+            let mut repo = repo;
+
+            let a_path = repo.path.join("a.txt");
+            test::write_txt_file_to_path(&a_path, "alpha")?;
+            let b_path = repo.path.join("b.txt");
+            test::write_txt_file_to_path(&b_path, "beta")?;
+            repositories::add(&repo, &a_path).await?;
+            repositories::add(&repo, &b_path).await?;
+            let commit = repositories::commit(&repo, "add a.txt and b.txt")?;
+
+            let remote = test::repo_remote_url_from(&repo.dirname());
+            command::config::set_remote(&mut repo, DEFAULT_REMOTE_NAME, &remote)?;
+            let remote_repo = test::create_remote_repo(&repo).await?;
+            repositories::push(&repo).await?;
+
+            let a_hash = repositories::tree::get_node_by_path(&repo, &commit, "a.txt")?
+                .expect("a.txt in commit")
+                .file()?
+                .hash()
+                .to_string();
+            let b_hash = repositories::tree::get_node_by_path(&repo, &commit, "b.txt")?
+                .expect("b.txt in commit")
+                .file()?
+                .hash()
+                .to_string();
+
+            // The server is missing both blobs, so both appear in the missing-files list.
+            let sync_dir =
+                PathBuf::from(std::env::var("SYNC_DIR").expect("SYNC_DIR set by bin/test-rust"));
+            let server = repositories::get_by_namespace_and_name(
+                &sync_dir,
+                constants::DEFAULT_NAMESPACE,
+                repo.dirname(),
+                None,
+            )?
+            .expect("server repo exists");
+            server.version_store().delete_version(&a_hash).await?;
+            server.version_store().delete_version(&b_hash).await?;
+
+            // This clone can supply a.txt but not b.txt.
+            repo.version_store().delete_version(&b_hash).await?;
+
+            let opts = PushOpts {
+                remote: DEFAULT_REMOTE_NAME.to_string(),
+                branch: DEFAULT_BRANCH_NAME.to_string(),
+                missing_files: true,
+                ..Default::default()
+            };
+            let result = repositories::push::push_remote_branch(&repo, &opts).await;
+
+            assert!(
+                matches!(&result, Err(OxenError::CannotPushShallowClone { .. })),
+                "expected CannotPushShallowClone, got {result:?}"
+            );
+            if let Err(OxenError::CannotPushShallowClone { help, .. }) = &result {
+                assert!(
+                    help.contains(&b_hash),
+                    "error should name the locally-absent hash {b_hash}: {help}"
+                );
+            }
+
+            // No partial repair: the file this clone *could* supply must not have been uploaded.
+            assert!(
+                !server.version_store().version_exists(&a_hash).await?,
+                "a failed shallow-clone push must upload nothing"
+            );
+
+            api::client::repositories::delete(&remote_repo).await?;
+            Ok(())
+        })
+        .await
+    }
 }


### PR DESCRIPTION
Fail `oxen push --missing-files` fast when the clone lacks any needed file, not mid-upload

`oxen push --missing-files` checked whether the local clone held the file data for only the first entry in the remote's missing-files list. If a later entry was absent locally, the guard passed, the push uploaded part of the set, and then errored mid-stream on the first absent file, leaving the remote in a confusing, partially-repaired state.

It now checks the whole upload set up front and, when this clone is missing any of it, fails immediately with `CannotPushShallowClone` naming the absent hashes and directing the user to re-run from a clone with the full history — uploading nothing. Completes the repair-verb correctness pair with the `--revalidate` fix (ENG-1185).

ENG-1186