### PR TITLE
S3 (27.3): Verify content hashes on all S3 content-addressed writes

### DIFF
--- a/crates/liboxen/src/storage/local.rs
+++ b/crates/liboxen/src/storage/local.rs
@@ -635,6 +635,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_rejects_mismatched_content() {
+        use crate::storage::version_store::verify_suite;
+        let (_temp_dir, store) = setup().await;
+        verify_suite::assert_rejects_mismatched_content(&store).await;
+    }
+
+    #[tokio::test]
     async fn test_version_location_returns_local_path() {
         let (_temp_dir, store) = setup().await;
         let hash = "abcdef1234567890";

--- a/crates/liboxen/src/storage/s3.rs
+++ b/crates/liboxen/src/storage/s3.rs
@@ -438,6 +438,14 @@ impl VersionStore for S3VersionStore {
         log::debug!("Storing version to S3");
         let key = self.generate_key(hash);
 
+        // Reject data that does not hash to its key before uploading anything.
+        let computed = hasher::hash_buffer(&data);
+        if computed != hash {
+            return Err(OxenError::upload(&format!(
+                "store_version hash mismatch: expected {hash}, computed {computed}"
+            )));
+        }
+
         let body = ByteStream::from(data);
         client
             .put_object()
@@ -833,6 +841,7 @@ impl VersionStore for S3VersionStore {
         let mut part_buf: Vec<u8> = Vec::new();
         let mut part_num: i32 = 1;
         let mut completed_parts: Vec<CompletedPart> = Vec::new();
+        let mut hasher = Xxh3::new();
 
         let result: Result<(), OxenError> = async {
             for (i, offset) in offsets.iter().enumerate() {
@@ -855,6 +864,10 @@ impl VersionStore for S3VersionStore {
                         ))
                     })?
                     .into_bytes();
+
+                // Feed every byte through the hasher in offset order so the digest covers the whole
+                // reassembled file.
+                hasher.update(&chunk_bytes);
 
                 // Append to part buffer
                 part_buf.extend_from_slice(&chunk_bytes);
@@ -888,6 +901,15 @@ impl VersionStore for S3VersionStore {
                         break;
                     }
                 }
+            }
+
+            // The reassembled file must hash to its key; on mismatch we fall to the abort below and
+            // commit nothing.
+            let computed = format!("{:x}", hasher.digest128());
+            if computed != hash {
+                return Err(OxenError::upload(&format!(
+                    "combine_version_chunks hash mismatch: expected {hash}, computed {computed}"
+                )));
             }
             Ok(())
         }
@@ -1135,8 +1157,10 @@ mod tests {
             Some(format!("http://{addr}")),
         );
 
+        let one_hash = hasher::hash_buffer(b"one");
+        let sibling_hash = hasher::hash_buffer(b"sibling");
         store
-            .store_version("aaaa1111", Bytes::from_static(b"one"))
+            .store_version(&one_hash, Bytes::from_static(b"one"))
             .await
             .unwrap();
         store
@@ -1144,15 +1168,15 @@ mod tests {
             .await
             .unwrap();
         sibling
-            .store_version("cccc3333", Bytes::from_static(b"sibling"))
+            .store_version(&sibling_hash, Bytes::from_static(b"sibling"))
             .await
             .unwrap();
 
         store.destroy().await.unwrap();
 
         assert!(store.list_versions().await.unwrap().is_empty());
-        assert!(!store.version_exists("aaaa1111").await.unwrap());
-        assert!(sibling.version_exists("cccc3333").await.unwrap());
+        assert!(!store.version_exists(&one_hash).await.unwrap());
+        assert!(sibling.version_exists(&sibling_hash).await.unwrap());
     }
 
     #[tokio::test]
