### PR TITLE
Async (4): branches::list to async

### DIFF
--- a/crates/liboxen/src/api/client/branches.rs
+++ b/crates/liboxen/src/api/client/branches.rs
@@ -412,7 +412,8 @@ mod tests {
             assert_eq!(current_branch.name, new_branch_name);
 
             // Check that old branch no longer exists
-            repositories::branches::list(&repo)?
+            repositories::branches::list(&repo)
+                .await?
                 .iter()
                 .for_each(|branch| {
                     assert_ne!(branch.name, og_branch_name);
@@ -561,7 +562,7 @@ mod tests {
             repositories::add(&repo, new_file).await?;
             repositories::commit(&repo, "Added a new file")?;
 
-            let og_branches = repositories::branches::list(&repo)?;
+            let og_branches = repositories::branches::list(&repo).await?;
             let og_branch = repositories::branches::current_branch(&repo)?.unwrap();
 
             let branch_name = "my-branch";
@@ -583,7 +584,7 @@ mod tests {
             }
 
             // Should be one less branch
-            let leftover_branches = repositories::branches::list(&repo)?;
+            let leftover_branches = repositories::branches::list(&repo).await?;
             assert_eq!(og_branches.len(), leftover_branches.len() - 1);
 
             Ok(())
@@ -600,7 +601,7 @@ mod tests {
             repositories::add(&repo, new_file).await?;
             repositories::commit(&repo, "Added a new file")?;
 
-            let og_branches = repositories::branches::list(&repo)?;
+            let og_branches = repositories::branches::list(&repo).await?;
             let og_branch = repositories::branches::current_branch(&repo)?.unwrap();
 
             let branch_name = "my-branch";
@@ -618,7 +619,7 @@ mod tests {
             repositories::branches::force_delete(&repo, branch_name)?;
 
             // Should be one less branch
-            let leftover_branches = repositories::branches::list(&repo)?;
+            let leftover_branches = repositories::branches::list(&repo).await?;
             assert_eq!(og_branches.len(), leftover_branches.len());
 
             Ok(())

--- a/crates/liboxen/src/core/refs/ref_manager.rs
+++ b/crates/liboxen/src/core/refs/ref_manager.rs
@@ -152,6 +152,16 @@ impl RefManager {
         matches!(db.get(name.as_bytes()), Ok(Some(_)))
     }
 
+    /// Whether the repo has no branches, reading only the first ref.
+    pub fn is_empty(&self) -> Result<bool, OxenError> {
+        let db = self.refs_db.read();
+        Ok(db
+            .iterator(IteratorMode::Start)
+            .next()
+            .transpose()?
+            .is_none())
+    }
+
     pub fn get_current_branch(&self) -> Result<Option<Branch>, OxenError> {
         let ref_name = self.read_head_ref()?;
         if ref_name.is_none() {

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -85,11 +85,10 @@ pub fn get_by_namespace_and_name(
         .map(Some)
 }
 
-pub fn is_empty(repo: &LocalRepository) -> Result<bool, OxenError> {
-    match branches::list(repo) {
-        Ok(branches) => Ok(branches.is_empty()),
-        Err(err) => Err(err),
-    }
+pub async fn is_empty(repo: &LocalRepository) -> Result<bool, OxenError> {
+    let repo = repo.clone();
+    tokio::task::spawn_blocking(move || with_ref_manager(&repo, |manager| manager.is_empty()))
+        .await?
 }
 
 pub fn list_namespaces(sync_dir: &Path) -> Result<Vec<String>, OxenError> {

--- a/crates/liboxen/src/repositories/branches.rs
+++ b/crates/liboxen/src/repositories/branches.rs
@@ -14,8 +14,10 @@ use crate::repositories;
 use crate::{core, util};
 
 /// List all the local branches within a repo
-pub fn list(repo: &LocalRepository) -> Result<Vec<Branch>, OxenError> {
-    with_ref_manager(repo, |manager| manager.list_branches())
+pub async fn list(repo: &LocalRepository) -> Result<Vec<Branch>, OxenError> {
+    let repo = repo.clone();
+    tokio::task::spawn_blocking(move || with_ref_manager(&repo, |manager| manager.list_branches()))
+        .await?
 }
 
 /// List all the local branches within a repo along with their head commits
@@ -542,7 +544,7 @@ mod tests {
     async fn test_local_delete_branch() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {
             // Get the original branches
-            let og_branches = repositories::branches::list(&repo)?;
+            let og_branches = repositories::branches::list(&repo).await?;
             let og_branch = repositories::branches::current_branch(&repo)?.unwrap();
 
             let branch_name = "my-branch";
@@ -555,7 +557,7 @@ mod tests {
             repositories::branches::delete(&repo, branch_name)?;
 
             // Should be same num as og_branches
-            let leftover_branches = repositories::branches::list(&repo)?;
+            let leftover_branches = repositories::branches::list(&repo).await?;
             assert_eq!(og_branches.len(), leftover_branches.len());
 
             Ok(())

--- a/crates/liboxen/src/repositories/checkout.rs
+++ b/crates/liboxen/src/repositories/checkout.rs
@@ -407,7 +407,7 @@ mod tests {
             let commits = repositories::commits::list(&repo)?;
             assert_eq!(commits.len(), 2);
 
-            let branches = repositories::branches::list(&repo)?;
+            let branches = repositories::branches::list(&repo).await?;
             assert_eq!(branches.len(), 2);
 
             // Make sure we have both files on disk in our repo dir

--- a/crates/liboxen/src/repositories/commits.rs
+++ b/crates/liboxen/src/repositories/commits.rs
@@ -1335,7 +1335,7 @@ A: Oxen.ai
         test::run_empty_data_repo_test_no_commits_async(|repo| async move {
             // Verify repo is empty (no commits)
             assert!(head_commit_maybe(&repo)?.is_none());
-            assert!(repositories::branches::list(&repo)?.is_empty());
+            assert!(repositories::branches::list(&repo).await?.is_empty());
 
             // Create initial commit
             let user = crate::model::User {
@@ -1356,7 +1356,7 @@ A: Oxen.ai
             assert_eq!(head.unwrap().id, commit.id);
 
             // Verify branch was created
-            let branches = repositories::branches::list(&repo)?;
+            let branches = repositories::branches::list(&repo).await?;
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].name, "main");
             assert_eq!(branches[0].commit_id, commit.id);
@@ -1402,7 +1402,7 @@ A: Oxen.ai
             let commit = create_initial_commit(&repo, "develop", &user, "Initial commit")?;
 
             // Verify branch was created with custom name
-            let branches = repositories::branches::list(&repo)?;
+            let branches = repositories::branches::list(&repo).await?;
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].name, "develop");
             assert_eq!(branches[0].commit_id, commit.id);

--- a/crates/liboxen/src/repositories/fetch.rs
+++ b/crates/liboxen/src/repositories/fetch.rs
@@ -26,7 +26,7 @@ pub async fn fetch_all(
 
     api::client::repositories::pre_fetch(&remote_repo).await?;
     let remote_branches = api::client::branches::list(&remote_repo).await?;
-    let local_branches = repositories::branches::list(repo)?;
+    let local_branches = repositories::branches::list(repo).await?;
 
     // Find branches that are on the remote but not on the local
     let mut branches_to_create = vec![];
@@ -157,13 +157,13 @@ mod tests {
                     &new_repo_dir.join("new_repo"),
                 )
                 .await?;
-                let branches = repositories::branches::list(&cloned_repo)?;
+                let branches = repositories::branches::list(&cloned_repo).await?;
 
                 assert_eq!(1, branches.len());
 
                 repositories::fetch_all(&cloned_repo, &FetchOpts::new()).await?;
 
-                let branches = repositories::branches::list(&cloned_repo)?;
+                let branches = repositories::branches::list(&cloned_repo).await?;
                 assert_eq!(3, branches.len());
 
                 let current_branch = repositories::branches::current_branch(&cloned_repo)?.unwrap();

--- a/crates/oxen-cli/src/cmd/branch.rs
+++ b/crates/oxen-cli/src/cmd/branch.rs
@@ -127,7 +127,7 @@ impl RunCmd for BranchCmd {
             if repo.is_remote_mode() {
                 self.list_branches_with_commits(&repo)?;
             } else {
-                self.list_branches(&repo)?;
+                self.list_branches(&repo).await?;
             }
         }
         Ok(())
@@ -136,7 +136,7 @@ impl RunCmd for BranchCmd {
 
 impl BranchCmd {
     pub async fn list_all_branches(&self, repo: &LocalRepository) -> Result<(), OxenError> {
-        self.list_branches(repo)?;
+        self.list_branches(repo).await?;
 
         for remote in repo.remotes().iter() {
             self.list_remote_branches(repo, &remote.name).await?;
@@ -145,8 +145,8 @@ impl BranchCmd {
         Ok(())
     }
 
-    pub fn list_branches(&self, repo: &LocalRepository) -> Result<(), OxenError> {
-        let branches = repositories::branches::list(repo)?;
+    pub async fn list_branches(&self, repo: &LocalRepository) -> Result<(), OxenError> {
+        let branches = repositories::branches::list(repo).await?;
         let current_branch = repositories::branches::current_branch(repo)?;
 
         for branch in branches.iter() {

--- a/crates/oxen-py/src/py_repo.rs
+++ b/crates/oxen-py/src/py_repo.rs
@@ -202,7 +202,8 @@ impl PyRepo {
 
     fn list_branches(&self) -> Result<Vec<PyBranch>, PyOxenError> {
         let repo = LocalRepository::from_dir(&self.path)?;
-        let branches = repositories::branches::list(&repo)?;
+        let branches = pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { repositories::branches::list(&repo).await })?;
         Ok(branches
             .iter()
             .map(|b| PyBranch::new(b.name.clone(), b.commit_id.clone()))

--- a/crates/oxen-server/src/controllers/branches.rs
+++ b/crates/oxen-server/src/controllers/branches.rs
@@ -72,7 +72,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, name)?;
 
-    let branches = repositories::branches::list(&repo)?;
+    let branches = repositories::branches::list(&repo).await?;
 
     let view = ListBranchesResponse {
         status: StatusMessage::resource_found(),

--- a/crates/oxen-server/src/controllers/commits.rs
+++ b/crates/oxen-server/src/controllers/commits.rs
@@ -130,7 +130,7 @@ pub async fn history(
         page_size: query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE),
     };
 
-    if repositories::is_empty(&repo)? {
+    if repositories::is_empty(&repo).await? {
         return Ok(HttpResponse::Ok().json(PaginatedCommits::success(
             vec![],
             Pagination::empty(pagination),

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -118,7 +118,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
         }));
     }
 
-    let branch_count = repositories::branches::list(&repository)?.len();
+    let branch_count = repositories::branches::list(&repository).await?.len();
 
     // Return the repository view
     Ok(HttpResponse::Ok().json(RepositoryDataTypesResponse {
@@ -129,7 +129,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
                 namespace,
                 name,
                 min_version: Some(repository.min_version().to_string()),
-                is_empty: repositories::is_empty(&repository)?,
+                is_empty: repositories::is_empty(&repository).await?,
                 storage_kind: repository.storage_config().kind,
             },
             size,
@@ -568,7 +568,7 @@ pub async fn transfer_namespace(
             namespace: to_namespace,
             name,
             min_version: Some(repo.min_version().to_string()),
-            is_empty: repositories::is_empty(&repo)?,
+            is_empty: repositories::is_empty(&repo).await?,
             storage_kind: repo.storage_config().kind,
         },
     }))

--- a/docs/async_policy.md
+++ b/docs/async_policy.md
@@ -80,6 +80,13 @@ pub async fn list(repo: &LocalRepository) -> Result<Vec<Branch>, OxenError> {
 
 The inner sync functions (`with_ref_manager`, `RefManager::list_branches`) stay synchronous; only the public API grows the `async` / `spawn_blocking` edge. Callers ripple outward to `.await` it — a thin sync wrapper that only forwards (e.g. `repositories::is_empty`) becomes `async` in turn, and its own callers, already `async` handlers, add `.await`. The conversion stops at the first `async` boundary above each caller.
 
+The granularity is **one `spawn_blocking` per converted API, not per handler.** A handler or CLI command that needs several reads resolves the repo once (`get_repo`) and `.await`s each converted API in sequence; it does **not** wrap them in one bespoke closure. The per-request hop overhead is negligible — µs-scale hops against ms-to-second-scale reads — and keeping one offload per API is what lets leaf endpoints convert independently.
+
+Two granularity rules that `branches::list` doesn't exercise but the leaf conversions will:
+
+- **A read loop is one operation, not N.** When an API iterates — a value per key, a walk over merkle nodes — the *entire loop* stays inside its single `spawn_blocking` (or moves to a bulk API); never dispatch one hop per iteration, which pays the dispatch tax on every element. (`branches::list`'s inner `list_branches` iterates the whole refs DB inside its one closure.)
+- **Independent reads may overlap with `tokio::try_join!`** (optional perf). When a handler's reads don't depend on each other, joining their separate offloads runs them on separate blocking-pool threads in parallel, and the DB handle caches dedup temporally-overlapping opens of the same database. Join the separate `async fn`s — do **not** merge their bodies into one closure, which can neither overlap nor dedup.
+
 ### Bracket: async → sync → async
 
 The handler is async. It does any required network calls up front, then a single `spawn_blocking` for the sync core, then any network calls at the end.

--- a/docs/async_policy.md
+++ b/docs/async_policy.md
@@ -50,6 +50,36 @@ Not all Oxen code should be async. All filesystem operations should be sync. Mos
 
 The patterns below cover the cases that come up in practice. Names are useful for code review shorthand.
 
+### Offload: converting a sync liboxen API to async
+
+The most common conversion here: a `liboxen` read or mutation API does purely synchronous sync-DB / filesystem work (no network) and is called from `async` HTTP handlers. Make the API an `async fn` and move its sync core into a single `spawn_blocking`. Three invariants make it correct:
+
+1. **One `spawn_blocking` at operation granularity** — wrap the whole operation in one closure, not one closure per DB call or syscall.
+2. **Return an owned result.** The closure's output is the API's result and must be `Send + 'static` — an owned `Vec<Branch>`, `String`, or domain struct. No borrow of the repo or of a DB guard may escape it.
+3. **Keep every `!Send` guard inside the closure.** RocksDB read guards, LMDB transactions, iterators/cursors, and `parking_lot` guards are created and dropped within the closure and never cross an `.await`.
+
+`repositories::branches::list` is the worked example. Before:
+
+```rust
+pub fn list(repo: &LocalRepository) -> Result<Vec<Branch>, OxenError> {
+    with_ref_manager(repo, |manager| manager.list_branches())
+}
+```
+
+After:
+
+```rust
+pub async fn list(repo: &LocalRepository) -> Result<Vec<Branch>, OxenError> {
+    let repo = repo.clone();
+    tokio::task::spawn_blocking(move || with_ref_manager(&repo, |manager| manager.list_branches()))
+        .await?
+}
+```
+
+`repo.clone()` gives the closure an owned `LocalRepository` to capture, since `spawn_blocking` requires `'static`. The RocksDB read guard that `RefManager::list_branches` acquires lives and dies inside the closure, so it never touches the `.await`, and the returned `Vec<Branch>` is fully owned — nothing `!Send` escapes. `.await?` unwraps twice: `From<JoinError> for OxenError` maps a panicked or cancelled blocking task to an `OxenError`, then the inner `Result` is returned as-is.
+
+The inner sync functions (`with_ref_manager`, `RefManager::list_branches`) stay synchronous; only the public API grows the `async` / `spawn_blocking` edge. Callers ripple outward to `.await` it — a thin sync wrapper that only forwards (e.g. `repositories::is_empty`) becomes `async` in turn, and its own callers, already `async` handlers, add `.await`. The conversion stops at the first `async` boundary above each caller.
+
 ### Bracket: async → sync → async
 
 The handler is async. It does any required network calls up front, then a single `spawn_blocking` for the sync core, then any network calls at the end.


### PR DESCRIPTION
Many oxen-server request handlers run synchronous RocksDB work inline on the actix worker threads, so a slow synchronous read (for example) pins a worker thread for its full duration and can starve fresh-connection accepts.

This PR converts the smallest, self-contained read API, (`branches::list`), to run its DB work on the blocking pool, freeing the worker to serve other requests while the read proceeds. We are using this PR as the canonical example for how to fix this situation.

`branches::list` is now an `async fn` that wraps its `RefManager` work in one operation-granularity `spawn_blocking` and returns an owned `Vec<Branch>`.

Extra fix: `repositories::is_empty` no longer materializes the whole branch list just to test for emptiness. A new `RefManager::is_empty` reads only the first ref, turning a full refs-DB scan into an `O(1)` check.

We added this conversion "recipe" to `docs/async_policy.md`, which should make it easier to be consistent about subsequent conversions.