### PR TITLE
Hardening (1.2): Run data-frame queries on a hardened read-only DuckDB connection

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -6,6 +6,7 @@ disallowed-methods = [
     { path = "std::path::Path::canonicalize", reason = "Use `liboxen::util::fs::canonicalize` — it falls back to `std::path::absolute` on filesystems that don't support canonicalization (e.g. Windows imdisk ramdisks used in the test suite)." },
 
     { path = "duckdb::Connection::open", reason = "Open DuckDB connections via `df_db::open_duckdb_connection` so connection-level configuration is applied in one place." },
+    { path = "duckdb::Connection::open_with_flags", reason = "Open hardened DuckDB connections via `df_db::open_hardened_query_connection` so hardened config (external access off, extensions off, locked) stays in one place." },
 
     # Non-atomic filesystem writes — production code must use `AtomicFile` # (`crates/liboxen/src/util/fs.rs`) so a crash
     # mid-write can never leave a torn or partially-written file. Commented out until the existing violations are migrated.

--- a/crates/liboxen/src/core/db/data_frames/df_db.rs
+++ b/crates/liboxen/src/core/db/data_frames/df_db.rs
@@ -34,8 +34,11 @@ use sql_query_builder as sql;
 
 const DF_DB_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
 
+/// A cached DuckDB connection slot; `None` when no connection is currently open.
+type CachedConn = Arc<Mutex<Option<duckdb::Connection>>>;
+
 // Static cache of DuckDB instances with LRU eviction
-static DF_DB_INSTANCES: LazyLock<RwLock<LruCache<PathBuf, Arc<Mutex<duckdb::Connection>>>>> =
+static DF_DB_INSTANCES: LazyLock<RwLock<LruCache<PathBuf, CachedConn>>> =
     LazyLock::new(|| RwLock::new(LruCache::new(DF_DB_CACHE_SIZE)));
 
 /// Removes a database instance from the cache.
@@ -81,7 +84,7 @@ pub fn remove_df_db_from_cache_with_children(
 /// caller is expected to have stopped its own use of the cache before
 /// calling — anything still locked is a safety-net case, not the norm.
 pub fn flush_all_df_db_connections() {
-    let entries: Vec<(PathBuf, Arc<Mutex<duckdb::Connection>>)> = {
+    let entries: Vec<(PathBuf, CachedConn)> = {
         let mut instances = DF_DB_INSTANCES.write();
         std::iter::from_fn(|| instances.pop_lru()).collect()
     };
@@ -98,13 +101,21 @@ pub fn flush_all_df_db_connections() {
     let mut skipped = 0usize;
     for (path, conn_lock) in entries {
         match conn_lock.try_lock() {
-            Some(conn) => match conn.execute_batch("CHECKPOINT") {
-                Ok(()) => checkpointed += 1,
-                Err(e) => {
-                    failed += 1;
-                    log::warn!("flush_all_df_db_connections: CHECKPOINT failed for {path:?}: {e}");
+            // An empty slot has no open connection to checkpoint (a hardened query
+            // closed it and left it for lazy reopen).
+            Some(guard) => {
+                if let Some(conn) = guard.as_ref() {
+                    match conn.execute_batch("CHECKPOINT") {
+                        Ok(()) => checkpointed += 1,
+                        Err(e) => {
+                            failed += 1;
+                            log::warn!(
+                                "flush_all_df_db_connections: CHECKPOINT failed for {path:?}: {e}"
+                            );
+                        }
+                    }
                 }
-            },
+            }
             None => {
                 skipped += 1;
                 log::warn!(
@@ -122,7 +133,8 @@ pub fn flush_all_df_db_connections() {
 
 #[derive(Clone)]
 pub struct DfDBManager {
-    df_db: Arc<Mutex<duckdb::Connection>>,
+    db_path: PathBuf,
+    df_db: CachedConn,
 }
 
 pub fn with_df_db_manager<F, T>(db_path: &Path, operation: F) -> Result<T, DataFrameError>
@@ -139,7 +151,10 @@ where
             cache_r.peek(&db_path).cloned()
         } {
             // Read lock has been dropped before executing user code.
-            return operation(&DfDBManager { df_db: db_lock });
+            return operation(&DfDBManager {
+                db_path: db_path.clone(),
+                df_db: db_lock,
+            });
         }
 
         // 2. If not exists, create the directory and open the db
@@ -163,37 +178,51 @@ where
             })?;
 
             // Wrap the connection in a Mutex and store it in the cache
-            let db_lock = Arc::new(Mutex::new(conn));
+            let db_lock = Arc::new(Mutex::new(Some(conn)));
             cache_w.put(db_path.clone(), db_lock.clone());
             db_lock
         }
     };
 
-    let manager = DfDBManager { df_db };
+    let manager = DfDBManager { db_path, df_db };
 
     // Execute the operation with our DfDBManager instance
     operation(&manager)
 }
 
 impl DfDBManager {
-    /// Execute an operation with the database connection
+    /// Execute an operation with the database connection, opening it if it is not
+    /// currently open.
     pub fn with_conn<F, T>(&self, operation: F) -> Result<T, DataFrameError>
     where
         F: FnOnce(&duckdb::Connection) -> Result<T, DataFrameError>,
     {
-        let conn = self.df_db.lock();
-        operation(&conn)
+        let mut slot = self.df_db.lock();
+        if let Some(conn) = slot.as_ref() {
+            return operation(conn);
+        }
+        let conn =
+            get_connection(&self.db_path).map_err(|e| DataFrameError::FailOpenDfDb(Box::new(e)))?;
+        let result = operation(&conn);
+        *slot = Some(conn);
+        result
     }
 
-    /// Execute an operation with the database connection (mutable access)
-    /// Note: This provides mutable access to the connection for functions that require it
+    /// Execute an operation with mutable access to the database connection, opening
+    /// it if it is not currently open.
     pub fn with_conn_mut<F, T>(&self, operation: F) -> Result<T, DataFrameError>
     where
         F: FnOnce(&mut duckdb::Connection) -> Result<T, DataFrameError>,
     {
-        let mut conn = self.df_db.lock();
-
-        operation(&mut conn)
+        let mut slot = self.df_db.lock();
+        if let Some(conn) = slot.as_mut() {
+            return operation(conn);
+        }
+        let mut conn =
+            get_connection(&self.db_path).map_err(|e| DataFrameError::FailOpenDfDb(Box::new(e)))?;
+        let result = operation(&mut conn);
+        *slot = Some(conn);
+        result
     }
 }
 
@@ -220,24 +249,28 @@ fn open_hardened_query_connection(path: &Path) -> Result<duckdb::Connection, duc
 }
 
 /// Run `operation` against a hardened, read-only connection to the DuckDB file at
-/// `db_path` — for executing caller-supplied query text. Opens a fresh connection
-/// per call, and acquires the db's connection lock internally, so it must not be
-/// called while that lock is already held (it is not reentrant).
+/// `db_path` — for executing caller-supplied query text. Acquires the db's
+/// connection lock internally, so it must not be called while that lock is already
+/// held (it is not reentrant).
 pub fn with_hardened_query_conn<F, T>(db_path: &Path, operation: F) -> Result<T, DataFrameError>
 where
     F: FnOnce(&duckdb::Connection) -> Result<T, DataFrameError>,
 {
-    // Checkpoint under the read-write connection's lock and open the read-only connection before
-    // releasing it: a read-only connection can crash replaying sequence / default-column WAL
-    // entries, so it must open against a flushed WAL, and holding the lock keeps a concurrent
-    // write out of the WAL until it has.
-    let conn = with_df_db_manager(db_path, |manager| {
-        manager.with_conn(|rw_conn| {
+    with_df_db_manager(db_path, |manager| {
+        let mut slot = manager.df_db.lock();
+        // Checkpoint and close the read-write connection so the file has no open
+        // handle — some platforms won't open a second handle to it — then open the
+        // hardened read-only connection as the sole handle and query it while still
+        // holding the lock so a concurrent write can't open the file underneath us.
+        // Checkpointing first also spares the read-only connection a WAL replay,
+        // which can crash on sequence / default-column entries. The slot is left
+        // empty for the next caller to reopen.
+        if let Some(rw_conn) = slot.take() {
             rw_conn.execute_batch("CHECKPOINT")?;
-            Ok(open_hardened_query_connection(db_path)?)
-        })
-    })?;
-    operation(&conn)
+        }
+        let conn = open_hardened_query_connection(db_path)?;
+        operation(&conn)
+    })
 }
 
 /// Get a connection to a duckdb database.

--- a/crates/liboxen/src/core/db/data_frames/df_db.rs
+++ b/crates/liboxen/src/core/db/data_frames/df_db.rs
@@ -197,12 +197,47 @@ impl DfDBManager {
     }
 }
 
-/// Open a DuckDB connection at `path`. All library-managed DuckDB connections
-/// are opened through this function.
+/// Open a read-write DuckDB connection at `path` with external file access enabled.
 // The one sanctioned `Connection::open` call; disallowed elsewhere (see clippy.toml).
 #[allow(clippy::disallowed_methods)]
 fn open_duckdb_connection(path: &Path) -> Result<duckdb::Connection, duckdb::Error> {
     duckdb::Connection::open(path)
+}
+
+/// Open a hardened, read-only DuckDB connection at `path`: external file access
+/// off, extension autoload/install off, configuration locked. Caller-supplied query
+/// text run on it can read the indexed tables but cannot read or write host files,
+/// attach other databases, or load extensions.
+// The one sanctioned `open_with_flags` call; disallowed elsewhere (see clippy.toml).
+#[allow(clippy::disallowed_methods)]
+fn open_hardened_query_connection(path: &Path) -> Result<duckdb::Connection, duckdb::Error> {
+    let config = duckdb::Config::default()
+        .access_mode(duckdb::AccessMode::ReadOnly)?
+        .enable_external_access(false)?
+        .enable_autoload_extension(false)?
+        .with("lock_configuration", "true")?;
+    duckdb::Connection::open_with_flags(path, config)
+}
+
+/// Run `operation` against a hardened, read-only connection to the DuckDB file at
+/// `db_path` — for executing caller-supplied query text. Opens a fresh connection
+/// per call, and acquires the db's connection lock internally, so it must not be
+/// called while that lock is already held (it is not reentrant).
+pub fn with_hardened_query_conn<F, T>(db_path: &Path, operation: F) -> Result<T, DataFrameError>
+where
+    F: FnOnce(&duckdb::Connection) -> Result<T, DataFrameError>,
+{
+    // Checkpoint under the read-write connection's lock and open the read-only connection before
+    // releasing it: a read-only connection can crash replaying sequence / default-column WAL
+    // entries, so it must open against a flushed WAL, and holding the lock keeps a concurrent
+    // write out of the WAL until it has.
+    let conn = with_df_db_manager(db_path, |manager| {
+        manager.with_conn(|rw_conn| {
+            rw_conn.execute_batch("CHECKPOINT")?;
+            Ok(open_hardened_query_connection(db_path)?)
+        })
+    })?;
+    operation(&conn)
 }
 
 /// Get a connection to a duckdb database.
@@ -991,6 +1026,77 @@ mod tests {
     use crate::test;
 
     use super::*;
+
+    #[test]
+    fn test_hardened_query_conn_blocks_file_access_but_reads_tables() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let db_file = dir.join("data.db");
+
+            // Populate via the cached read-write connection and leave it open, so the
+            // hardened connection is opened alongside it as it is in production.
+            with_df_db_manager(&db_file, |manager| {
+                manager.with_conn(|conn| {
+                    conn.execute_batch("CREATE TABLE df AS SELECT 42 AS x")?;
+                    Ok(())
+                })
+            })?;
+
+            // A host file that exists on disk — readable only if external access is on.
+            let secret = dir.join("secret.csv");
+            std::fs::write(&secret, "col\nvalue\n")?;
+            let secret_path = secret.to_string_lossy().to_string();
+            let out_path = dir.join("out.csv");
+            let out = out_path.to_string_lossy().to_string();
+
+            with_hardened_query_conn(&db_file, |conn| {
+                // Reads the indexed table (coexists with the cached read-write conn).
+                let x: i64 = conn.query_row("SELECT x FROM df", [], |r| r.get(0))?;
+                assert_eq!(x, 42);
+
+                // Refuses to read host files — and specifically because access is off,
+                // not because the file is missing (it exists).
+                match conn.execute_batch(&format!("SELECT * FROM read_csv('{secret_path}')")) {
+                    Ok(()) => panic!("read_csv on a hardened connection should be blocked"),
+                    Err(e) => assert!(
+                        format!("{e}").contains("disabled by configuration"),
+                        "expected an external-access error, got: {e}"
+                    ),
+                }
+
+                // Refuses to write host files.
+                assert!(
+                    conn.execute_batch(&format!("COPY (SELECT 1) TO '{out}'"))
+                        .is_err(),
+                    "COPY ... TO on a hardened connection should be blocked"
+                );
+                assert!(
+                    !out_path.exists(),
+                    "COPY ... TO must not have written a file"
+                );
+                Ok(())
+            })?;
+
+            // A fresh hardened connection sees rows committed after the previous one
+            // ran — each call opens a new connection and picks up the latest state.
+            with_df_db_manager(&db_file, |manager| {
+                manager.with_conn(|conn| {
+                    conn.execute_batch("INSERT INTO df VALUES (99)")?;
+                    Ok(())
+                })
+            })?;
+            with_hardened_query_conn(&db_file, |conn| {
+                let count: i64 = conn.query_row("SELECT COUNT(*) FROM df", [], |r| r.get(0))?;
+                assert_eq!(
+                    count, 2,
+                    "hardened connection must see the newly committed row"
+                );
+                Ok(())
+            })?;
+
+            remove_df_db_from_cache(&db_file)?;
+            Ok(())
+        })
+    }
 
     #[test]
     fn test_df_db_create() -> Result<(), OxenError> {

--- a/crates/liboxen/src/core/df/sql.rs
+++ b/crates/liboxen/src/core/df/sql.rs
@@ -6,10 +6,7 @@ use crate::core::v_latest::workspaces;
 use crate::model::LocalRepository;
 use crate::opts::DFOpts;
 use crate::repositories;
-use crate::{
-    core::db::data_frames::df_db::{self, with_df_db_manager},
-    error::OxenError,
-};
+use crate::{core::db::data_frames::df_db, error::OxenError};
 use polars::frame::DataFrame;
 use uuid::Uuid;
 
@@ -33,9 +30,7 @@ pub async fn query_df_from_repo(
         workspaces::data_frames::get_queryable_data_frame_workspace(repo, path, &commit)?;
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-    let df = with_df_db_manager(&db_path, |manager| {
-        manager.with_conn_mut(|conn| query_df(conn, sql, Some(opts)))
-    })?;
+    let df = df_db::with_hardened_query_conn(&db_path, |conn| query_df(conn, sql, Some(opts)))?;
 
     // If we are doing this from the CLI, we don't want to export the hidden Oxen columns
     let df = tabular::strip_excluded_cols(df)?;
@@ -43,7 +38,7 @@ pub async fn query_df_from_repo(
 }
 
 pub fn query_df(
-    conn: &mut duckdb::Connection,
+    conn: &duckdb::Connection,
     sql: String,
     opts: Option<&DFOpts>,
 ) -> Result<DataFrame, DataFrameError> {

--- a/crates/liboxen/src/core/v_latest/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames.rs
@@ -1,4 +1,4 @@
-use crate::core::db::data_frames::df_db::with_df_db_manager;
+use crate::core::db::data_frames::df_db::with_hardened_query_conn;
 use crate::core::df::{sql, tabular};
 use crate::core::staged::get_staged_db_manager;
 use crate::error::OxenError;
@@ -155,9 +155,7 @@ async fn handle_sql_querying(
 
     if let (Some(sql), Some(workspace)) = (opts.sql.clone(), workspace) {
         let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-        let df = with_df_db_manager(&db_path, |manager| {
-            manager.with_conn_mut(|conn| sql::query_df(conn, sql, None))
-        })?;
+        let df = with_hardened_query_conn(&db_path, |conn| sql::query_df(conn, sql, None))?;
         log::debug!("handle_sql_querying got df {df:?}");
         let paginated_df = tabular::collect_with_opts(df.clone().lazy(), opts.clone()).await?;
 

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -8,7 +8,7 @@ use sql_query_builder::Select;
 use crate::constants::{MODS_DIR, OXEN_HIDDEN_DIR};
 use crate::constants::{OXEN_COLS, TABLE_NAME};
 use crate::core;
-use crate::core::db::data_frames::df_db::with_df_db_manager;
+use crate::core::db::data_frames::df_db::{with_df_db_manager, with_hardened_query_conn};
 use crate::core::db::data_frames::{DataFrameError, df_db};
 use crate::core::df::sql;
 use crate::error::OxenError;
@@ -122,27 +122,31 @@ pub fn query(
     log::debug!("query_staged_df() got db_path: {db_path:?}");
     log::debug!("query() opts: {opts:?}");
 
-    with_df_db_manager(&db_path, |manager| {
-        manager.with_conn_mut(|conn| {
-            // Right now embeddings and sql are mutually exclusive
-            let df = if let Some(embedding_opts) = opts.get_sort_by_embedding_query() {
-                log::debug!("querying embeddings: {embedding_opts:?}");
+    // Embeddings need the vss extension, so they run on the cached read-write connection;
+    // every other query is a read and runs on a hardened, read-only connection with no external
+    // file access. (Embeddings and sql are mutually exclusive.)
+    if let Some(embedding_opts) = opts.get_sort_by_embedding_query() {
+        log::debug!("querying embeddings: {embedding_opts:?}");
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn_mut(|conn| {
                 repositories::workspaces::data_frames::embeddings::query_with_conn(
                     conn,
                     workspace,
                     &embedding_opts,
-                )?
-            } else if let Some(sql) = &opts.sql {
+                )
+            })
+        })
+    } else {
+        with_hardened_query_conn(&db_path, |conn| {
+            if let Some(sql) = &opts.sql {
                 log::debug!("querying sql: {sql:?}");
-                return sql::query_df(conn, sql.clone(), None);
+                sql::query_df(conn, sql.clone(), None)
             } else {
                 let select = Select::new().select("*").from(TABLE_NAME);
-                df_db::select(conn, &select, Some(opts))?
-            };
-
-            Ok(df)
+                df_db::select(conn, &select, Some(opts))
+            }
         })
-    })
+    }
 }
 
 pub fn export(


### PR DESCRIPTION
Caller-supplied data-frame query text now executes on a hardened, read-only DuckDB connection. This connection has external file access off, extension autoload/install off, and configuration locked. On the hardened connection, queries can read the indexed tables but not reach the host filesystem, other databases, or DuckDB extensions.

Indexing, edits, and embeddings continue on the existing read-write connection.

ENG-1220