@@ -1296,9 +1320,10 @@ mod tests {
     async fn test_copy_version_to_path_streams_to_dest() {
         let (store, _tmp, _server) = setup().await;
         let data = b"streamed to destination";
+        let hash = hasher::hash_buffer(data);
 
         store
-            .store_version("eeedef1234567890", Bytes::from_static(data))
+            .store_version(&hash, Bytes::from_static(data))
             .await
             .unwrap();
 
@@ -1307,7 +1332,7 @@ mod tests {
         let mtime = SystemTime::UNIX_EPOCH + std::time::Duration::new(1_700_000_000, 123_456_789);
 
         store
-            .copy_version_to_path("eeedef1234567890", &dest_path, mtime)
+            .copy_version_to_path(&hash, &dest_path, mtime)
             .await
             .unwrap();
 
@@ -1395,7 +1420,8 @@ mod tests {
     #[tokio::test]
     async fn test_delete_version_removes_data_and_chunks() {
         let (store, _tmp, _server) = setup().await;
-        let hash = "abcdef1234567890abcdef1234567890";
+        let hash = hasher::hash_buffer(b"main data");
+        let hash = hash.as_str();
 
         // Store main data + two chunks
         store
@@ -1503,8 +1529,10 @@ mod tests {
     #[tokio::test]
     async fn test_delete_version_isolates_by_hash() {
         let (store, _tmp, _server) = setup().await;
-        let hash_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let hash_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let hash_a = hasher::hash_buffer(b"a data");
+        let hash_a = hash_a.as_str();
+        let hash_b = hasher::hash_buffer(b"b data");
+        let hash_b = hash_b.as_str();
 
         store
             .store_version(hash_a, Bytes::from_static(b"a data"))
@@ -1524,8 +1552,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_version_chunk_mid_file() {
         let (store, _tmp, _server) = setup().await;
-        let hash = "abcdef1234567890abcdef1234567890";
         let data: Vec<u8> = (0..100u8).collect();
+        let hash = hasher::hash_buffer(&data);
+        let hash = hash.as_str();
         store
             .store_version(hash, Bytes::copy_from_slice(&data))
             .await
@@ -1538,8 +1567,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_version_chunk_from_start() {
         let (store, _tmp, _server) = setup().await;
-        let hash = "abcdef1234567890abcdef1234567890";
         let data = b"hello world!";
+        let hash = hasher::hash_buffer(data);
+        let hash = hash.as_str();
         store
             .store_version(hash, Bytes::from_static(data))
             .await
@@ -1561,7 +1591,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_version_chunk_past_eof_errors() {
         let (store, _tmp, _server) = setup().await;
-        let hash = "abcdef1234567890abcdef1234567890";
+        let hash = hasher::hash_buffer(b"small");
+        let hash = hash.as_str();
         store
             .store_version(hash, Bytes::from_static(b"small"))
             .await
@@ -1679,25 +1710,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_rejects_mismatched_content() {
+        use crate::storage::version_store::verify_suite;
+        let (store, _tmp, _server) = setup().await;
+        verify_suite::assert_rejects_mismatched_content(&store).await;
+    }
+
+    #[tokio::test]
     async fn test_list_versions() {
         let (store, _tmp, _server) = setup().await;
 
         // Insert out of order; list_versions is documented to return sorted results.
+        let hash_a = hasher::hash_buffer(b"a data");
+        let hash_b = hasher::hash_buffer(b"b data");
+        let hash_c = hasher::hash_buffer(b"c data");
         store
-            .store_version("cccc", Bytes::from_static(b"c data"))
+            .store_version(&hash_c, Bytes::from_static(b"c data"))
             .await
             .unwrap();
         store
-            .store_version("aaaa", Bytes::from_static(b"a data"))
+            .store_version(&hash_a, Bytes::from_static(b"a data"))
             .await
             .unwrap();
         store
-            .store_version("bbbb", Bytes::from_static(b"b data"))
+            .store_version(&hash_b, Bytes::from_static(b"b data"))
             .await
             .unwrap();
 
+        let mut expected = vec![hash_a, hash_b, hash_c];
+        expected.sort();
         let versions = store.list_versions().await.unwrap();
-        assert_eq!(versions, vec!["aaaa", "bbbb", "cccc"]);
+        assert_eq!(versions, expected);
     }
 
     #[tokio::test]
@@ -1714,7 +1757,8 @@ mod tests {
         // With common-prefix listing they should collapse to a single entry per hash.
         let (store, _tmp, _server) = setup().await;
 
-        let hash = "abcdef1234567890abcdef1234567890";
+        let hash = hasher::hash_buffer(b"main");
+        let hash = hash.as_str();
         store
             .store_version(hash, Bytes::from_static(b"main"))
             .await

--- a/crates/liboxen/src/storage/version_store.rs
+++ b/crates/liboxen/src/storage/version_store.rs
@@ -203,7 +203,9 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     /// Initialize the storage backend
     async fn init(&self) -> Result<(), OxenError>;
 
-    /// Store a version file from an async reader
+    /// Store a version file from an async reader.
+    ///
+    /// The streamed bytes must hash to `hash`; on mismatch the call rejects and stores nothing.
     ///
     /// # Arguments
     /// * `hash` - The content hash that identifies this version
@@ -216,14 +218,19 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         size: u64,
     ) -> Result<(), OxenError>;
 
-    /// Store a version file from bytes
+    /// Store a version file from bytes.
+    ///
+    /// The `data` must hash to `hash`; on mismatch the call rejects and stores nothing.
     ///
     /// # Arguments
     /// * `hash` - The content hash that identifies this version
     /// * `data` - The raw bytes to store
     async fn store_version(&self, hash: &str, data: Bytes) -> Result<(), OxenError>;
 
-    /// Store a chunk of a version file
+    /// Store a chunk of a version file.
+    ///
+    /// `data` is a byte range of a larger file, not content addressed by its own hash, so unlike
+    /// the whole-file store methods this one cannot verify its bytes against `hash`.
     ///
     /// # Arguments
     /// * `hash` - The content hash that identifies this version
@@ -236,7 +243,11 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
         data: Bytes,
     ) -> Result<(), OxenError>;
 
-    /// Store a derived file (resized image, video thumbnail, etc.) corresponding to a file version
+    /// Store a derived file (resized image, video thumbnail, etc.) corresponding to a file version.
+    ///
+    /// The derived bytes are generated artifacts keyed by `orig_hash` + `derived_filename`, not
+    /// content addressed by their own hash, so unlike the whole-file store methods this one cannot
+    /// verify its bytes.
     ///
     /// # Arguments
     /// * `orig_hash` - The content hash of the parent version
@@ -273,6 +284,9 @@ pub trait VersionStore: Debug + Send + Sync + 'static {
     async fn list_version_chunks(&self, hash: &str) -> Result<Vec<u64>, OxenError>;
 
     /// Combine all the chunks for a version file into a single file, then delete the chunks.
+    ///
+    /// The reassembled file must hash to `hash`; on mismatch the call rejects, commits no combined
+    /// file, and leaves the chunks in place.
     ///
     /// # Arguments
     /// * `hash` - The content hash that identifies this version
@@ -572,5 +586,79 @@ mod tests {
         let store = create_version_store(&repo_dir, &s3_config(), Some(&opts))
             .expect("S3 store should construct when server opts are present");
         assert_eq!(store.storage_kind(), StorageKind::S3);
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod verify_suite {
+    //! Backend-agnostic assertions that a `VersionStore` verifies its content-addressed writes.
+    //! Each backend runs this against a live store so the invariant -- every content-addressed
+    //! store method rejects bytes that don't hash to their key and commits no version object --
+    //! holds for any current or future backend.
+    use super::*;
+    use crate::util::hasher;
+    use std::io::Cursor;
+
+    const DATA: &[u8] = b"the quick brown fox jumps over the lazy dog";
+    /// A validly formatted 32-hex-digit hash that is not the hash of `DATA`.
+    const WRONG_HASH: &str = "deadbeefdeadbeefdeadbeefdeadbeef";
+
+    fn assert_mismatch(result: Result<(), OxenError>, method: &str) {
+        match result {
+            Ok(()) => panic!("{method} accepted content that does not hash to its key"),
+            Err(e) => assert!(
+                e.to_string().to_lowercase().contains("mismatch"),
+                "{method} must reject with a hash mismatch, got: {e}"
+            ),
+        }
+    }
+
+    /// Assert every content-addressed store method rejects mismatched bytes and leaves no version
+    /// object at the key. The exempt methods (`store_version_chunk`, `store_version_derived`) are
+    /// not addressed by their own bytes and so are not exercised here.
+    pub(crate) async fn assert_rejects_mismatched_content(store: &dyn VersionStore) {
+        assert_ne!(
+            hasher::hash_buffer(DATA),
+            WRONG_HASH,
+            "test fixture is broken: WRONG_HASH must not be the hash of DATA"
+        );
+
+        assert_mismatch(
+            store
+                .store_version(WRONG_HASH, Bytes::from_static(DATA))
+                .await,
+            "store_version",
+        );
+        assert!(
+            !store.version_exists(WRONG_HASH).await.unwrap(),
+            "store_version committed a version object on mismatch"
+        );
+
+        let reader = Box::new(Cursor::new(DATA.to_vec()));
+        assert_mismatch(
+            store
+                .store_version_from_reader(WRONG_HASH, reader, DATA.len() as u64)
+                .await,
+            "store_version_from_reader",
+        );
+        assert!(
+            !store.version_exists(WRONG_HASH).await.unwrap(),
+            "store_version_from_reader committed a version object on mismatch"
+        );
+
+        // Stage one chunk (exempt from verification), then combine under a key the reassembled
+        // bytes don't hash to.
+        store
+            .store_version_chunk(WRONG_HASH, 0, Bytes::from_static(DATA))
+            .await
+            .unwrap();
+        assert_mismatch(
+            store.combine_version_chunks(WRONG_HASH).await,
+            "combine_version_chunks",
+        );
+        assert!(
+            !store.version_exists(WRONG_HASH).await.unwrap(),
+            "combine_version_chunks committed a version object on mismatch"
+        );
     }
 }


### PR DESCRIPTION
Make `store_version` and `combine_version_chunks` reject a write whose bytes don't hash to the key. Update the trait documentation to point out which methods verify hashes and which don't.

Add a backend-agnostic test suite to run against both the local and in-memory S3 stores. Existing S3 tests that stored bytes under arbitrary non-matching hashes now use real content hashes.