### PR TITLE
Async (6): add async versions of get_repo + parse_resource

### DIFF
--- a/crates/liboxen/src/core/v_latest/resource.rs
+++ b/crates/liboxen/src/core/v_latest/resource.rs
@@ -63,6 +63,18 @@ pub fn parse_resource_from_path(
     Ok(None)
 }
 
+/// Parse a resource identifier from a URL-style path, off the async worker.
+///
+/// Resolution order: commits, then branches, then workspaces.
+pub async fn parse_resource_from_path_async(
+    repo: &LocalRepository,
+    path: &Path,
+) -> Result<Option<ParsedResource>, OxenError> {
+    let repo = repo.clone();
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || parse_resource_from_path(&repo, &path)).await?
+}
+
 fn parsed_from_commit(resource_path: &Path, commit: Commit, file_path: PathBuf) -> ParsedResource {
     ParsedResource {
         version: PathBuf::from(commit.id.to_string()),

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -85,6 +85,23 @@ pub fn get_by_namespace_and_name(
         .map(Some)
 }
 
+/// Look up a repo by `<namespace>/<name>` under `sync_dir`, off the async worker.
+pub async fn get_by_namespace_and_name_async(
+    sync_dir: &Path,
+    namespace: &str,
+    name: &str,
+    server_s3_opts: Option<&S3Opts>,
+) -> Result<Option<LocalRepository>, OxenError> {
+    let sync_dir = sync_dir.to_path_buf();
+    let namespace = namespace.to_string();
+    let name = name.to_string();
+    let server_s3_opts = server_s3_opts.cloned();
+    tokio::task::spawn_blocking(move || {
+        get_by_namespace_and_name(&sync_dir, &namespace, &name, server_s3_opts.as_ref())
+    })
+    .await?
+}
+
 pub fn is_empty(repo: &LocalRepository) -> Result<bool, OxenError> {
     match branches::list(repo) {
         Ok(branches) => Ok(branches.is_empty()),

--- a/crates/liboxen/src/resource.rs
+++ b/crates/liboxen/src/resource.rs
@@ -1,4 +1,6 @@
-pub use crate::core::v_latest::resource::parse_resource_from_path;
+pub use crate::core::v_latest::resource::{
+    parse_resource_from_path, parse_resource_from_path_async,
+};
 
 #[cfg(test)]
 mod tests {
@@ -312,6 +314,34 @@ mod tests {
             let path = Path::new("nonexistent-thing/file.txt");
             let result = resource::parse_resource_from_path(&repo, path)?;
             assert!(result.is_none(), "unknown identifier should return None");
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_parse_resource_from_path_async_matches_sync() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+            let path_str = format!("{}/some/file.txt", commit.id);
+            let path = Path::new(&path_str);
+
+            let sync = resource::parse_resource_from_path(&repo, path)?;
+            let async_ = resource::parse_resource_from_path_async(&repo, path).await?;
+
+            let sync = sync.expect("should resolve");
+            let async_ = async_.expect("should resolve");
+            assert_eq!(async_.commit.unwrap().id, sync.commit.unwrap().id);
+            assert_eq!(async_.path, sync.path);
+
+            // Unknown identifiers resolve to None on the async path too.
+            let unknown = Path::new("nonexistent-thing/file.txt");
+            assert!(
+                resource::parse_resource_from_path_async(&repo, unknown)
+                    .await?
+                    .is_none()
+            );
 
             Ok(())
         })

--- a/crates/oxen-server/src/controllers/dir.rs
+++ b/crates/oxen-server/src/controllers/dir.rs
@@ -1,6 +1,6 @@
 use crate::errors::OxenHttpError;
-use crate::helpers::get_repo;
-use crate::params::{PageNumVersionQuery, app_data, parse_resource, path_param};
+use crate::helpers::get_repo_async;
+use crate::params::{PageNumVersionQuery, app_data, parse_resource_async, path_param};
 
 use liboxen::opts::{PaginateOpts, SortOpts};
 use liboxen::perf_guard;
@@ -37,8 +37,8 @@ pub async fn get(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(app_data, &namespace, &repo_name)?;
-    let resource = parse_resource(&req, &repo)?;
+    let repo = get_repo_async(app_data, &namespace, &repo_name).await?;
+    let resource = parse_resource_async(&req, &repo).await?;
 
     let page: usize = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size: usize = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);

--- a/crates/oxen-server/src/controllers/revisions.rs
+++ b/crates/oxen-server/src/controllers/revisions.rs
@@ -1,6 +1,6 @@
 use crate::errors::OxenHttpError;
-use crate::helpers::get_repo;
-use crate::params::{app_data, parse_resource, path_param};
+use crate::helpers::get_repo_async;
+use crate::params::{app_data, parse_resource_async, path_param};
 
 use actix_web::{HttpRequest, HttpResponse, Result};
 
@@ -30,9 +30,9 @@ pub async fn get(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repository = get_repo(app_data, namespace, repo_name)?;
+    let repository = get_repo_async(app_data, &namespace, &repo_name).await?;
 
-    let resource = parse_resource(&req, &repository)?;
+    let resource = parse_resource_async(&req, &repository).await?;
     let response = ParseResourceResponse {
         status: StatusMessage::resource_found(),
         resource: resource.into(),

--- a/crates/oxen-server/src/helpers.rs
+++ b/crates/oxen-server/src/helpers.rs
@@ -33,6 +33,31 @@ pub fn get_repo(
     Ok(repo)
 }
 
+/// Look up a repo by `<namespace>/<name>` under the server's sync dir, off the async worker.
+pub async fn get_repo_async(
+    app_data: &OxenAppData,
+    namespace: &str,
+    name: &str,
+) -> Result<LocalRepository, OxenHttpError> {
+    let repo = repositories::get_by_namespace_and_name_async(
+        &app_data.path,
+        namespace,
+        name,
+        app_data.config.storage.s3(),
+    )
+    .await?;
+    let Some(repo) = repo else {
+        return Err(
+            OxenError::RepoNotFound(Box::new(RepoNew::from_namespace_name(
+                namespace, name, None,
+            )))
+            .into(),
+        );
+    };
+
+    Ok(repo)
+}
+
 // Helper function for user creation
 pub fn create_user_from_options(
     name: Option<String>,

--- a/crates/oxen-server/src/params.rs
+++ b/crates/oxen-server/src/params.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 use liboxen::error::OxenError;
 use liboxen::model::{Branch, Commit, LocalRepository, ParsedResource};
-use liboxen::resource::parse_resource_from_path;
+use liboxen::resource::{parse_resource_from_path, parse_resource_from_path_async};
 use liboxen::{constants, repositories};
 
 use actix_web::HttpRequest;
@@ -136,6 +136,26 @@ pub fn parse_resource(
         "parse_resource_from_path looking for resource: {resource:?} decoded_resource: {decoded_resource:?}"
     );
     parse_resource_from_path(repo, &decoded_resource)?
+        .ok_or_else(|| OxenError::path_does_not_exist(resource).into())
+}
+
+/// Resolve the `resource` query param against `repo`, off the async worker.
+pub async fn parse_resource_async(
+    req: &HttpRequest,
+    repo: &LocalRepository,
+) -> Result<ParsedResource, OxenHttpError> {
+    let resource: PathBuf = PathBuf::from(query_param(req, "resource"));
+    let resource_path_str = resource.to_string_lossy();
+
+    // Decode the URL, handling both %20 and + as spaces
+    let decoded_path = decode_resource_path(&resource_path_str);
+
+    let decoded_resource = PathBuf::from(decoded_path);
+    log::debug!(
+        "parse_resource_from_path looking for resource: {resource:?} decoded_resource: {decoded_resource:?}"
+    );
+    parse_resource_from_path_async(repo, &decoded_resource)
+        .await?
         .ok_or_else(|| OxenError::path_does_not_exist(resource).into())
 }
 


### PR DESCRIPTION
Repo lookup and resource resolution sit at the front of nearly every oxen-server request. Today they run their synchronous RocksDB/LMDB/filesystem work directly on the actix worker thread, so a slow lookup pins that worker for its full duration; under load, enough pinned workers stall other requests and even fresh-connection accepts.

This PR adds async variants of `get_repo` and `parse_resource` that do the same work off the actix worker. We will remove the sync originals once every caller has moved over.

The directory-listing and revision-resolution endpoints are switched over in this PR as the first users of the new functions.

ENG-1282