### PR TITLE
Drop official Windows support for oxen-server

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -112,9 +112,7 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           echo "OXEN_TEST_RUN_DIR=$env:RUNNER_TEMP\oxen_test\test" >> $env:GITHUB_ENV
-          echo "SYNC_DIR=$env:RUNNER_TEMP\oxen_test\sync" >> $env:GITHUB_ENV
           mkdir $env:RUNNER_TEMP\oxen_test\test
-          mkdir $env:RUNNER_TEMP\oxen_test\sync
 
       # Oxen Rust Tests
       - name: Setup test directories (Linux/macOS)
@@ -128,7 +126,8 @@ jobs:
         run: |
           mkdir .\data\test\runs
 
-      - name: Build oxen rust project
+      - name: Build oxen rust project (Linux/macOS)
+        if: matrix.platform != 'windows'
         run: cargo build --workspace
 
       - name: Setup oxen-server user (Linux/macOS)
@@ -137,23 +136,17 @@ jobs:
           ./target/debug/oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
           cp user_config.toml data/test/config/user_config.toml
 
-      - name: Setup oxen-server user (Windows)
-        if: matrix.platform == 'windows'
-        run: |
-          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
-          copy user_config.toml data\test\config\user_config.toml
-
       - name: Run oxen rust tests (Linux/macOS)
         if: matrix.platform != 'windows'
         run: |
           ./target/debug/oxen-server start --test &
           cargo test --workspace --no-fail-fast
 
+      # oxen-server is unsupported on Windows: exclude its crate; the
+      # server-dependent tests are marked #[cfg_attr(windows, ignore)].
       - name: Run oxen rust tests (Windows)
         if: matrix.platform == 'windows'
-        run: |
-          Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start","--test"
-          cargo test --workspace --no-fail-fast
+        run: cargo test --workspace --exclude oxen-server --no-fail-fast
 
   python-test:
     name: Python Tests
@@ -226,8 +219,15 @@ jobs:
         run: |
           mkdir .\data\test\runs
 
-      - name: Build oxen rust project
+      - name: Build oxen rust project (Linux/macOS)
+        if: matrix.platform != 'windows'
         run: cargo build --workspace
+
+      # oxen-server is unsupported on Windows: build only the client crates
+      # (the oxen CLI backs the CLI tests). Server tests skip via each conftest.
+      - name: Build oxen rust project (Windows)
+        if: matrix.platform == 'windows'
+        run: cargo build --workspace --exclude oxen-server
 
       - name: Setup oxen-server user (Linux/macOS)
         if: matrix.platform != 'windows'
@@ -235,19 +235,9 @@ jobs:
           ./target/debug/oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml
           cp user_config.toml data/test/config/user_config.toml
 
-      - name: Setup oxen-server user (Windows)
-        if: matrix.platform == 'windows'
-        run: |
-          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
-          copy user_config.toml data\test\config\user_config.toml
-
       - name: Start oxen-server (Linux/macOS)
         if: matrix.platform != 'windows'
         run: ./target/debug/oxen-server start &
-
-      - name: Start oxen-server (Windows)
-        if: matrix.platform == 'windows'
-        run: Start-Process ".\target\debug\oxen-server.exe" -ArgumentList "start"
 
       # CLI Tests
       - name: Run CLI tests (Linux/macOS)

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -64,7 +64,7 @@ jobs:
             ]
 
   release_windows:
-    name: Build Oxen CLI, Server, and Python wheels
+    name: Build Oxen CLI and Python wheels
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
     defaults:
@@ -162,7 +162,8 @@ jobs:
       - name: Build oxen binaries
         run: |
           refreshenv
-          cargo build --workspace --exclude oxen-py --release
+          # oxen-server is not supported on Windows; build the CLI only.
+          cargo build --workspace --exclude oxen-py --exclude oxen-server --release
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Build Python wheels
@@ -198,10 +199,9 @@ jobs:
           aws s3 cp C:\deptree-out.tar s3://oxen-release-build-cache/deptree/$env:DEPTREE_KEY.tar
           Write-Host "DEPTREE saved ($env:DEPTREE_KEY)"
 
-      - name: Create zip with oxen binaries
+      - name: Create zip with oxen binary
         run: |
           Compress-Archive -Path "${{ github.workspace }}\target\release\oxen.exe" -DestinationPath "${{ github.workspace }}\release\oxen-windows-${{ inputs.ARCHITECTURE }}.exe.zip"
