### PR TITLE
Async (7): Tree/entries read layer to async

### DIFF
--- a/crates/liboxen/src/repositories/entries.rs
+++ b/crates/liboxen/src/repositories/entries.rs
@@ -4,7 +4,7 @@
 use crate::core;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::merkle_tree::node::FileNode;
+use crate::model::merkle_tree::node::{DirNode, FileNode};
 use crate::opts::{PaginateOpts, SortOpts};
 use crate::repositories;
 use crate::util::concurrency;
@@ -20,6 +20,18 @@ use std::path::{Path, PathBuf};
 
 /// Get a directory object for a commit
 pub use crate::core::v_latest::entries::get_directory;
+
+/// Get a directory object for a commit, off the async worker.
+pub async fn get_directory_async(
+    repo: &LocalRepository,
+    commit: &Commit,
+    path: impl AsRef<Path>,
+) -> Result<Option<DirNode>, OxenError> {
+    let repo = repo.clone();
+    let commit = commit.clone();
+    let path = path.as_ref().to_path_buf();
+    tokio::task::spawn_blocking(move || get_directory(&repo, &commit, &path)).await?
+}
 
 /// Get a file node for a commit
 pub fn get_file(
@@ -114,6 +126,36 @@ pub fn list_directory_w_workspace_depth(
     )
 }
 
+/// List the entries within a directory to a given depth, off the async worker.
+#[allow(clippy::too_many_arguments)]
+pub async fn list_directory_w_workspace_depth_async(
+    repo: &LocalRepository,
+    directory: impl AsRef<Path>,
+    revision: impl AsRef<str>,
+    workspace: Option<Workspace>,
+    paginate_opts: &PaginateOpts,
+    sort_opts: &SortOpts,
+    depth: usize,
+) -> Result<PaginatedDirEntries, OxenError> {
+    let repo = repo.clone();
+    let directory = directory.as_ref().to_path_buf();
+    let revision = revision.as_ref().to_string();
+    let paginate_opts = paginate_opts.clone();
+    let sort_opts = sort_opts.clone();
+    tokio::task::spawn_blocking(move || {
+        list_directory_w_workspace_depth(
+            &repo,
+            &directory,
+            &revision,
+            workspace,
+            &paginate_opts,
+            &sort_opts,
+            depth,
+        )
+    })
+    .await?
+}
+
 pub fn update_metadata(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<(), OxenError> {
     match repo.min_version() {
         MinOxenVersion::LATEST => core::v_latest::entries::update_metadata(repo, revision),
@@ -141,6 +183,19 @@ pub fn get_meta_entry(
             core::v_latest::entries::get_meta_entry(repo, &parsed_resource, path)
         }
     }
+}
+
+/// Get the entry for a given path in a commit, off the async worker.
+/// Could be a file or a directory.
+pub async fn get_meta_entry_async(
+    repo: &LocalRepository,
+    commit: &Commit,
+    path: impl AsRef<Path>,
+) -> Result<MetadataEntry, OxenError> {
+    let repo = repo.clone();
+    let commit = commit.clone();
+    let path = path.as_ref().to_path_buf();
+    tokio::task::spawn_blocking(move || get_meta_entry(&repo, &commit, &path)).await?
 }
 
 /// List the paths of all the directories in a given commit
@@ -1130,6 +1185,87 @@ mod tests {
                 assert_eq!(sub_children.len(), 1);
                 assert_eq!(sub_children[0].filename, "file_sub.txt");
             }
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_get_directory_async_matches_sync() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let commits = repositories::commits::list(&repo)?;
+            let commit = commits.first().unwrap();
+            let path = Path::new("annotations").join("train");
+
+            let sync = repositories::entries::get_directory(&repo, commit, &path)?;
+            let async_ = repositories::entries::get_directory_async(&repo, commit, &path).await?;
+            assert_eq!(async_, sync);
+            assert!(sync.is_some());
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_get_meta_entry_async_matches_sync() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let commits = repositories::commits::list(&repo)?;
+            let commit = commits.first().unwrap();
+
+            for path in [
+                Path::new("annotations").join("train"),
+                test::test_nlp_classification_csv(),
+            ] {
+                let sync = repositories::entries::get_meta_entry(&repo, commit, &path)?;
+                let async_ =
+                    repositories::entries::get_meta_entry_async(&repo, commit, &path).await?;
+                assert_eq!(async_.filename, sync.filename);
+                assert_eq!(async_.hash, sync.hash);
+                assert_eq!(async_.is_dir, sync.is_dir);
+            }
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_w_workspace_depth_async_matches_sync() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let commits = repositories::commits::list(&repo)?;
+            let commit = commits.first().unwrap();
+            let paginate_opts = PaginateOpts {
+                page_num: 1,
+                page_size: 100,
+            };
+
+            let sync = repositories::entries::list_directory_w_workspace_depth(
+                &repo,
+                Path::new(""),
+                &commit.id,
+                None,
+                &paginate_opts,
+                &SortOpts::default(),
+                1,
+            )?;
+            let async_ = repositories::entries::list_directory_w_workspace_depth_async(
+                &repo,
+                Path::new(""),
+                &commit.id,
+                None,
+                &paginate_opts,
+                &SortOpts::default(),
+                1,
+            )
+            .await?;
+
+            assert_eq!(async_.total_entries, sync.total_entries);
+            assert_eq!(async_.total_pages, sync.total_pages);
+            let async_names: Vec<&str> = async_.entries.iter().map(|e| e.filename()).collect();
+            let sync_names: Vec<&str> = sync.entries.iter().map(|e| e.filename()).collect();
+            assert_eq!(async_names, sync_names);
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -227,6 +227,18 @@ pub fn get_file_by_path(
     }
 }
 
