### PR TITLE
Merkle LMDB (0.2): Select a repo's Merkle node backend at creation

### DIFF
--- a/crates/liboxen/src/api/requests/repo_new.rs
+++ b/crates/liboxen/src/api/requests/repo_new.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::constants::DEFAULT_HOST;
+use crate::core::db::merkle_node::MerkleNodeBackend;
 use crate::error::OxenError;
 use crate::model::commit::Commit;
 use crate::model::file::FileNew;
@@ -36,6 +37,9 @@ pub struct RepoNew {
     /// Which storage backend the server should use for this repo (e.g. "local", "s3").
     #[serde(default)]
     pub storage_kind: Option<StorageKind>,
+    /// Which engine backs the repo's Merkle node store. `None` uses the server's default.
+    #[serde(default)]
+    pub merkle_node_backend: Option<MerkleNodeBackend>,
 }
 
 impl std::fmt::Display for RepoNew {
@@ -85,6 +89,7 @@ impl RepoNew {
             description: None,
             files: None,
             storage_kind,
+            merkle_node_backend: None,
         })
     }
 
@@ -112,6 +117,7 @@ impl RepoNew {
             description: None,
             files: None,
             storage_kind,
+            merkle_node_backend: None,
         }
     }
 
@@ -131,6 +137,7 @@ impl RepoNew {
             description: None,
             files: None,
             storage_kind,
+            merkle_node_backend: None,
         }
     }
 
@@ -149,6 +156,7 @@ impl RepoNew {
             description: None,
             files: None,
             storage_kind: None,
+            merkle_node_backend: None,
         }
     }
 
@@ -168,6 +176,7 @@ impl RepoNew {
             description: None,
             files: Some(files),
             storage_kind,
+            merkle_node_backend: None,
         }
     }
 
@@ -196,6 +205,29 @@ impl RepoNew {
             description: None,
             files: None,
             storage_kind: None,
+            merkle_node_backend: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merkle_node_backend_round_trips_through_json() {
+        let mut repo = RepoNew::from_namespace_name("ns", "repo", None);
+        repo.merkle_node_backend = Some(MerkleNodeBackend::Lmdb);
+        let json = serde_json::to_string(&repo).expect("serialize");
+        let parsed: RepoNew = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.merkle_node_backend, Some(MerkleNodeBackend::Lmdb));
+    }
+
+    /// An older client omits the field entirely; the server reads it as "no preference".
+    #[test]
+    fn missing_merkle_node_backend_deserializes_to_none() {
+        let parsed: RepoNew =
+            serde_json::from_str(r#"{"namespace":"ns","name":"repo"}"#).expect("deserialize");
+        assert_eq!(parsed.merkle_node_backend, None);
     }
 }

--- a/crates/liboxen/src/core/db/merkle_node.rs
+++ b/crates/liboxen/src/core/db/merkle_node.rs
@@ -3,7 +3,9 @@ pub mod lmdb_merkle_node_store;
 pub mod merkle_node_db;
 pub mod merkle_node_store;
 
+pub use merkle_node_store::MerkleNodeBackend;
+
 pub(crate) use merkle_node_db::MerkleNodeDB;
 pub(crate) use merkle_node_store::{
-    DEFAULT_MERKLE_NODE_BACKEND, MerkleNodeBackend, MerkleNodeStore, create_merkle_node_store,
+    DEFAULT_MERKLE_NODE_BACKEND, MerkleNodeStore, create_merkle_node_store,
 };

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::error::OxenError;
 use crate::model::MerkleHash;
@@ -37,13 +38,25 @@ use super::merkle_node_db::MerkleDbError;
 /// Persisted per-repo as `merkle_node_backend` in `config.toml` (serialized lowercase:
 /// `"filesystem"` / `"lmdb"`); see [`create_merkle_node_store`] for how a repo's backend is
 /// resolved.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum MerkleNodeBackend {
     /// Two files per node under `.oxen/tree/nodes` (the historical, default backend).
     Filesystem,
     /// One LMDB env under `.oxen/tree/nodes_lmdb`.
     Lmdb,
+}
+
+impl std::str::FromStr for MerkleNodeBackend {
+    type Err = OxenError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "filesystem" => Ok(MerkleNodeBackend::Filesystem),
+            "lmdb" => Ok(MerkleNodeBackend::Lmdb),
+            other => Err(OxenError::UnsupportedMerkleNodeBackend(other.to_string())),
+        }
+    }
 }
 
 /// The backend a newly created repo uses when the caller doesn't request a specific one.

