### PR TITLE
Merkle LMDB (0.1): Resolve the merkle backend per repo, drop the env override

### DIFF
--- a/crates/liboxen/src/api/client/tree.rs
+++ b/crates/liboxen/src/api/client/tree.rs
@@ -513,11 +513,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_tree_from_path() -> Result<(), OxenError> {
-        // FS-pinned: this test counts node directories under the on-disk `tree/nodes` layout, which
-        // only the filesystem backend produces.
-        if test::skip_fs_pinned_under_lmdb() {
-            return Ok(());
-        }
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
             let commit = repositories::commits::head_commit(&local_repo)?;
             let remote_repo_clone = remote_repo.clone();
@@ -590,11 +585,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_trees_from() -> Result<(), OxenError> {
-        // FS-pinned: this test counts node directories under the on-disk `tree/nodes` layout, which
-        // only the filesystem backend produces.
-        if test::skip_fs_pinned_under_lmdb() {
-            return Ok(());
-        }
         test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
             let commit = repositories::commits::head_commit(&local_repo)?;
             let remote_repo_clone = remote_repo.clone();

--- a/crates/liboxen/src/command/migrate/m20260626_migrate_merkle_nodes_to_lmdb.rs
+++ b/crates/liboxen/src/command/migrate/m20260626_migrate_merkle_nodes_to_lmdb.rs
@@ -6,10 +6,9 @@
 //!   - **down** clears the FS node tree (the backup kept by `up`, which may have gone stale), copies
 //!     an LMDB-backed repo's nodes back into it, then removes the env.
 //!
-//! After `up`, `create_merkle_node_store` resolves the repo to the LMDB backend (it prefers an
-//! existing LMDB env over the FS tree), so the repo runs on LMDB from then on while the source
-//! directory stays untouched. The node blobs themselves are identical across backends — only their
-//! storage location changes.
+//! After `up`, the repo's config records the LMDB backend, so `create_merkle_node_store` resolves
+//! it to LMDB from then on while the source FS tree stays untouched. The node blobs themselves are
+//! identical across backends — only their storage location changes.
 //!
 //! Neither direction cleans up on error: a failed run leaves its partial artifacts on disk for
 //! inspection rather than rolling them back. Because the source backend always remains the repo's
@@ -264,11 +263,6 @@ mod tests {
     /// migrates back down to the filesystem — with the same node set throughout.
     #[tokio::test]
     async fn test_merkle_nodes_migrate_fs_to_lmdb_keeps_source_and_back() -> Result<(), OxenError> {
-        // FS-pinned: this exercises the FS→LMDB direction, so the repo must start on the filesystem
-        // backend regardless of the global `OXEN_MERKLE_NODE_BACKEND` default.
-        if test::skip_fs_pinned_under_lmdb() {
-            return Ok(());
-        }
         test::run_empty_dir_test_async(|dir| async move {
             let repo = test::init_fs_merkle_backend(&dir)?;
             // Commit a file so the repo has filesystem-backed merkle nodes.
@@ -365,11 +359,6 @@ mod tests {
     /// temp dir is left in place for inspection.
     #[tokio::test]
     async fn test_up_reports_leftover_temp_env_without_cleanup() -> Result<(), OxenError> {
-        // FS-pinned: `up` must start from the filesystem backend (not already on LMDB) for the
-        // leftover-temp-env guard to be the thing under test, regardless of the global default.
-        if test::skip_fs_pinned_under_lmdb() {
-            return Ok(());
-        }
         test::run_empty_dir_test_async(|dir| async move {
             let repo = test::init_fs_merkle_backend(&dir)?;
             let file = repo.path.join("a.txt");

--- a/crates/liboxen/src/config/repository_config.rs
+++ b/crates/liboxen/src/config/repository_config.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 use crate::constants::{DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
-use crate::core::db::merkle_node::MerkleNodeBackend;
+use crate::core::db::merkle_node::{DEFAULT_MERKLE_NODE_BACKEND, MerkleNodeBackend};
 use crate::error::OxenError;
 use crate::model::{LocalRepository, Remote};
 use crate::storage::StorageConfig;
@@ -51,13 +51,17 @@ pub struct RepositoryConfig {
     pub workspaces: Option<Vec<String>>,
     /// Which engine backs this repo's Merkle node store. The authoritative record of the repo's
     /// backend: written at `init` and updated by the file ↔ LMDB migration. `None` for repos whose
-    /// config predates the field, which fall back to on-disk evidence (see `create_merkle_node_store`).
+    /// config predates the field, which fall back to on-disk evidence — an FS node tree means
+    /// filesystem, else LMDB (see `create_merkle_node_store`).
     pub merkle_node_backend: Option<MerkleNodeBackend>,
 }
 
 impl Default for RepositoryConfig {
     /// Default matches what `oxen init` writes to a fresh repo's `config.toml`: the current
-    /// `MIN_OXEN_VERSION`, the default vnode size, and `None` for every per-repo override.
+    /// `MIN_OXEN_VERSION`, the default vnode size, the default merkle node backend, and `None` for
+    /// every other per-repo override. A config *loaded* from disk that predates the
+    /// `merkle_node_backend` field deserializes it as `None` (not via this default), so the backend
+    /// is resolved from on-disk data — see `create_merkle_node_store`.
     fn default() -> Self {
         RepositoryConfig {
             remote_name: None,
@@ -71,7 +75,7 @@ impl Default for RepositoryConfig {
             remote_mode: None,
             workspace_name: None,
             workspaces: None,
-            merkle_node_backend: None,
+            merkle_node_backend: Some(DEFAULT_MERKLE_NODE_BACKEND),
         }
     }
 }
@@ -133,6 +137,13 @@ mod tests {
 
     fn parse(toml_str: &str) -> RepositoryConfig {
         toml::from_str(toml_str).expect("test fixture must parse")
+    }
+
+    /// A config that predates the `merkle_node_backend` field deserializes it as `None` (not via
+    /// `Default`), so an existing repo's backend is resolved from on-disk data rather than assumed.
+    #[test]
+    fn missing_merkle_node_backend_deserializes_to_none() {
+        assert_eq!(parse("remotes = []\n").merkle_node_backend, None);
     }
 
     #[test]

--- a/crates/liboxen/src/core/db/merkle_node.rs
+++ b/crates/liboxen/src/core/db/merkle_node.rs
@@ -4,4 +4,6 @@ pub mod merkle_node_db;
 pub mod merkle_node_store;
 
 pub(crate) use merkle_node_db::MerkleNodeDB;
-pub(crate) use merkle_node_store::{MerkleNodeBackend, MerkleNodeStore, create_merkle_node_store};
+pub(crate) use merkle_node_store::{
+    DEFAULT_MERKLE_NODE_BACKEND, MerkleNodeBackend, MerkleNodeStore, create_merkle_node_store,
+};

--- a/crates/liboxen/src/core/db/merkle_node/fs_merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/fs_merkle_node_store.rs
@@ -28,6 +28,22 @@ impl FsMerkleNodeStore {
         }
     }
 
+    /// Whether a filesystem merkle node tree exists on disk for `repo_path`. Checks for the nodes
+    /// directory so a caller can pick a backend without touching node data.
+    pub(crate) fn exists_on_disk(repo_path: &Path) -> bool {
+        std::fs::metadata(Self::nodes_dir(repo_path))
+            .map(|meta| meta.is_dir())
+            .unwrap_or(false)
+    }
+
+    /// The nodes directory for the repo rooted at `repo_path` (`.oxen/tree/nodes`).
+    fn nodes_dir(repo_path: &Path) -> PathBuf {
+        repo_path
+            .join(constants::OXEN_HIDDEN_DIR)
+            .join(constants::TREE_DIR)
+            .join(constants::NODES_DIR)
+    }
+
     /// Read one of a node's files into owned bytes, mapping a missing file to
     /// [`MerkleDbError::MissingNodeDir`] so the absent-node contract matches across backends.
     fn read_blob(path: &Path, hash: &MerkleHash) -> Result<Bytes, MerkleDbError> {
@@ -85,11 +101,7 @@ impl MerkleNodeStore for FsMerkleNodeStore {
     }
 
     fn list_hashes(&self) -> Result<Vec<MerkleHash>, MerkleDbError> {
-        let nodes_dir = self
-            .repo_path
-            .join(constants::OXEN_HIDDEN_DIR)
-            .join(constants::TREE_DIR)
-            .join(constants::NODES_DIR);
+        let nodes_dir = Self::nodes_dir(&self.repo_path);
 
         // A repo with no committed nodes (e.g. freshly init'd) has no nodes dir yet.
         let prefix_entries = match std::fs::read_dir(&nodes_dir) {

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -35,8 +35,7 @@ use super::merkle_node_db::MerkleDbError;
 /// without a migration.
 ///
 /// Persisted per-repo as `merkle_node_backend` in `config.toml` (serialized lowercase:
-/// `"filesystem"` / `"lmdb"`), which records a repo's backend unless overridden by the
-/// `OXEN_MERKLE_NODE_BACKEND` environment variable — see [`create_merkle_node_store`] for how it's
+/// `"filesystem"` / `"lmdb"`); see [`create_merkle_node_store`] for how a repo's backend is
 /// resolved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -47,26 +46,8 @@ pub enum MerkleNodeBackend {
     Lmdb,
 }
 
-/// The global backend override, read from the `OXEN_MERKLE_NODE_BACKEND` environment variable
-/// (`"lmdb"` selects LMDB, `"filesystem"` selects the filesystem backend). When set, it takes
-/// precedence over every per-repo signal — the persisted config and the on-disk node data alike
-/// (see [`create_merkle_node_store`]). Setting it to a backend that disagrees with where a repo's
-/// nodes actually live will make that repo read from an empty store, so it is a deliberate global
-/// switch, not a safety net.
-const MERKLE_NODE_BACKEND_ENV: &str = "OXEN_MERKLE_NODE_BACKEND";
-
-impl MerkleNodeBackend {
-    /// The backend named by the environment, or `None` when the variable is unset or empty.
-    /// `"lmdb"` selects LMDB; any other non-empty value selects the filesystem backend.
-    pub(crate) fn from_env() -> Option<Self> {
-        match std::env::var(MERKLE_NODE_BACKEND_ENV) {
-            Ok(value) if value.trim().is_empty() => None,
-            Ok(value) if value.trim().eq_ignore_ascii_case("lmdb") => Some(MerkleNodeBackend::Lmdb),
-            Ok(_) => Some(MerkleNodeBackend::Filesystem),
-            Err(_) => None,
-        }
-    }
-}
+/// The backend a newly created repo uses when the caller doesn't request a specific one.
+pub(crate) const DEFAULT_MERKLE_NODE_BACKEND: MerkleNodeBackend = MerkleNodeBackend::Filesystem;
 
 /// Engine-agnostic persistence for Merkle tree node bytes, keyed by [`MerkleHash`]. A node is two
 /// blobs (`node` + `children`); see the module docs for the layout. Implementations persist and
@@ -134,20 +115,18 @@ pub(crate) trait MerkleNodeStore: Debug + Send + Sync {
 
 /// Build the node store for the repo rooted at `repo_path`, choosing the backend once at repo
 /// construction (mirroring [`create_version_store`](crate::storage::create_version_store)).
-/// `configured` is the repo's persisted `merkle_node_backend` from `config.toml` (`None` for repos
-/// whose config predates the field). Returns the store alongside the backend it resolved to, so the
-/// caller can persist the choice.
+/// `configured` is the repo's persisted `merkle_node_backend` from `config.toml`. Returns the store
+/// alongside the backend it resolved to, so the caller can persist the choice.
 ///
-/// The backend comes from exactly two places: the [`OXEN_MERKLE_NODE_BACKEND`] environment override
-/// and the persisted `config.toml` value. The environment override wins when set; otherwise the
-/// config value is used; otherwise the filesystem default applies. The choice is never inferred from
-/// node data on disk, so pointing either knob at a backend that disagrees with where a repo's nodes
-/// actually live makes the repo read from an empty store.
+/// The persisted config is authoritative. When it is absent (`None`, for a repo whose config
+/// predates the field) the backend is inferred from on-disk data: an FS node tree under
+/// `.oxen/tree/nodes` means the filesystem backend, otherwise LMDB. New repos record their backend
+/// at `init` ([`DEFAULT_MERKLE_NODE_BACKEND`]), so this inference only applies to legacy repos.
 pub(crate) fn create_merkle_node_store(
     repo_path: &Path,
     configured: Option<MerkleNodeBackend>,
 ) -> Result<(Arc<dyn MerkleNodeStore>, MerkleNodeBackend), OxenError> {
-    let backend = resolve_backend(MerkleNodeBackend::from_env(), configured);
+    let backend = resolve_load_backend(configured, repo_path);
     let store: Arc<dyn MerkleNodeStore> = match backend {
         MerkleNodeBackend::Lmdb => Arc::new(LmdbMerkleNodeStore::new(repo_path)?),
         MerkleNodeBackend::Filesystem => Arc::new(FsMerkleNodeStore::new(repo_path)),
@@ -155,53 +134,64 @@ pub(crate) fn create_merkle_node_store(
     Ok((store, backend))
 }
 
-/// Decide a repo's backend: the environment override if set, else the persisted config value, else
-/// the filesystem default. See [`create_merkle_node_store`] for the rationale.
-fn resolve_backend(
-    env_override: Option<MerkleNodeBackend>,
+/// Resolve an existing repo's backend: the persisted `configured` value if present, else inferred
+/// from on-disk data — an FS node tree ⇒ filesystem, otherwise LMDB.
+fn resolve_load_backend(
     configured: Option<MerkleNodeBackend>,
+    repo_path: &Path,
 ) -> MerkleNodeBackend {
-    env_override
-        .or(configured)
-        .unwrap_or(MerkleNodeBackend::Filesystem)
+    configured.unwrap_or_else(|| {
+        if FsMerkleNodeStore::exists_on_disk(repo_path) {
+            MerkleNodeBackend::Filesystem
+        } else {
+            MerkleNodeBackend::Lmdb
+        }
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The environment override wins over the persisted config, and over both backends.
+    /// The persisted config is authoritative when present, regardless of on-disk data.
     #[test]
-    fn resolve_backend_env_override_wins() {
+    fn resolve_load_backend_uses_config_when_set() {
+        let dir = tempfile::tempdir().expect("create temp dir");
         assert_eq!(
-            resolve_backend(
-                Some(MerkleNodeBackend::Filesystem),
-                Some(MerkleNodeBackend::Lmdb)
-            ),
-            MerkleNodeBackend::Filesystem
+            resolve_load_backend(Some(MerkleNodeBackend::Lmdb), dir.path()),
+            MerkleNodeBackend::Lmdb
         );
         assert_eq!(
-            resolve_backend(
-                Some(MerkleNodeBackend::Lmdb),
-                Some(MerkleNodeBackend::Filesystem)
-            ),
-            MerkleNodeBackend::Lmdb
+            resolve_load_backend(Some(MerkleNodeBackend::Filesystem), dir.path()),
+            MerkleNodeBackend::Filesystem
         );
     }
 
-    /// With no environment override, the persisted config decides; with neither, the filesystem
-    /// default applies.
+    /// With no persisted config, an on-disk FS node tree resolves to the filesystem backend.
     #[test]
-    fn resolve_backend_falls_back_to_config_then_default() {
+    fn resolve_load_backend_detects_fs_tree() -> Result<(), OxenError> {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        // Writing a node creates the `.oxen/tree/nodes` tree the detector looks for.
+        FsMerkleNodeStore::new(dir.path()).write_node(
+            &MerkleHash::new(0x1),
+            Bytes::from_static(b"n"),
+            Bytes::new(),
+        )?;
         assert_eq!(
-            resolve_backend(None, Some(MerkleNodeBackend::Lmdb)),
-            MerkleNodeBackend::Lmdb
-        );
-        assert_eq!(
-            resolve_backend(None, Some(MerkleNodeBackend::Filesystem)),
+            resolve_load_backend(None, dir.path()),
             MerkleNodeBackend::Filesystem
         );
-        assert_eq!(resolve_backend(None, None), MerkleNodeBackend::Filesystem);
+        Ok(())
+    }
+
+    /// With no persisted config and no FS node tree, resolution falls back to LMDB.
+    #[test]
+    fn resolve_load_backend_falls_back_to_lmdb() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        assert_eq!(
+            resolve_load_backend(None, dir.path()),
+            MerkleNodeBackend::Lmdb
+        );
     }
 
     /// `MerkleNodeBackend` serializes to the lowercase tokens persisted in `config.toml`.

--- a/crates/liboxen/src/core/v_latest/init.rs
+++ b/crates/liboxen/src/core/v_latest/init.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::config::RepositoryConfig;
+use crate::core::db::merkle_node::DEFAULT_MERKLE_NODE_BACKEND;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::LocalRepository;
@@ -39,6 +40,7 @@ pub fn init_with_version_default(
 
     let config = RepositoryConfig {
         min_version: Some(version.to_string()),
+        merkle_node_backend: Some(DEFAULT_MERKLE_NODE_BACKEND),
         ..Default::default()
     };
     let repo = LocalRepository::new(path, config)?;
@@ -63,6 +65,7 @@ pub async fn init_with_version_and_storage_config(
     let config = RepositoryConfig {
         min_version: Some(version.to_string()),
         storage: storage_config,
+        merkle_node_backend: Some(DEFAULT_MERKLE_NODE_BACKEND),
         ..Default::default()
     };
     let repo = LocalRepository::new(path, config)?;

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -1,7 +1,9 @@
 use crate::config::RepositoryConfig;
 use crate::constants::SHALLOW_FLAG;
 use crate::constants::{self, DEFAULT_VNODE_SIZE};
-use crate::core::db::merkle_node::{MerkleNodeBackend, MerkleNodeStore, create_merkle_node_store};
+use crate::core::db::merkle_node::{
+    DEFAULT_MERKLE_NODE_BACKEND, MerkleNodeBackend, MerkleNodeStore, create_merkle_node_store,
+};
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
@@ -201,7 +203,8 @@ impl LocalRepository {
         let path = std::env::current_dir()?.join(view.name);
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config, None)?;
-        let (merkle_node_store, merkle_node_backend) = create_merkle_node_store(&path, None)?;
+        let (merkle_node_store, merkle_node_backend) =
+            create_merkle_node_store(&path, Some(DEFAULT_MERKLE_NODE_BACKEND))?;
         Ok(LocalRepository {
             path,
             remotes: vec![],
@@ -226,7 +229,8 @@ impl LocalRepository {
         let path = path.to_owned();
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config, None)?;
-        let (merkle_node_store, merkle_node_backend) = create_merkle_node_store(&path, None)?;
+        let (merkle_node_store, merkle_node_backend) =
+            create_merkle_node_store(&path, Some(DEFAULT_MERKLE_NODE_BACKEND))?;
         Ok(LocalRepository {
             path,
             remotes: vec![repo.remote],

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -329,6 +329,7 @@ mod tests {
     use crate::api::requests::RepoNew;
     use crate::config::UserConfig;
     use crate::constants;
+    use crate::core::db::merkle_node::MerkleNodeBackend;
     use crate::error::OxenError;
     use crate::model::file::{FileContents, FileNew};
     use crate::model::{Commit, LocalRepository};
@@ -532,6 +533,17 @@ mod tests {
                 other => panic!("Expected InvalidRepoName error, got: {other:?}"),
             }
 
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_create_defaults_to_filesystem_backend() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|sync_dir| async move {
+            let repo_new = RepoNew::from_namespace_name("ns", "repo", None);
+            let repo = repositories::create(&sync_dir, repo_new, None).await?;
+            assert_eq!(repo.merkle_node_backend(), MerkleNodeBackend::Filesystem);
             Ok(())
         })
         .await

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -2937,11 +2937,6 @@ mod tests {
     /// silent `id.len() == 32` gate that dropped these entries.
     #[tokio::test]
     async fn test_unpack_recovers_hash_with_leading_zero_nibbles() -> Result<(), OxenError> {
-        // FS-pinned: this asserts on the short-hex hash recovered from the on-disk `tree/nodes`
-        // path layout, which only the filesystem backend produces.
-        if test::skip_fs_pinned_under_lmdb() {
-            return Ok(());
-        }
         test::run_empty_dir_test_async(|dir| async move {
             let repo = test::init_fs_merkle_backend(&dir)?;
             // Pick a small `u128` whose hex form is much shorter than 32 chars.

--- a/crates/liboxen/src/test.rs
+++ b/crates/liboxen/src/test.rs
@@ -424,10 +424,10 @@ where
     Ok(())
 }
 
-/// Init a repo pinned to the filesystem Merkle node backend, ignoring the global
-/// `OXEN_MERKLE_NODE_BACKEND` default. For tests whose assertions read the on-disk `tree/nodes`
-/// layout — the wire-format byte-compat oracles and the FS→LMDB migration source — which only the
-/// filesystem backend produces. Persists `merkle_node_backend = filesystem` to `config.toml`, the
+/// Init a repo pinned to the filesystem Merkle node backend. For tests whose assertions read the
+/// on-disk `tree/nodes` layout — the wire-format byte-compat oracles and the FS→LMDB migration
+/// source — which only the filesystem backend produces. Persists `merkle_node_backend = filesystem`
+/// to `config.toml`, the
 /// authoritative record `create_merkle_node_store` resolves from. Pair with
 /// [`run_empty_dir_test_async`] for empty repos, or use
 /// [`run_one_commit_local_repo_test_async_fs_backend`] when one committed file is needed.
@@ -449,28 +449,9 @@ pub fn init_fs_merkle_backend(path: &Path) -> Result<LocalRepository, OxenError>
     Ok(repo)
 }
 
-/// Whether a filesystem-pinned test must skip because the global `OXEN_MERKLE_NODE_BACKEND` override
-/// selects LMDB. The wire-format byte-compat oracles and the FS→LMDB migration source read the
-/// on-disk `tree/nodes` layout that only the filesystem backend produces. The env override outranks
-/// the per-repo config that [`init_fs_merkle_backend`] persists (see `resolve_backend` in
-/// `core::db::merkle_node`), so under it these tests cannot pin the filesystem backend and must skip
-/// rather than fail. Logs the skip, keyed by the nextest thread name (the test's path). The CI
-/// filesystem job leaves the variable unset, so they still run there.
-pub fn skip_fs_pinned_under_lmdb() -> bool {
-    if matches!(MerkleNodeBackend::from_env(), Some(MerkleNodeBackend::Lmdb)) {
-        let handle = std::thread::current();
-        let name = handle.name().unwrap_or("filesystem-pinned test");
-        log::warn!("skipping `{name}`: OXEN_MERKLE_NODE_BACKEND forces the LMDB backend");
-        return true;
-    }
-    false
-}
-
 /// Like [`run_one_commit_local_repo_test_async`], but pins the repo to the filesystem Merkle node
-/// backend regardless of the global `OXEN_MERKLE_NODE_BACKEND` default (see
-/// [`init_fs_merkle_backend`]). Skips when the env override forces LMDB (see
-/// [`skip_fs_pinned_under_lmdb`]). For empty repos, use [`run_empty_dir_test_async`] +
-/// [`init_fs_merkle_backend`] directly, guarding the body with [`skip_fs_pinned_under_lmdb`].
+/// backend (see [`init_fs_merkle_backend`]). For empty repos, use [`run_empty_dir_test_async`] +
+/// [`init_fs_merkle_backend`] directly.
 pub async fn run_one_commit_local_repo_test_async_fs_backend<T, Fut>(
     test: T,
 ) -> Result<(), OxenError>
@@ -479,9 +460,6 @@ where
     Fut: Future<Output = Result<(), OxenError>>,
 {
     init_test_env();
-    if skip_fs_pinned_under_lmdb() {
-        return Ok(());
-    }
     let repo_dir = create_repo_dir(test_run_dir())?;
     let repo = init_fs_merkle_backend(&repo_dir)?;
 


### PR DESCRIPTION
A repository's merkle node backend is now decided from the repository itself. Its persisted `config.toml` is authoritative, and a repo whose config predates determines which merkle backend is used from its on-disk data. An existing filesystem node tree means the filesystem backend, otherwise LMDB. This drops the `OXEN_MERKLE_NODE_BACKEND` environment variable, a process-wide override that could point every repo on a server at the wrong store and make them read as empty. The backend is no longer a global switch that can silently disagree with where a repo's nodes actually live.

Resolving an existing repo's merkle tree backend is now separate from choosing a new repo's backend. New repos record a single default in their config at init, so the on-disk inference only ever applies to legacy repos. The default is unchanged (new repos are still filesystem-backed) so this is behavior-neutral groundwork for making LMDB the production backend.