+/// Get the file node at `path` in a commit, off the async worker.
+pub async fn get_file_by_path_async(
+    repo: &LocalRepository,
+    commit: &Commit,
+    path: impl AsRef<Path>,
+) -> Result<Option<FileNode>, OxenError> {
+    let repo = repo.clone();
+    let commit = commit.clone();
+    let path = path.as_ref().to_path_buf();
+    tokio::task::spawn_blocking(move || get_file_by_path(&repo, &commit, &path)).await?
+}
+
 pub fn get_dir_with_children(
     repo: &LocalRepository,
     commit: &Commit,
@@ -3376,6 +3388,34 @@ mod tests {
                     "hash {h} not readable in vfs-cloned repo"
                 );
             }
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_get_file_by_path_async_matches_sync() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            util::fs::write(repo.path.join("hello.txt"), "hello world")?;
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commit(&repo, "Adding hello.txt")?;
+
+            let sync = repositories::tree::get_file_by_path(&repo, &commit, "hello.txt")?;
+            let async_ =
+                repositories::tree::get_file_by_path_async(&repo, &commit, "hello.txt").await?;
+            assert_eq!(
+                async_.as_ref().map(|f| f.hash()),
+                sync.as_ref().map(|f| f.hash())
+            );
+            assert!(sync.is_some());
+
+            // A directory path resolves to None on the async path too.
+            assert!(
+                repositories::tree::get_file_by_path_async(&repo, &commit, "")
+                    .await?
+                    .is_none()
+            );
+
             Ok(())
         })
         .await


### PR DESCRIPTION
The read APIs behind directory listings, file and directory metadata, and repo detail are the highest-fan-out data path in oxen-server, and the handlers that serve those endpoints run their synchronous merkle/RocksDB/LMDB reads inline on the actix worker threads. Each read pins a worker for its full duration, so under load these paths starve new-connection accepts and health checks.

Give `entries::get_directory`, `entries::get_meta_entry`, `entries::list_directory_w_workspace_depth`, and `tree::get_file_by_path` async variants that run their reads off the worker thread, so the handlers can await them instead of blocking the async runtime. The variants land alongside the sync originals so the dir, meta, and repo-detail endpoints can adopt them independently, without a flag-day signature flip across every caller; the sync originals are removed in a later cleanup.

ENG-1283