--- a/crates/liboxen/src/core/v_latest/init.rs
+++ b/crates/liboxen/src/core/v_latest/init.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::config::RepositoryConfig;
-use crate::core::db::merkle_node::DEFAULT_MERKLE_NODE_BACKEND;
+use crate::core::db::merkle_node::{DEFAULT_MERKLE_NODE_BACKEND, MerkleNodeBackend};
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::LocalRepository;
@@ -53,6 +53,7 @@ pub async fn init_with_version_and_storage_config(
     path: &Path,
     version: MinOxenVersion,
     storage_config: Option<StorageConfig>,
+    merkle_backend: Option<MerkleNodeBackend>,
 ) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
 
@@ -65,7 +66,7 @@ pub async fn init_with_version_and_storage_config(
     let config = RepositoryConfig {
         min_version: Some(version.to_string()),
         storage: storage_config,
-        merkle_node_backend: Some(DEFAULT_MERKLE_NODE_BACKEND),
+        merkle_node_backend: Some(merkle_backend.unwrap_or(DEFAULT_MERKLE_NODE_BACKEND)),
         ..Default::default()
     };
     let repo = LocalRepository::new(path, config)?;

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -274,6 +274,10 @@ pub enum OxenError {
     #[error("Unsupported storage kind: {0}")]
     UnsupportedStorageKind(String),
 
+    /// A caller supplied a Merkle node backend that isn't recognized.
+    #[error("Unsupported Merkle node backend: {0}. Expected 'filesystem' or 'lmdb'.")]
+    UnsupportedMerkleNodeBackend(String),
+
     /// An S3-backed repo was requested but the server has no S3 opts configured (the
     /// `s3_bucket` is unset in the server's TOML). On the repo-create path this normally surfaces
     /// as a 400 from `StoragePolicy::resolve()` before construction; this variant catches the

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -6,6 +6,7 @@
 use crate::api::requests::RepoNew;
 use crate::constants;
 use crate::core;
+use crate::core::db::merkle_node::DEFAULT_MERKLE_NODE_BACKEND;
 use crate::core::refs::with_ref_manager;
 use crate::error::OxenError;
 use crate::model::Commit;
@@ -242,6 +243,11 @@ pub async fn create(
                 kind,
                 versions_path: None,
             }),
+        merkle_node_backend: Some(
+            new_repo
+                .merkle_node_backend
+                .unwrap_or(DEFAULT_MERKLE_NODE_BACKEND),
+        ),
         ..Default::default()
     };
     let local_repo = LocalRepository::new_with_server_opts(&repo_dir, config, server_s3_opts)?;
@@ -544,6 +550,18 @@ mod tests {
             let repo_new = RepoNew::from_namespace_name("ns", "repo", None);
             let repo = repositories::create(&sync_dir, repo_new, None).await?;
             assert_eq!(repo.merkle_node_backend(), MerkleNodeBackend::Filesystem);
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_create_honors_requested_merkle_backend() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|sync_dir| async move {
+            let mut repo_new = RepoNew::from_namespace_name("ns", "repo", None);
+            repo_new.merkle_node_backend = Some(MerkleNodeBackend::Lmdb);
+            let repo = repositories::create(&sync_dir, repo_new, None).await?;
+            assert_eq!(repo.merkle_node_backend(), MerkleNodeBackend::Lmdb);
             Ok(())
         })
         .await

--- a/crates/liboxen/src/repositories/init.rs
+++ b/crates/liboxen/src/repositories/init.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 use crate::constants::MIN_OXEN_VERSION;
 use crate::core;
+use crate::core::db::merkle_node::MerkleNodeBackend;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
 use crate::model::LocalRepository;
