### PR TITLE
Log requests at start, and fix the empty request id in the access log

### DIFF
--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -34,7 +34,7 @@ use actix_web::{App, HttpServer, web};
 use actix_web_httpauth::middleware::HttpAuthentication;
 use thiserror::Error;
 
-use middleware::{MetricsMiddleware, RequestIdMiddleware};
+use middleware::{MetricsMiddleware, RequestIdMiddleware, RequestStartLogMiddleware, request_id};
 use tracing_actix_web::TracingLogger;
 
 // Note: These 'view' imports are all for the auto-generated docs with utoipa
@@ -670,9 +670,15 @@ async fn start(
             .service(web::scope("/api/repos").configure(routes::config))
             .default_service(web::route().to(controllers::not_found::index))
             .wrap(DefaultHeaders::new().add(("oxen-version", OXEN_VERSION)))
-            .wrap(Logger::new(
-                "%a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T %{x-oxen-request-id}o",
-            ))
+            .wrap(
+                Logger::new(
+                    "end %a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T req=%{request_id}xo",
+                )
+                .custom_response_replace("request_id", |res| request_id(res.request())),
+            )
+            .wrap(RequestStartLogMiddleware)
+            // RequestId must stay outer of the Logger/RequestStartLog above (actix runs the last
+            // .wrap outermost) so the request-id extension those two read is populated before them.
             .wrap(RequestIdMiddleware)
             .wrap(MetricsMiddleware)
             .wrap(TracingLogger::default())

--- a/crates/oxen-server/src/middleware.rs
+++ b/crates/oxen-server/src/middleware.rs
@@ -1,6 +1,7 @@
 use actix_web::{
-    Error, HttpMessage,
+    Error, HttpMessage, HttpRequest,
     dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready},
+    http::header,
 };
 use futures_util::future::LocalBoxFuture;
 use liboxen::request_context::REQUEST_ID;
@@ -19,6 +20,17 @@ pub fn extract_or_generate_request_id(headers: &actix_web::http::header::HeaderM
 
 pub fn generate_request_id() -> String {
     uuid::Uuid::new_v4().to_string()
+}
+
+/// The request id assigned by [`RequestIdMiddleware`], stored in the request's extensions.
+struct RequestId(String);
+
+/// Returns the request id [`RequestIdMiddleware`] stored on the request, or `"-"` if none.
+pub fn request_id(req: &HttpRequest) -> String {
+    req.extensions()
+        .get::<RequestId>()
+        .map(|id| id.0.clone())
+        .unwrap_or_else(|| "-".to_string())
 }
 
 /// Middleware factory for request ID injection
@@ -62,7 +74,7 @@ where
         let request_id = extract_or_generate_request_id(req.headers());
 
         // Store in request extensions for later retrieval if needed
-        req.extensions_mut().insert(request_id.clone());
+        req.extensions_mut().insert(RequestId(request_id.clone()));
 
         let fut = self.service.call(req);
 
@@ -83,6 +95,75 @@ where
             },
         ))
     }
+}
+
+/// Logs each request at INFO on entry: remote addr, request line, Referer, User-Agent, request id.
+pub struct RequestStartLogMiddleware;
+
+impl<S, B> Transform<S, ServiceRequest> for RequestStartLogMiddleware
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = RequestStartLogMiddlewareService<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(RequestStartLogMiddlewareService { service }))
+    }
+}
+
+pub struct RequestStartLogMiddlewareService<S> {
+    service: S,
+}
+
+impl<S, B> Service<ServiceRequest> for RequestStartLogMiddlewareService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = S::Future;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let request_id = request_id(req.request());
+        // Mirror the access log's start-known fields (%a "%r" "%{Referer}i" "%{User-Agent}i").
+        let remote_addr = req.connection_info().peer_addr().unwrap_or("-").to_string();
+        let request_line = if req.query_string().is_empty() {
+            format!("{} {} {:?}", req.method(), req.path(), req.version())
+        } else {
+            format!(
+                "{} {}?{} {:?}",
+                req.method(),
+                req.path(),
+                req.query_string(),
+                req.version()
+            )
+        };
+        let referer = request_header_or_dash(&req, header::REFERER);
+        let user_agent = request_header_or_dash(&req, header::USER_AGENT);
+        log::info!(
+            "start {remote_addr} \"{request_line}\" \"{referer}\" \"{user_agent}\" req={request_id}"
+        );
+
+        self.service.call(req)
+    }
+}
+
+/// Renders a request header the way the access log does: its UTF-8-lossy value, or "-" if absent.
+fn request_header_or_dash(req: &ServiceRequest, name: header::HeaderName) -> String {
+    req.headers()
+        .get(name)
+        .map(|val| String::from_utf8_lossy(val.as_bytes()).into_owned())
+        .unwrap_or_else(|| "-".to_string())
 }
 
 /// Middleware that records HTTP request count and duration for every route.
@@ -248,5 +329,24 @@ mod tests {
 
         // Should be valid UUID format
         assert_eq!(id.len(), 36); // UUID length with hyphens
+    }
+
+    #[actix_web::test]
+    async fn test_request_start_log_middleware_passes_through() {
+        use actix_web::{App, HttpResponse, http::header, test, web};
+
+        let app = test::init_service(App::new().wrap(RequestStartLogMiddleware).route(
+            "/x",
+            web::get().to(|| async { HttpResponse::Ok().finish() }),
+        ))
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/x?page=1")
+            .insert_header((header::USER_AGENT, "oxen-test-agent"))
+            .insert_header((header::REFERER, "http://example.test/prev"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
     }
 }


### PR DESCRIPTION
Every request now produces an `INFO` log line the moment it arrives, alongside the existing completion line. A request that is still in flight (or one that hangs and never finishes) previously left no trace in the logs at all. Now it is visible as soon as it is received, which is exactly what you need when the server stops responding and you want to see what it was working on.

The completion (access) log line also advertised a request id but always logged it empty. It read the `x-oxen-request-id` response header, which is only set after the access logger has already rendered its line. It now reads the id straight from the request, so every completion line has the real id.

Both lines are prefixed with `start` and `end` and end with `req=<id>`, so the two halves of one request are easy to find together and tell apart. Each carries the fields the access log already knew at request time.

ENG-1332