### PR TITLE
Add back in Field.changes and subfields

### DIFF
--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames/columns.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames/columns.rs
@@ -256,6 +256,7 @@ fn sync_workspace_columns_into_metadata(
                 name: table_field.name,
                 dtype: table_field.dtype,
                 metadata: carried.and_then(|f| f.metadata.clone()),
+                changes: None,
             }
         })
         .collect();

--- a/crates/liboxen/src/model/data_frame/schema/field.rs
+++ b/crates/liboxen/src/model/data_frame/schema/field.rs
@@ -73,3 +73,68 @@ impl Field {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    // Mirrors the on-disk `Field` layout from before `changes` was briefly
+    // dropped: `changes` is the trailing element. Merkle nodes embed schema
+    // fields and are serialized positionally via `rmp_serde::to_vec`, so blobs
+    // written by older versions still carry (or omit) this trailing element and
+    // must keep deserializing into the current `Field`.
+    #[derive(Serialize)]
+    struct OldField {
+        name: String,
+        dtype: String,
+        metadata: Option<Value>,
+        changes: Option<OldChanges>,
+    }
+
+    #[derive(Serialize)]
+    struct OldChanges {
+        status: String,
+        previous: Option<Box<OldField>>,
+    }
+
+    #[test]
+    fn test_deserialize_field_missing_changes_element() {
+        // The interim format dropped `changes` entirely (three-element array).
+        #[derive(Serialize)]
+        struct FieldWithoutChanges {
+            name: String,
+            dtype: String,
+            metadata: Option<Value>,
+        }
+        let bytes = rmp_serde::to_vec(&FieldWithoutChanges {
+            name: "col".to_owned(),
+            dtype: "str".to_owned(),
+            metadata: None,
+        })
+        .expect("serialize field without changes");
+
+        let field: Field =
+            rmp_serde::from_slice(&bytes).expect("deserialize interim format into current Field");
+        assert_eq!(field.name, "col");
+        assert_eq!(field.dtype, "str");
+        assert!(field.changes.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_field_with_null_changes() {
+        let bytes = rmp_serde::to_vec(&OldField {
+            name: "col".to_owned(),
+            dtype: "str".to_owned(),
+            metadata: None,
+            changes: None,
+        })
+        .expect("serialize old field with null changes");
+
+        let field: Field =
+            rmp_serde::from_slice(&bytes).expect("deserialize old format into current Field");
+        assert_eq!(field.name, "col");
+        assert_eq!(field.dtype, "str");
+        assert!(field.changes.is_none());
+    }
+}

--- a/crates/liboxen/src/model/data_frame/schema/field.rs
+++ b/crates/liboxen/src/model/data_frame/schema/field.rs
@@ -10,6 +10,20 @@ pub struct Field {
     pub name: String,
     pub dtype: String,
     pub metadata: Option<Value>,
+    pub changes: Option<Changes>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct PreviousField {
+    pub name: String,
+    pub dtype: String,
+    pub metadata: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct Changes {
+    pub status: String,
+    pub previous: Option<PreviousField>,
 }
 
 impl PartialEq for Field {
@@ -24,6 +38,7 @@ impl Field {
             name: name.to_owned(),
             dtype: dtype.to_owned(),
             metadata: None,
+            changes: None,
         }
     }
 

--- a/crates/liboxen/src/model/data_frame/schema/field.rs
+++ b/crates/liboxen/src/model/data_frame/schema/field.rs
@@ -10,6 +10,7 @@ pub struct Field {
     pub name: String,
     pub dtype: String,
     pub metadata: Option<Value>,
+    #[serde(default)]
     pub changes: Option<Changes>,
 }
 

--- a/crates/liboxen/src/model/merkle_tree/node/file_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/file_node.rs
@@ -89,11 +89,16 @@ impl FileNode {
     pub fn deserialize(data: &[u8]) -> Result<FileNode, rmp_serde::decode::Error> {
         let file_node: FileNode = match rmp_serde::from_slice(data) {
             Ok(file_node) => file_node,
-            Err(_) => {
+            Err(primary_error) => {
                 // This is a fallback for old versions of the file node
-                let file_node: FileNodeDataV0_25_0 = rmp_serde::from_slice(data)?;
-                Self {
-                    node: EFileNode::V0_25_0(file_node),
+                match rmp_serde::from_slice(data) {
+                    Ok(file_node) => Self {
+                        node: EFileNode::V0_25_0(file_node),
+                    },
+                    // Wrapped nodes should report why their current representation failed to
+                    // decode, not the misleading error from interpreting `V0_25_0` as a raw
+                    // `MerkleTreeNodeType` in the legacy fallback.
+                    Err(_) => return Err(primary_error),
                 }
             }
         };

--- a/crates/liboxen/src/repositories/diffs/join_diff.rs
+++ b/crates/liboxen/src/repositories/diffs/join_diff.rs
@@ -176,6 +176,7 @@ fn build_compare_schema_diff(
                 name: col.clone(),
                 dtype: dtype.dtype().to_string(),
                 metadata: None,
+                changes: None,
             })
         })
         .collect::<Result<Vec<Field>, OxenError>>()?;
@@ -189,6 +190,7 @@ fn build_compare_schema_diff(
                 name: col.clone(),
                 dtype: dtype.dtype().to_string(),
                 metadata: None,
+                changes: None,
             })
         })
         .collect::<Result<Vec<Field>, OxenError>>()?;


### PR DESCRIPTION
Add back in Field.changes, Changes, and PreviousField and updated current Field constructors to set changes: None because we were getting a crash serializing the object from the old format.

The crash was a little misleading:

Error: Err status [500 Internal Server Error] from url [Cannot decode a Merkle node: unknown variant `V0_25_0`, expected one of `Commit`, `File`, `Dir`, `VNode`, `FileChunk`
]

So we pass through a real error now.