### PR TITLE
Fix default merkle tree backend, reduce merkle tree lmdb virtual address space usage

### DIFF
--- a/bin/install-ffmpeg
+++ b/bin/install-ffmpeg
@@ -2,12 +2,12 @@
 #
 # install-ffmpeg
 #
-# Install a pinned FFmpeg 8 (LGPL shared build from BtbN/FFmpeg-Builds) under a prefix and register
-# its libraries with ldconfig. Shared by bin/install-prereqs, the production-build CI workflow, and
-# the Dockerfiles, which all provision FFmpeg from this one place. Pins live in tool-versions.env.
+# Install a pinned FFmpeg 8 (LGPL shared build) under a prefix and register its libraries with
+# ldconfig. Shared by bin/install-prereqs, the production-build CI workflow, and the Dockerfiles,
+# which all provision FFmpeg from this one place. Pins live in tool-versions.env.
 #
-# BtbN prunes old autobuild releases over time; refresh the pin in tool-versions.env periodically,
-# or mirror the asset to storage we control.
+# The tarballs are served from Oxen-AI/oxen-ffmpeg-downloads, a mirror we control, so a pinned
+# release stays available — the upstream BtbN/FFmpeg-Builds autobuilds get pruned within weeks.
 #
 # Usage: install-ffmpeg [PREFIX]            (PREFIX defaults to /opt/ffmpeg)
 #   TOOL_VERSIONS_FILE   path to tool-versions.env (default: alongside this script's repo root)
@@ -33,14 +33,14 @@ as_root() {
 }
 
 stamp="$PREFIX/.oxen-ffmpeg-version"
