### PR TITLE
Hardening (1.3): Run data-frame export queries on the hardened connection

### DIFF
--- a/crates/liboxen/src/core/db/data_frames.rs
+++ b/crates/liboxen/src/core/db/data_frames.rs
@@ -97,6 +97,9 @@ pub enum DataFrameError {
     #[error("No FROM found in query")]
     NoFromInQuery,
 
+    #[error("Export result exceeds the maximum of {0} rows; add a LIMIT to the query")]
+    ExportResultTooLarge(usize),
+
     #[error("Dataset is not indexed")]
     NotIndexed,
 

--- a/crates/liboxen/src/core/db/data_frames/df_db.rs
+++ b/crates/liboxen/src/core/db/data_frames/df_db.rs
@@ -722,6 +722,27 @@ pub fn select_raw_with_params<P: duckdb::Params>(
     Ok(df)
 }
 
+/// Like [`select_raw`], but returns `None` instead of a `DataFrame` when the
+/// result exceeds `max_rows`, and stops reading once it does.
+pub fn select_raw_capped(
+    conn: &duckdb::Connection,
+    stmt: &str,
+    max_rows: usize,
+) -> Result<Option<DataFrame>, DataFrameError> {
+    let mut records: Vec<RecordBatch> = Vec::new();
+    let mut total_rows: usize = 0;
+    let mut stmt = conn.prepare(stmt)?;
+    for batch in stmt.query_arrow([])? {
+        total_rows += batch.num_rows();
+        records.push(batch);
+        if total_rows > max_rows {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(record_batches_to_polars_df(records)?))
+}
+
 pub fn modify_row_with_polars_df(
     conn: &duckdb::Connection,
     table_name: &str,
@@ -1104,6 +1125,32 @@ mod tests {
             })?;
 
             remove_df_db_from_cache(&db_file)?;
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_select_raw_capped_refuses_results_over_the_cap() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let db_file = dir.join("data.db");
+            let conn = get_connection(&db_file)?;
+            conn.execute_batch("CREATE TABLE df AS SELECT * FROM range(5) t(x)")?;
+
+            // Result fits under the cap: full DataFrame is returned.
+            let under = select_raw_capped(&conn, "SELECT x FROM df", 10)?;
+            assert_eq!(
+                under.expect("expected a DataFrame under the cap").height(),
+                5
+            );
+
+            // Result exactly at the cap is still returned.
+            let at = select_raw_capped(&conn, "SELECT x FROM df", 5)?;
+            assert_eq!(at.expect("expected a DataFrame at the cap").height(), 5);
+
+            // Result over the cap is refused rather than materialized.
+            let over = select_raw_capped(&conn, "SELECT x FROM df", 4)?;
+            assert!(over.is_none(), "result over the cap must return None");
+
             Ok(())
         })
     }

--- a/crates/liboxen/src/core/db/data_frames/df_db.rs
+++ b/crates/liboxen/src/core/db/data_frames/df_db.rs
@@ -998,29 +998,6 @@ pub fn index_file_with_id(
     Ok(())
 }
 
-pub fn from_clause_from_disk_path(path: &Path) -> Result<String, DataFrameError> {
-    let extension: &str = &util::fs::extension_from_path(path);
-    match extension {
-        "csv" => {
-            let str_path = path.to_string_lossy().to_string();
-            Ok(format!("read_csv('{str_path}')"))
-        }
-        "tsv" => {
-            let str_path = path.to_string_lossy().to_string();
-            Ok(format!("read_csv('{str_path}')"))
-        }
-        "parquet" => {
-            let str_path = path.to_string_lossy().to_string();
-            Ok(format!("read_parquet('{str_path}')"))
-        }
-        "jsonl" | "json" | "ndjson" => {
-            let str_path = path.to_string_lossy().to_string();
-            Ok(format!("read_json('{str_path}')"))
-        }
-        _ => Err(DataFrameError::InvalidFileType),
-    }
-}
-
 pub fn preview(conn: &duckdb::Connection, table_name: &str) -> Result<DataFrame, DataFrameError> {
     let query = format!("SELECT * FROM {table_name} LIMIT 10");
     let df = select_raw(conn, &query)?;

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -1,4 +1,4 @@
-use crate::core::df::tabular::write_df_parquet;
+use crate::core::df::tabular::{write_df, write_df_parquet};
 use crate::model::merkle_tree::node::FileNodeWithDir;
 use crate::view::data_frames::columns::NewColumn;
 use polars::frame::DataFrame;
@@ -154,34 +154,38 @@ pub fn export(
     path: &Path,
     opts: &DFOpts,
     temp_file: &Path,
-) -> Result<(), DataFrameError> {
+) -> Result<(), OxenError> {
     let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
     log::debug!("export() got db_path: {db_path:?}");
 
-    with_df_db_manager(&db_path, |manager| {
-        manager.with_conn(|conn| {
-            let sql = if let Some(embedding_opts) = opts.get_sort_by_embedding_query() {
-                let exclude_cols = true;
-                repositories::workspaces::data_frames::embeddings::similarity_query_with_conn(
-                    conn,
-                    workspace,
-                    &embedding_opts,
-                    exclude_cols,
-                )?
-            } else if let Some(sql) = opts.sql.clone() {
-                add_exclude_to_sql(&sql)?
-            } else {
-                let sql = format!("SELECT * FROM {TABLE_NAME}");
-                add_exclude_to_sql(&sql)?
-            };
+    // Embeddings (vss extension) and the default full export use DuckDB's COPY
+    // writer on the read-write connection. Caller-supplied SQL runs on the hardened
+    // read-only connection and is serialized in Rust, never reaching the COPY path.
+    if let Some(embedding_opts) = opts.get_sort_by_embedding_query() {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| {
+                let sql =
+                    embeddings::similarity_query_with_conn(conn, workspace, &embedding_opts, true)?;
+                sql::export_df(conn, sql, Some(opts), temp_file)?;
+                Ok(())
+            })
+        })?;
+    } else if let Some(sql) = opts.sql.clone() {
+        let sql = add_exclude_to_sql(&sql)?;
+        log::debug!("exporting data frame with sql: {sql:?}");
+        let mut df = with_hardened_query_conn(&db_path, |conn| df_db::select_raw(conn, &sql))?;
+        write_df(&mut df, temp_file)?;
+    } else {
+        with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| {
+                let sql = add_exclude_to_sql(&format!("SELECT * FROM {TABLE_NAME}"))?;
+                sql::export_df(conn, sql, Some(opts), temp_file)?;
+                Ok(())
+            })
+        })?;
+    }
 
