### PR TITLE
Async (13): compare/commits to async

### DIFF
--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -839,51 +839,58 @@ pub fn list_between(
 /// The second walk pops by timestamp only to order the output newest first; a
 /// commit still always precedes its parents because a parent is pushed to the
 /// heap only after its child has been popped.
-pub fn list_between_exclusive(
+pub async fn list_between_exclusive(
     repo: &LocalRepository,
     base: &Commit,
     head: &Commit,
 ) -> Result<Vec<Commit>, OxenError> {
-    // Pass 1: mark everything reachable from base. Purely graph-based, so the
-    // outcome can't hinge on the order commits happen to sort in.
-    let mut on_base: HashSet<String> = HashSet::new();
-    let mut stack = vec![base.clone()];
-    on_base.insert(base.id.clone());
-    while let Some(commit) = stack.pop() {
-        for parent_id in &commit.parent_ids {
-            let Some(parent) = get_by_hash(repo, &parent_id.parse()?)? else {
-                continue;
-            };
-            if on_base.insert(parent.id.clone()) {
-                stack.push(parent);
+    // Sync core: both passes are sync RocksDB reads over the commit graph — one blocking unit.
+    let repo = repo.clone();
+    let base = base.clone();
+    let head = head.clone();
+    tokio::task::spawn_blocking(move || -> Result<Vec<Commit>, OxenError> {
+        // Pass 1: mark everything reachable from base. Purely graph-based, so the
+        // outcome can't hinge on the order commits happen to sort in.
+        let mut on_base: HashSet<String> = HashSet::new();
+        let mut stack = vec![base.clone()];
+        on_base.insert(base.id.clone());
+        while let Some(commit) = stack.pop() {
+            for parent_id in &commit.parent_ids {
+                let Some(parent) = get_by_hash(&repo, &parent_id.parse()?)? else {
+                    continue;
+                };
+                if on_base.insert(parent.id.clone()) {
+                    stack.push(parent);
+                }
             }
         }
-    }
 
-    // Pass 2: emit head's ancestry that isn't on base, newest first.
-    let mut heap: BinaryHeap<TimestampedCommit> = BinaryHeap::new();
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut results = vec![];
+        // Pass 2: emit head's ancestry that isn't on base, newest first.
+        let mut heap: BinaryHeap<TimestampedCommit> = BinaryHeap::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut results = vec![];
 
-    if !on_base.contains(&head.id) {
-        seen.insert(head.id.clone());
-        heap.push(TimestampedCommit(head.clone()));
-    }
-
-    while let Some(TimestampedCommit(commit)) = heap.pop() {
-        for parent_id in &commit.parent_ids {
-            let Some(parent) = get_by_hash(repo, &parent_id.parse()?)? else {
-                continue;
-            };
-            // An on_base parent (and everything above it) already lives on base.
-            if !on_base.contains(&parent.id) && seen.insert(parent.id.clone()) {
-                heap.push(TimestampedCommit(parent));
-            }
+        if !on_base.contains(&head.id) {
+            seen.insert(head.id.clone());
+            heap.push(TimestampedCommit(head.clone()));
         }
-        results.push(commit);
-    }
 
-    Ok(results)
+        while let Some(TimestampedCommit(commit)) = heap.pop() {
+            for parent_id in &commit.parent_ids {
+                let Some(parent) = get_by_hash(&repo, &parent_id.parse()?)? else {
+                    continue;
+                };
+                // An on_base parent (and everything above it) already lives on base.
+                if !on_base.contains(&parent.id) && seen.insert(parent.id.clone()) {
+                    heap.push(TimestampedCommit(parent));
+                }
+            }
+            results.push(commit);
+        }
+
+        Ok(results)
+    })
+    .await?
 }
 
 /// Retrieve entries with filepaths matching a provided glob pattern
@@ -1108,7 +1115,7 @@ mod tests {
                 shared.timestamp - time::Duration::seconds(100),
             )?;
 
-            let range = list_between_exclusive(&repo, &base, &head)?;
+            let range = list_between_exclusive(&repo, &base, &head).await?;
             let ids: HashSet<String> = range.iter().map(|c| c.id.clone()).collect();
             assert_eq!(ids, HashSet::from([head.id.clone()]), "got {range:?}");
             assert!(

--- a/crates/liboxen/src/repositories/commits.rs
+++ b/crates/liboxen/src/repositories/commits.rs
@@ -784,8 +784,10 @@ mod tests {
 
     // Differential check: list_between_exclusive must equal the reference set, list
     // no commit twice, and never place a commit before one of its children.
-    fn assert_range_matches_reference(repo: &LocalRepository, base: &Commit, head: &Commit) {
-        let got = repositories::commits::list_between_exclusive(repo, base, head).unwrap();
+    async fn assert_range_matches_reference(repo: &LocalRepository, base: &Commit, head: &Commit) {
+        let got = repositories::commits::list_between_exclusive(repo, base, head)
+            .await
+            .unwrap();
         let order: HashMap<String, usize> = got
             .iter()
             .enumerate()
@@ -824,10 +826,10 @@ mod tests {
 
     // Every ordered pair drawn from `commits` must satisfy the reference, including
     // self-pairs (empty) and reversed pairs (head behind base).
-    fn assert_all_pairs(repo: &LocalRepository, commits: &[&Commit]) {
+    async fn assert_all_pairs(repo: &LocalRepository, commits: &[&Commit]) {
         for base in commits {
             for head in commits {
-                assert_range_matches_reference(repo, base, head);
+                assert_range_matches_reference(repo, base, head).await;
             }
         }
     }
@@ -840,15 +842,23 @@ mod tests {
             let b = add_commit(&repo, "b").await?;
             let c = add_commit(&repo, "c").await?;
 
-            let range = repositories::commits::list_between_exclusive(&repo, &a, &c)?;
+            let range = repositories::commits::list_between_exclusive(&repo, &a, &c).await?;
             let ids: HashSet<String> = range.iter().map(|x| x.id.clone()).collect();
             assert_eq!(ids, HashSet::from([b.id.clone(), c.id.clone()]));
 
             // Empty when head == base, and when head is behind base.
-            assert!(repositories::commits::list_between_exclusive(&repo, &c, &c)?.is_empty());
-            assert!(repositories::commits::list_between_exclusive(&repo, &c, &a)?.is_empty());
+            assert!(
+                repositories::commits::list_between_exclusive(&repo, &c, &c)
+                    .await?
+                    .is_empty()
+            );
+            assert!(
+                repositories::commits::list_between_exclusive(&repo, &c, &a)
+                    .await?
+                    .is_empty()
+            );
 
-            assert_all_pairs(&repo, &[&root, &a, &b, &c]);
+            assert_all_pairs(&repo, &[&root, &a, &b, &c]).await;
             Ok(())
         })
         .await
@@ -870,17 +880,17 @@ mod tests {
                 .await?
                 .unwrap();
 
-            let ids: HashSet<String> =
-                repositories::commits::list_between_exclusive(&repo, &a, &m)?
-                    .into_iter()
-                    .map(|x| x.id)
-                    .collect();
+            let ids: HashSet<String> = repositories::commits::list_between_exclusive(&repo, &a, &m)
+                .await?
+                .into_iter()
+                .map(|x| x.id)
+                .collect();
             assert_eq!(
                 ids,
                 HashSet::from([b.id.clone(), f1.id.clone(), m.id.clone()])
             );
 
-            assert_all_pairs(&repo, &[&a, &b, &f1, &m]);
+            assert_all_pairs(&repo, &[&a, &b, &f1, &m]).await;
             Ok(())
         })
         .await
@@ -909,7 +919,8 @@ mod tests {
 
             // base = main tip (c3), head = feature tip (f2): only feature's own work.
             let ids: HashSet<String> =
-                repositories::commits::list_between_exclusive(&repo, &c3, &f2)?
+                repositories::commits::list_between_exclusive(&repo, &c3, &f2)
+                    .await?
                     .into_iter()
                     .map(|x| x.id)
                     .collect();
@@ -925,7 +936,7 @@ mod tests {
                 "list_between is expected to over-include base history here"
             );
 
-            assert_all_pairs(&repo, &[&c1, &c2, &c3, &f1, &merge, &f2]);
+            assert_all_pairs(&repo, &[&c1, &c2, &c3, &f1, &merge, &f2]).await;
             Ok(())
         })
         .await
@@ -958,11 +969,11 @@ mod tests {
             // reachable(ma) and reachable(mb) share {a1, b1, root}; each range is
             // exactly the other merge node.
             let ma_to_mb: Vec<Commit> =
-                repositories::commits::list_between_exclusive(&repo, &ma, &mb)?;
+                repositories::commits::list_between_exclusive(&repo, &ma, &mb).await?;
             assert_eq!(ma_to_mb.len(), 1);
             assert_eq!(ma_to_mb[0].id, mb.id);
 
-            assert_all_pairs(&repo, &[&a1, &b1, &ma, &mb]);
+            assert_all_pairs(&repo, &[&a1, &b1, &ma, &mb]).await;
             Ok(())
         })
         .await

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -77,7 +77,8 @@ pub async fn commits(
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
     let commits =
-        repositories::commits::list_between_exclusive(&repository, &base_commit, &head_commit)?;
+        repositories::commits::list_between_exclusive(&repository, &base_commit, &head_commit)
+            .await?;
     let (paginated, pagination) = util::paginate(commits, page, page_size);
 
     let compare = CompareCommits {


### PR DESCRIPTION
The compare-commits endpoint finds the commits that are on head but not on base. It does this by walking the commit graph and reading each commit from RocksDB. That walk ran on the worker thread that serves requests, so a long history kept the worker busy until it finished. When a lot of requests come in together, busy workers can't pick up new ones.

`commits::list_between_exclusive` is now async and runs the walk on a background thread, so the worker stays free. The walk itself works exactly as before.

Completes ENG-1289