-want="${FFMPEG_VERSION}+${FFMPEG_BTBN_TAG}"
+want="${FFMPEG_VERSION}"
 if [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$want" ]; then
     echo "FFmpeg ${FFMPEG_VERSION} already installed at $PREFIX"
     exit 0
 fi
 
-tarball="ffmpeg-n${FFMPEG_VERSION}${FFMPEG_BUILD_SUFFIX:-}-${ff_arch}-lgpl-shared-${FFMPEG_BRANCH}.tar.xz"
-url="https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_BTBN_TAG}/${tarball}"
+tarball="ffmpeg-${FFMPEG_VERSION}-${ff_arch}-lgpl-shared.tar.xz"
+url="https://github.com/Oxen-AI/oxen-ffmpeg-downloads/releases/download/ffmpeg-${FFMPEG_VERSION}/${tarball}"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 

--- a/crates/liboxen/src/config/repository_config.rs
+++ b/crates/liboxen/src/config/repository_config.rs
@@ -52,7 +52,8 @@ pub struct RepositoryConfig {
     /// Which engine backs this repo's Merkle node store. The authoritative record of the repo's
     /// backend: written at `init` and updated by the file ↔ LMDB migration. `None` for repos whose
     /// config predates the field, which fall back to on-disk evidence — an FS node tree means
-    /// filesystem, else LMDB (see `create_merkle_node_store`).
+    /// filesystem, an existing LMDB env means LMDB, and neither means filesystem (see
+    /// `create_merkle_node_store`).
     pub merkle_node_backend: Option<MerkleNodeBackend>,
 }
 

--- a/crates/liboxen/src/core/db/merkle_node/lmdb_merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/lmdb_merkle_node_store.rs
@@ -29,7 +29,7 @@ const NODES_DB_NAME: &str = "nodes";
 const MAX_DBS: u32 = 1;
 /// Sparse upper bound on the env's mapped size — LMDB reserves this much address space but only
 /// occupies what is written, so it is sized generously to avoid `MDB_MAP_FULL` on large repos.
-const MERKLE_NODE_MAP_SIZE: ByteSize = ByteSize::gib(256);
+const MERKLE_NODE_MAP_SIZE: ByteSize = ByteSize::mib(512);
 /// LMDB's data file name within the env directory (a stable LMDB convention); used only to detect
 /// an existing LMDB store without opening (and thereby creating) the env.
 const LMDB_DATA_FILE: &str = "data.mdb";

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_store.rs
@@ -131,10 +131,12 @@ pub(crate) trait MerkleNodeStore: Debug + Send + Sync {
 /// `configured` is the repo's persisted `merkle_node_backend` from `config.toml`. Returns the store
 /// alongside the backend it resolved to, so the caller can persist the choice.
 ///
-/// The persisted config is authoritative. When it is absent (`None`, for a repo whose config
-/// predates the field) the backend is inferred from on-disk data: an FS node tree under
-/// `.oxen/tree/nodes` means the filesystem backend, otherwise LMDB. New repos record their backend
-/// at `init` ([`DEFAULT_MERKLE_NODE_BACKEND`]), so this inference only applies to legacy repos.
+/// The persisted config is authoritative. When it is absent (`None`) the backend is inferred from
+/// on-disk data: an FS node tree under `.oxen/tree/nodes` means the filesystem backend, an existing
+/// LMDB env under `.oxen/tree/nodes_lmdb` means LMDB, and a tree with neither present yet falls back
+/// to the filesystem backend. New repos record their backend at `init`
+/// ([`DEFAULT_MERKLE_NODE_BACKEND`]); the inference covers repos whose config predates the field and
+/// freshly created trees such as workspaces that have not written any nodes yet.
 pub(crate) fn create_merkle_node_store(
     repo_path: &Path,
     configured: Option<MerkleNodeBackend>,
@@ -148,7 +150,8 @@ pub(crate) fn create_merkle_node_store(
 }
 
 /// Resolve an existing repo's backend: the persisted `configured` value if present, else inferred
-/// from on-disk data — an FS node tree ⇒ filesystem, otherwise LMDB.
+/// from on-disk data — an FS node tree ⇒ filesystem, an LMDB env ⇒ LMDB, and neither present ⇒
+/// filesystem (the safe default for a tree with nothing written yet, such as a fresh workspace).
 fn resolve_load_backend(
     configured: Option<MerkleNodeBackend>,
     repo_path: &Path,
@@ -156,8 +159,10 @@ fn resolve_load_backend(
     configured.unwrap_or_else(|| {
         if FsMerkleNodeStore::exists_on_disk(repo_path) {
             MerkleNodeBackend::Filesystem
-        } else {
+        } else if LmdbMerkleNodeStore::exists_on_disk(repo_path) {
             MerkleNodeBackend::Lmdb
+        } else {
+            MerkleNodeBackend::Filesystem
         }
     })
 }
@@ -197,14 +202,29 @@ mod tests {
         Ok(())
     }
 
-    /// With no persisted config and no FS node tree, resolution falls back to LMDB.
+    /// With no persisted config and neither an FS node tree nor an LMDB env on disk, resolution
+    /// falls back to the filesystem backend.
     #[test]
-    fn resolve_load_backend_falls_back_to_lmdb() {
+    fn resolve_load_backend_falls_back_to_filesystem() {
         let dir = tempfile::tempdir().expect("create temp dir");
+        assert_eq!(
+            resolve_load_backend(None, dir.path()),
+            MerkleNodeBackend::Filesystem
+        );
+    }
+
+    /// With no persisted config, an existing on-disk LMDB env resolves to the LMDB backend so a
+    /// repo already written in that format stays readable.
+    #[test]
+    fn resolve_load_backend_detects_lmdb_env() -> Result<(), OxenError> {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        // Opening the store creates the `.oxen/tree/nodes_lmdb` env the detector looks for.
+        LmdbMerkleNodeStore::new(dir.path())?;
         assert_eq!(
             resolve_load_backend(None, dir.path()),
             MerkleNodeBackend::Lmdb
         );
+        Ok(())
     }
 
     /// `MerkleNodeBackend` serializes to the lowercase tokens persisted in `config.toml`.

--- a/tool-versions.env
+++ b/tool-versions.env
@@ -18,18 +18,13 @@ CARGO_NEXTEST_VERSION=0.9.136
 # Shell tools
 SHELLCHECK_VERSION=0.11.0
 
-# FFmpeg (prebuilt LGPL shared build from BtbN/FFmpeg-Builds, for the `ffmpeg` feature on Linux).
-# These pins are the single source read by bin/install-ffmpeg, which provisions FFmpeg for Linux
-# dev (bin/install-prereqs), the Dockerfiles, and the production-build CI. BtbN prunes old autobuild
-# releases over time; refresh the pin periodically, or mirror the asset to storage we control.
-#
-# FFMPEG_BUILD_SUFFIX is the git-describe tail BtbN appends to the release-branch filenames once the
-# branch advances past its tag (e.g. `-22-g94138f6973` for 22 commits past n8.1.2). Leave it empty
-# when the branch tip sits exactly on the tag.
-FFMPEG_BTBN_TAG=autobuild-2026-07-08-13-30
+# FFmpeg (prebuilt LGPL shared build, for the `ffmpeg` feature on Linux). Served from
+# Oxen-AI/oxen-ffmpeg-downloads, a mirror we control, so the pinned release can't be pruned out from
+# under CI the way the upstream BtbN/FFmpeg-Builds autobuilds are. These pins are the single source
+# read by bin/install-ffmpeg, which provisions FFmpeg for Linux dev (bin/install-prereqs), the
+# Dockerfiles, and the production-build CI. To bump: publish the new tarballs to the mirror repo
+# (release tag `ffmpeg-<version>`), then update the version and SHAs here.
 FFMPEG_VERSION=8.1.2
-FFMPEG_BUILD_SUFFIX=-22-g94138f6973
-FFMPEG_BRANCH=8.1
 FFMPEG_SHA256_LINUX_X86_64=9d9de50c45777c84721719f281618e6e6ea387f02815a75d8eb97a2910c7e19f
 FFMPEG_SHA256_LINUX_AARCH64=8f6bd90024beb2bd2ee3bcae1e0f8c9a61f2bda41487cbc3fddfe55029b364d4
 


### PR DESCRIPTION
One of my recent changes erroneously made it so that when no merkle tree backend implementation was present, we defaulted to the new LMDB backend. We make extensive use of workspaces in production, and every workspace starts with an empty merkle tree backend, so new workspaces all started switching to the LMDB backend. Our LMDB merkle tree backend was sized without taking workspaces into account at all--we assumed one merkle tree backend per repository -- but one repository may have tens of thousands of workspaces. So the virtual address reservation that was sized to high combined with a large amount of unexpected usage of it, and hit virtual address space limits.

This PR:
- Lowers the virtual address space usage of a merkle tree LMDB backend
- Fixes the default to revert back to the filesystem backend we had been using

In the future we will likely use different virtual address space limits for the merkle trees in workspaces vs the merkle tree for the main repository. And migration to the LMDB backend will be intentional.

Update: Had to throw in an install-prerequisites fix to download ffmpeg 8 from our stable repo where we store them.