-            log::debug!("exporting data frame with sql: {sql:?}");
-
-            sql::export_df(conn, sql, Some(opts), temp_file)?;
-
-            Ok(())
-        })
-    })
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1657,6 +1661,51 @@ mod tests {
         Path::new("annotations")
             .join("train")
             .join("bounding_box.csv")
+    }
+
+    #[tokio::test]
+    async fn test_export_with_sql_cannot_read_host_files() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let path = list_typed_add_row_test_paths();
+            workspaces::data_frames::index(&repo, &workspace, &path).await?;
+
+            // A host file the export must not be able to read.
+            let secret = repo.path.join("secret.csv");
+            std::fs::write(&secret, "col\nvalue\n")?;
+
+            // Caller SQL that reads a host file runs on the hardened connection, so
+            // it is blocked and writes no output.
+            let out_bad = repo.path.join("bad_export.csv");
+            let mut malicious = DFOpts::empty();
+            malicious.sql = Some(format!(
+                "SELECT * FROM read_csv('{}')",
+                secret.to_string_lossy()
+            ));
+            assert!(
+                export(&workspace, &path, &malicious, &out_bad).is_err(),
+                "export must not read host files through caller SQL"
+            );
+            assert!(
+                !out_bad.exists(),
+                "a blocked export must write no output file"
+            );
+
+            // A normal caller-SQL export still writes its output.
+            let out_ok = repo.path.join("ok_export.csv");
+            let mut normal = DFOpts::empty();
+            normal.sql = Some(format!("SELECT * FROM {TABLE_NAME}"));
+            export(&workspace, &path, &normal, &out_ok)?;
+            assert!(out_ok.exists(), "a normal export must write an output file");
+
+            Ok(())
+        })
+        .await
     }
 
     #[tokio::test]

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -5,8 +5,8 @@ use polars::frame::DataFrame;
 
 use sql_query_builder::Select;
 
+use crate::constants::{MAX_QUERYABLE_ROWS, OXEN_COLS, TABLE_NAME};
 use crate::constants::{MODS_DIR, OXEN_HIDDEN_DIR};
-use crate::constants::{OXEN_COLS, TABLE_NAME};
 use crate::core;
 use crate::core::db::data_frames::df_db::{with_df_db_manager, with_hardened_query_conn};
 use crate::core::db::data_frames::{DataFrameError, df_db};
@@ -173,7 +173,13 @@ pub fn export(
     } else if let Some(sql) = opts.sql.clone() {
         let sql = add_exclude_to_sql(&sql)?;
         log::debug!("exporting data frame with sql: {sql:?}");
-        let mut df = with_hardened_query_conn(&db_path, |conn| df_db::select_raw(conn, &sql))?;
+        // Cap the export at MAX_QUERYABLE_ROWS rows; larger results are refused, not truncated.
+        let capped = with_hardened_query_conn(&db_path, |conn| {
+            df_db::select_raw_capped(conn, &sql, MAX_QUERYABLE_ROWS)
+        })?;
+        let Some(mut df) = capped else {
+            return Err(DataFrameError::ExportResultTooLarge(MAX_QUERYABLE_ROWS).into());
+        };
         write_df(&mut df, temp_file)?;
     } else {
         with_df_db_manager(&db_path, |manager| {

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -1693,9 +1693,11 @@ mod tests {
                 "SELECT * FROM read_csv('{}')",
                 secret.to_string_lossy()
             ));
+            let err = export(&workspace, &path, &malicious, &out_bad)
+                .expect_err("export must not read host files through caller SQL");
             assert!(
-                export(&workspace, &path, &malicious, &out_bad).is_err(),
-                "export must not read host files through caller SQL"
+                format!("{err}").contains("disabled by configuration"),
+                "expected an external-access error, got: {err}"
             );
             assert!(
                 !out_bad.exists(),


### PR DESCRIPTION
Data-frame export/download now runs caller-supplied query text on the hardened, read-only DuckDB connection and serializes the result in Rust. The query can read the indexed tables but cannot reach the host filesystem, other databases, or extensions. Embeddings and full-table exports keep the built-in DuckDB writer on the read-write connection. Also removes the unused `from_clause_from_disk_path` helper.

ENG-1335