### PR TITLE
Merkle LMDB (1.1.8): Expose a repo's merkle node backend to the client

### DIFF
--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -104,7 +104,7 @@ impl LocalRepository {
     }
 
     /// The backend this repo's Merkle node store resolved to (see `create_merkle_node_store`).
-    pub(crate) fn merkle_node_backend(&self) -> MerkleNodeBackend {
+    pub fn merkle_node_backend(&self) -> MerkleNodeBackend {
         self.merkle_node_backend
     }
 

--- a/crates/liboxen/src/model/repository/remote_repository.rs
+++ b/crates/liboxen/src/model/repository/remote_repository.rs
@@ -1,4 +1,5 @@
 use crate::api;
+use crate::core::db::merkle_node::MerkleNodeBackend;
 use crate::storage::StorageKind;
 use crate::view::RepositoryView;
 use crate::view::repository::RepositoryCreationView;
@@ -15,6 +16,9 @@ pub struct RemoteRepository {
     pub is_empty: bool,
     /// The server's version-store backend for this repo (local filesystem or S3).
     pub storage_kind: StorageKind,
+    /// The repo's Merkle node backend (filesystem / lmdb), read-only observability. `None` from a
+    /// server that predates the field.
+    pub merkle_node_backend: Option<MerkleNodeBackend>,
 }
 
 impl RemoteRepository {
@@ -26,6 +30,7 @@ impl RemoteRepository {
             min_version: repository.min_version.clone(),
             is_empty: repository.is_empty,
             storage_kind: repository.storage_kind,
+            merkle_node_backend: repository.merkle_node_backend,
         }
     }
 
@@ -40,6 +45,7 @@ impl RemoteRepository {
             min_version: repository.min_version.clone(),
             is_empty: true,
             storage_kind: repository.storage_kind,
+            merkle_node_backend: repository.merkle_node_backend,
         }
     }
 

--- a/crates/liboxen/src/view/repository.rs
+++ b/crates/liboxen/src/view/repository.rs
@@ -1,4 +1,5 @@
 use super::{DataTypeCount, StatusMessage};
+use crate::core::db::merkle_node::MerkleNodeBackend;
 use crate::model::parsed_resource::ParsedResourceView;
 use crate::model::{Commit, EntryDataType};
 use crate::storage::StorageKind;
@@ -20,6 +21,10 @@ pub struct RepositoryView {
     pub min_version: Option<String>,
     pub is_empty: bool,
     pub storage_kind: StorageKind,
+    /// The repo's Merkle node backend (`"filesystem"` / `"lmdb"`), read-only. `None` when deserialized
+    /// from a server that predates the field, so an older backend response still parses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merkle_node_backend: Option<MerkleNodeBackend>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -57,6 +62,10 @@ pub struct RepositoryCreationView {
     pub latest_commit: Option<Commit>,
     pub min_version: Option<String>,
     pub storage_kind: StorageKind,
+    /// The repo's Merkle node backend (`"filesystem"` / `"lmdb"`), read-only. `None` when deserialized
+    /// from a server that predates the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merkle_node_backend: Option<MerkleNodeBackend>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -240,6 +249,7 @@ mod tests {
                 min_version: Some("0.0.0".to_string()),
                 is_empty: false,
                 storage_kind: StorageKind::S3,
+                merkle_node_backend: Some(MerkleNodeBackend::Lmdb),
             },
             size: 42,
             data_types: vec![],
@@ -251,6 +261,7 @@ mod tests {
         // nested under a "repository" key.
         assert_eq!(json["namespace"], "ox");
         assert_eq!(json["storage_kind"], "s3");
+        assert_eq!(json["merkle_node_backend"], "lmdb");
         assert_eq!(json["size"], 42);
         assert!(json.get("repository").is_none());
     }
@@ -293,9 +304,11 @@ mod tests {
             latest_commit: None,
             min_version: Some("0.0.0".to_string()),
             storage_kind: StorageKind::S3,
+            merkle_node_backend: Some(MerkleNodeBackend::Filesystem),
         };
         let json = serde_json::to_value(&view).expect("view should serialize");
         assert_eq!(json["storage_kind"], "s3");
+        assert_eq!(json["merkle_node_backend"], "filesystem");
 
         // A create response missing storage_kind must fail rather than defaulting.
         let missing = serde_json::json!({ "namespace": "ox", "name": "test" });
@@ -313,6 +326,7 @@ mod tests {
                 min_version: Some("0.0.0".to_string()),
                 is_empty: false,
                 storage_kind: StorageKind::S3,
+                merkle_node_backend: Some(MerkleNodeBackend::Lmdb),
             },
             size: 1_073_741_824,
             data_types: vec![],
@@ -323,8 +337,39 @@ mod tests {
         let back: RepositoryDataTypesView =
             serde_json::from_str(&json).expect("view should round-trip through the flatten");
         assert_eq!(back.repository.storage_kind, StorageKind::S3);
+        assert_eq!(
+            back.repository.merkle_node_backend,
+            Some(MerkleNodeBackend::Lmdb)
+        );
         assert_eq!(back.repository.namespace, "ox");
         assert_eq!(back.size, 1_073_741_824);
         assert_eq!(back.branch_count, 3);
+    }
+
+    #[test]
+    fn repository_view_merkle_node_backend_is_optional_and_lowercase() {
+        // A payload from a server that predates the field still deserializes, with None — the
+        // no-flag-day guarantee that lets a newer client read an older server.
+        let without = serde_json::json!({
+            "namespace": "ox",
+            "name": "test",
+            "is_empty": false,
+            "storage_kind": "local",
+        });
+        let view: RepositoryView =
+            serde_json::from_value(without).expect("older payload without the field must parse");
+        assert_eq!(view.merkle_node_backend, None);
+
+        // When present it deserializes, and the enum round-trips as its lowercase token.
+        let with = serde_json::json!({
+            "namespace": "ox",
+            "name": "test",
+            "is_empty": false,
+            "storage_kind": "local",
+            "merkle_node_backend": "lmdb",
+        });
+        let view: RepositoryView =
+            serde_json::from_value(with).expect("payload with the field must parse");
+        assert_eq!(view.merkle_node_backend, Some(MerkleNodeBackend::Lmdb));
     }
 }

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -140,6 +140,7 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
                 min_version: Some("0.36.0".to_string()),
                 is_empty: branch_count == 0,
                 storage_kind: repository.storage_config().kind,
+                merkle_node_backend: Some(repository.merkle_node_backend()),
             },
             size,
             data_types,
@@ -458,6 +459,7 @@ async fn create_repo_response(
                     latest_commit,
                     min_version: Some("0.36.0".to_string()),
                     storage_kind: repo.storage_config().kind,
+                    merkle_node_backend: Some(repo.merkle_node_backend()),
                 },
             }))
         }
@@ -579,6 +581,7 @@ pub async fn transfer_namespace(
             min_version: Some("0.36.0".to_string()),
             is_empty: repositories::is_empty(&repo).await?,
             storage_kind: repo.storage_config().kind,
+            merkle_node_backend: Some(repo.merkle_node_backend()),
         },
     }))
 }


### PR DESCRIPTION
Surface each repo's merkle node backend (filesystem / lmdb) end to end so clients and the UI can see which backend a repo uses. This is read-only observability. The serialized repo view and `RemoteRepository` now carry an optional `merkle_node_backend`, and the server populates it on the repo-show, create, and transfer responses.

The field is optional so a newer client still deserializes a response from an older server that doesn't emit it. This will all go away when the filesystem backend is retired.