### PR TITLE
Keep large pushes alive by streaming heartbeats during tree-node unpack

### DIFF
--- a/crates/oxen-server/src/controllers/tree.rs
+++ b/crates/oxen-server/src/controllers/tree.rs
@@ -21,7 +21,7 @@ use liboxen::view::tree::nodes::{
 };
 
 use crate::errors::OxenHttpError;
-use crate::helpers::get_repo;
+use crate::helpers::{get_repo, stream_with_heartbeat};
 use crate::params::TreeDepthQuery;
 use crate::params::parse_resource;
 use crate::params::{app_data, path_param};
@@ -189,11 +189,15 @@ pub async fn create_nodes(
     // Unpacking decompresses the archive and writes every node to the store. That is blocking CPU
     // and disk work, and it takes longer the bigger the tree is. Run it on the blocking pool so a
     // large tree never stalls the async workers that serve every other request this server handles.
-    tokio::task::spawn_blocking(move || repositories::tree::unpack_nodes(&repository, &bytes[..]))
+    // The connection is silent for the whole unpack, so stream heartbeats to hold idle timers off.
+    Ok(stream_with_heartbeat(async move {
+        tokio::task::spawn_blocking(move || {
+            repositories::tree::unpack_nodes(&repository, &bytes[..])
+        })
         .await
         .map_err(|e| OxenError::basic_str(format!("create_nodes unpack task panicked: {e}")))??;
-
-    Ok(HttpResponse::Ok().json(StatusMessage::resource_found()))
+        Ok(StatusMessage::resource_found())
+    }))
 }
 
 #[tracing::instrument(skip_all)]

--- a/crates/oxen-server/src/helpers.rs
+++ b/crates/oxen-server/src/helpers.rs
@@ -1,10 +1,19 @@
 // use liboxen::constants::DEFAULT_REDIS_URL;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
 use actix_web::http::header;
+use actix_web::web::Bytes;
 use actix_web::{HttpResponse, HttpResponseBuilder};
+use futures_util::stream;
 use liboxen::api::requests::RepoNew;
 use liboxen::error::OxenError;
 use liboxen::model::{LocalRepository, User};
 use liboxen::repositories;
+use liboxen::view::StatusMessage;
+use serde::Serialize;
+use tokio::time::{Interval, interval};
 
 use crate::app_data::OxenAppData;
 use crate::errors::OxenHttpError;
@@ -92,6 +101,100 @@ pub fn file_stream_response(
     response
 }
 
