### PR TITLE
Async (2): Revert temporary bump to oxen-server worker count

### DIFF
--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -635,16 +635,6 @@ async fn start(
     // to the client as a dropped connection (502 Bad Gateway).
     const ACTIX_KEEP_ALIVE_SECS: u64 = 75;
 
-    // Oversubscribe HTTP workers to 4× the core count as a temporary fix. We've got lots of
-    // workers getting blocked by sync i/o or sync inefficient algorithms. We'll revert this once
-    // we've cleaned up a batch of the worst offenders.
-    let num_cores = std::thread::available_parallelism().map_or(1, |n| n.get());
-    let http_workers = 4 * num_cores;
-
-    let workers_msg = format!("HTTP worker threads: {http_workers} ({num_cores} cores × 4)");
-    eprintln!("{workers_msg}");
-    log::info!("{workers_msg}");
-
     let server_result = HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
@@ -687,7 +677,6 @@ async fn start(
             .wrap(MetricsMiddleware)
             .wrap(TracingLogger::default())
     })
-    .workers(http_workers)
     .keep_alive(Duration::from_secs(ACTIX_KEEP_ALIVE_SECS))
     .bind((host.to_owned(), port))?
     .shutdown_timeout(ACTIX_SHUTDOWN_TIMEOUT_SECS)


### PR DESCRIPTION
Reverts Oxen-AI/Oxen#741, as planned, now that the [`v0.51.5`](https://github.com/Oxen-AI/Oxen/releases/tag/v0.51.5) release has been tagged.