@@ -37,16 +38,23 @@ pub async fn init_with_storage_config(
     path: impl AsRef<Path>,
     storage_config: Option<StorageConfig>,
 ) -> Result<LocalRepository, OxenError> {
-    init_with_version_and_storage_config(path, MIN_OXEN_VERSION, storage_config).await
+    init_with_version_and_storage_config(path, MIN_OXEN_VERSION, storage_config, None).await
 }
 
 pub async fn init_with_version_and_storage_config(
     path: impl AsRef<Path>,
     version: MinOxenVersion,
     storage_config: Option<StorageConfig>,
+    merkle_backend: Option<MerkleNodeBackend>,
 ) -> Result<LocalRepository, OxenError> {
     let path = path.as_ref();
-    core::v_latest::init_with_version_and_storage_config(path, version, storage_config).await
+    core::v_latest::init_with_version_and_storage_config(
+        path,
+        version,
+        storage_config,
+        merkle_backend,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/oxen-cli/src/cmd/create_remote.rs
+++ b/crates/oxen-cli/src/cmd/create_remote.rs
@@ -9,6 +9,7 @@ use liboxen::api;
 use liboxen::api::requests::RepoNew;
 use liboxen::config::UserConfig;
 use liboxen::constants::{DEFAULT_HOST, DEFAULT_SCHEME};
+use liboxen::core::db::merkle_node::MerkleNodeBackend;
 use liboxen::model::file::{FileContents, FileNew};
 use liboxen::storage::StorageKind;
 
@@ -68,6 +69,13 @@ impl RunCmd for CreateRemoteCmd {
                 .value_parser(["local", "s3"])
                 .action(clap::ArgAction::Set),
         )
+        .arg(
+            Arg::new("merkle-backend")
+                .long("merkle-backend")
+                .help("Which engine backs the remote repo's Merkle node store (default: the server's default)")
+                .value_parser(["filesystem", "lmdb"])
+                .action(clap::ArgAction::Set),
+        )
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
@@ -81,6 +89,11 @@ impl RunCmd for CreateRemoteCmd {
         let storage_kind = args
             .get_one::<String>("storage-backend")
             .map(|s| StorageKind::from_str(s))
+            .transpose()?;
+
+        let merkle_backend = args
+            .get_one::<String>("merkle-backend")
+            .map(|s| MerkleNodeBackend::from_str(s))
             .transpose()?;
 
         // Default the host to the oxen.ai hub
@@ -115,6 +128,7 @@ impl RunCmd for CreateRemoteCmd {
 
         if empty {
             let mut repo_new = RepoNew::from_namespace_name(namespace, name, storage_kind);
+            repo_new.merkle_node_backend = merkle_backend;
             repo_new.host = Some(host);
             repo_new.is_public = Some(is_public);
             repo_new.scheme = Some(scheme);
@@ -175,6 +189,7 @@ Happy Mooooooving of data 🐂
                 user,
             }];
             let mut repo = RepoNew::from_files(namespace, name, files, storage_kind);
+            repo.merkle_node_backend = merkle_backend;
             repo.host = Some(host);
             repo.is_public = Some(is_public);
             repo.scheme = Some(scheme);

--- a/crates/oxen-cli/src/cmd/init.rs
+++ b/crates/oxen-cli/src/cmd/init.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
+use liboxen::core::db::merkle_node::MerkleNodeBackend;
 use liboxen::core::versions::MinOxenVersion;
 
 use crate::cmd::RunCmd;
@@ -39,6 +41,13 @@ impl RunCmd for InitCmd {
                     .help("The oxen version to use, if you want to test older CLI versions (default: latest)")
                     .action(clap::ArgAction::Set),
             )
+            .arg(
+                Arg::new("merkle-backend")
+                    .long("merkle-backend")
+                    .help("Which engine backs the repo's Merkle node store (default: filesystem)")
+                    .value_parser(["filesystem", "lmdb"])
+                    .action(clap::ArgAction::Set),
+            )
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), anyhow::Error> {
@@ -56,6 +65,11 @@ impl RunCmd for InitCmd {
             .map(|s| s.to_string());
         let oxen_version = MinOxenVersion::or_latest(version_str)?;
 
+        let merkle_backend = args
+            .get_one::<String>("merkle-backend")
+            .map(|s| MerkleNodeBackend::from_str(s))
+            .transpose()?;
+
         // Make sure the remote version is compatible
         let (scheme, host) = get_scheme_and_host_or_default()?;
 
@@ -63,8 +77,13 @@ impl RunCmd for InitCmd {
 
         // Initialize the repository
         let directory = util::fs::canonicalize(PathBuf::from(&path))?;
-        repositories::init::init_with_version_and_storage_config(&directory, oxen_version, None)
-            .await?;
+        repositories::init::init_with_version_and_storage_config(
+            &directory,
+            oxen_version,
+            None,
+            merkle_backend,
+        )
+        .await?;
         println!("🐂 repository initialized at: {directory:?}");
         println!("{AFTER_INIT_MSG}");
         Ok(())


### PR DESCRIPTION
A new repository can now be created directly on the LMDB Merkle node backend instead of the filesystem backend, which lets us stand up and exercise LMDB-backed repos ahead of making LMDB the default. Without this, the only route onto LMDB was migrating an already-created filesystem-backend repo; now the choice can be made up front.

The selector is exposed only where we need it for our own testing:
- `oxen init --merkle-backend <filesystem|lmdb>` for local repos
- `oxen create-remote --merkle-backend <filesystem|lmdb>` for remote repos
- a `merkle_node_backend` field on the repo-create request that the server honors

It is deliberately not surfaced in the Python bindings or the public docs.