### PR TITLE
Async (12): commits reads + handler (commits::history) to async

### DIFF
--- a/crates/liboxen/src/repositories/commits.rs
+++ b/crates/liboxen/src/repositories/commits.rs
@@ -192,65 +192,76 @@ pub fn search_entries(
 }
 
 /// List paginated commits starting from the given revision
-pub fn list_from_paginated(
+pub async fn list_from_paginated(
     repo: &LocalRepository,
     revision: &str,
     pagination: PaginateOpts,
 ) -> Result<PaginatedCommits, OxenError> {
-    let _perf = crate::perf_guard!("commits::list_from_paginated");
+    let repo = repo.clone();
+    let revision = revision.to_string();
+    tokio::task::spawn_blocking(move || {
+        let _perf = crate::perf_guard!("commits::list_from_paginated");
 
-    // Calculate skip and limit based on pagination parameters
-    let skip = if pagination.page_num == 0 {
-        0
-    } else {
-        (pagination.page_num - 1) * pagination.page_size
-    };
-    let limit = pagination.page_size;
+        // Calculate skip and limit based on pagination parameters
+        let skip = if pagination.page_num == 0 {
+            0
+        } else {
+            (pagination.page_num - 1) * pagination.page_size
+        };
+        let limit = pagination.page_size;
 
-    let _perf_list = crate::perf_guard!("commits::list_from_paginated_optimized");
-    let (commits, total_entries, cached) =
-        core::v_latest::commits::list_from_paginated_impl(repo, revision, skip, limit)?;
-    log::info!(
-        "list_from_paginated {} got {} commits out of {} total (cached: {})",
-        revision,
-        commits.len(),
-        total_entries,
-        cached
-    );
-    drop(_perf_list);
+        let _perf_list = crate::perf_guard!("commits::list_from_paginated_optimized");
+        let (commits, total_entries, cached) =
+            core::v_latest::commits::list_from_paginated_impl(&repo, &revision, skip, limit)?;
+        log::info!(
+            "list_from_paginated {} got {} commits out of {} total (cached: {})",
+            revision,
+            commits.len(),
+            total_entries,
+            cached
+        );
+        drop(_perf_list);
 
-    // Calculate pagination metadata
-    let total_pages = if pagination.page_size > 0 {
-        (total_entries as f64 / pagination.page_size as f64).ceil() as usize
-    } else {
-        0
-    };
+        // Calculate pagination metadata
+        let total_pages = if pagination.page_size > 0 {
+            (total_entries as f64 / pagination.page_size as f64).ceil() as usize
+        } else {
+            0
+        };
 
-    let pagination = crate::view::Pagination {
-        page_size: pagination.page_size,
-        page_number: pagination.page_num,
-        total_pages,
-        total_entries,
-    };
+        let pagination = crate::view::Pagination {
+            page_size: pagination.page_size,
+            page_number: pagination.page_num,
+            total_pages,
+            total_entries,
+        };
 
-    Ok(PaginatedCommits {
-        status: StatusMessage::resource_found(),
-        commits,
-        pagination,
+        Ok(PaginatedCommits {
+            status: StatusMessage::resource_found(),
+            commits,
+            pagination,
+        })
     })
+    .await?
 }
 
 /// List paginated commits by resource
-pub fn list_by_path_from_paginated(
+pub async fn list_by_path_from_paginated(
     repo: &LocalRepository,
     commit: &Commit,
     path: &Path,
     pagination: PaginateOpts,
 ) -> Result<PaginatedCommits, OxenError> {
-    let _perf = crate::perf_guard!("commits::list_by_path_from_paginated");
+    let repo = repo.clone();
+    let commit = commit.clone();
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let _perf = crate::perf_guard!("commits::list_by_path_from_paginated");
 
-    log::info!("list_by_path_from_paginated: {commit:?} {path:?}");
-    core::v_latest::commits::list_by_path_from_paginated(repo, commit, path, pagination)
+        log::info!("list_by_path_from_paginated: {commit:?} {path:?}");
+        core::v_latest::commits::list_by_path_from_paginated(&repo, &commit, &path, pagination)
+    })
+    .await?
 }
 
 pub use crate::core::v_latest::commits::count_from;
@@ -1314,7 +1325,8 @@ A: Oxen.ai
                 &head_commit,
                 &target_file_path,
                 pagination_opts,
-            )?;
+            )
+            .await?;
 
             assert_eq!(paginated_result.commits.len(), expected_commits.len());
 
