### PR TITLE
Async (8b): repo-detail reads only the root directory node

### DIFF
--- a/crates/liboxen/src/core/v_latest/entries.rs
+++ b/crates/liboxen/src/core/v_latest/entries.rs
@@ -24,7 +24,15 @@ pub fn get_directory(
     commit: &Commit,
     path: impl AsRef<Path>,
 ) -> Result<Option<DirNode>, OxenError> {
-    let node = repositories::tree::get_node_by_path(repo, commit, path)?;
+    // Read just the directory node: its num_bytes and data_type_counts are stored on the node
+    // itself, so its children (which the DirNode conversion drops) are never loaded.
+    let node = match CommitMerkleTree::dir_node_only(repo, commit, path) {
+        Ok(node) => node,
+        Err(e) => {
+            log::warn!("Error getting node by path: {e:?}");
+            return Ok(None);
+        }
+    };
     let Some(node) = node else {
         return Ok(None);
     };

--- a/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
@@ -586,6 +586,24 @@ impl CommitMerkleTree {
         }
     }
 
+    /// Read the directory node at `path` for `commit` without loading any children.
+    ///
+    /// The node's own fields — including the precomputed `num_bytes` and `data_type_counts`
+    /// aggregates — are populated; none of its VNodes or entries are read. Returns `Ok(None)`
+    /// when `path` is not a directory in the commit.
+    pub fn dir_node_only(
+        repo: &LocalRepository,
+        commit: &Commit,
+        path: impl AsRef<Path>,
+    ) -> Result<Option<MerkleTreeNode>, OxenError> {
+        let node_path = path.as_ref();
+        let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
+        match dir_hashes.get(node_path).cloned() {
+            Some(node_hash) => Ok(Some(MerkleTreeNode::from_hash(repo, &node_hash)?)),
+            None => Ok(None),
+        }
+    }
+
     pub fn dir_with_children(
         repo: &LocalRepository,
         commit: &Commit,

--- a/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/crates/liboxen/src/core/v_latest/index/commit_merkle_tree.rs
@@ -596,7 +596,13 @@ impl CommitMerkleTree {
         commit: &Commit,
         path: impl AsRef<Path>,
     ) -> Result<Option<MerkleTreeNode>, OxenError> {
+        // "." denotes the repo root, which is stored under the empty path.
         let node_path = path.as_ref();
+        let node_path = if node_path == Path::new(".") {
+            Path::new("")
+        } else {
+            node_path
+        };
         let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
         match dir_hashes.get(node_path).cloned() {
             Some(node_hash) => Ok(Some(MerkleTreeNode::from_hash(repo, &node_hash)?)),

--- a/crates/liboxen/src/repositories/entries.rs
+++ b/crates/liboxen/src/repositories/entries.rs
@@ -1209,6 +1209,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_directory_preserves_aggregates_without_children() -> Result<(), OxenError> {
+        test::run_training_data_repo_test_fully_committed_async(|repo| async move {
+            let commits = repositories::commits::list(&repo)?;
+            let commit = commits.first().unwrap();
+            let path = Path::new("annotations").join("train");
+
+            // get_directory reads only the directory node.
+            let dir_node = repositories::entries::get_directory(&repo, commit, &path)?
+                .expect("directory should exist");
+
+            // A full-depth read of the same directory must report identical aggregates, since
+            // num_bytes and data_type_counts are stored on the directory node itself.
+            let full = repositories::tree::get_node_by_path(&repo, commit, &path)?
+                .expect("directory node should exist")
+                .dir()?;
+
+            assert_eq!(dir_node.num_bytes(), full.num_bytes());
+            assert_eq!(dir_node.data_type_counts(), full.data_type_counts());
+            assert!(dir_node.num_bytes() > 0);
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_get_meta_entry_async_matches_sync() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|repo| async move {
             let commits = repositories::commits::list(&repo)?;

--- a/crates/liboxen/src/repositories/entries.rs
+++ b/crates/liboxen/src/repositories/entries.rs
@@ -1213,21 +1213,23 @@ mod tests {
         test::run_training_data_repo_test_fully_committed_async(|repo| async move {
             let commits = repositories::commits::list(&repo)?;
             let commit = commits.first().unwrap();
-            let path = Path::new("annotations").join("train");
+            // "" and "." both denote the repo root; a nested path resolves normally.
+            let nested = Path::new("annotations").join("train");
+            for path in [Path::new(""), Path::new("."), nested.as_path()] {
+                // get_directory reads only the directory node.
+                let dir_node = repositories::entries::get_directory(&repo, commit, path)?
+                    .expect("directory should exist");
 
-            // get_directory reads only the directory node.
-            let dir_node = repositories::entries::get_directory(&repo, commit, &path)?
-                .expect("directory should exist");
+                // A full-depth read of the same directory must report identical aggregates, since
+                // num_bytes and data_type_counts are stored on the directory node itself.
+                let full = repositories::tree::get_node_by_path(&repo, commit, path)?
+                    .expect("directory node should exist")
+                    .dir()?;
 
-            // A full-depth read of the same directory must report identical aggregates, since
-            // num_bytes and data_type_counts are stored on the directory node itself.
-            let full = repositories::tree::get_node_by_path(&repo, commit, &path)?
-                .expect("directory node should exist")
-                .dir()?;
-
-            assert_eq!(dir_node.num_bytes(), full.num_bytes());
-            assert_eq!(dir_node.data_type_counts(), full.data_type_counts());
-            assert!(dir_node.num_bytes() > 0);
+                assert_eq!(dir_node.num_bytes(), full.num_bytes());
+                assert_eq!(dir_node.data_type_counts(), full.data_type_counts());
+                assert!(dir_node.num_bytes() > 0);
+            }
 
             Ok(())
         })


### PR DESCRIPTION
(Stacked on #755)

The repo-detail endpoint (`GET /api/repos/{namespace}/{repo_name}`) reports a commit's total size and data-type counts, which are precomputed aggregates stored on the root directory node. To get them it read the root node plus a level of the merkle tree (the root's VNodes, every top-level entry, and one level into each subdirectory) then discarded all of that and kept only the root node. On repos with a large or flat root directory this read thousands of merkle nodes per request for numbers that live on a single node.

Read only the root directory node. A corrupt or missing node still yields size 0 rather than an error, matching the prior behavior. The size and data-type aggregates are unchanged because they are deserialized from the directory node itself, not recomputed from its children.

ENG-1284