-          Compress-Archive -Path "${{ github.workspace }}\target\release\oxen-server.exe" -DestinationPath "${{ github.workspace }}\release\oxen-server-windows-${{ inputs.ARCHITECTURE }}.exe.zip"
 
       - name: Create zip with Python wheels
         run: |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ To learn what everything Oxen can do, the full documentation can be found at [ht
 
 You can install through homebrew or pip or from our [releases page](https://github.com/Oxen-AI/Oxen/releases).
 
+### 🖥️ Platform Support
+
+| Component | Linux | macOS | Windows |
+|---|:---:|:---:|:---:|
+| `oxen` CLI | ✅ | ✅ | ✅ |
+| `oxenai` Python package | ✅ | ✅ | ✅ |
+| `oxen-server` | ✅ | ✅ | ❌ |
+
+`oxen-server` is not supported on Windows — run it on Linux, macOS, or in Docker. The `oxen` CLI and Python client are supported on Windows and connect to a server hosted on a supported platform.
+
 ### 🐂 Install Command Line Tool
 
 Install via [Homebrew](https://brew.sh/):

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,7 +50,7 @@ Monitor the workflow run in the **Actions** tab. If any platform build fails, th
 | Linux x86_64 | `oxen-linux-x86_64.tar.gz`, `oxen-server-linux-x86_64.tar.gz`, `oxen-linux-x86_64.deb`, `oxen-server-linux-x86_64.deb`, `oxen-wheels-linux-x86_64.tar.gz` |
 | macOS arm64 | `oxen-macos-arm64.tar.gz`, `oxen-server-macos-arm64.tar.gz`, `oxen-wheels-macos-arm64.tar.gz` |
 | macOS x86_64 | `oxen-macos-x86_64.tar.gz`, `oxen-server-macos-x86_64.tar.gz`, `oxen-wheels-macos-x86_64.tar.gz` |
-| Windows x86_64 | `oxen-windows-x86_64.exe.zip`, `oxen-server-windows-x86_64.exe.zip`, `oxen-wheels-windows-x86_64.zip` |
+| Windows x86_64 | `oxen-windows-x86_64.exe.zip`, `oxen-wheels-windows-x86_64.zip` (no server — oxen-server is not supported on Windows) |
 | Docker arm64 | `oxen-server-docker-arm64.tar` |
 | Docker x86_64 | `oxen-server-docker-x86_64.tar` |
 

--- a/cli-test/conftest.py
+++ b/cli-test/conftest.py
@@ -3,6 +3,7 @@ Pytest configuration and shared fixtures for Oxen CLI tests.
 """
 
 import os
+import sys
 import shutil
 import subprocess
 import tempfile
@@ -15,6 +16,16 @@ from dotenv import load_dotenv
 
 # Load environment variables
 load_dotenv()
+
+
+def pytest_collection_modifyitems(config, items):
+    # oxen-server is not supported on Windows, so skip tests marked needs_oxen_server.
+    if sys.platform != "win32":
+        return
+    skip = pytest.mark.skip(reason="oxen-server is not supported on Windows")
+    for item in items:
+        if "needs_oxen_server" in item.keywords:
+            item.add_marker(skip)
 
 
 def run_system_command(cmd: str, cwd: Optional[str] = None) -> None:
@@ -94,21 +105,23 @@ def setup_test_environment(tmp_path):
     """Setup test environment before each test."""
     # Configure oxen user
     run_system_command("oxen config --name python-test --email test@oxen.ai")
-    # Try to delete any existing test remote repos
-    subprocess.run(
-        "oxen delete-remote --name ox/performance-test --host localhost:3000 -y --scheme http",
-        shell=True,
-        capture_output=True
-    )
+    # Try to delete any existing test remote repos. There's no oxen-server on
+    # Windows, so skip the server round-trip there.
+    if sys.platform != "win32":
+        subprocess.run(
+            "oxen delete-remote --name ox/performance-test --host localhost:3000 -y --scheme http",
+            shell=True,
+            capture_output=True
+        )
 
     yield
 
-    # Cleanup after test
-    subprocess.run(
-        "oxen delete-remote --name ox/performance-test --host localhost:3000 -y --scheme http",
-        shell=True,
-        capture_output=True
-    )
+    if sys.platform != "win32":
+        subprocess.run(
+            "oxen delete-remote --name ox/performance-test --host localhost:3000 -y --scheme http",
+            shell=True,
+            capture_output=True
+        )
 
 
 @pytest.fixture

--- a/cli-test/pyproject.toml
+++ b/cli-test/pyproject.toml
@@ -5,6 +5,7 @@ addopts = ["-v", "-s", "--tb=short", "--strict-markers", "--timeout=120"]
 markers = [
     "performance: marks tests as performance tests",
     "integration: marks tests as integration tests",
+    "needs_oxen_server: test requires a running oxen-server",
 ]
 timeout = 120
 timeout_method = "thread"

--- a/cli-test/tests/test_add.py
+++ b/cli-test/tests/test_add.py
@@ -5,6 +5,7 @@ Converted from Ruby/RSpec to Python/pytest.
 
 import os
 from pathlib import Path
+import pytest
 from tests.helpers import create_test_file, create_remote_repo, cleanup_remote_repo
 
 
@@ -55,6 +56,7 @@ class TestAddCommand:
         nested_path = Path("images") / "test" / "nested.txt"
         assert nested_path.read_text() == "nested\n"
 
+    @pytest.mark.needs_oxen_server
     def test_add_with_remote_mode_repo(self, test_dir, oxen, unique_id):
         """Test oxen add with remote mode repository."""
 

--- a/cli-test/tests/test_download.py
+++ b/cli-test/tests/test_download.py
@@ -5,7 +5,11 @@ Converted from Ruby/RSpec to Python/pytest.
 
 import os
 from pathlib import Path
+import pytest
 from tests.helpers import create_test_file, create_remote_repo, cleanup_remote_repo
+
+# Every download test pushes to and pulls from an oxen-server.
+pytestmark = pytest.mark.needs_oxen_server
 
 
 class TestDownloadCommand:

--- a/crates/liboxen/src/api/client/branches.rs
+++ b/crates/liboxen/src/api/client/branches.rs
@@ -225,6 +225,7 @@ mod tests {
     use crate::test;
     use crate::util;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_remote_branch() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -251,6 +252,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_remote_branch_from_existing() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -280,6 +282,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_branch_by_name() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -308,6 +311,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_remote_branches() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -350,6 +354,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_branch() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -424,6 +429,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_remote_branch() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|mut repo| async move {
@@ -463,6 +469,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_should_not_push_branch_that_does_not_exist() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|mut repo| async move {
@@ -627,6 +634,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_entry_versions() -> Result<(), OxenError> {
         test::run_select_data_repo_test_committed_async("annotations", |mut repo| async move {

--- a/crates/liboxen/src/api/client/commits.rs
+++ b/crates/liboxen/src/api/client/commits.rs
@@ -889,6 +889,7 @@ mod tests {
     use crate::repositories;
     use crate::test;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_remote_commits_all() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|local_repo| async move {
@@ -921,6 +922,7 @@ mod tests {
     }
 
     /* Commented out because it's expensive to find the initial commit id
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_commit_history_for_path() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|local_repo| async move {
@@ -982,6 +984,7 @@ mod tests {
     */
 
     /* Commented out because it's expensive to find the initial commit id
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_commit_history_for_dir() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|local_repo| async move {
@@ -1051,6 +1054,7 @@ mod tests {
     }
      */
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_remote_commits_base_head() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -1082,6 +1086,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_missing_hashes_filters_via_merkle_tree() -> Result<(), OxenError> {
         // The server filters requested commit hashes by checking which merkle-tree

--- a/crates/liboxen/src/api/client/compare.rs
+++ b/crates/liboxen/src/api/client/compare.rs
@@ -212,6 +212,7 @@ mod tests {
 
     use std::path::PathBuf;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_compare_commits() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -259,6 +260,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_compare_change_at_root_dir_tree() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|mut local_repo, remote_repo| async move {
@@ -308,6 +310,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_compare_change_tabular_at_root_dir_tree() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|mut local_repo, remote_repo| async move {
@@ -394,6 +397,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_compare_nested_dir_tree() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -445,6 +449,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_create_compare_get_derived() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -546,6 +551,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_compare_does_not_update_automatically() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/data_frames.rs
+++ b/crates/liboxen/src/api/client/data_frames.rs
@@ -119,6 +119,7 @@ mod tests {
 
     use serde_json::json;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_fetch_schema_metadata() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -235,6 +236,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_paginate_df_page_one() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -283,6 +285,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_paginate_df_page_1_page_size_20() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -333,6 +336,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_paginate_df_after_sql() -> Result<(), OxenError> {
         if std::env::consts::OS == "windows" {
@@ -428,6 +432,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_get_schema_df_on_branch() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -539,6 +544,7 @@ mod tests {
     }
 
     // Tests passing in no slice or page params for data/test/parquet/wiki_1k.parquet file
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_parquet_no_params() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -605,6 +611,7 @@ mod tests {
     }
 
     // Tests page=4 page_size=6 for data/test/parquet/wiki_1k.parquet file
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_paginate_remote_parquet() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -668,6 +675,7 @@ mod tests {
     }
 
     // Test slice=330..333 for data/test/parquet/wiki_1k.parquet file
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_slice_remote_parquet() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -724,6 +732,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_from_directory() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -832,6 +841,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_from_directory_with_images_sets_metadata() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -932,6 +942,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_from_directory_mixed_files_no_image_metadata() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {

--- a/crates/liboxen/src/api/client/diff.rs
+++ b/crates/liboxen/src/api/client/diff.rs
@@ -76,6 +76,7 @@ mod tests {
     use crate::util;
 
     // Test diff add image
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_diff_entries_add_image() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -156,6 +157,7 @@ mod tests {
     }
 
     // Test diff modify image
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_diff_entries_modify_image_resize() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -248,6 +250,7 @@ mod tests {
     }
 
     // Test diff add rows to a csv
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_diff_entries_modify_add_rows_csv() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -368,6 +371,7 @@ mod tests {
     }
 
     // Test diff add rows to a csv
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_diff_entries_modify_add_and_remove_rows_csv() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -507,6 +511,7 @@ define the word,what does the word 'the' mean?,it is a stopword.,language
     }
 
     // Test diff add cols to a csv
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_diff_entries_modify_remove_columns_csv() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -645,6 +650,7 @@ who won the game?,The packers beat up on the bears,packers
     }
 
     // Test diff modify image passing the commit ids instead of the branch names
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_diff_entries_modify_image_pass_commit_ids() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -734,6 +740,7 @@ who won the game?,The packers beat up on the bears,packers
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_cifar_csvs() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -846,6 +853,7 @@ who won the game?,The packers beat up on the bears,packers
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_added_images_in_dir() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -938,6 +946,7 @@ who won the game?,The packers beat up on the bears,packers
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_added_images_in_subdirs() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -1095,6 +1104,7 @@ who won the game?,The packers beat up on the bears,packers
     }
 
     /*
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_removing_images_in_subdir() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -1210,6 +1220,7 @@ who won the game?,The packers beat up on the bears,packers
     }
     */
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_removing_images_by_rming_parent_in_subdir()
     -> Result<(), OxenError> {
@@ -1327,6 +1338,7 @@ who won the game?,The packers beat up on the bears,packers
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_adding_images_in_one_subdir_two_levels() -> Result<(), OxenError>
     {
@@ -1460,6 +1472,7 @@ who won the game?,The packers beat up on the bears,packers
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_adding_images_in_subdirs() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -1601,6 +1614,7 @@ who won the game?,The packers beat up on the bears,packers
     }
 
     /*
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_modifying_images_in_subdir() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -1715,6 +1729,7 @@ who won the game?,The packers beat up on the bears,packers
     }
     */
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_removing_images_in_dir() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {
@@ -1808,6 +1823,7 @@ who won the game?,The packers beat up on the bears,packers
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_diff_entries_changed_images_in_dir() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {

--- a/crates/liboxen/src/api/client/dir.rs
+++ b/crates/liboxen/src/api/client/dir.rs
@@ -133,6 +133,7 @@ mod tests {
     use std::path::Path;
     use std::path::PathBuf;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_dir_has_correct_commits() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|local_repo| async move {
@@ -344,6 +345,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_dir_has_populates_resource_path() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
@@ -388,6 +390,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_dir_encoding() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
@@ -438,6 +441,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_dir_with_workspace() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -516,6 +520,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_dir_sort_opts() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {
@@ -561,6 +566,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_dir_depth_and_nested_sort_opts() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {

--- a/crates/liboxen/src/api/client/entries.rs
+++ b/crates/liboxen/src/api/client/entries.rs
@@ -926,6 +926,7 @@ mod tests {
 
     use std::path::Path;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_tabular_entries() -> Result<(), OxenError> {
         if std::env::consts::OS == "windows" {
@@ -1000,6 +1001,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_file_large() -> Result<(), OxenError> {
         test::run_select_data_sync_remote("large_files", |local_repo, remote_repo| async move {
@@ -1016,6 +1018,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_file_large_to_dir() -> Result<(), OxenError> {
         test::run_select_data_sync_remote("large_files", |local_repo, remote_repo| async move {
@@ -1034,6 +1037,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_file_large_to_dir_does_not_exist() -> Result<(), OxenError> {
         test::run_select_data_sync_remote("large_files", |local_repo, remote_repo| async move {
@@ -1055,6 +1059,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_file_large_to_dir_does_exist() -> Result<(), OxenError> {
         test::run_select_data_sync_remote("large_files", |local_repo, remote_repo| async move {
@@ -1078,6 +1083,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_small_file_to_dir_does_exist() -> Result<(), OxenError> {
         test::run_select_data_sync_remote("annotations", |local_repo, remote_repo| async move {
@@ -1101,6 +1107,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_different_dir() -> Result<(), OxenError> {
         test::run_select_data_sync_remote("annotations", |local_repo, remote_repo| async move {
@@ -1124,6 +1131,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_root_entry_metadata() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|_local_repo, remote_repo| async move {
@@ -1138,6 +1146,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_small_entry_hash_mismatch_skips_publish() -> Result<(), OxenError> {
         // download_small_entry: pass a deliberately-wrong `expected_hash` and verify the

--- a/crates/liboxen/src/api/client/export.rs
+++ b/crates/liboxen/src/api/client/export.rs
@@ -75,6 +75,7 @@ mod tests {
     use std::path::PathBuf;
     use zip::ZipArchive;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_dir_as_zip() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/file.rs
+++ b/crates/liboxen/src/api/client/file.rs
@@ -234,6 +234,7 @@ mod tests {
     use crate::{api, repositories, test, util};
     use std::path::{Path, PathBuf};
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_update_file() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -270,6 +271,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_update_file_on_empty_repo() -> Result<(), OxenError> {
         test::run_empty_configured_remote_repo_test(|local_repo, remote_repo| async move {
@@ -306,6 +308,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_update_file_to_full_path() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -339,6 +342,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_update_file_to_full_path_on_empty_repo() -> Result<(), OxenError> {
         test::run_empty_configured_remote_repo_test(|local_repo, remote_repo| async move {
@@ -372,6 +376,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_file() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -396,6 +401,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_file() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -440,6 +446,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_file_after_upload() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -487,6 +494,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_mv_file() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -545,6 +553,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_file_with_workspace() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -601,6 +610,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     #[cfg(feature = "ffmpeg")]
     async fn test_upload_video_and_get_thumbnail() -> Result<(), OxenError> {
@@ -709,6 +719,7 @@ mod tests {
     }
 
     // Test that downloading a file from a deleted directory returns an error
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_rm_directory() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/import.rs
+++ b/crates/liboxen/src/api/client/import.rs
@@ -107,6 +107,7 @@ mod tests {
 
     use std::io::Write;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_upload_zip_file() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -168,6 +169,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_upload_zip_file_empty_repo() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -238,6 +240,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_import_url_reupload_unchanged_is_noop() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/merger.rs
+++ b/crates/liboxen/src/api/client/merger.rs
@@ -55,6 +55,7 @@ mod tests {
     use crate::repositories;
     use crate::test;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_merger_no_commits() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -81,6 +82,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_merger_base_is_ahead() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -119,6 +121,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_merger_mergeable_multiple_commits() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -172,6 +175,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_merger_multiple_commits_conflict_head_is_ahead() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -236,6 +240,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_merger_merge_unique() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/metadata.rs
+++ b/crates/liboxen/src/api/client/metadata.rs
@@ -45,6 +45,7 @@ mod tests {
 
     use std::path::Path;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_file_entry() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -85,6 +86,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_dir_entry() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -105,6 +107,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_remote_metadata() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -124,6 +127,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_latest_commit_by_branch() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -173,6 +177,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_file_with_workspace() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/prune.rs
+++ b/crates/liboxen/src/api/client/prune.rs
@@ -88,6 +88,7 @@ mod tests {
     use crate::test;
     use crate::util;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_prune_dry_run() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -122,6 +123,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_prune_removes_dangling_branch() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {

--- a/crates/liboxen/src/api/client/repositories.rs
+++ b/crates/liboxen/src/api/client/repositories.rs
@@ -486,6 +486,7 @@ mod tests {
     use crate::test;
     use crate::view::entries::EMetadataEntry;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_repo_pre_and_post_clone() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {
@@ -520,6 +521,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_repo_pre_and_post_push() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|local_repo| async move {
@@ -558,6 +560,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_remote_repository() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {
@@ -577,6 +580,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_remote_repository_with_readme() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {
@@ -612,6 +616,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_by_name() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {
@@ -629,6 +634,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_repository() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {
@@ -649,6 +655,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_transfer_remote_repository() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {

--- a/crates/liboxen/src/api/client/revisions.rs
+++ b/crates/liboxen/src/api/client/revisions.rs
@@ -39,6 +39,7 @@ mod tests {
     use crate::repositories;
     use crate::test;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_revision_from_commit() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {
@@ -54,6 +55,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_revision_from_branch() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/schemas.rs
+++ b/crates/liboxen/src/api/client/schemas.rs
@@ -100,6 +100,7 @@ mod tests {
 
     use serde_json::json;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_list_schemas() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|mut local_repo| async move {
@@ -152,6 +153,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_get_schema2() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
@@ -245,6 +247,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_get_schema_on_branch() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {

--- a/crates/liboxen/src/api/client/stats.rs
+++ b/crates/liboxen/src/api/client/stats.rs
@@ -49,6 +49,7 @@ mod tests {
     use crate::util;
 
     // NOTE: Keep this test to ensure we compute sizes on the backend
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_get_stats() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut local_repo| async move {

--- a/crates/liboxen/src/api/client/tree.rs
+++ b/crates/liboxen/src/api/client/tree.rs
@@ -498,6 +498,7 @@ mod tests {
     use std::collections::HashSet;
     use std::path::PathBuf;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_has_node() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {
@@ -511,6 +512,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_tree_from_path() -> Result<(), OxenError> {
         // FS-pinned: this test counts node directories under the on-disk `tree/nodes` layout, which
@@ -588,6 +590,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_trees_from() -> Result<(), OxenError> {
         // FS-pinned: this test counts node directories under the on-disk `tree/nodes` layout, which
@@ -676,6 +679,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_missing_node_hashes() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/versions.rs
+++ b/crates/liboxen/src/api/client/versions.rs
@@ -603,6 +603,7 @@ mod tests {
     use crate::error::OxenError;
     use crate::test;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_upload_large_file_in_chunks() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -639,6 +640,7 @@ mod tests {
     /// on the server, the server's pre-flight check returns a structured 404 and the
     /// client's retry loop short-circuits — instead of paying multiple rounds of
     /// exponential backoff that won't change the outcome.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_bulk_download_short_circuits_on_missing_blob_on_server() -> Result<(), OxenError>
     {

--- a/crates/liboxen/src/api/client/workspaces.rs
+++ b/crates/liboxen/src/api/client/workspaces.rs
@@ -200,6 +200,7 @@ mod tests {
     use crate::repositories;
     use crate::test;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_workspace() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -214,6 +215,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_workspace_with_name() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -247,6 +249,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_workspace_by_name() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -281,6 +284,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_workspace_by_name_does_not_exist() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -294,6 +298,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_workspace_by_id_does_not_exist() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -307,6 +312,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clear_workspaces() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -332,6 +338,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_workspaces() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -347,6 +354,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_empty_workspaces() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -358,6 +366,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_workspace() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -375,6 +384,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_commit_fails_if_schema_changed() -> Result<(), OxenError> {
         // Skip if on windows
@@ -455,6 +465,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_commit_staging_behind_main() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -549,6 +560,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_not_named_workspaces_closing_after_commit() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -581,6 +593,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_named_workspaces_not_closing_after_commit() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/workspaces/changes.rs
+++ b/crates/liboxen/src/api/client/workspaces/changes.rs
@@ -78,6 +78,7 @@ mod tests {
 
     use std::path::Path;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_empty_changes_none_pushed() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -120,6 +121,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_empty_changes_all_data_pushed() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/workspaces/commits.rs
+++ b/crates/liboxen/src/api/client/workspaces/commits.rs
@@ -76,6 +76,7 @@ mod tests {
     use crate::test;
     use crate::{api, util};
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_commit_staged_multiple_files() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -123,6 +124,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_mergeability_no_conflicts() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -156,6 +158,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_mergeability_with_no_conflicts_different_files() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -244,6 +247,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_mergeability_with_conflicts() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -337,6 +341,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_commit_added_column_in_dataframe() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -413,6 +418,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_commit_same_data_frame_file_twice() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
@@ -514,6 +520,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_reupload_unchanged_file_does_not_commit() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {

--- a/crates/liboxen/src/api/client/workspaces/data_frames.rs
+++ b/crates/liboxen/src/api/client/workspaces/data_frames.rs
@@ -246,6 +246,7 @@ mod tests {
     use crate::{api, repositories, util};
     use crate::{command, test};
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_by_resource() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -280,6 +281,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_workspace_data_frames() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -308,6 +310,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_rename_data_frame() -> Result<(), OxenError> {
         // Skip workspace ops on windows
@@ -384,6 +387,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_edit_rename_and_commit_data_frame_to_nonexistent_folder() -> Result<(), OxenError>
     {
@@ -490,6 +494,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_edit_rename_and_commit_data_frame() -> Result<(), OxenError> {
         // Skip workspace ops on windows
@@ -595,6 +600,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_query_workspace_data_frames_with_sql() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_, remote_repo| async move {
@@ -637,6 +643,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_nonexistent_data_frame_returns_resource_not_found()
     -> Result<(), OxenError> {
@@ -676,6 +683,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_workspace_data_frames() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -719,6 +727,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_workspace_data_frames_to_different_format() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -763,6 +772,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_workspace_data_frames_with_sql() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_, remote_repo| async move {
@@ -807,6 +817,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_workspace_data_frames_with_aggregation_sql() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_, remote_repo| async move {
@@ -852,6 +863,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_index_workspace_data_frames() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -878,6 +890,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_index_workspace_data_frame_with_binary_column() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -913,6 +926,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_restore_modified_dataframe() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -988,6 +1002,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_get_modified_dataframe_row_count() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -1038,6 +1053,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_row_from_modified_dataframe() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -1123,6 +1139,7 @@ mod tests {
     # update data frame file on server
     oxen pull repo_a (should be fast forward)
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_update_df_on_server_fast_forward_pull() -> Result<(), OxenError> {
         if std::env::consts::OS == "windows" {
@@ -1224,6 +1241,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_update_root_df_on_server_fast_forward_pull() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/api/client/workspaces/data_frames/columns.rs
+++ b/crates/liboxen/src/api/client/workspaces/data_frames/columns.rs
@@ -198,6 +198,7 @@ mod tests {
 
     use std::path::Path;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_column_in_dataframe() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -262,6 +263,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_column() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -335,6 +337,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_update_column() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -412,6 +415,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_rename_column_and_add_metadata() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -506,6 +510,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_column_and_add_metadata() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -587,6 +592,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_metadata_and_rename_column() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -681,6 +687,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_commit_metadata_and_rename_column() -> Result<(), OxenError> {
         // Skip duckdb if on windows

--- a/crates/liboxen/src/api/client/workspaces/data_frames/embeddings.rs
+++ b/crates/liboxen/src/api/client/workspaces/data_frames/embeddings.rs
@@ -146,6 +146,7 @@ mod tests {
         ))
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_no_embeddings_in_dataframe() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -188,6 +189,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_index_embeddings_in_dataframe() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -227,6 +229,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_query_embeddings_by_id() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -297,6 +300,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_query_embeddings_by_embedding() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
@@ -368,6 +372,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_embeddings_by_id() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -437,6 +442,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_query_embeddings_invalid_query() -> Result<(), OxenError> {
         // Skip duckdb if on windows

--- a/crates/liboxen/src/api/client/workspaces/data_frames/rows.rs
+++ b/crates/liboxen/src/api/client/workspaces/data_frames/rows.rs
@@ -217,6 +217,7 @@ mod tests {
 
     use std::path::Path;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_stage_row_on_dataframe_json() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -252,6 +253,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_should_not_stage_invalid_schema_for_dataframe() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -285,6 +287,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_list_status_modified_dataframe() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -334,6 +337,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_delete_row() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -414,6 +418,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_update_row() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -500,6 +505,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_stage_delete_row_keeps_remote_status_modified() -> Result<(), OxenError> {
         if std::env::consts::OS == "windows" {
@@ -576,6 +582,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_row_with_data() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -630,6 +637,7 @@ mod tests {
         }).await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_row_with_empty_data() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -707,6 +715,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_batch_update() -> Result<(), OxenError> {
         // Skip duckdb if on windows
@@ -817,6 +826,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_batch_update_with_embeddings() -> Result<(), OxenError> {
         // Skip duckdb if on windows

--- a/crates/liboxen/src/api/client/workspaces/files.rs
+++ b/crates/liboxen/src/api/client/workspaces/files.rs
@@ -1193,6 +1193,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_stage_single_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1249,6 +1250,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_stage_large_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1297,6 +1299,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_stage_multiple_files() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1348,6 +1351,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_remote_readme_repo_and_commit_multiple_data_frames()
     -> Result<(), OxenError> {
@@ -1480,6 +1484,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_commit_staged_single_file_and_pull() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1556,6 +1561,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_commit_schema_on_branch() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1644,6 +1650,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_rm_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1698,6 +1705,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_stage_file_in_multiple_subdirectories() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1745,6 +1753,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_multiple_files() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1800,6 +1809,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_file_with_absolute_path() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -1857,6 +1867,7 @@ mod tests {
     }
 
     // Download file from the workspace's base repo using the workspace download endpoint
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_version_file_from_workspace() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
@@ -1890,6 +1901,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_mv_file() -> Result<(), OxenError> {
         // Skip workspace ops on windows
@@ -1969,6 +1981,7 @@ mod tests {
     }
 
     // Test that downloading a non-existent file returns OxenError::ResourceNotFound
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_file_from_nonexistent_workspace() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
@@ -2018,6 +2031,7 @@ mod tests {
     }
 
     // Test that downloading a file uploaded to the workspace works
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_uploaded_file_from_workspace() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
@@ -2071,6 +2085,7 @@ mod tests {
 
     // Test the fallback path: download from commit when file not in workspace
     // This tests the download_entry function which is used as fallback in CLI
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_entry_fallback_for_committed_file() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
@@ -2105,6 +2120,7 @@ mod tests {
     }
 
     // Test workspace lookup by name for download scenario
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_workspace_lookup_by_name_for_download() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
@@ -2149,6 +2165,7 @@ mod tests {
     }
 
     // Test that workspace lookup by non-existent name returns None
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_workspace_lookup_by_nonexistent_name() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
@@ -2163,6 +2180,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_nonexistent_file_returns_path_dne() -> Result<(), OxenError> {
         test::run_remote_created_and_readme_remote_repo_test(|remote_repo| async move {
@@ -2195,6 +2213,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_files_preserves_paths_local_repo_relative_paths() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
@@ -2204,6 +2223,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_files_preserves_paths_local_repo_absolute_paths() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
@@ -2218,6 +2238,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_files_preserves_paths_tempdir_relative_paths() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_, remote_repo| async move {
@@ -2229,6 +2250,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_add_files_preserves_paths_tempdir_absolute_paths() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_, remote_repo| async move {

--- a/crates/liboxen/src/repositories/add.rs
+++ b/crates/liboxen/src/repositories/add.rs
@@ -57,6 +57,7 @@ mod tests {
 
     use crate::util;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_root_subtree_depth_1_add_file() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -92,6 +93,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_annotations_test_subtree_add_file() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/branches.rs
+++ b/crates/liboxen/src/repositories/branches.rs
@@ -584,6 +584,7 @@ mod tests {
 
     // Every server ref-advance path — branch update, new-branch create, and push-time merge —
     // must refuse to point a ref at a commit whose newly-added blob is missing.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_ref_advance_gates_reject_incomplete_commit() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {
@@ -684,6 +685,7 @@ mod tests {
     // The gate also refuses a commit whose objects are all present but whose dir-hashes index is
     // missing — the tree can't be served by path without it. The check lives in the shared
     // `verify_reachable_objects`, so exercising the update gate covers all three ref-advance paths.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_ref_advance_gate_requires_dir_hashes() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {
@@ -743,6 +745,7 @@ mod tests {
 
     // Creating a branch *from another branch* is a ref advance too: it must refuse when the source
     // branch's head commit is missing an added blob, just like commit-based creation.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_ref_advance_gate_rejects_create_from_incomplete_branch() -> Result<(), OxenError>
     {

--- a/crates/liboxen/src/repositories/checkout.rs
+++ b/crates/liboxen/src/repositories/checkout.rs
@@ -680,6 +680,7 @@ mod tests {
     }
 
     // Test the default clone (not --all or --shallow) can revert to files that are not local
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_checkout_deleted_after_clone() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -749,6 +750,7 @@ mod tests {
     IO(Os { code: 2, kind: NotFound, message: "No such file or directory" })
 
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_checkout_old_commit_checkout_new_commit() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {
@@ -785,6 +787,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_checkout_local_does_not_remove_untracked_files() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -841,6 +844,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_checkout_remote_does_not_remove_untracked_files() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/clone.rs
+++ b/crates/liboxen/src/repositories/clone.rs
@@ -111,6 +111,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_remote() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {
@@ -146,6 +147,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_move_local_repo_path_valid() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|local_repo| async move {
@@ -182,6 +184,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_root_subtree_depth_1() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -215,6 +218,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_annotations_subtree() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -267,6 +271,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_annotations_test_subtree() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -297,6 +302,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_multiple_subtrees() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -331,6 +337,7 @@ mod tests {
     }
 
     // Test for clone --all that checks to make sure we have all commits, all deleted files, etc
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_dash_all() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -398,6 +405,7 @@ mod tests {
     }
 
     // Test for clone --all that checks to make sure we have all commits, all deleted files, etc
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_all_push_all_full_commit_history() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|_local_repo, remote_repo| async move {
@@ -442,6 +450,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_all_push_all_modified_deleted_files() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {
@@ -519,6 +528,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_full() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -579,6 +589,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_oxen_clone_empty_repo() -> Result<(), OxenError> {
         test::run_no_commit_remote_repo_test(|remote_repo| async move {
@@ -604,6 +615,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_oxen_clone_empty_repo_then_push() -> Result<(), OxenError> {
         test::run_no_commit_remote_repo_test(|remote_repo| async move {
@@ -638,6 +650,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_subtree_and_checkout_branch() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -750,6 +763,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_cloned_repos_not_set_as_remote_mode_by_default() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|mut _local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/commits.rs
+++ b/crates/liboxen/src/repositories/commits.rs
@@ -1193,6 +1193,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_annotations_test_subtree_commit_file() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -1229,6 +1230,7 @@ A: Oxen.ai
     // Test for updating file size after cloning subtree
     // I cloned subtree, added an empty file, committed, pushed, then edited the file and committed again
     // The file size should be updated in the index
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_clone_subtree_commit_file_update_size() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/data_frames/schemas.rs
+++ b/crates/liboxen/src/repositories/data_frames/schemas.rs
@@ -697,6 +697,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_schemas_merge_fast_forward_pull() -> Result<(), OxenError> {
         test::run_select_data_sync_remote("README.md", |_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/download.rs
+++ b/crates/liboxen/src/repositories/download.rs
@@ -76,6 +76,7 @@ mod tests {
 
     use crate::constants;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_download_directory() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -120,6 +121,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_download_directory_with_large_file() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -170,6 +172,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_download_directory_local_path() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -215,6 +218,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_one_file() -> Result<(), OxenError> {
         test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
@@ -250,6 +254,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_download_dir() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/fetch.rs
+++ b/crates/liboxen/src/repositories/fetch.rs
@@ -126,6 +126,7 @@ mod tests {
     use crate::repositories;
     use crate::test;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_fetch_branches() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|mut repo| async move {

--- a/crates/liboxen/src/repositories/merge.rs
+++ b/crates/liboxen/src/repositories/merge.rs
@@ -849,6 +849,7 @@ mod tests {
     oxen push
     oxen pull repo_a (should be fast forward)
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_command_merge_fast_forward_pull() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/pull.rs
+++ b/crates/liboxen/src/repositories/pull.rs
@@ -1291,6 +1291,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     /// `oxen pull` should always walks the merkle tree and re-fetch any missing blobs.
     async fn test_pull_re_fetches_missing_blobs() -> Result<(), OxenError> {

--- a/crates/liboxen/src/repositories/pull.rs
+++ b/crates/liboxen/src/repositories/pull.rs
@@ -59,6 +59,7 @@ mod tests {
     use std::path::Path;
     use std::path::PathBuf;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_command_push_clone_pull_push() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -200,6 +201,7 @@ mod tests {
     // * remove file *
     // push
     // pull
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_command_add_modify_remove_push_pull() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -265,6 +267,7 @@ mod tests {
     }
 
     // Make sure we can push again after pulling on the other side, then pull again
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_pull_push_pull_on_branch() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|mut repo| async move {
@@ -372,6 +375,7 @@ mod tests {
     }
 
     // Make sure we can push again after pulling on the other side, then pull again
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_pull_push_pull_on_other_branch() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -458,6 +462,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_pull_file_without_extension() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits_async(|mut repo| async move {
@@ -523,6 +528,7 @@ mod tests {
         # should only have the data on main
 
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_pull_separate_branch_less_files() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -603,6 +609,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_pull_separate_branch_more_files() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -676,6 +683,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_pull_moved_files() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -727,6 +735,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_new_branch_default_clone() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_, remote_repo| async move {
@@ -784,6 +793,7 @@ mod tests {
     // 4) User B changes same file, commits, and pushes and fails
     // 5) User B pulls user A's changes, there is a merge conflict
     // 6) User B cannot push until merge conflict is resolved
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_flags_merge_conflict_on_subtree_pull() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -874,6 +884,7 @@ mod tests {
     // 4) User B changes same file, commits, and pushes and fails
     // 5) User B pulls user A's changes, there is a merge conflict
     // 6) User B cannot push until merge conflict is resolved
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_flags_merge_conflict_on_root_subtree_pull() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -961,6 +972,7 @@ mod tests {
     // 4) User B changes same file, commits, and pushes and fails
     // 5) User B pulls user A's changes, there is a merge conflict
     // 6) User B cannot push until merge conflict is resolved
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_flags_merge_conflict_on_pull() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -1031,6 +1043,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_does_not_remove_local_files() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -1094,6 +1107,7 @@ mod tests {
         })
         .await
     }
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_does_not_remove_untracked_files() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -1218,6 +1232,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_multiple_commits() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -1361,6 +1376,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_data_frame() -> Result<(), OxenError> {
         test::run_select_data_repo_test_no_commits_async("annotations", |mut repo| async move {
@@ -1416,6 +1432,7 @@ mod tests {
     }
 
     // Test that we pull down the proper data frames
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_multiple_data_frames_multiple_schemas() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|mut repo| async move {
@@ -1478,6 +1495,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_full_commit_history() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -1552,6 +1570,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_full_commit_history_after_shallow_clone() -> Result<(), OxenError> {
         test::run_training_data_repo_test_fully_committed_async(|mut repo| async move {
@@ -1595,6 +1614,7 @@ mod tests {
     When the remote advances, and you have local changes,
     you do not want to overwrite when pulling from the remote
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_does_not_overwrite_new_file_modified_by_remote() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -1660,6 +1680,7 @@ mod tests {
     When the remote advances, and you have local changes,
     you do not want to overwrite when pulling from the remote
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_does_not_overwrite_modified_files_after_remote_modification()
     -> Result<(), OxenError> {
@@ -1723,6 +1744,7 @@ mod tests {
     This one tests modifying the file on the local before it is modified on the remote
     Regardless, the local file should not be overwritten
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_does_not_overwrite_modified_files_before_remote_modification()
     -> Result<(), OxenError> {
@@ -1795,6 +1817,7 @@ mod tests {
     /*
     Modify a different file on the remote, and modify the readme locally, and make sure that the local readme is not overwritten
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_does_not_overwrite_modified_files_after_modifying_different_file()
     -> Result<(), OxenError> {
@@ -1864,6 +1887,7 @@ mod tests {
     /*
     Remove the README.md on the remote, and modify the readme locally, and make sure that the local readme is not overwritten
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_does_not_overwrite_modified_files_after_removing_file()
     -> Result<(), OxenError> {
@@ -1932,6 +1956,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_subtree_clone_branch_push_pull() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -2018,6 +2043,7 @@ mod tests {
     }
 
     // Pull and merge a non-empty remote with a non-empty repo
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_and_merge_non_empty_repos() -> Result<(), OxenError> {
         // Create a remote repo with a commit
@@ -2061,6 +2087,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_pull_missing_files_redownloads_deleted_versions() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/push.rs
+++ b/crates/liboxen/src/repositories/push.rs
@@ -55,6 +55,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_command_push_one_commit() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {
@@ -109,6 +110,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_command_push_inbetween_two_commits() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {
@@ -171,6 +173,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_command_push_after_two_commits() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {
@@ -227,6 +230,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_latest_commit_is_computed_properly() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {
@@ -339,6 +343,7 @@ mod tests {
     }
 
     // This broke when you tried to add the "." directory to add everything, after already committing the train directory.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_command_push_after_two_commits_adding_dot() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {
@@ -397,6 +402,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_branch_with_with_no_new_commits() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|repo, remote_repo| async move {
@@ -420,6 +426,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_cannot_push_two_separate_empty_roots() -> Result<(), OxenError> {
         test::run_no_commit_remote_repo_test(|remote_repo| async move {
@@ -487,6 +494,7 @@ mod tests {
     // 2) Create repo B with data
     // 3) Push Repo A
     // 4) Push repo B to repo A and fail
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_cannot_push_two_separate_repos() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|mut repo_1| async move {
@@ -532,6 +540,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_many_commits_default_branch() -> Result<(), OxenError> {
         test::run_many_local_commits_empty_sync_remote_test(|local_repo, remote_repo| async move {
@@ -555,6 +564,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_many_commits_new_branch() -> Result<(), OxenError> {
         test::run_many_local_commits_empty_sync_remote_test(|local_repo, remote_repo| async move {
@@ -612,6 +622,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_cannot_push_while_another_user_is_pushing() -> Result<(), OxenError> {
         test::run_no_commit_remote_repo_test(|remote_repo| async move {
@@ -677,6 +688,7 @@ mod tests {
     // 2) Clone repo B with data
     // 3) Push Repo A
     // 4) Push repo B to repo A and fail
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_tree_cannot_push_two_separate_cloned_repos() -> Result<(), OxenError> {
         // Push the first repo with data
@@ -759,6 +771,7 @@ mod tests {
     // * User A makes a commit and pushes
     // * User B makes a different commit — normal push fails
     // * User B force pushes — succeeds and remote matches user B's history
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_force_push_when_remote_is_ahead() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_, remote_repo| async move {
@@ -833,6 +846,7 @@ mod tests {
     // * User B makes commit modifying `README.md` pushes and fails
     // * User B pulls user A's changes and there is a conflict
     // * User B fixes the conflict and pushes and succeeds
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_tree_cannot_push_when_remote_repo_is_ahead_same_file() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -922,6 +936,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_tree_cannot_push_tree_conflict_deleted_file() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -977,6 +992,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_move_entire_directory() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -1039,6 +1055,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_only_one_modified_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
@@ -1076,6 +1093,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_root_subtree_depth_1() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -1123,6 +1141,7 @@ A: Oxen.ai is a great tool for this! It can handle any size dataset, and is opti
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_annotations_test_subtree() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -1179,6 +1198,7 @@ A: Checkout Oxen.ai
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_partial_clone_nlp_classification() -> Result<(), OxenError> {
         // Push the Remote Repo
@@ -1330,6 +1350,7 @@ A: Checkout Oxen.ai
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_file_with_exact_avg_chunk_size() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
@@ -1407,6 +1428,7 @@ A: Checkout Oxen.ai
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_merge_conflict_push_failure() -> Result<(), OxenError> {
         // Test that after a merge conflict, pushing again should fail
@@ -1484,6 +1506,7 @@ A: Checkout Oxen.ai
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_create_nodes_before_starting_push() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|local_repo, remote_repo| async move {
@@ -1539,6 +1562,7 @@ A: Checkout Oxen.ai
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_large_file_and_clone_verify() -> Result<(), OxenError> {
         // Push a file just over the streamed-transfer threshold so the chunked path is
@@ -1604,6 +1628,7 @@ A: Checkout Oxen.ai
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_push_large_file_in_subdir_and_clone_verify() -> Result<(), OxenError> {
         // Test pushing a >10MB file inside a subdirectory, then cloning.
@@ -1684,6 +1709,7 @@ A: Checkout Oxen.ai
     // `oxen push --revalidate` must re-push a blob the remote is simply MISSING, not only one that
     // is corrupt-but-present. `versions::clean` reports zero corrupted for an absent blob, so the
     // repair used to no-op on the common case.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_revalidate_repushes_a_missing_blob() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {
@@ -1742,6 +1768,7 @@ A: Checkout Oxen.ai
 
     // `--missing-files` from a clone missing some of the files the remote needs must fail fast with
     // CannotPushShallowClone and upload nothing — not partially upload and then error mid-stream.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_missing_files_fails_fast_on_shallow_clone() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async {

--- a/crates/liboxen/src/repositories/remote_mode.rs
+++ b/crates/liboxen/src/repositories/remote_mode.rs
@@ -36,6 +36,7 @@ mod tests {
     use crate::test;
     use crate::util;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_clone_only_downloads_tree() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
@@ -92,6 +93,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_list_tabular_files() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
@@ -164,6 +166,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_merkle_two_files_same_hash() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/remote_mode/add.rs
+++ b/crates/liboxen/src/repositories/remote_mode/add.rs
@@ -17,6 +17,7 @@ mod tests {
     // 1: Err_files
     // 2: Adding modified files
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_add_file_with_full_path() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -81,6 +82,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_add_file_with_relative_path() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -136,6 +138,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_add_file_with_canon_path() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -190,6 +193,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_add_and_modify_file_in_new_subdir() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -340,6 +344,7 @@ mod tests {
 
     // Note: The current behavior with untracked dirs is that we display just the dir with their 'item count'
     // This means we're looking for untracked dirs, as opposed to files, in the test below
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_add_multiple_files_in_sub_dir() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -411,6 +416,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_add_files_with_glob_path() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -532,6 +538,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_add_dir_recursive() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -595,6 +602,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_cannot_add_if_not_modified() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/remote_mode/checkout.rs
+++ b/crates/liboxen/src/repositories/remote_mode/checkout.rs
@@ -163,6 +163,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_checkout_current_branch_name_does_nothing() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|mut _local_repo, remote_repo| async move {
@@ -192,6 +193,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_checkout_changes_workspace() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -239,6 +241,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_checkout_updates_branch() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -280,6 +283,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_checkout_added_file_and_workspace() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -362,6 +366,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_checkout_added_file_keep_untracked() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -449,6 +454,7 @@ mod tests {
     // exists in the source branch's tree but is not materialized on disk.
     // Previously, r_remove_if_not_in_target would push non-existent paths
     // into files_to_store, causing store_version_from_reader to fail with NotFound.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_checkout_file_in_tree_but_not_on_disk() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -522,6 +528,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_checkout_modified_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/remote_mode/commit.rs
+++ b/crates/liboxen/src/repositories/remote_mode/commit.rs
@@ -57,6 +57,7 @@ mod tests {
     use crate::model::staged_data::StagedDataOpts;
     use std::path::{Path, PathBuf};
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_commit_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -121,6 +122,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_commit_several_times() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -224,6 +226,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_add_and_commit_downloaded_dir() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -318,6 +321,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_cannot_commit_without_staged_files() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -362,6 +366,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_commit_removed_file() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -430,6 +435,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_commit_removed_dir() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -514,6 +520,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_commit_invalid_parquet_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/remote_mode/restore.rs
+++ b/crates/liboxen/src/repositories/remote_mode/restore.rs
@@ -53,6 +53,7 @@ mod tests {
 
     use crate::{repositories, test};
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_restore_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|mut _local_repo, remote_repo| async move {
@@ -101,6 +102,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_restore_file_with_full_path() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|mut _local_repo, remote_repo| async move {
@@ -149,6 +151,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_restore_subdirectory_file() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(
@@ -211,6 +214,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_restore_dir() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|mut _local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/remote_mode/rm.rs
+++ b/crates/liboxen/src/repositories/remote_mode/rm.rs
@@ -18,6 +18,7 @@ mod tests {
     use crate::model::NewCommitBody;
     use crate::model::StagedEntryStatus;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_rm_synced_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -76,6 +77,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_rm_unsynced_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -127,6 +129,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_rm_unsynced_file_with_full_path() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -179,6 +182,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_rm_dir_that_is_not_committed_should_throw_error()
     -> Result<(), OxenError> {
@@ -217,6 +221,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_rm_staged_file() -> Result<(), OxenError> {
         test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
@@ -291,6 +296,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_rm_one_file_in_dir() -> Result<(), OxenError> {
         test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
@@ -397,6 +403,7 @@ mod tests {
 
     // TODO: 'status.print()' has weird behavior when staging subdirs for removal
     //       Resolve this at some point
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_rm_dir_with_asterisk() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -478,6 +485,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_rm_dir_with_glob_path() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/remote_mode/status.rs
+++ b/crates/liboxen/src/repositories/remote_mode/status.rs
@@ -118,6 +118,7 @@ mod tests {
     // LICENSE
     // README.md
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_repo_clean_with_all_files_unsynced_after_remote_mode_clone()
     -> Result<(), OxenError> {
@@ -158,6 +159,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_subdirectory_status() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
@@ -308,6 +310,7 @@ mod tests {
     // from local disk should still surface as unsynced — only `Removed`-status entries
     // should suppress the unsynced classification. Earlier the gate used a plain
     // `contains_key` check on the staged-files map, which over-suppressed.
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_status_unsynced_when_modified_stage_missing_on_disk()
     -> Result<(), OxenError> {
@@ -394,6 +397,7 @@ mod tests {
     //       TODO: Consider fixing this
 
     /*
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_mode_status_move_regular_file() -> Result<(), OxenError> {
         test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {

--- a/crates/liboxen/src/repositories/rm.rs
+++ b/crates/liboxen/src/repositories/rm.rs
@@ -143,6 +143,7 @@ mod tests {
 
     When loading the remote, only the README.md remained.
     */
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_rm_r_dir_at_root() -> Result<(), OxenError> {
         test::run_empty_data_repo_test_no_commits_async(|mut repo| async move {

--- a/crates/liboxen/src/repositories/workspaces.rs
+++ b/crates/liboxen/src/repositories/workspaces.rs
@@ -1037,6 +1037,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_concurrent_workspace_commits() -> Result<(), OxenError> {
         test::run_one_commit_sync_repo_test(|repo, remote_repo| async move {
@@ -1126,6 +1127,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_fully_concurrent_workspace_operations() -> Result<(), OxenError> {
         // Number of concurrent tasks to run

--- a/crates/liboxen/src/repositories/workspaces/upload.rs
+++ b/crates/liboxen/src/repositories/workspaces/upload.rs
@@ -31,6 +31,7 @@ mod tests {
 
     use crate::constants;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_upload_file_to_root_dir() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -90,6 +91,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_upload_file_to_sub_dir() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {
@@ -152,6 +154,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_remote_upload_file_to_new_branch() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|mut repo| async move {

--- a/crates/liboxen/src/test.rs
+++ b/crates/liboxen/src/test.rs
@@ -9,6 +9,7 @@ use crate::constants;
 use crate::constants::DEFAULT_REMOTE_NAME;
 use crate::core;
 use crate::core::db::merkle_node::MerkleNodeBackend;
+use crate::core::df::duckdb_setup;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::Schema;
@@ -97,6 +98,12 @@ pub fn init_test_env() {
                 // Store the guard globally so it outlives this block.
                 if let Ok(mut slot) = WORKER_GUARD.lock() {
                     *slot = Some(guard);
+                }
+
+                // Preinstall DuckDB extensions once, before any parallel DuckDB use, so
+                // concurrent tests don't race on first-use autoload.
+                if let Err(e) = duckdb_setup::preload_extensions() {
+                    log::warn!("Failed to preload DuckDB extensions for tests: {e}");
                 }
 
                 *logging_setup = true;

--- a/crates/oxen-cli/src/cmd/workspace/status.rs
+++ b/crates/oxen-cli/src/cmd/workspace/status.rs
@@ -216,6 +216,7 @@ mod tests {
     use liboxen::api;
     use liboxen::error::OxenError;
 
+    #[cfg_attr(windows, ignore = "oxen-server is not supported on Windows")]
     #[tokio::test]
     async fn test_workspace_status_by_name() -> Result<(), OxenError> {
         liboxen::test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {

--- a/oxen-python/tests/conftest.py
+++ b/oxen-python/tests/conftest.py
@@ -1,11 +1,24 @@
 import pytest
 import logging
 
+import sys
 import uuid
 import os
 from pathlib import PurePath
 
 from oxen import Repo, RemoteRepo
+
+
+def pytest_collection_modifyitems(config, items):
+    # oxen-server is not supported on Windows, so skip tests that use a remote-repo
+    # fixture (those need a running server).
+    if sys.platform != "win32":
+        return
+    skip = pytest.mark.skip(reason="oxen-server is not supported on Windows")
+    for item in items:
+        if any("remote_repo" in name for name in getattr(item, "fixturenames", [])):
+            item.add_marker(skip)
+
 
 FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
 logging.basicConfig(format=FORMAT)


### PR DESCRIPTION
oxen-server (just the server) is no longer officially supported or tested on Windows. It may still work, but it's best-effort. NOTE: The oxen CLI, the oxenai Python package, and liboxen code that backs them stay fully supported on Windows.

Windows CI no longer builds or runs oxen-server or its server-dependent tests, so the Windows Rust and Python jobs are substantially faster and no longer fail on an unsupported setup. Those tests are skipped on Windows only. They still run on Linux and macOS. The Windows release stops shipping `oxen-server.exe`, and the `README` now documents which components run on which platform.

Tracked in ENG-1233