### PR TITLE
Repo Integrity (1.14.3): Exclude concurrent writes during destructive maintenance ops

### DIFF
--- a/crates/liboxen/src/repositories/prune.rs
+++ b/crates/liboxen/src/repositories/prune.rs
@@ -1,6 +1,5 @@
 //! Prune orphaned nodes and version files from the repository
 
-use crate::core::repo_locks;
 use crate::core::v_latest::prune::{
     PruneStats, prune as prune_impl, prune_remote as prune_remote_impl,
 };
@@ -19,15 +18,7 @@ use crate::model::{LocalRepository, RemoteRepository};
 /// # Returns
 /// Statistics about the prune operation
 pub async fn prune(repo: &LocalRepository, dry_run: bool) -> Result<PruneStats, OxenError> {
-    let work = prune_impl(repo, dry_run);
-    if dry_run {
-        // Dry run only reports what would be removed; no exclusive lock needed.
-        work.await
-    } else {
-        // The sweep deletes nodes and version files; hold the whole-repo exclusive lock so no
-        // write lands mid-prune.
-        repo_locks::with_repo_exclusive(repo, work).await
-    }
+    prune_impl(repo, dry_run).await
 }
 
 /// Prune orphaned nodes and version files from a remote repository

--- a/crates/oxen-server/src/controllers/prune.rs
+++ b/crates/oxen-server/src/controllers/prune.rs
@@ -2,8 +2,9 @@ use crate::errors::OxenHttpError;
 use crate::helpers::get_repo;
 use crate::params::{app_data, path_param};
 use actix_web::{HttpRequest, HttpResponse, web};
+use liboxen::core::repo_locks;
 use liboxen::repositories;
-use liboxen::view::http::{STATUS_ERROR, STATUS_SUCCESS};
+use liboxen::view::http::STATUS_SUCCESS;
 use liboxen::view::oxen_response::ErrorResponse;
 use serde::{Deserialize, Serialize};
 
@@ -50,51 +51,36 @@ pub async fn prune(
 
     log::info!("Prune requested for {namespace}/{repo_name} (dry_run: {dry_run})");
 
-    // Run the prune operation
-    match repositories::prune::prune(&repository, dry_run).await {
-        Ok(stats) => {
-            let status_message = if dry_run {
-                "Prune dry-run completed successfully. No files were deleted.".to_string()
-            } else {
-                "Prune completed successfully.".to_string()
-            };
+    // Prune deletes nodes and version files; hold the whole-repo exclusive lock so no write lands
+    // mid-prune. A dry run only reports what would be removed, so it needs no lock.
+    let stats = if dry_run {
+        repositories::prune::prune(&repository, true).await?
+    } else {
+        repo_locks::with_repo_exclusive(&repository, repositories::prune::prune(&repository, false))
+            .await?
+    };
 
-            let response = PruneResponse {
-                status: STATUS_SUCCESS.to_string(),
-                status_message,
-                status_description: None,
-                error: None,
-                stats: PruneStatsResponse {
-                    nodes_scanned: stats.nodes_scanned,
-                    nodes_kept: stats.nodes_kept,
-                    nodes_removed: stats.nodes_removed,
-                    versions_scanned: stats.versions_scanned,
-                    versions_kept: stats.versions_kept,
-                    versions_removed: stats.versions_removed,
-                    bytes_freed: stats.bytes_freed,
-                },
-            };
+    let status_message = if dry_run {
+        "Prune dry-run completed successfully. No files were deleted.".to_string()
+    } else {
+        "Prune completed successfully.".to_string()
+    };
 
-            Ok(HttpResponse::Ok().json(response))
-        }
-        Err(err) => {
-            log::error!("Prune failed: {err}");
-            let response = PruneResponse {
-                status: STATUS_ERROR.to_string(),
-                status_message: format!("Prune failed: {err}"),
-                status_description: None,
-                error: None,
-                stats: PruneStatsResponse {
-                    nodes_scanned: 0,
-                    nodes_kept: 0,
-                    nodes_removed: 0,
-                    versions_scanned: 0,
-                    versions_kept: 0,
-                    versions_removed: 0,
-                    bytes_freed: 0,
-                },
-            };
-            Ok(HttpResponse::InternalServerError().json(response))
-        }
-    }
+    let response = PruneResponse {
+        status: STATUS_SUCCESS.to_string(),
+        status_message,
+        status_description: None,
+        error: None,
+        stats: PruneStatsResponse {
+            nodes_scanned: stats.nodes_scanned,
+            nodes_kept: stats.nodes_kept,
+            nodes_removed: stats.nodes_removed,
+            versions_scanned: stats.versions_scanned,
+            versions_kept: stats.versions_kept,
+            versions_removed: stats.versions_removed,
+            bytes_freed: stats.bytes_freed,
+        },
+    };
+
+    Ok(HttpResponse::Ok().json(response))
 }

--- a/crates/oxen-server/src/controllers/workspaces.rs
+++ b/crates/oxen-server/src/controllers/workspaces.rs
@@ -3,6 +3,7 @@ use crate::helpers::get_repo;
 use crate::params::{NameParam, app_data, path_param};
 
 use liboxen::constants::INITIAL_COMMIT_MSG;
+use liboxen::core::repo_locks;
 use liboxen::error::OxenError;
 use liboxen::model::{NewCommitBody, User};
 use liboxen::repositories;
@@ -267,7 +268,10 @@ pub async fn clear(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let namespace = path_param(&req, "namespace")?.to_string();
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
-    repositories::workspaces::clear(&repo)?;
+    // Clearing all workspaces is a destructive write; hold the whole-repo exclusive lock so no
+    // write lands mid-clear.
+    repo_locks::with_repo_exclusive(&repo, async { repositories::workspaces::clear(&repo) })
+        .await?;
     Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))
 }
 

--- a/crates/oxen-server/src/controllers/workspaces.rs
+++ b/crates/oxen-server/src/controllers/workspaces.rs
@@ -269,9 +269,14 @@ pub async fn clear(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let repo_name = path_param(&req, "repo_name")?.to_string();
     let repo = get_repo(app_data, namespace, repo_name)?;
     // Clearing all workspaces is a destructive write; hold the whole-repo exclusive lock so no
-    // write lands mid-clear.
-    repo_locks::with_repo_exclusive(&repo, async { repositories::workspaces::clear(&repo) })
-        .await?;
+    // write lands mid-clear. The sweep is synchronous IO, so it runs off the actix worker thread.
+    let clear_repo = repo.clone();
+    repo_locks::with_repo_exclusive(&repo, async move {
+        tokio::task::spawn_blocking(move || repositories::workspaces::clear(&clear_repo))
+            .await
+            .map_err(OxenError::from)?
+    })
+    .await?;
     Ok(HttpResponse::Ok().json(StatusMessage::resource_created()))
 }
 


### PR DESCRIPTION
The workspaces clear endpoint now holds the whole-repo exclusive lock while it runs, so a concurrent workspace write (create/commit/import/data-frame mutation) can no longer race its directory removal into a torn state, an orphaned DuckDB handle, or an NFS ENOTEMPTY failure.

Prune's wrap also moves out of `repositories::prune::prune` down into its controller, so both exclusive consumers live uniformly at the server controllers and the exclusion never fires on the single-process CLI path. The prune controller now propagates failures through OxenHttpError like every other handler rather than wrapping them in a 500 with a zero-stats body, so lock contention surfaces as 429 + Retry-After and callers back off and retry.

ENG-1409