### PR TITLE
DuckDB Tracking (4/4): Clean up client surfaces after the tracking-column removal

### DIFF
--- a/crates/liboxen/src/view/json_data_frame_view.rs
+++ b/crates/liboxen/src/view/json_data_frame_view.rs
@@ -187,14 +187,16 @@ impl JsonDataFrameView {
         // Unpaginated means we don't need to slice the df
         let mut opts = opts.clone();
         opts.slice = None;
-        // Sorting was likewise already applied upstream (DuckDB's ORDER BY for
-        // indexed workspace frames, the read-time transform otherwise) and may
-        // name SQL-only pseudo-columns like `rowid` that don't exist in the
-        // materialized frame — re-sorting here would panic on them.
-        opts.sort_by = None;
 
+        // Keep the requested sort visible in the response metadata, but do not
+        // re-apply it here: sorting was already applied upstream (DuckDB's
+        // ORDER BY for indexed workspace frames, the read-time transform
+        // otherwise) and may name SQL-only pseudo-columns like `rowid` that
+        // don't exist in the materialized frame — re-sorting would panic.
         let opts_view = DFOptsView::from_df_opts(&opts);
-        let mut sliced_df = tabular::transform(df, opts.clone()).await.unwrap();
+        let mut transform_opts = opts.clone();
+        transform_opts.sort_by = None;
+        let mut sliced_df = tabular::transform(df, transform_opts).await.unwrap();
 
         // Merge the metadata from the original schema
         let mut slice_schema = Schema::from_polars(sliced_df.schema());

--- a/crates/liboxen/src/view/json_data_frame_view.rs
+++ b/crates/liboxen/src/view/json_data_frame_view.rs
@@ -187,6 +187,11 @@ impl JsonDataFrameView {
         // Unpaginated means we don't need to slice the df
         let mut opts = opts.clone();
         opts.slice = None;
+        // Sorting was likewise already applied upstream (DuckDB's ORDER BY for
+        // indexed workspace frames, the read-time transform otherwise) and may
+        // name SQL-only pseudo-columns like `rowid` that don't exist in the
+        // materialized frame — re-sorting here would panic on them.
+        opts.sort_by = None;
 
         let opts_view = DFOptsView::from_df_opts(&opts);
         let mut sliced_df = tabular::transform(df, opts.clone()).await.unwrap();

--- a/crates/oxen-cli/src/cmd/df.rs
+++ b/crates/oxen-cli/src/cmd/df.rs
@@ -234,7 +234,7 @@ impl RunCmd for DFCmd {
         .arg(
             Arg::new("delete-row")
                 .long("delete-row")
-                .help("Delete a row from a data frame. Currently only works with remote data frames with the value from _id column.")
+                .help("Delete a row from a data frame. Currently only works with remote data frames, using the row id from the _oxen_id column.")
                 .action(clap::ArgAction::Set),
         )
         .arg(

--- a/oxen-python/python/oxen/data_frame.py
+++ b/oxen-python/python/oxen/data_frame.py
@@ -432,4 +432,3 @@ class DataFrame:
                 The branch to commit the changes to. Defaults to the current branch.
         """
         self._workspace.commit(message, branch)
-

--- a/oxen-python/python/oxen/data_frame.py
+++ b/oxen-python/python/oxen/data_frame.py
@@ -42,10 +42,6 @@ class DataFrame:
     # Delete a row
     data_frame.delete_row(row_id)
 
-    # Get the current changes to the data frame
-    status = data_frame.diff()
-    print(status.added_files())
-
     # Commit the changes
     data_frame.commit("Updating data.csv")
     ```
@@ -104,7 +100,6 @@ class DataFrame:
         except Exception as e:
             print(e)
             self.data_frame = None
-        self.filter_keys = ["_oxen_diff_hash", "_oxen_diff_status", "_oxen_row_id"]
 
     def __repr__(self):
         name = f"{self._workspace._repo.namespace}/{self._workspace._repo.name}"
@@ -155,7 +150,6 @@ class DataFrame:
         # convert string to dict
         # this is not the most efficient but gets it working
         data = json.loads(results)
-        data = self._filter_keys_arr(data)
         return data
 
     def insert_row(self, data: dict, workspace: Optional[Workspace] = None):
@@ -203,7 +197,6 @@ class DataFrame:
             )
             results = self.data_frame.list(1)
             results = json.loads(results)
-            print(results)
             return results[0]["_oxen_id"]
         else:
             # convert dict to json string
@@ -215,11 +208,7 @@ class DataFrame:
         """
         Get the columns of the data frame.
         """
-        # filter out the columns that are in the filter_keys list
-        columns = [
-            c for c in self.data_frame.get_columns() if c.name not in self.filter_keys
-        ]
-        return columns
+        return self.data_frame.get_columns()
 
     def add_column(self, name: str, data_type: str):
         """
@@ -389,8 +378,6 @@ class DataFrame:
         # convert string to dict
         # this is not the most efficient but gets it working
         data = json.loads(data)
-        # filter out .oxen.diff.hash and .oxen.diff.status and _oxen_row_id
-        data = self._filter_keys_arr(data)
 
         if len(data) == 0:
             return None
@@ -415,7 +402,6 @@ class DataFrame:
         data = json.dumps(data)
         result = self.data_frame.update_row(id, data)
         result = json.loads(result)
-        result = self._filter_keys_arr(result)
         return result
 
     def delete_row(self, id: str):
@@ -430,7 +416,8 @@ class DataFrame:
 
     def restore(self):
         """
-        Unstage any changes to the schema or contents of a data frame
+        Discard all staged edits to the data frame by re-indexing it from
+        the committed version
         """
         self.data_frame.restore()
 
@@ -446,17 +433,3 @@ class DataFrame:
         """
         self._workspace.commit(message, branch)
 
-    def _filter_keys(self, data: dict):
-        """
-        Filter out the keys that are not needed in the dataset.
-        """
-        # TODO: why do we use periods vs underscores...?
-        # filter out .oxen.diff.hash and .oxen.diff.status and _oxen_row_id
-        # from each element in the list of dicts
-        return {k: v for k, v in data.items() if k not in self.filter_keys}
-
-    def _filter_keys_arr(self, data: List[dict]):
-        """
-        Filter out the keys that are not needed in the dataset.
-        """
-        return [self._filter_keys(d) for d in data]

--- a/oxen-python/python/oxen/data_frame.py
+++ b/oxen-python/python/oxen/data_frame.py
@@ -416,8 +416,8 @@ class DataFrame:
 
     def restore(self):
         """
-        Discard all staged edits to the data frame by re-indexing it from
-        the committed version
+        Discard all uncommitted edits to the data frame by re-indexing it
+        from the committed version
         """
         self.data_frame.restore()
 

--- a/oxen-python/tests/test_data_frame.py
+++ b/oxen-python/tests/test_data_frame.py
@@ -234,7 +234,7 @@ def test_data_frame_add_column(celeba_remote_repo_fully_pushed):
     # Get the columns
     columns = df.get_columns()
     assert len(columns) == 3, (
-        "DataFrame should have 3 columns (plus the _oxen_id column)"
+        "DataFrame should have 2 data columns plus the _oxen_id column"
     )
 
     # Add a column


### PR DESCRIPTION
**Stack:** #749 → #742 → #744 → **#751 (this)**

## Summary

Client-side polish now that the tracking columns are gone:

- **Python `DataFrame`**: removes the `filter_keys` machinery — the legacy tracking columns it hid (`_oxen_diff_hash`, `_oxen_diff_status`, `_oxen_row_id`) no longer exist server-side, and `_oxen_id` remains visible as the row handle (as it always was). Also drops the class docstring example calling a `diff()` method that never existed, clarifies the `restore()` docstring (discard staged edits by re-indexing), and removes a stray debug `print` from `insert_row`.
- **CLI**: fixes the stale `oxen df --delete-row` help text to name the `_oxen_id` column.

### Docs site
The workspace data frame pages on docs.oxen.ai need a follow-up in the docs repo: remove mentions of the staged data frame diff (`oxen workspace diff`) and row/column restore, and note that edits apply directly (whole-data-frame restore still discards all staged edits).

### Testing
- `bin/test-rust -p`: 80/80
- clippy clean


---

## How to review
- Small, client-only diff: the Python `DataFrame` cleanup (filter machinery removal — check `insert_row`/`get_row_by_id` still surface `_oxen_id`), the CLI help-text fix, and the `sort_by` clear in `JsonDataFrameView` (companion to sorting by DuckDB's virtual `rowid`; prevents the view-layer re-sort from panicking on SQL-only pseudo-columns).
- Follow-up owed after merge: the docs.oxen.ai pages for workspace data frames (separate docs repo) — remove staged-diff/row-restore mentions.

## How to merge
Top of the stack — merge last, after #744. Squash + delete branch. Once all four are in, the stack is fully landed and `main` carries: crash fix → reversibility removal → single-column schema → client polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
