### PR TITLE
S3 (27.2): Fix workspace add reporting failure on a successful upload

### DIFF
--- a/crates/liboxen/src/api/client/workspaces/files.rs
+++ b/crates/liboxen/src/api/client/workspaces/files.rs
@@ -679,15 +679,12 @@ fn staging_filename(staging_path: &Path) -> String {
 }
 
 /// The path the workspace `files` endpoint stages a file at (and echoes back in its response),
-/// given the request `directory` and the file's staging path. This MUST mirror the server `add`
-/// handler: it stages at `directory.join(validate_and_normalize_path(<multipart filename>))`.
-///
-/// Used to reconcile which files staged. Deriving the key the same way the server does — rather
-/// than joining the raw `staging_path` — keeps client and server in agreement across path
-/// normalization (`.` components, separators) so a file that staged isn't misread as failed.
+/// given the request `directory` and the file's staging path. Used to reconcile which files staged.
+/// Delegates to [`util::fs::workspace_staged_path`], the single source of truth the server `add`
+/// handler also stages through, so the two can't drift across path normalization.
 fn expected_staged_path(directory: &str, staging_path: &Path) -> Result<PathBuf, OxenError> {
-    let normalized = util::fs::validate_and_normalize_path(staging_filename(staging_path))?;
-    Ok(Path::new(directory).join(normalized))
+    let filename = staging_filename(staging_path);
+    util::fs::workspace_staged_path(directory, Path::new(&filename))
 }
 
 /// Build a gzipped multipart part whose filename is the staging path. The server reads the filename
@@ -1140,6 +1137,17 @@ mod tests {
             super::expected_staged_path("data", Path::new("train\\img.jpg")).unwrap(),
             PathBuf::from("data/train/img.jpg"),
         );
+        // The CLI's default directory is ".", which the server collapses when it normalizes the
+        // joined path. The client must collapse it too, or a successfully-staged file reconciles
+        // against "./img.jpg" while the server reports "img.jpg".
+        assert_eq!(
+            super::expected_staged_path(".", Path::new("img.jpg")).unwrap(),
+            PathBuf::from("img.jpg"),
+        );
+        assert_eq!(
+            super::expected_staged_path(".", Path::new("train/img.jpg")).unwrap(),
+            PathBuf::from("train/img.jpg"),
+        );
     }
 
     #[test]
@@ -1168,6 +1176,23 @@ mod tests {
         assert!(
             remaining.is_empty(),
             "all staged files should reconcile, got unstaged: {remaining:?}"
+        );
+    }
+
+    #[test]
+    fn test_unstaged_files_reconciles_dot_directory() {
+        // Regression for the "added 0 entries ... failed to upload 1 entries" bug: `oxen workspace
+        // add` stages with the default directory ".", the server collapses it and echoes back
+        // "logo.png", and the client must reconcile that rather than reporting a false failure.
+        let files = vec![super::FileToStage {
+            disk_path: PathBuf::from("/tmp/logo.png"),
+            staging_path: PathBuf::from("logo.png"),
+        }];
+        let staged = vec![PathBuf::from("logo.png")];
+        let remaining = super::unstaged_files(files, &staged, ".");
+        assert!(
+            remaining.is_empty(),
+            "a file staged under a '.' directory must reconcile, got unstaged: {remaining:?}"
         );
     }
 
