### PR TITLE
Fix NFS test failures by draining response bodies before cleanup

### DIFF
--- a/crates/oxen-server/src/controllers/file.rs
+++ b/crates/oxen-server/src/controllers/file.rs
@@ -909,6 +909,10 @@ mod tests {
             header::CONTENT_LENGTH.as_str()
         );
 
+        // Drain the body to close the streamed file handle before cleanup; on NFS an
+        // unlinked-but-still-open file lingers as .nfsXXXX and the rmdir fails with ENOTEMPTY.
+        actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+
         test::cleanup_repo_and_sync_dir(repo, &sync_dir)?;
         Ok(())
     }

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -723,6 +723,10 @@ mod tests {
             header::CONTENT_LENGTH.as_str()
         );
 
+        // Drain the body to close the streamed file handle before cleanup; on NFS an
+        // unlinked-but-still-open file lingers as .nfsXXXX and the rmdir fails with ENOTEMPTY.
+        actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+
         test::cleanup_repo_and_sync_dir(repo, &sync_dir)?;
         Ok(())
     }


### PR DESCRIPTION
This is a test-only fix.

Draining each response body before cleanup closes the handle first as every other file-download test in these modules already does, making the tests pass again.

Two tests asserted content-length headers but never read the response body, so the streamed response and its still-open handle to the version blob stayed alive while the repo directory was torn down. On NFS, unlinking a file a process still holds open leaves a hidden .nfsXXXX entry behind, so the follow-up rmdir fails with ENOTEMPTY and the test errors out.