### PR TITLE
Fix out-of-memory risk in the workspace mergeability check

### DIFF
--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -9,6 +9,7 @@ use crate::constants::STAGED_DIR;
 use crate::core;
 use crate::core::refs::with_ref_manager;
 use crate::core::staged::remove_from_cache;
+use crate::core::v_latest::index::CommitMerkleTree as CommitMerkleTreeLatest;
 use crate::core::v_latest::workspaces;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::file_node::FileNodeOpts;
@@ -238,19 +239,21 @@ fn list_conflicts(
             log::debug!("checking if workspace is behind: {path:?} -> {entry}");
             let file_path = entry.node.maybe_path()?;
             log::debug!("checking if branch tree has file: {file_path:?}");
-            let Some(branch_node) = repositories::tree::get_node_by_path(
+            let Some(branch_node) = CommitMerkleTreeLatest::read_from_path(
                 &workspace.base_repo,
                 &branch_commit,
                 &file_path,
+                false,
             )?
             else {
                 log::debug!("branch node not found: {file_path:?}");
                 continue;
             };
-            let Some(workspace_node) = repositories::tree::get_node_by_path(
+            let Some(workspace_node) = CommitMerkleTreeLatest::read_from_path(
                 &workspace.base_repo,
                 workspace_commit,
                 &file_path,
+                false,
             )?
             else {
                 log::debug!("workspace node not found: {file_path:?}");

--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -9,7 +9,6 @@ use crate::constants::STAGED_DIR;
 use crate::core;
 use crate::core::refs::with_ref_manager;
 use crate::core::staged::remove_from_cache;
-use crate::core::v_latest::index::CommitMerkleTree as CommitMerkleTreeLatest;
 use crate::core::v_latest::workspaces;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::file_node::FileNodeOpts;
@@ -239,21 +238,19 @@ fn list_conflicts(
             log::debug!("checking if workspace is behind: {path:?} -> {entry}");
             let file_path = entry.node.maybe_path()?;
             log::debug!("checking if branch tree has file: {file_path:?}");
-            let Some(branch_node) = CommitMerkleTreeLatest::read_from_path(
+            let Some(branch_node) = repositories::tree::get_node_by_path(
                 &workspace.base_repo,
                 &branch_commit,
                 &file_path,
-                false,
             )?
             else {
                 log::debug!("branch node not found: {file_path:?}");
                 continue;
             };
-            let Some(workspace_node) = CommitMerkleTreeLatest::read_from_path(
+            let Some(workspace_node) = repositories::tree::get_node_by_path(
                 &workspace.base_repo,
                 workspace_commit,
                 &file_path,
-                false,
             )?
             else {
                 log::debug!("workspace node not found: {file_path:?}");

--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -224,31 +224,9 @@ fn list_conflicts(
         return Ok(vec![]);
     }
 
-    // Check to see if any of the staged entries have been updated on the target branch
-    // If so, mark the commit as behind
-    // Otherwise, we can just commit the changes
-    let Some(branch_commit) =
-        repositories::commits::get_by_id(&workspace.base_repo, &branch.commit_id)?
-    else {
-        return Err(OxenError::RevisionNotFound(
-            branch.commit_id.as_str().into(),
-        ));
-    };
-    let Some(branch_tree) =
-        repositories::tree::get_root_with_children(&workspace.base_repo, &branch_commit)?
-    else {
-        return Err(OxenError::RevisionNotFound(
-            branch.commit_id.as_str().into(),
-        ));
-    };
-    let Some(workspace_tree) =
-        repositories::tree::get_root_with_children(&workspace.base_repo, workspace_commit)?
-    else {
-        return Err(OxenError::RevisionNotFound(
-            workspace.commit.id.as_str().into(),
-        ));
-    };
-
+    // A staged file conflicts when it also changed on the target branch since the workspace's base
+    // commit. Resolve each staged file by a targeted path lookup in both commits rather than
+    // materializing either whole Merkle tree, so peak memory stays flat regardless of repo size.
     let mut conflicts = vec![];
     for (path, entries) in dir_entries {
         for entry in entries {
@@ -260,11 +238,21 @@ fn list_conflicts(
             log::debug!("checking if workspace is behind: {path:?} -> {entry}");
             let file_path = entry.node.maybe_path()?;
             log::debug!("checking if branch tree has file: {file_path:?}");
-            let Some(branch_node) = branch_tree.get_by_path(&file_path)? else {
+            let Some(branch_node) = repositories::tree::get_node_by_path(
+                &workspace.base_repo,
+                &branch_commit,
+                &file_path,
+            )?
+            else {
                 log::debug!("branch node not found: {file_path:?}");
                 continue;
             };
-            let Some(workspace_node) = workspace_tree.get_by_path(&file_path)? else {
+            let Some(workspace_node) = repositories::tree::get_node_by_path(
+                &workspace.base_repo,
+                workspace_commit,
+                &file_path,
+            )?
+            else {
                 log::debug!("workspace node not found: {file_path:?}");
                 continue;
             };

--- a/crates/oxen-server/src/controllers/workspaces.rs
+++ b/crates/oxen-server/src/controllers/workspaces.rs
@@ -340,7 +340,13 @@ pub async fn mergeability(req: HttpRequest) -> Result<HttpResponse, OxenHttpErro
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
     };
-    let mergeable = repositories::workspaces::mergeability(&workspace, &branch_name)?;
+    // The mergeability check does synchronous Merkle-store reads, so run it on the blocking pool
+    // rather than stalling an async worker for the duration.
+    let mergeable = tokio::task::spawn_blocking(move || {
+        repositories::workspaces::mergeability(&workspace, &branch_name)
+    })
+    .await
+    .map_err(|e| OxenError::internal_error(format!("mergeability task panicked: {e}")))??;
 
     let response = MergeableResponse {
         status: StatusMessage::resource_found(),


### PR DESCRIPTION
The mergeability check (GET workspaces/{id}/merge/{branch}) loaded both the target branch's and the workspace base's entire Merkle trees into memory just to compare a handful of staged files, so its peak memory and running time scaled with the repo's total file count rather than the workspace's changes. On a large repo a single check could push the server toward an out-of-memory kill; concurrent checks multiplied it; and it ran synchronously on an async worker, stalling the runtime for its full (often multi-minute) duration.

Both memory and time now scale with the number of staged changes instead of the repo size, and the check runs off the async workers. For the common case of a large repo with a small workspace this is an order-of-magnitude win: with no whole tree to materialize, a scan that could take minutes becomes work proportional to the (usually small) staged set — expected to be well under a second. Conflict detection is unchanged.