### PR TITLE
Bound file descriptors when reassembling chunked version files

### DIFF
--- a/crates/liboxen/src/api/client/entries.rs
+++ b/crates/liboxen/src/api/client/entries.rs
@@ -653,27 +653,20 @@ pub async fn download_large_entry(
         util::fs::create_dir_all(parent)?;
     }
 
-    // Chain the per-chunk files into one `Read`, stream that through the verify-before-commit
-    // atomic-write helper, then reclaim the chunk dir.
+    // Reassemble the per-chunk files through the verify-before-commit atomic-write helper, then
+    // reclaim the chunk dir.
     let chunk_paths: Vec<PathBuf> = (0..num_chunks)
         .map(|i| tmp_dir.join(format!("chunk_{i}")))
         .collect();
     let tmp_dir_for_cleanup = tmp_dir.clone();
     let local_path_for_blocking = local_path.to_path_buf();
     spawn_blocking(move || -> Result<(), OxenError> {
-        let mut combined: Box<dyn std::io::Read> = Box::new(std::io::empty());
-        for chunk_path in &chunk_paths {
-            let chunk_file = std::fs::File::open(chunk_path)?;
-            combined = Box::new(std::io::Read::chain(combined, chunk_file));
-        }
         AtomicFile::new(&local_path_for_blocking)
             .with_hash(expected_hash)
-            .stream(&mut combined)?;
+            .stream_from_paths(&chunk_paths)?;
 
-        // Close the chunk file handles before removing their directory. On NFS, unlinking a
-        // still-open file leaves a hidden .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
-        drop(combined);
-
+        // The reassembled file is committed and every chunk handle closed before this point, so
+        // removing the chunk directory is safe.
         if tmp_dir_for_cleanup.exists() {
             std::fs::remove_dir_all(&tmp_dir_for_cleanup)?;
         }

--- a/crates/liboxen/src/storage/local.rs
+++ b/crates/liboxen/src/storage/local.rs
@@ -364,23 +364,14 @@ impl VersionStore for LocalVersionStore {
             .collect();
 
         // Run the full read-chunks + atomic-write + cleanup sequence in one `spawn_blocking`
-        // closure: chain each chunk file as a sync `Read` and pipe the concatenation through
-        // `AtomicFile::stream` with the expected hash so the rename only happens if the
-        // reassembled bytes hash to the file's canonical hash.
+        // closure: `stream_from_paths` concatenates the chunks in offset order.
         spawn_blocking(move || -> Result<(), OxenError> {
-            let mut combined: Box<dyn std::io::Read> = Box::new(std::io::empty());
-            for chunk_path in &chunk_paths {
-                let chunk_file = std::fs::File::open(chunk_path)?;
-                combined = Box::new(std::io::Read::chain(combined, chunk_file));
-            }
             AtomicFile::new(&version_path)
                 .with_hash(expected_hash)
-                .stream(&mut combined)?;
+                .stream_from_paths(&chunk_paths)?;
 
-            // Close the chunk file handles before removing their directory. On NFS, unlinking a
-            // still-open file leaves a hidden .nfsXXXX entry that fails the rmdir with ENOTEMPTY.
-            drop(combined);
-
+            // The reassembled file is committed and every chunk handle closed before this point,
+            // so removing the chunk directory is safe.
             if chunks_dir.exists() {
                 std::fs::remove_dir_all(&chunks_dir)?;
             }

--- a/crates/liboxen/src/util/CLAUDE.md
+++ b/crates/liboxen/src/util/CLAUDE.md
@@ -21,7 +21,7 @@ The builders are `.with_hash(expected)` and `.with_mtime(t)`; both default to `N
 - **`.with_hash(expected)`** when the bytes are content-addressed (the canonical filename embeds the hash) or arrive from an untrusted / network source. On mismatch the publish aborts without touching the canonical path. `write` hashes the in-memory bytes before opening any temp file (verify-before-publish); the streaming and copy variants hash in-passing and drop the temp on mismatch.
 - **`.with_mtime(t)`** when publishing into the working tree so the `oxen status` size+mtime fast path stays effective on the next pass. The mtime is stamped on the temp file atomically with the rename, so a kill can never leave a complete-but-wrong-mtime file behind.
 
-Terminal methods are `.write(bytes)` (in-memory) / `.stream(reader)` (sync `Read`) / `.stream_async(reader).await` (async `AsyncRead`, via the Channel hand-off pattern) / `.copy_from(src)` (file → file). Pick by the source-kind you have in hand.
+Terminal methods are `.write(bytes)` (in-memory) / `.stream(reader)` (sync `Read`) / `.stream_async(reader).await` (async `AsyncRead`, via the Channel hand-off pattern) / `.copy_from(src)` (file → file) / `.stream_from_paths(&[path])` (many files → file). Pick by the source-kind you have in hand.
 
 `AtomicFile` is `#[must_use]` — forgetting a terminal method is a compile-time warning, not a silent no-op. The full contract (including atime behavior, cancel-safety, and the verify-before-publish guarantee) lives on the struct rustdoc. Read it before adding a new caller.
 

--- a/crates/liboxen/src/util/fs/atomic_file.rs
+++ b/crates/liboxen/src/util/fs/atomic_file.rs
@@ -561,18 +561,18 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
-    async fn test_atomic_stream_from_paths_concatenates_and_verifies() -> Result<(), OxenError> {
+    #[test]
+    fn test_atomic_stream_from_paths_concatenates_and_verifies() -> Result<(), OxenError> {
         use xxhash_rust::xxh3::xxh3_128;
 
-        test::run_empty_dir_test_async(|dir| async move {
+        test::run_empty_dir_test(|dir| {
             let chunks_dir = dir.join("chunks");
-            tokio::fs::create_dir(&chunks_dir).await?;
+            std::fs::create_dir(&chunks_dir)?;
             let parts: [&[u8]; 3] = [b"hello ", b"brave ", b"world"];
             let mut paths = Vec::new();
             for (i, part) in parts.iter().enumerate() {
                 let p = chunks_dir.join(format!("{i}"));
-                tokio::fs::write(&p, part).await?;
+                std::fs::write(&p, part)?;
                 paths.push(p);
             }
             let full: Vec<u8> = parts.concat();
@@ -583,27 +583,25 @@ mod tests {
                 .with_hash(expected)
                 .stream_from_paths(&paths)?;
 
-            let written = tokio::fs::read(&target).await?;
+            let written = std::fs::read(&target)?;
             assert_eq!(written, full);
 
             // No stray `.oxentmp.<uuid>` next to the target (dir holds blob.bin + chunks/).
-            let mut entries = tokio::fs::read_dir(&dir).await?;
             let mut names = Vec::new();
-            while let Some(e) = entries.next_entry().await? {
-                names.push(e.file_name().to_string_lossy().to_string());
+            for entry in std::fs::read_dir(dir)? {
+                names.push(entry?.file_name().to_string_lossy().to_string());
             }
             names.sort();
             assert_eq!(names, vec!["blob.bin".to_string(), "chunks".to_string()]);
             Ok(())
         })
-        .await
     }
 
-    #[tokio::test]
-    async fn test_atomic_stream_from_paths_aborts_on_mismatch() -> Result<(), OxenError> {
-        test::run_empty_dir_test_async(|dir| async move {
+    #[test]
+    fn test_atomic_stream_from_paths_aborts_on_mismatch() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
             let chunk = dir.join("chunk0");
-            tokio::fs::write(&chunk, b"payload").await?;
+            std::fs::write(&chunk, b"payload")?;
             let bogus = MerkleHash::new(0xdead_beef_dead_beef_dead_beef_dead_beefu128);
 
             let target = dir.join("blob.bin");
@@ -615,7 +613,6 @@ mod tests {
             assert!(!target.exists(), "target must not be published on mismatch");
             Ok(())
         })
-        .await
     }
 
     #[tokio::test]

--- a/crates/liboxen/src/util/fs/atomic_file.rs
+++ b/crates/liboxen/src/util/fs/atomic_file.rs
@@ -7,7 +7,7 @@
 
 use bytes::{Bytes, BytesMut};
 use std::fs::File;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use tokio::io::AsyncReadExt;
@@ -180,7 +180,7 @@ impl AtomicTempFile {
 /// `std::fs` and run inside a `tokio::task::spawn_blocking` provided by the calling operation.
 /// [`stream_async`][Self::stream_async] is the only `async` terminal, and uses the Channel
 /// hand-off pattern to bridge an async reader to a sync writer.
-#[must_use = "AtomicFile does nothing until a terminal method (write/stream/stream_async/copy_from) is called"]
+#[must_use = "AtomicFile does nothing until a terminal method (write/stream/stream_from_paths/stream_async/copy_from) is called"]
 #[derive(Debug, Clone)]
 pub struct AtomicFile {
     target: PathBuf,
@@ -258,6 +258,50 @@ impl AtomicFile {
             actual
         };
         if let (Some(expected), Some(actual)) = (self.expected_hash, actual_hash)
+            && actual != expected
+        {
+            return Err(OxenError::HashMismatch {
+                path: self.target,
+                expected,
+                actual,
+            });
+        }
+        if let Some(mtime) = self.mtime {
+            tmp.set_mtime(mtime)?;
+        }
+        tmp.commit()
+    }
+
+    /// Publish the in-order concatenation of `paths` to the target path, opening one source file
+    /// at a time. Bounds open file descriptors to O(1) regardless of how many paths there are —
+    /// the fit for reassembling a file from many chunk files. On success the concatenated bytes
+    /// are hash-verified — when a hash was set via [`with_hash`][Self::with_hash] — and atomically
+    /// renamed into place; on any error the scratch file drops without touching the target.
+    pub fn stream_from_paths(self, paths: &[PathBuf]) -> Result<(), OxenError> {
+        let mut tmp = AtomicTempFile::create(&self.target)?;
+        // Reuse one large buffer across every chunk and write each block straight to the temp
+        // file. At most one chunk descriptor and one buffer are live at a time, and both reads and
+        // writes move in ~10 MB blocks rather than the 8 KB `std::io::copy` default.
+        let mut hasher = self.expected_hash.map(|_| Xxh3::new());
+        let mut buf = vec![0u8; constants::STREAMING_BUF_SIZE];
+        {
+            let writer = tmp.as_writer();
+            for path in paths {
+                let mut src = File::open(path)?;
+                loop {
+                    let n = src.read(&mut buf)?;
+                    if n == 0 {
+                        break;
+                    }
+                    if let Some(h) = hasher.as_mut() {
+                        h.update(&buf[..n]);
+                    }
+                    writer.write_all(&buf[..n])?;
+                }
+            }
+        }
+        let hash_result = hasher.map(|h| MerkleHash::new(h.digest128()));
+        if let (Some(expected), Some(actual)) = (self.expected_hash, hash_result)
             && actual != expected
         {
             return Err(OxenError::HashMismatch {
@@ -512,6 +556,63 @@ mod tests {
                 names.push(entry.file_name());
             }
             assert_eq!(names.len(), 1, "unexpected leftover files: {names:?}");
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_atomic_stream_from_paths_concatenates_and_verifies() -> Result<(), OxenError> {
+        use xxhash_rust::xxh3::xxh3_128;
+
+        test::run_empty_dir_test_async(|dir| async move {
+            let chunks_dir = dir.join("chunks");
+            tokio::fs::create_dir(&chunks_dir).await?;
+            let parts: [&[u8]; 3] = [b"hello ", b"brave ", b"world"];
+            let mut paths = Vec::new();
+            for (i, part) in parts.iter().enumerate() {
+                let p = chunks_dir.join(format!("{i}"));
+                tokio::fs::write(&p, part).await?;
+                paths.push(p);
+            }
+            let full: Vec<u8> = parts.concat();
+            let expected = MerkleHash::new(xxh3_128(&full));
+
+            let target = dir.join("blob.bin");
+            AtomicFile::new(&target)
+                .with_hash(expected)
+                .stream_from_paths(&paths)?;
+
+            let written = tokio::fs::read(&target).await?;
+            assert_eq!(written, full);
+
+            // No stray `.oxentmp.<uuid>` next to the target (dir holds blob.bin + chunks/).
+            let mut entries = tokio::fs::read_dir(&dir).await?;
+            let mut names = Vec::new();
+            while let Some(e) = entries.next_entry().await? {
+                names.push(e.file_name().to_string_lossy().to_string());
+            }
+            names.sort();
+            assert_eq!(names, vec!["blob.bin".to_string(), "chunks".to_string()]);
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_atomic_stream_from_paths_aborts_on_mismatch() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|dir| async move {
+            let chunk = dir.join("chunk0");
+            tokio::fs::write(&chunk, b"payload").await?;
+            let bogus = MerkleHash::new(0xdead_beef_dead_beef_dead_beef_dead_beefu128);
+
+            let target = dir.join("blob.bin");
+            let result = AtomicFile::new(&target)
+                .with_hash(bogus)
+                .stream_from_paths(&[chunk]);
+
+            assert!(matches!(result, Err(OxenError::HashMismatch { .. })));
+            assert!(!target.exists(), "target must not be published on mismatch");
             Ok(())
         })
         .await


### PR DESCRIPTION
Reassembling an uploaded file's chunks opened every chunk at once and held all of them open for the whole copy. With 10 MB chunks, that means a 100 GB file opens ~10,240 descriptors in a single request. We were hitting the process file-descriptor limit and returning 500 errors.

Reassemble version files through a new `AtomicFile::stream_from_paths` that concatenates the chunks in offset order, opening one file at a time.