@@ -1508,7 +1520,8 @@ A: Oxen.ai
                 &head,
                 &PathBuf::from("data/a.txt"),
                 opts.clone(),
-            )?;
+            )
+            .await?;
             assert_eq!(
                 result.commits.len(),
                 4,
@@ -1522,7 +1535,8 @@ A: Oxen.ai
                 &head,
                 &PathBuf::from("src/b.txt"),
                 opts.clone(),
-            )?;
+            )
+            .await?;
             assert_eq!(
                 result.commits.len(),
                 2,
@@ -1536,7 +1550,8 @@ A: Oxen.ai
                 &head,
                 &PathBuf::from("src/c.txt"),
                 opts.clone(),
-            )?;
+            )
+            .await?;
             assert_eq!(
                 result.commits.len(),
                 1,
@@ -1550,7 +1565,8 @@ A: Oxen.ai
                 &head,
                 &PathBuf::from("other.txt"),
                 opts.clone(),
-            )?;
+            )
+            .await?;
             assert_eq!(
                 result.commits.len(),
                 1,
@@ -1564,7 +1580,8 @@ A: Oxen.ai
                 &head,
                 &PathBuf::from("data"),
                 opts.clone(),
-            )?;
+            )
+            .await?;
             assert_eq!(
                 result.commits.len(),
                 4,
@@ -1578,7 +1595,8 @@ A: Oxen.ai
                 &head,
                 &PathBuf::from("src"),
                 opts.clone(),
-            )?;
+            )
+            .await?;
             assert_eq!(
                 result.commits.len(),
                 3,

--- a/crates/oxen-server/src/controllers/commits.rs
+++ b/crates/oxen-server/src/controllers/commits.rs
@@ -23,9 +23,9 @@ use os_path::OsPath;
 
 use crate::app_data::OxenAppData;
 use crate::errors::OxenHttpError;
-use crate::helpers::get_repo;
+use crate::helpers::{get_repo, get_repo_async};
 use crate::params::PageNumQuery;
-use crate::params::parse_resource;
+use crate::params::parse_resource_async;
 use crate::params::{app_data, path_param};
 
 use actix_web::{Error, HttpRequest, HttpResponse, web};
@@ -122,7 +122,7 @@ pub async fn history(
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(app_data, namespace, repo_name)?;
+    let repo = get_repo_async(app_data, &namespace, &repo_name).await?;
     let resource_param = path_param(&req, "resource")?.to_string();
 
     let pagination = PaginateOpts {
@@ -145,7 +145,7 @@ pub async fn history(
     let (resource, revision, commit) = if resource_param.contains("..") {
         (None, Some(resource_param), None)
     } else {
-        let resource = parse_resource(&req, &repo)?;
+        let resource = parse_resource_async(&req, &repo).await?;
         let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
         (Some(resource), None, Some(commit))
     };
@@ -160,7 +160,8 @@ pub async fn history(
                 commit.as_ref().unwrap(), // Safe unwrap: `commit` is Some if `resource` is Some
                 &resource.path,
                 pagination,
-            )?;
+            )
+            .await?;
 
             log::debug!("commit_history got {} commits", commits.commits.len());
 
@@ -173,7 +174,8 @@ pub async fn history(
             if let Some(revision_id) = revision_id {
                 let _perf_list = perf_guard!("commits::history_list_from_revision");
                 let commits =
-                    repositories::commits::list_from_paginated(&repo, revision_id, pagination)?;
+                    repositories::commits::list_from_paginated(&repo, revision_id, pagination)
+                        .await?;
 
                 log::debug!("commit_history got {} commits", commits.commits.len());
                 // log::debug!("commit_history commits: {:?}", commits.commits);


### PR DESCRIPTION
The `commits::history` endpoint reads commit history synchronously, walking RocksDB and the merkle tree inline on the actix worker that serves the request. Each oxen-server worker is single-threaded, so a large-history request holds its worker for the read's full duration, blocking that worker from accepting or serving anything else.

Move the endpoint's synchronous work off the worker. `repositories::commits::` list_from_paginated and `list_by_path_from_paginated` become async, each wrapping its whole operation in one `spawn_blocking`. The history handler resolves the repo and resource via the `async get_repo/parse_resource` variants and awaits both reads, freeing the worker to serve other requests while the database is read.