### PR TITLE
Bump to rust 1.97.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"


### PR DESCRIPTION
Just a hotfix to the LLVM layer of compilation. See the [blog post](https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/) for details.