@@ -1794,6 +1819,58 @@ mod tests {
             .await?;
             assert_eq!(entries.added_files.entries.len(), 2);
             assert_eq!(entries.added_files.total_entries, 2);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_add_file_under_dot_directory_reports_no_failure() -> Result<(), OxenError> {
+        // `oxen workspace add` stages under the default "." directory, which the server collapses
+        // when it normalizes the joined path. The client must reconcile against the same collapsed
+        // path or a staged file reads as failed. The load-bearing assertion is that the returned
+        // failure list is empty -- the sibling add tests only check is_ok(), which stays true even
+        // when every file is wrongly reported as failed.
+        test::run_readme_remote_repo_test(|_local_repo, remote_repo| async move {
+            let branch_name = "add-under-dot-directory";
+            let branch = api::client::branches::create_from_branch(
+                &remote_repo,
+                branch_name,
+                DEFAULT_BRANCH_NAME,
+            )
+            .await?;
+            assert_eq!(branch.name, branch_name);
+
+            let workspace_id = uuid::Uuid::new_v4().to_string();
+            let workspace =
+                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+            assert_eq!(workspace.id, workspace_id);
+
+            // local_repo None mirrors the CLI: the staging path is the bare filename, sent under ".".
+            let failed = api::client::workspaces::files::add(
+                &remote_repo,
+                &workspace_id,
+                ".",
+                vec![test::test_img_file()],
+                &None,
+            )
+            .await?;
+            assert!(
+                failed.is_empty(),
+                "a file staged under the default '.' directory must not read as failed, got: {failed:?}"
+            );
+
+            // Confirm the file actually staged at the workspace root.
+            let entries = api::client::workspaces::changes::list(
+                &remote_repo,
+                &workspace_id,
+                Path::new(""),
+                constants::DEFAULT_PAGE_NUM,
+                constants::DEFAULT_PAGE_SIZE,
+            )
+            .await?;
+            assert_eq!(entries.added_files.total_entries, 1);
 
             Ok(remote_repo)
         })

--- a/crates/liboxen/src/util/fs.rs
+++ b/crates/liboxen/src/util/fs.rs
@@ -1709,6 +1709,14 @@ pub fn validate_and_normalize_path(path: impl AsRef<Path>) -> Result<PathBuf, Ox
     Ok(normalized)
 }
 
+/// The canonical path a workspace file stages at, given the request `directory` and the file's
+/// path relative to it: join, then [`validate_and_normalize_path`] (collapse `.`, reject `..` and
+/// absolute paths). The workspace `files` server handler stages here and echoes it back; the upload
+/// client reconciles against it, so both sides must derive the staged path through this helper.
+pub fn workspace_staged_path(directory: &str, relative: &Path) -> Result<PathBuf, OxenError> {
+    validate_and_normalize_path(Path::new(directory).join(relative))
+}
+
 /// Unpack an async-tar archive to a destination directory without calling `canonicalize`. This is
 /// needed because `archive.unpack()` and `entry.unpack_in()` internally call
 /// `std::fs::canonicalize`, which fails on filesystems that don't support it (e.g. Windows imdisk

--- a/crates/oxen-cli/src/cmd/workspace/add.rs
+++ b/crates/oxen-cli/src/cmd/workspace/add.rs
@@ -99,7 +99,7 @@ impl RunCmd for WorkspaceAddCmd {
             ));
         }
 
-        api::client::workspaces::files::add(
+        let failed_to_upload = api::client::workspaces::files::add(
             &remote_repo,
             workspace_identifier,
             directory,
@@ -107,6 +107,13 @@ impl RunCmd for WorkspaceAddCmd {
             &None,
         )
         .await?;
+
+        if !failed_to_upload.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Failed to upload {} file(s) to the workspace",
+                failed_to_upload.len()
+            ));
+        }
 
         Ok(())
     }

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -217,19 +217,21 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
         upload_files.len(),
     );
 
-    let base_dir = PathBuf::from(&directory);
     let mut files_to_stage = Vec::with_capacity(upload_files.len());
     for upload_file in upload_files {
-        // The multipart filename is the staging path relative to `directory`. Normalize the full
-        // destination so subdirectories are preserved while rejecting absolute paths and `..`
-        // traversal from either the untrusted `directory` or the filename. An empty or `.`
-        // directory normalizes to the workspace root.
-        let joined = base_dir.join(&upload_file.path);
-        let dst_path = match util::fs::validate_and_normalize_path(&joined) {
+        // The multipart filename is the staging path relative to `directory`. `workspace_staged_path`
+        // joins and normalizes both (preserving subdirectories, rejecting absolute paths and `..`
+        // traversal from either the untrusted `directory` or the filename, collapsing an empty or `.`
+        // directory to the workspace root) -- the client reconciles against the same helper.
+        let dst_path = match util::fs::workspace_staged_path(&directory, &upload_file.path) {
             Ok(dst_path) => dst_path,
             Err(e) => {
                 return Err(OxenHttpError::BadRequest(
-                    format!("Invalid staging path {joined:?}: {e}").into(),
+                    format!(
+                        "Invalid staging path (directory {directory:?}, file {:?}): {e}",
+                        upload_file.path
+                    )
+                    .into(),
                 ));
             }
         };


### PR DESCRIPTION
`oxen workspace add` printed `added 0 entries ... failed to upload N entries` and still exited 0 when the upload had actually succeeded. Every successful add with the CLI at the root directory showed this false failure. A genuinely failed upload was indistinguishable because the command exited 0 either way. Python's `workspace.add(file, ".")` raised a spurious "Failed to upload" error on success for the same reason.


This fixes the problem by deriving the staged path on both the server and the CLI through the same helper function (`util::fs::workspace_staged_path`). Now the CLI exits nonzero when a file genuinely fails to upload, and does not emit a failure message when it succeeds.