### PR TITLE
Remove vestigial Redis references and code

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -83,8 +83,7 @@ jobs:
         if: matrix.platform == 'macos'
         run: |
           brew update
-          brew install redis pkg-config
-          brew services start redis
+          brew install pkg-config
 
       - name: Install nextest runner
         uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
@@ -217,8 +216,7 @@ jobs:
         if: matrix.platform == 'macos'
         run: |
           brew update
-          brew install redis pkg-config
-          brew services start redis
+          brew install pkg-config
 
       - name: Setup test directories (Linux/macOS)
         if: matrix.platform != 'windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,10 +4516,8 @@ dependencies = [
  "pathdiff",
  "polars",
  "qsv-sniffer",
- "r2d2",
  "rand 0.8.5",
  "rayon",
- "redis",
  "regex",
  "reqwest 0.13.2",
  "rmp-serde",
@@ -6709,17 +6707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r2d2"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
-dependencies = [
- "log",
- "parking_lot",
- "scheduled-thread-pool",
-]
-
-[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6915,25 +6902,6 @@ checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "redis"
-version = "0.27.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
-dependencies = [
- "arc-swap",
- "combine",
- "itertools 0.13.0",
- "itoa",
- "num-bigint",
- "percent-encoding",
- "r2d2",
- "ryu",
- "sha1_smol",
- "socket2 0.5.10",
- "url",
 ]
 
 [[package]]
@@ -7569,15 +7537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7824,12 +7783,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.11.2",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,10 +126,8 @@ pyo3 = { version = "0.25", features = ["abi3-py311"] }
 pyo3-async-runtimes = { version = "0.25", features = ["attributes", "tokio-runtime"] }
 pyo3-polars = { version = "0.22", features = ["dtype-full"] }
 qsv-sniffer = "0.10.3"
-r2d2 = "0.8.10"
 rand = "0.8.5"
 rayon = "1.8.0"
-redis = { version = "0.27.2", features = ["r2d2"] }
 regex = "1.10.2"
 reqwest = { version = "0.13.2", features = ["multipart", "json", "gzip", "stream", "query"] }
 rmp-serde = "1.3.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,5 @@ ENV RUST_MIN_STACK=50000000
 # Set the log level to info for the server
 ENV RUST_LOG=info
 ENV SYNC_DIR=/var/oxen/data
-ENV REDIS_URL=redis://localhost:6379
 EXPOSE 3001
 CMD ["oxen-server", "start", "-p", "3001"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -62,7 +62,6 @@ ENV RUST_MIN_STACK=50000000
 # Set the log level to info for the server
 ENV RUST_LOG=info
 ENV SYNC_DIR=/var/oxen/data
-ENV REDIS_URL=redis://localhost:6379
 ENV OXEN_PERF_LOGGING=1
 
 EXPOSE 3000

--- a/crates/liboxen/Cargo.toml
+++ b/crates/liboxen/Cargo.toml
@@ -102,10 +102,8 @@ parking_lot = { workspace = true }
 pathdiff = { workspace = true }
 polars = { workspace = true }
 qsv-sniffer = { workspace = true }
-r2d2 = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-redis = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 rmp-serde = { workspace = true }

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -493,14 +493,6 @@ pub enum OxenError {
     #[error("Image processing error: {0}")]
     ImageError(#[from] image::ImageError),
 
-    /// Wraps any error that we get from Redis client use.
-    #[error("Redis error: {0}")]
-    RedisError(#[from] redis::RedisError),
-
-    /// Wraps any error that we get from using r2d2 (the connection pool).
-    #[error("Connection pool error: {0}")]
-    R2D2Error(#[from] r2d2::Error),
-
     /// Wraps any error that we get from using jwalk (directory traversal).
     #[error("Directory traversal error: {0}")]
     JwalkError(#[from] jwalk::Error),
@@ -787,8 +779,7 @@ impl OxenError {
             IO(io_err) if io_err.kind() == PermissionDenied => {
                 "Check file permissions and try again."
             }
-            DB(_) | ArrowError(_) | BinCodeError(_) | RedisError(_) | R2D2Error(_)
-            | RmpDecodeError(_) => {
+            DB(_) | ArrowError(_) | BinCodeError(_) | RmpDecodeError(_) => {
                 "This is an internal error. Run with RUST_LOG=debug for more details."
             }
             WorkspaceStagedDbCorrupted { .. } => {

--- a/crates/oxen-server/src/helpers.rs
+++ b/crates/oxen-server/src/helpers.rs
@@ -1,4 +1,3 @@
-// use liboxen::constants::DEFAULT_REDIS_URL;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
@@ -283,17 +282,3 @@ mod tests {
         assert_eq!(parsed.status, "success");
     }
 }
-
-// #[allow(dependency_on_unit_never_type_fallback)]
-// pub fn get_redis_connection() -> Result<r2d2::Pool<redis::Client>, OxenError> {
-//     let redis_url = std::env::var("REDIS_URL").unwrap_or_else(|_| DEFAULT_REDIS_URL.to_string());
-//     let redis_client = redis::Client::open(redis_url)?;
-
-//     // First, ping redis to see if available - builder retries infinitely and spews error messages
-//     let mut test_conn = redis_client.get_connection()?;
-//     let _: () = redis::cmd("ECHO").arg("test").query(&mut test_conn)?;
-
-//     // If echo test didn't error, init the builder
-//     let pool = r2d2::Pool::builder().build(redis_client)?;
-//     Ok(pool)
-// }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,4 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.oxen.rule=Host(`0.0.0.0`)"
-  redis:
-    image: redis:latest
-    ports:
-      - "6379:6379"
 


### PR DESCRIPTION
Redis was removed from oxen-server's runtime some time ago; no code reads REDIS_URL or opens a Redis connection anymore. This drops the leftover scaffolding:

- liboxen error variants RedisError/R2D2Error (and their user-facing-hint match arm), which were the only thing keeping the redis and r2d2 crates linked
- the redis and r2d2 workspace/liboxen Cargo dependencies (and their Cargo.lock entries)
- the commented-out get_redis_connection() helper and its dead import in oxen-server
- the REDIS_URL env var in Dockerfile and Dockerfile.dev
- the redis service in docker-compose.yml
- the brew install/start redis steps in CI