### PR TITLE
Async (1): Temporarily bump oxen-server worker count

### DIFF
--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -635,12 +635,13 @@ async fn start(
     // to the client as a dropped connection (502 Bad Gateway).
     const ACTIX_KEEP_ALIVE_SECS: u64 = 75;
 
-    // Oversubscribe HTTP workers far above the CPU count as a temporary fix. We've got lots of
+    // Oversubscribe HTTP workers to 4× the core count as a temporary fix. We've got lots of
     // workers getting blocked by sync i/o or sync inefficient algorithms. We'll revert this once
     // we've cleaned up a batch of the worst offenders.
-    const HTTP_WORKERS: usize = 256;
+    let num_cores = std::thread::available_parallelism().map_or(1, |n| n.get());
+    let http_workers = 4 * num_cores;
 
-    let workers_msg = format!("HTTP worker threads: {HTTP_WORKERS}");
+    let workers_msg = format!("HTTP worker threads: {http_workers} ({num_cores} cores × 4)");
     eprintln!("{workers_msg}");
     log::info!("{workers_msg}");
 
@@ -686,7 +687,7 @@ async fn start(
             .wrap(MetricsMiddleware)
             .wrap(TracingLogger::default())
     })
-    .workers(HTTP_WORKERS)
+    .workers(http_workers)
     .keep_alive(Duration::from_secs(ACTIX_KEEP_ALIVE_SECS))
     .bind((host.to_owned(), port))?
     .shutdown_timeout(ACTIX_SHUTDOWN_TIMEOUT_SECS)

--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -635,6 +635,15 @@ async fn start(
     // to the client as a dropped connection (502 Bad Gateway).
     const ACTIX_KEEP_ALIVE_SECS: u64 = 75;
 
+    // Oversubscribe HTTP workers far above the CPU count as a temporary fix. We've got lots of
+    // workers getting blocked by sync i/o or sync inefficient algorithms. We'll revert this once
+    // we've cleaned up a batch of the worst offenders.
+    const HTTP_WORKERS: usize = 256;
+
+    let workers_msg = format!("HTTP worker threads: {HTTP_WORKERS}");
+    eprintln!("{workers_msg}");
+    log::info!("{workers_msg}");
+
     let server_result = HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
@@ -677,6 +686,7 @@ async fn start(
             .wrap(MetricsMiddleware)
             .wrap(TracingLogger::default())
     })
+    .workers(HTTP_WORKERS)
     .keep_alive(Duration::from_secs(ACTIX_KEEP_ALIVE_SECS))
     .bind((host.to_owned(), port))?
     .shutdown_timeout(ACTIX_SHUTDOWN_TIMEOUT_SECS)


### PR DESCRIPTION
Quadruple the number of HTTP workers (from the default 1-per-CPU for our production setup) to keep oxen-server answering `/api/health` and accepting new connections despite the blocking, synchronous calls that are happening inline in the actix worker threads on many operations.

This is a temporary bandaid ahead of moving the handlers' blocking work off the worker threads, so we will revert this PR right after it ships in a release. Then the following release will contain a batch of fixes.