### PR TITLE
Repo Integrity (1.14.2): Hold the write guard on every server write endpoint

### DIFF
--- a/crates/liboxen/src/core/repo_locks.rs
+++ b/crates/liboxen/src/core/repo_locks.rs
@@ -102,6 +102,8 @@ fn lock_timeout() -> OxenError {
 
 /// A held write reservation on a repo. An exclusive acquire on the same repo waits for every
 /// outstanding guard to drop. Acquire it at a write entry point and hold it for the whole write.
+#[must_use = "the write reservation is released the moment this guard drops; bind it \
+              (e.g. `let _write = acquire_write(repo)?;`) so it lives for the whole write"]
 pub struct RepoWriteGuard {
     gate: Arc<RepoGate>,
 }

--- a/crates/oxen-server/src/controllers/branches.rs
+++ b/crates/oxen-server/src/controllers/branches.rs
@@ -6,6 +6,7 @@ use crate::params::{PageNumQuery, app_data, path_param};
 
 use actix_web::{HttpRequest, HttpResponse, web};
 
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::util::{self, paginate};
@@ -148,6 +149,10 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
 
     let repo = get_repo(app_data, namespace, repo_name)?;
 
+    // Hold the repo write guard for the whole write so a maintenance op (migration/prune) drains
+    // against it; returns 429 while an exclusive op holds the repo.
+    let _write = repo_locks::acquire_write(&repo)?;
+
     log::debug!("Create branch: {body}");
 
     // Try to deserialize the body into a BranchNewFromBranchName
@@ -246,6 +251,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let name = path_param(&req, "repo_name")?.to_string();
     let branch_name = path_param(&req, "branch_name")?.to_string();
     let repository = get_repo(app_data, namespace, name)?;
+    let _write = repo_locks::acquire_write(&repository)?;
 
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?;
 
@@ -289,6 +295,7 @@ pub async fn update(
     let name = path_param(&req, "repo_name")?.to_string();
     let branch_name = path_param(&req, "branch_name")?.to_string();
     let repository = get_repo(app_data, namespace, name)?;
+    let _write = repo_locks::acquire_write(&repository)?;
 
     let data: Result<BranchUpdate, serde_json::Error> = serde_json::from_str(&body);
     let data = data.map_err(|err| OxenHttpError::BadRequest(format!("{err:?}").into()))?;
@@ -338,6 +345,7 @@ pub async fn maybe_create_merge(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let repository = get_repo(app_data, namespace, name)?;
+    let _write = repo_locks::acquire_write(&repository)?;
     let branch_name = path_param(&req, "branch_name")?.to_string();
     let branch = repositories::branches::get_by_name(&repository, &branch_name)?;
 

--- a/crates/oxen-server/src/controllers/commits.rs
+++ b/crates/oxen-server/src/controllers/commits.rs
@@ -5,6 +5,7 @@ use liboxen::constants::DIRS_DIR;
 use liboxen::constants::HISTORY_DIR;
 use liboxen::constants::VERSION_FILE_NAME;
 
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::{Commit, LocalRepository};
 use liboxen::opts::PaginateOpts;
@@ -697,6 +698,7 @@ pub async fn create(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repository = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repository)?;
 
     let new_commit: Commit = match serde_json::from_str(&body) {
         Ok(commit) => commit,
@@ -759,6 +761,7 @@ pub async fn upload_chunk(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     let hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
     let id = query.hash.clone();
@@ -999,6 +1002,7 @@ pub async fn upload(
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, &namespace, &name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     // Read bytes from body
     let mut bytes = Vec::new();

--- a/crates/oxen-server/src/controllers/data_frames.rs
+++ b/crates/oxen-server/src/controllers/data_frames.rs
@@ -4,6 +4,7 @@ use crate::params::df_opts_query::{self, DFOptsQuery};
 use crate::params::{app_data, parse_resource, path_param};
 
 use liboxen::constants;
+use liboxen::core::repo_locks;
 use liboxen::error::PathBufError;
 use liboxen::model::{DataFrameSize, NewCommitBody};
 use liboxen::opts::df_opts::DFOptsView;
@@ -144,6 +145,7 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
 
@@ -212,6 +214,7 @@ pub async fn from_directory(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.clone().commit.ok_or(OxenHttpError::NotFound)?;
     let branch = resource.clone().branch.ok_or(OxenHttpError::NotFound)?;

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -5,6 +5,7 @@ use crate::errors::OxenHttpError;
 
 use actix_web::{HttpRequest, HttpResponse, web};
 use liboxen::core::df::tabular;
+use liboxen::core::repo_locks;
 use liboxen::core::v_latest::diff::get_dir_diff_entry_with_summary;
 use liboxen::error::OxenError;
 use liboxen::model::data_frame::DataFrameSchemaSize;
@@ -410,6 +411,7 @@ pub async fn create_df_diff(
     let name = path_param(&req, "repo_name")?.to_string();
 
     let repository = get_repo(app_data, namespace, name)?;
+    let _write = repo_locks::acquire_write(&repository)?;
 
     let data: Result<TabularCompareBody, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
@@ -517,6 +519,7 @@ pub async fn update_df_diff(
     let name = path_param(&req, "repo_name")?.to_string();
     let compare_id = path_param(&req, "compare_id")?.to_string();
     let repository = get_repo(app_data, namespace, name)?;
+    let _write = repo_locks::acquire_write(&repository)?;
 
     let data: Result<TabularCompareBody, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
@@ -707,6 +710,7 @@ pub async fn delete_df_diff(req: HttpRequest) -> Result<HttpResponse, OxenHttpEr
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let compare_id = path_param(&req, "compare_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     repositories::diffs::delete_df_diff(&repo, &compare_id)?;
 

--- a/crates/oxen-server/src/controllers/file.rs
+++ b/crates/oxen-server/src/controllers/file.rs
@@ -8,6 +8,7 @@ use actix_multipart::{Field, MultipartError};
 use actix_web::{HttpRequest, HttpResponse, web};
 use futures_util::TryStreamExt as _;
 use futures_util::future::LocalBoxFuture;
+use liboxen::core::repo_locks;
 use liboxen::core::staged::get_staged_db_manager;
 use liboxen::error::OxenError;
 use liboxen::model::Commit;
@@ -138,6 +139,9 @@ pub async fn get(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    // This GET writes a resized/thumbnail derived blob on a cache miss (tech-debt ENG-1373); guard
+    // the whole handler so a stop-the-world op (migration/prune/fsck) blocks it.
+    let _write = repo_locks::acquire_write(&repo)?;
     let version_store = repo.version_store();
     let resource = parse_resource(&req, &repo)?;
     let workspace = resource.workspace.as_ref();
@@ -265,6 +269,7 @@ pub async fn put(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     // If there's no head commit, handle initial upload
     if repositories::commits::head_commit_maybe(&repo)?.is_none() {
@@ -377,6 +382,7 @@ pub async fn delete(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     // Parse the resource (branch/commit/path)
     let resource = parse_resource(&req, &repo)?;
@@ -468,6 +474,7 @@ pub async fn mv(req: HttpRequest, body: String) -> actix_web::Result<HttpRespons
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     // Parse the resource (branch/commit/path)
     let resource = parse_resource(&req, &repo)?;

--- a/crates/oxen-server/src/controllers/import.rs
+++ b/crates/oxen-server/src/controllers/import.rs
@@ -10,6 +10,7 @@ use crate::errors::OxenHttpError;
 use crate::helpers::{create_user_from_options, get_repo};
 use crate::params::{app_data, parse_resource, path_param, query_param};
 
+use liboxen::core::repo_locks;
 use liboxen::core::v_latest::workspaces::files::decompress_zip;
 use liboxen::error::OxenError;
 use liboxen::model::NewCommitBody;
@@ -103,6 +104,7 @@ pub async fn import(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let resource = parse_resource(&req, &repo)?;
 
     // Resource must specify branch for committing the workspace
@@ -238,6 +240,7 @@ pub async fn upload_zip(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     // If there's no head commit, handle initial upload
     if repositories::commits::head_commit_maybe(&repo)?.is_none() {

--- a/crates/oxen-server/src/controllers/merger.rs
+++ b/crates/oxen-server/src/controllers/merger.rs
@@ -4,6 +4,7 @@ use crate::params::{app_data, parse_base_head, path_param, resolve_base_head_bra
 
 use actix_web::{HttpRequest, HttpResponse};
 
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::User;
 use liboxen::repositories;
@@ -122,6 +123,7 @@ pub async fn merge(
 
     // Get the repository or return error
     let repo = get_repo(app_data, namespace, name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;

--- a/crates/oxen-server/src/controllers/metadata.rs
+++ b/crates/oxen-server/src/controllers/metadata.rs
@@ -2,6 +2,7 @@ use crate::errors::OxenHttpError;
 use crate::helpers::{get_repo, get_repo_async};
 use crate::params::{app_data, parse_resource, parse_resource_async, path_param};
 
+use liboxen::core::repo_locks;
 use liboxen::view::StatusMessage;
 use liboxen::view::entries::EMetadataEntry;
 use liboxen::view::entry_metadata::EMetadataEntryResponseView;
@@ -117,6 +118,7 @@ pub async fn update_metadata(req: HttpRequest) -> actix_web::Result<HttpResponse
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let resource = parse_resource(&req, &repo)?;
 
     let version_str = resource

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -8,6 +8,7 @@ use futures_util::stream::StreamExt;
 use liboxen::api::requests::RepoNew;
 // Import StreamExt for the next() method
 use liboxen::constants::DEFAULT_BRANCH_NAME;
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::file::{FileContents, FileNew};
 use liboxen::model::parsed_resource::ParsedResourceView;
@@ -234,6 +235,7 @@ pub async fn update_size(req: HttpRequest) -> actix_web::Result<HttpResponse, Ox
     let name = path_param(&req, "repo_name")?.to_string();
 
     let repository = get_repo(app_data, &namespace, &name)?;
+    let _write = repo_locks::acquire_write(&repository)?;
     repositories::size::update_size(&repository)?;
 
     Ok(HttpResponse::Ok().json(StatusMessage::resource_updated()))
@@ -260,6 +262,9 @@ pub async fn get_size(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
     let name = path_param(&req, "repo_name")?.to_string();
 
     let repository = get_repo(app_data, &namespace, &name)?;
+    // `size::get_size` writes the size cache on a miss (a GET that mutates — tech-debt ENG-1374);
+    // guard the whole handler so a stop-the-world op (migration/prune/fsck) blocks it.
+    let _write = repo_locks::acquire_write(&repository)?;
     let size = repositories::size::get_size(&repository)?;
     Ok(HttpResponse::Ok().json(size))
 }

--- a/crates/oxen-server/src/controllers/tree.rs
+++ b/crates/oxen-server/src/controllers/tree.rs
@@ -2,6 +2,7 @@ use actix_web::{HttpRequest, HttpResponse, web};
 use bytesize::ByteSize;
 use futures_util::stream::{self, StreamExt as _};
 use liboxen::core::node_sync_status;
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::Commit;
 use liboxen::model::LocalRepository;
@@ -147,6 +148,7 @@ pub async fn mark_nodes_as_synced(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repository = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repository)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -177,6 +179,9 @@ pub async fn create_nodes(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repository = get_repo(app_data, namespace, repo_name)?;
+    // Acquire before streaming so a contended write is rejected with 429 up front; the guard is
+    // moved into the work future below to stay held across the deferred unpack.
+    let write_guard = repo_locks::acquire_write(&repository)?;
 
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
@@ -191,6 +196,8 @@ pub async fn create_nodes(
     // large tree never stalls the async workers that serve every other request this server handles.
     // The connection is silent for the whole unpack, so stream heartbeats to hold idle timers off.
     Ok(stream_with_heartbeat(async move {
+        // Hold the write guard across the deferred unpack (the handler has already returned).
+        let _write = write_guard;
         tokio::task::spawn_blocking(move || {
             repositories::tree::unpack_nodes(&repository, &bytes[..])
         })

--- a/crates/oxen-server/src/controllers/versions.rs
+++ b/crates/oxen-server/src/controllers/versions.rs
@@ -12,6 +12,7 @@ use async_zip::base::write::ZipFileWriter;
 use flate2::read::GzDecoder;
 use futures_util::{StreamExt, TryStreamExt as _};
 use liboxen::constants::stream_segment_size;
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::model::metadata::metadata_image::ImgResize;
@@ -118,6 +119,9 @@ pub async fn download(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    // This GET writes a resized derived blob on a cache miss (tech-debt ENG-1373); guard the whole
+    // handler so a stop-the-world op (migration/prune/fsck) blocks it.
+    let _write = repo_locks::acquire_write(&repo)?;
     let version_store = repo.version_store();
     let resource = parse_resource(&req, &repo)?;
     let commit = resource.commit.clone().ok_or(OxenHttpError::NotFound)?;
@@ -529,6 +533,7 @@ pub async fn batch_upload(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let err_files = save_multiparts(payload, &repo).await?;
     log::debug!("batch upload complete with err_files: {}", err_files.len());
 

--- a/crates/oxen-server/src/controllers/versions/chunks.rs
+++ b/crates/oxen-server/src/controllers/versions/chunks.rs
@@ -8,6 +8,7 @@ use actix_web::{HttpRequest, HttpResponse, web};
 use futures_util::stream::StreamExt as _;
 use liboxen::constants::stream_segment_size;
 use liboxen::core;
+use liboxen::core::repo_locks;
 use liboxen::repositories;
 use liboxen::view::StatusMessage;
 use liboxen::view::versions::CompleteVersionUploadRequest;
@@ -32,6 +33,7 @@ pub async fn upload(
     let offset = query.offset.unwrap_or(0);
 
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     log::debug!(
         "/upload version {} chunk offset{} to repo: {:?}",
@@ -62,6 +64,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let version_id = path_param(&req, "version_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     log::debug!("/complete version chunk upload to repo: {:?}", repo.path);
 

--- a/crates/oxen-server/src/controllers/workspaces.rs
+++ b/crates/oxen-server/src/controllers/workspaces.rs
@@ -3,6 +3,7 @@ use crate::helpers::get_repo;
 use crate::params::{NameParam, app_data, path_param};
 
 use liboxen::constants::INITIAL_COMMIT_MSG;
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::{NewCommitBody, User};
 use liboxen::repositories;
@@ -52,6 +53,7 @@ pub async fn get_or_create(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     let data: Result<NewWorkspace, serde_json::Error> = serde_json::from_str(&body);
     let data = match data {
@@ -294,6 +296,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -384,6 +387,7 @@ pub async fn commit(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let branch_name = path_param(&req, "branch")?.to_string();
 
     log::debug!(

--- a/crates/oxen-server/src/controllers/workspaces/changes.rs
+++ b/crates/oxen-server/src/controllers/workspaces/changes.rs
@@ -3,6 +3,7 @@ use crate::helpers::get_repo;
 use crate::params::{PageNumQuery, app_data, path_param};
 
 use liboxen::constants;
+use liboxen::core::repo_locks;
 use liboxen::core::staged::get_staged_db_manager;
 use liboxen::model::LocalRepository;
 use liboxen::model::Workspace;
@@ -114,6 +115,7 @@ pub async fn unstage(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let path = PathBuf::from(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -155,6 +157,7 @@ pub async fn unstage_many(
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     log::debug!("unstage_many found repo {repo_name}, workspace_id {workspace_id}");
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {

--- a/crates/oxen-server/src/controllers/workspaces/data_frames.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames.rs
@@ -9,6 +9,7 @@ use actix_web::{HttpRequest, HttpResponse, web};
 use liboxen::constants::{self, TABLE_NAME};
 use liboxen::core::db::data_frames::df_db::with_df_db_manager;
 use liboxen::core::db::data_frames::workspace_df_db::schema_without_oxen_cols;
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::{ParsedResource, Schema, Workspace};
 use liboxen::opts::DFOpts;
@@ -239,6 +240,9 @@ pub async fn get_schema(req: HttpRequest) -> Result<HttpResponse, OxenHttpError>
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    // This GET auto-indexes on a cache miss (tech-debt ENG-1375); guard the whole handler so a
+    // stop-the-world op (migration/prune/fsck) blocks it.
+    let _write = repo_locks::acquire_write(&repo)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -541,6 +545,7 @@ pub async fn put(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHtt
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     log::debug!("workspace {workspace_id} data frame put {file_path:?}");
@@ -570,6 +575,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -587,6 +593,7 @@ pub async fn rename(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let path = PathBuf::from(path_param(&req, "path")?);
     // Attempt to parse the body
     let body: RenameRequest = serde_json::from_str(&body)?; // Use the Json wrapper to get the inner value

--- a/crates/oxen-server/src/controllers/workspaces/data_frames/columns.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames/columns.rs
@@ -5,6 +5,7 @@ use crate::helpers::get_repo;
 use crate::params::{app_data, path_param};
 
 use actix_web::{HttpRequest, HttpResponse};
+use liboxen::core::repo_locks;
 use liboxen::error::StringError;
 use liboxen::model::Schema;
 use liboxen::model::data_frame::DataFrameSchemaSize;
@@ -24,6 +25,7 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace.clone(), repo_name.clone())?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     let mut body_json: Value = serde_json::from_str(&body).map_err(|_err| {
@@ -95,6 +97,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace.clone(), repo_name.clone())?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let column_name = path_param(&req, "column_name")
         .map_err(|_| OxenHttpError::BadRequest("Column name missing in path parameters".into()))?;
@@ -162,6 +165,7 @@ pub async fn update(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace.clone(), repo_name.clone())?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let column_name = path_param(&req, "column_name")
         .map_err(|_| OxenHttpError::BadRequest("Column name missing in path parameters".into()))?;
@@ -274,6 +278,7 @@ pub async fn add_column_metadata(
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let path = path_param(&req, "path")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()

--- a/crates/oxen-server/src/controllers/workspaces/data_frames/embeddings.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames/embeddings.rs
@@ -5,6 +5,7 @@ use crate::helpers::get_repo;
 use crate::params::{app_data, path_param};
 
 use actix_web::{HttpRequest, HttpResponse, web::Bytes};
+use liboxen::core::repo_locks;
 use liboxen::model::Schema;
 use liboxen::opts::{DFOpts, PaginateOpts};
 use liboxen::repositories;
@@ -149,6 +150,7 @@ pub async fn post(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, OxenHt
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let file_path = Path::new(path_param(&req, "path")?);
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {

--- a/crates/oxen-server/src/controllers/workspaces/data_frames/rows.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames/rows.rs
@@ -5,6 +5,7 @@ use crate::helpers::get_repo;
 use crate::params::{app_data, path_param};
 
 use actix_web::{HttpRequest, HttpResponse, web::Bytes};
+use liboxen::core::repo_locks;
 use liboxen::model::Schema;
 use liboxen::model::data_frame::DataFrameSchemaSize;
 use liboxen::model::data_frame::update_result::UpdateResult;
@@ -24,6 +25,7 @@ pub async fn create(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace.clone(), repo_name.clone())?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let file_path = PathBuf::from(path_param(&req, "path")?);
 
     let data = String::from_utf8(bytes.to_vec()).expect("Could not parse bytes as utf8");
@@ -134,6 +136,7 @@ pub async fn update(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, Oxen
     let row_id = path_param(&req, "row_id")?.to_string();
 
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Ok(data) = String::from_utf8(bytes.to_vec()) else {
@@ -198,6 +201,7 @@ pub async fn delete(req: HttpRequest, _bytes: Bytes) -> Result<HttpResponse, Oxe
     let row_id = path_param(&req, "row_id")?.to_string();
 
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -238,6 +242,7 @@ pub async fn batch_update(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
 
     let repo = get_repo(app_data, &namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Ok(data) = String::from_utf8(bytes.to_vec()) else {

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -4,6 +4,7 @@ use crate::params::{app_data, client_must_use_multipart_staging, path_param};
 
 use liboxen::constants::stream_segment_size;
 use liboxen::core;
+use liboxen::core::repo_locks;
 use liboxen::core::staged::get_staged_db_manager;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
@@ -80,6 +81,9 @@ pub async fn get(
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    // This GET writes a resized/thumbnail derived blob on a cache miss (tech-debt ENG-1373); guard
+    // the whole handler so a stop-the-world op (migration/prune/fsck) blocks it.
+    let _write = repo_locks::acquire_write(&repo)?;
     let version_store = repo.version_store();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -203,6 +207,7 @@ pub async fn add(req: HttpRequest, payload: Multipart) -> Result<HttpResponse, O
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, &repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let directory = path_param(&req, "path")?.to_string();
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
@@ -304,6 +309,7 @@ pub async fn add_version_files(
     let directory = path_param(&req, "directory")?.to_string();
 
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
@@ -361,6 +367,7 @@ pub async fn rm_files(
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
 
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
         return Ok(HttpResponse::NotFound()
@@ -443,6 +450,7 @@ pub async fn mv(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttp
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let workspace_id = path_param(&req, "workspace_id")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
+    let _write = repo_locks::acquire_write(&repo)?;
     let path = PathBuf::from(path_param(&req, "path")?);
 
     // Parse request body


### PR DESCRIPTION
Make the whole-repo exclusive lock actually exclude concurrent writes: every oxen-server write endpoint now holds the per-repo write guard for its duration, so a maintenance operation that takes the exclusive lock — a migration, prune, or fsck — drains the in-flight writes and rejects new ones with a 429 rather than racing them. The guard mechanism shipped earlier, but no writer held it, so the exclusive lock had nothing to drain and writes ran unblocked.

Two deliberate scoping calls: the few GET endpoints that write on a cache miss (image resize, repo size, data-frame schema) take the guard for the whole handler, so those reads also back off during a maintenance op — they're tracked for migration off GET (ENG-1373/1374/1375). Destructive ops (versions clean, fsck, workspace clear) and repo lifecycle (create/delete/transfer) are exclusive-side work handled in later steps, not here.