+/// Interval between newline keep-alive bytes emitted while a long operation runs.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Stream `work`'s JSON result, emitting a newline keep-alive byte every [`HEARTBEAT_INTERVAL`]
+/// until it finishes. The leading newlines keep the idle timers along the connection (proxy, load
+/// balancer, client) from firing during the silent stretch while the server processes a request,
+/// and every JSON parser skips leading whitespace, so the client reads the final body unchanged.
+///
+/// The `200 OK` status commits with the first byte, so a failure once the work has started is
+/// reported as a `StatusMessage::error` in the body — which the client still reads as a failure via
+/// the body's `status` field — rather than as an error status code. `work` must own everything it
+/// captures (`'static`); resolve the repo and read the request body before calling this so those
+/// failures still return a real error status.
+pub fn stream_with_heartbeat<F, T>(work: F) -> HttpResponse
+where
+    F: Future<Output = Result<T, OxenError>> + 'static,
+    T: Serialize + 'static,
+{
+    stream_with_heartbeat_every(work, HEARTBEAT_INTERVAL)
+}
+
+/// [`stream_with_heartbeat`] with an explicit heartbeat interval (tests use a short one).
+fn stream_with_heartbeat_every<F, T>(work: F, heartbeat_interval: Duration) -> HttpResponse
+where
+    F: Future<Output = Result<T, OxenError>> + 'static,
+    T: Serialize + 'static,
+{
+    enum State<F> {
+        Running { work: Pin<Box<F>>, ticker: Interval },
+        Done,
+    }
+
+    let body = stream::unfold(
+        State::Running {
+            work: Box::pin(work),
+            ticker: interval(heartbeat_interval),
+        },
+        |state| async move {
+            let State::Running {
+                mut work,
+                mut ticker,
+            } = state
+            else {
+                return None;
+            };
+            // Poll the work first: a fast (or already-failed) operation returns its result on the
+            // first step with no heartbeat; otherwise emit a newline and keep waiting.
+            tokio::select! {
+                biased;
+                result = work.as_mut() => {
+                    Some((Ok(result_to_json_bytes(result)), State::Done))
+                }
+                _ = ticker.tick() => {
+                    Some((
+                        Ok::<Bytes, std::io::Error>(Bytes::from_static(b"\n")),
+                        State::Running { work, ticker },
+                    ))
+                }
+            }
+        },
+    );
+
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .streaming(body)
+}
+
+/// Serialize a heartbeat operation's outcome: the value on success, or a `StatusMessage::error`
+/// (which the client reads as a failure) on error.
+fn result_to_json_bytes<T: Serialize>(result: Result<T, OxenError>) -> Bytes {
+    match result {
+        Ok(value) => match serde_json::to_vec(&value) {
+            Ok(bytes) => Bytes::from(bytes),
+            Err(err) => {
+                log::error!("failed to serialize heartbeat response body: {err}");
+                error_status_bytes(&format!("failed to serialize response: {err}"))
+            }
+        },
+        Err(err) => {
+            log::error!("operation behind heartbeat stream failed: {err}");
+            error_status_bytes(&err.to_string())
+        }
+    }
+}
+
+fn error_status_bytes(message: &str) -> Bytes {
+    match serde_json::to_vec(&StatusMessage::error(message)) {
+        Ok(bytes) => Bytes::from(bytes),
+        Err(_) => Bytes::from_static(
+            b"{\"status\":\"error\",\"status_message\":\"internal serialization error\"}",
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,6 +232,55 @@ mod tests {
             values,
             vec!["X-Existing-Header", header::CONTENT_LENGTH.as_str()]
         );
+    }
+
+    // A slow operation streams leading newline heartbeats, then its JSON result — and the whole
+    // body still deserializes (leading whitespace is skipped), the way the client parses it.
+    #[actix_web::test]
+    async fn test_stream_with_heartbeat_emits_newlines_then_json() {
+        let work = async {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            Ok(StatusMessage::success("done"))
+        };
+        let response = stream_with_heartbeat_every(work, Duration::from_millis(15));
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("collect body");
+
+        assert!(body.starts_with(b"\n"), "expected a leading heartbeat byte");
+        let parsed: StatusMessage = serde_json::from_slice(&body).expect("body parses as JSON");
+        assert_eq!(parsed.status, "success");
+    }
+
+    // A failure once the work has started is reported in the body as an error StatusMessage.
+    #[actix_web::test]
+    async fn test_stream_with_heartbeat_reports_error_in_body() {
+        let work = async { Err::<StatusMessage, _>(OxenError::basic_str("boom")) };
+        let response = stream_with_heartbeat_every(work, Duration::from_millis(15));
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("collect body");
+
+        let parsed: StatusMessage = serde_json::from_slice(&body).expect("error body parses");
+        assert_eq!(parsed.status, "error");
+        assert!(parsed.status_message.contains("boom"));
+    }
+
+    // A fast operation finishes before the first tick, so it emits its result with no heartbeat.
+    #[actix_web::test]
+    async fn test_stream_with_heartbeat_fast_op_emits_no_heartbeat() {
+        let work = async { Ok(StatusMessage::success("done")) };
+        let response = stream_with_heartbeat_every(work, Duration::from_millis(15));
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("collect body");
+
+        assert!(
+            !body.starts_with(b"\n"),
+            "a fast operation should emit no heartbeat"
+        );
+        let parsed: StatusMessage = serde_json::from_slice(&body).expect("body parses as JSON");
+        assert_eq!(parsed.status, "success");
     }
 }
 


### PR DESCRIPTION
Stream a newline "heartbeat" byte every 15 seconds while `POST /tree/nodes` unpacks, then send the JSON result as the final bytes, so idle timers keep resetting and an arbitrarily long unpack stays alive.

Large `oxen push` operations could fail with a 502 when the server went silent unpacking an uploaded merkle tree: with no bytes on the connection, the idle timers along the path could kill the request mid-operation. 

Leading whitespace is skipped by every JSON parser, so the client reads the final body unchanged. This needs no client, proxy, or frontend change and no minimum-version bump. The request body is drained before the response starts, so heartbeats cover only the silent unpack and the request is never read while the response streams.

Because the 200 status commits with the first heartbeat byte, a failure once the unpack has started is reported as an error in the response body (which the client still reads as a failure) rather than as an error status code.