### PR TITLE
Async (9): dir handler (dir::get) to async

### DIFF
--- a/crates/oxen-server/src/controllers/dir.rs
+++ b/crates/oxen-server/src/controllers/dir.rs
@@ -68,7 +68,7 @@ pub async fn get(
     };
 
     let _perf_list = perf_guard!("dir::get_list_directory");
-    let paginated_entries = repositories::entries::list_directory_w_workspace_depth(
+    let paginated_entries = repositories::entries::list_directory_w_workspace_depth_async(
         &repo,
         &resource.path,
         revision,
@@ -79,7 +79,8 @@ pub async fn get(
         },
         &sort_opts,
         depth,
-    )?;
+    )
+    .await?;
     drop(_perf_list);
 
     let _perf_serialize = perf_guard!("dir::get_serialize_response");


### PR DESCRIPTION
(Stacked on #753)

Directory listings (`GET /api/repos/.../dir/...`) no longer block an actix worker for the full duration of a directory read. This handler ran synchronous RocksDB/merkle work inline on the single-threaded workers, so a slow or large listing blocked unrelated requests sharing that worker.

`dir::get` now awaits `list_directory_w_workspace_depth_async`, which runs the read in one `spawn_blocking` and returns an owned result, keeping the sync DB work off the async worker. Pagination, sort, depth, and response shape are unchanged.