### PR TITLE
 Merkle LMDB (1.1.3): Remove the CLI `oxen migrate --all` feature

### DIFF
--- a/crates/liboxen/src/command/migrate.rs
+++ b/crates/liboxen/src/command/migrate.rs
@@ -1,17 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
-
-use crate::{
-    error::OxenError,
-    model::LocalRepository,
-    repositories,
-    util::{
-        self,
-        progress_bar::{ProgressBarType, oxen_progress_bar},
-    },
-};
+use crate::{error::OxenError, model::LocalRepository};
 
 use colored::Colorize;
 
@@ -112,99 +99,6 @@ pub fn all_migrations(migration_name: &str) -> Option<&dyn Migrate> {
         }
     }
     None
-}
-
-/// The successful vs. failed migrations per-repository.
-pub struct MigrationResults {
-    pub executed: Vec<(PathBuf, MigrationResult)>,
-    pub errored: Vec<(PathBuf, OxenError)>,
-}
-
-/// Run a migration on all repositories accessible from the given directory.
-///
-/// Assumes that `path` points to oxen repositories in the `namespace/repository`
-/// format. That is, `path`'s contents are only directories: each one of these is
-/// some `namespace`. Within each `namespace` directory is also only directories.
-/// Each one of these is a `repository` in the `namespace`.
-///
-/// This maps onto `oxen-server`'s concept of `namespace/repository`. It allows for
-/// a straightforward way to update all repositories being served.
-///
-/// If `is_sever` is `true`, then the progress bar is not printed and only log statements
-/// are used. If it is `false`, then there's a progress bar and only STDOUT messages.
-pub fn run_on_all_repos(
-    is_server: bool,
-    migration: &dyn Migrate,
-    direction: Direction,
-    run_optional: bool,
-    path: &Path,
-) -> Result<MigrationResults, OxenError> {
-    let msg = |msg: &str| {
-        if is_server {
-            log::info!("{msg}");
-        } else {
-            println!("{msg}");
-        }
-    };
-
-    let path = util::fs::canonicalize(path)?;
-    msg(&format!(
-        "🐂 Collecting namespaces to migrate in {}",
-        path.display()
-    ));
-
-    let namespaces = repositories::list_namespaces(&path)?;
-    msg(&format!("🐂 Migrating {} namespaces", namespaces.len()));
-
-    let bar = if is_server {
-        Arc::new(indicatif::ProgressBar::hidden())
-    } else {
-        oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter)
-    };
-
-    let mut migration_results = MigrationResults {
-        executed: vec![],
-        errored: vec![],
-    };
-
-    for namespace in namespaces {
-        // is canoncial because we made sure `path` is
-        let namespace_path = path.join(namespace);
-        log::debug!(
-            "This is the namespace path we're walking: {}",
-            namespace_path.display()
-        );
-        for repo in repositories::list_repos_in_namespace(&namespace_path) {
-            log::debug!("Migrating repository: {}", repo.path.display());
-
-            let repo_path = repo.path.clone();
-            match try_apply_migration(migration, direction, run_optional, repo) {
-                Ok(mr) => {
-                    if !mr.did_run() {
-                        msg(&format!("Did not run migration: {}", mr.as_hint(is_server)));
-                        migration_results.executed.push((repo_path, mr));
-                    }
-                }
-                Err(err) => {
-                    let message = format!(
-                        "Could not run migration {direction} {} for repo {}\nError: {}",
-                        migration.name(),
-                        repo_path.display(),
-                        err
-                    );
-                    if is_server {
-                        log::error!("{message}");
-                    } else {
-                        println!("[ERROR] {message}");
-                    }
-                    migration_results.errored.push((repo_path, err));
-                }
-            }
-        }
-        bar.inc(1);
-    }
-
-    Ok(migration_results)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -249,9 +249,6 @@ pub enum OxenError {
     #[error("Migration unimplemented for direction: {0}")]
     MigrationUnimplemented(Direction),
 
-    #[error("Migration failed to run")]
-    MigrationFailed,
-
     //
     // Version Store
     /// An error uploading a file to the version store

--- a/crates/oxen-cli/src/cmd/migrate.rs
+++ b/crates/oxen-cli/src/cmd/migrate.rs
@@ -3,9 +3,7 @@ use std::str::FromStr;
 
 use async_trait::async_trait;
 use clap::{Arg, Command};
-use liboxen::command::migrate::{
-    ALL_MIGRATIONS, MigrationResults, all_migrations, run_on_all_repos, try_apply_migration,
-};
+use liboxen::command::migrate::{ALL_MIGRATIONS, all_migrations, try_apply_migration};
 use liboxen::{command::migrate::Direction, error::OxenError, model::LocalRepository};
 
 use crate::cmd::RunCmd;
@@ -19,22 +17,9 @@ pub fn migrate_args(name: &'static str, desc: &'static str) -> Command {
             Arg::new("PATH")
                 .help(
                     "Directory in which to apply the migration. Must be the root \
-                    of the repository, unless --all is specified.",
+                    of the repository.",
                 )
                 .required(true),
-        )
-        .arg(
-            Arg::new("all")
-                .long("all")
-                .short('a')
-                .help(
-                    "Run the migration for all oxen repositories in the directory. \
-                    Expects the directory to contain \"namespace/repository\" format. \
-                    The direct directories inside must be namespaces. Each directory \
-                    inside the namespace must be a repository. (Skips directories \
-                    that don't have a .oxen/ directory in them).",
-                )
-                .action(clap::ArgAction::SetTrue),
         )
         .arg(
             Arg::new("run-optional")
@@ -68,7 +53,7 @@ impl RunCmd for MigrateCmd {
     fn args(&self) -> Command {
         // Setups the CLI args for the command
         Command::new(NAME)
-            .about("Run a named migration on a server repository or set of repositories")
+            .about("Run a named migration on a repository")
             .subcommand_required(true)
             .subcommand(subcommands("up", "Apply a named migration forward."))
             .subcommand(subcommands("down", "Apply a named migration backward."))
@@ -88,38 +73,15 @@ impl RunCmd for MigrateCmd {
             let path_str = sub_matches.get_one::<String>("PATH").expect("required");
             let path = Path::new(path_str);
 
-            let all = sub_matches.get_flag("all");
             let run_optional = sub_matches.get_flag("run-optional");
 
-            if all {
-                let MigrationResults { executed, errored } =
-                    run_on_all_repos(false, migration, direction, run_optional, path)?;
-
-                if errored.is_empty() {
-                    println!(
-                        "\u{2705} Migration completed: successfully migrated {} repositories",
-                        executed.len(),
-                    );
-                } else {
-                    println!(
-                        "\u{274C} [ERROR] Migration completed with {} success(es) and {} failure(s):",
-                        executed.len(),
-                        errored.len(),
-                    );
-                    for (repo_path, error) in errored {
-                        println!("\t[FAIL] \"{}\" due to: {error}", repo_path.display());
-                    }
-                    Err(OxenError::MigrationFailed)?;
-                }
-            } else {
-                let mr = try_apply_migration(
-                    migration,
-                    direction,
-                    run_optional,
-                    LocalRepository::from_dir(path)?,
-                )?;
-                println!("{}", mr.as_hint(false));
-            }
+            let mr = try_apply_migration(
+                migration,
+                direction,
+                run_optional,
+                LocalRepository::from_dir(path)?,
+            )?;
+            println!("{}", mr.as_hint(false));
         }
 
         Ok(())


### PR DESCRIPTION
In production, we manage rolling repository migrations from the hub. Having an individual migration attempt to manage multiple migrations as well is not going to lead to a good experience for open source server users. For now, let users manage their own migration however they like. In the future, if we want to support multiple migrations from the server side, let's give it some real design thought and implement it in a nice way that will apply to any migration.