### PR TITLE
Speed up file metadata and directory listings on workspace-heavy repos

### DIFF
--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -6,6 +6,10 @@ use crate::core::db::data_frames::df_db;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
 use crate::core::staged::get_staged_db_manager;
 use crate::core::v_latest::workspaces::files::{add, track_modified_data_frame};
+use crate::repositories::workspaces::data_frames::duckdb_path_in_dir;
+use crate::repositories::workspaces::{
+    list_dirs as list_workspace_dirs, read_config as read_workspace_config,
+};
 use parking_lot::Mutex;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -43,14 +47,57 @@ pub fn is_queryable_data_frame_indexed_from_file_node(
     file_node: &FileNode,
     path: &Path,
 ) -> Result<bool, OxenError> {
-    match get_queryable_data_frame_workspace_from_file_node(repo, file_node.last_commit_id(), path)
-    {
-        Ok(_workspace) => Ok(true),
-        Err(e) => match e {
-            OxenError::QueryableWorkspaceNotFound => Ok(false),
-            _ => Err(e),
-        },
+    let dir = find_queryable_workspace_dir(repo, file_node.last_commit_id(), path)?;
+    Ok(dir.is_some())
+}
+
+/// Directory of the non-editable workspace holding a fully-indexed queryable table for `path` at
+/// `commit_id`, or `None` when no workspace holds one. Costs one config read per workspace in the
+/// repo, and loads no workspace.
+fn find_queryable_workspace_dir(
+    repo: &LocalRepository,
+    commit_id: &MerkleHash,
+    path: &Path,
+) -> Result<Option<PathBuf>, OxenError> {
+    log::debug!("Looking for workspace with commit id {commit_id:?}");
+
+    for workspace_dir in list_workspace_dirs(repo)? {
+        let Some(config) = read_workspace_config(&workspace_dir)? else {
+            // A workspace dir with no config is one being created or torn down.
+            log::debug!("No workspace config in {workspace_dir:?}, skipping");
+            continue;
+        };
+        // Matching on parsed hashes, not strings: an unparseable id names no commit at all.
+        let Ok(workspace_commit_id) = config.workspace_commit_id.parse::<MerkleHash>() else {
+            log::warn!(
+                "Workspace {workspace_dir:?} is pinned to an unreadable commit id {:?}, skipping",
+                config.workspace_commit_id
+            );
+            continue;
+        };
+        if config.is_editable || workspace_commit_id != *commit_id {
+            continue;
+        }
+
+        let db_path = duckdb_path_in_dir(&workspace_dir, path);
+        if !db_path.exists() {
+            continue;
+        }
+
+        // Only treat this as the queryable workspace if its DuckDB table is
+        // fully indexed (all OXEN_COLS present). A missing file, or a partial
+        // table left by an interrupted index, is treated as not indexed so the
+        // caller rebuilds rather than serving a table the read path can't bind.
+        match with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| Ok(df_db::table_is_fully_indexed(conn, TABLE_NAME)?))
+        }) {
+            Ok(true) => return Ok(Some(workspace_dir)),
+            Ok(false) => {}
+            Err(e) => log::warn!("Failed to check index completeness for {db_path:?}: {e}"),
+        }
     }
+
+    Ok(None)
 }
 
 pub fn get_queryable_data_frame_workspace_from_file_node(
@@ -58,42 +105,12 @@ pub fn get_queryable_data_frame_workspace_from_file_node(
     commit_id: &MerkleHash,
     path: &Path,
 ) -> Result<Workspace, OxenError> {
-    let workspaces = repositories::workspaces::list(repo)?;
-    log::debug!("Looking for workspace with commit id {commit_id:?}");
+    let Some(workspace_dir) = find_queryable_workspace_dir(repo, commit_id, path)? else {
+        return Err(OxenError::QueryableWorkspaceNotFound);
+    };
 
-    for workspace in workspaces {
-        // log::debug!("is workspace editable: {:?}", workspace.is_editable);
-        // log::debug!("workspace commit id: {:?}", workspace.commit.id);
-        // Ensure the workspace is not editable and matches the commit ID of the resource
-        if !workspace.is_editable && workspace.commit.id == commit_id.to_string() {
-            // Construct the path to the DuckDB resource within the workspace
-            let workspace_file_db_path =
-                repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-
-            // Only treat this as the queryable workspace if its DuckDB table is
-            // fully indexed (all OXEN_COLS present). A missing file, or a partial
-            // table left by an interrupted index, is treated as not indexed so the
-            // caller rebuilds rather than serving a table the read path can't bind.
-            if workspace_file_db_path.exists() {
-                let fully_indexed = match with_df_db_manager(&workspace_file_db_path, |manager| {
-                    manager.with_conn(|conn| Ok(df_db::table_is_fully_indexed(conn, TABLE_NAME)?))
-                }) {
-                    Ok(fully_indexed) => fully_indexed,
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to check index completeness for {workspace_file_db_path:?}: {e}"
-                        );
-                        false
-                    }
-                };
-                if fully_indexed {
-                    return Ok(workspace);
-                }
-            }
-        }
-    }
-
-    Err(OxenError::QueryableWorkspaceNotFound)
+    repositories::workspaces::get_by_dir(repo, &workspace_dir)?
+        .ok_or(OxenError::QueryableWorkspaceNotFound)
 }
 
 pub fn get_queryable_data_frame_workspace(

--- a/crates/liboxen/src/repositories/workspaces.rs
+++ b/crates/liboxen/src/repositories/workspaces.rs
@@ -67,16 +67,11 @@ pub fn get_by_dir(
 ) -> Result<Option<Workspace>, OxenError> {
     let workspace_dir = workspace_dir.as_ref();
     let workspace_id = workspace_dir.file_name().unwrap().to_str().unwrap();
-    let config_path = Workspace::config_path_from_dir(workspace_dir);
 
-    if !config_path.exists() {
+    let Some(config) = read_config(workspace_dir)? else {
         log::debug!("workspace::get workspace not found: {workspace_dir:?}");
         return Ok(None);
-    }
-
-    let config_contents = util::fs::read_from_path(&config_path)?;
-    let config: WorkspaceConfig = toml::from_str(&config_contents)
-        .map_err(|e| OxenError::basic_str(format!("Failed to parse workspace config: {e}")))?;
+    };
 
     let Some(commit) = repositories::commits::get_by_id(repo, &config.workspace_commit_id)? else {
         return Err(OxenError::basic_str(format!(
@@ -101,6 +96,21 @@ pub fn get_by_dir(
         commit,
         is_editable: config.is_editable,
     }))
+}
+
+/// Config of the workspace whose directory is `workspace_dir`, or `None` when that directory holds
+/// no workspace config. Much cheaper than [`get_by_dir`], which also resolves the pinned commit and
+/// builds two `LocalRepository` values — prefer this when only the config's own fields are needed.
+pub(crate) fn read_config(workspace_dir: &Path) -> Result<Option<WorkspaceConfig>, OxenError> {
+    let config_path = Workspace::config_path_from_dir(workspace_dir);
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    let config_contents = util::fs::read_from_path(&config_path)?;
+    let config = toml::from_str(&config_contents)
+        .map_err(|e| OxenError::basic_str(format!("Failed to parse workspace config: {e}")))?;
+    Ok(Some(config))
 }
 
 pub fn get_by_name(
@@ -456,30 +466,33 @@ fn check_existing_workspace_name(
     Ok(())
 }
 
+/// Directory of every workspace in the repository, without loading any workspace state. Pair with
+/// [`read_config`] to filter on config fields before paying for a full [`get_by_dir`] load.
+pub(crate) fn list_dirs(repo: &LocalRepository) -> Result<Vec<PathBuf>, OxenError> {
+    let workspaces_dir = Workspace::workspaces_dir(repo);
+    if !workspaces_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    util::fs::list_dirs_in_dir(&workspaces_dir)
+        .map_err(|e| OxenError::basic_str(format!("Error listing workspace directories: {e}")))
+}
+
 /// Returns a lazy iterator over all workspaces in the repository.
 /// Each workspace is loaded from the filesystem on demand.
 fn iter_workspaces(
     repo: &LocalRepository,
 ) -> Result<impl Iterator<Item = Result<Option<Workspace>, OxenError>> + '_, OxenError> {
-    let workspaces_dir = Workspace::workspaces_dir(repo);
-    log::debug!("workspace::iter_workspaces got workspaces_dir: {workspaces_dir:?}");
-
-    let workspace_hashes = if workspaces_dir.exists() {
-        util::fs::list_dirs_in_dir(&workspaces_dir).map_err(|e| {
-            OxenError::basic_str(format!("Error listing workspace directories: {e}"))
-        })?
-    } else {
-        Vec::new()
-    };
+    let workspace_dirs = list_dirs(repo)?;
 
     log::debug!(
         "workspace::iter_workspaces got {} workspaces",
-        workspace_hashes.len()
+        workspace_dirs.len()
     );
 
-    Ok(workspace_hashes
+    Ok(workspace_dirs
         .into_iter()
-        .map(move |workspace_hash| get_by_dir(repo, &workspace_hash)))
+        .map(move |workspace_dir| get_by_dir(repo, &workspace_dir)))
 }
 
 pub fn list(repo: &LocalRepository) -> Result<Vec<Workspace>, OxenError> {

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -395,15 +395,16 @@ pub async fn set_media_render_metadata_if_applicable(
 }
 
 pub fn duckdb_path(workspace: &Workspace, path: &Path) -> PathBuf {
+    duckdb_path_in_dir(&workspace.dir(), path)
+}
+
+/// Path of the DuckDB index for the data frame at `path` within the workspace directory
+/// `workspace_dir`.
+pub(crate) fn duckdb_path_in_dir(workspace_dir: &Path, path: &Path) -> PathBuf {
     let path = util::fs::linux_path(path);
-    log::debug!(
-        "duckdb_path path: {:?} workspace: {:?}",
-        path,
-        workspace.dir()
-    );
+    log::debug!("duckdb_path path: {path:?} workspace dir: {workspace_dir:?}");
     let path_hash = util::hasher::hash_str(path.to_string_lossy());
-    workspace
-        .dir()
+    workspace_dir
         .join(OXEN_HIDDEN_DIR)
         .join(MODS_DIR)
         .join("duckdb")
@@ -473,6 +474,7 @@ mod tests {
     use crate::repositories;
     use crate::repositories::workspaces;
     use crate::test;
+    use crate::util::fs::AtomicFile;
 
     #[tokio::test]
     async fn test_add_row() -> Result<(), OxenError> {
@@ -2038,6 +2040,93 @@ mod tests {
             let inner = series.list()?.get_as_series(0).unwrap();
             let values: Vec<f64> = inner.f64()?.into_iter().map(|v| v.unwrap()).collect();
             assert_eq!(values, vec![0.1, 0.2, 0.3]);
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_queryable_lookup_skips_editable_and_unloadable_workspaces()
+    -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+
+            // An editable workspace's indexed table holds staged edits, not a queryable index.
+            let editable = workspaces::create(&repo, &commit, "editable-df", true)?;
+            workspaces::data_frames::index(&repo, &editable, &file_path).await?;
+            assert!(!is_queryable_data_frame_indexed(
+                &repo, &file_path, &commit
+            )?);
+
+            let queryable = workspaces::create(&repo, &commit, "queryable-df", false)?;
+            workspaces::data_frames::index(&repo, &queryable, &file_path).await?;
+            assert!(is_queryable_data_frame_indexed(&repo, &file_path, &commit)?);
+            let found = get_queryable_data_frame_workspace(&repo, &file_path, &commit)?;
+            assert_eq!(found.id, queryable.id);
+
+            // Point a sibling workspace at a commit the merkle tree doesn't hold, so nothing can
+            // load it. The lookup still answers from the workspace holding the index — where the
+            // pre-change lookup, which loaded every workspace up front, failed the whole request.
+            repoint_workspace(&editable, &"f".repeat(32))?;
+
+            assert!(is_queryable_data_frame_indexed(&repo, &file_path, &commit)?);
+            let found = get_queryable_data_frame_workspace(&repo, &file_path, &commit)?;
+            assert_eq!(found.id, queryable.id);
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// Rewrites a workspace's config to be non-editable and pinned to `commit_id`, which
+    /// create-time validation would otherwise reject.
+    fn repoint_workspace(workspace: &Workspace, commit_id: &str) -> Result<(), OxenError> {
+        let mut config = workspaces::read_config(&workspace.dir())?
+            .expect("a just-created workspace has a config");
+        config.is_editable = false;
+        config.workspace_commit_id = commit_id.to_string();
+        let toml_string = toml::to_string(&config).expect("workspace config serializes to TOML");
+        AtomicFile::new(workspace.config_path()).write(toml_string.as_bytes())?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_queryable_lookup_walks_past_workspaces_it_cannot_load() -> Result<(), OxenError> {
+        // Skip duckdb if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let commit = repositories::commits::head_commit(&repo)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+
+            // Nothing here is queryable, so the lookup cannot return early and has to walk past
+            // every workspace: one pinned to a commit the merkle tree doesn't hold, one whose
+            // pinned id isn't a hash at all. Both must be skipped, not raised.
+            let dangling = workspaces::create(&repo, &commit, "dangling-df", true)?;
+            let unparseable = workspaces::create(&repo, &commit, "unparseable-df", true)?;
+            repoint_workspace(&dangling, &"f".repeat(32))?;
+            repoint_workspace(&unparseable, "not-a-hash")?;
+
+            assert!(!is_queryable_data_frame_indexed(
+                &repo, &file_path, &commit
+            )?);
+            assert!(matches!(
+                get_queryable_data_frame_workspace(&repo, &file_path, &commit),
+                Err(OxenError::QueryableWorkspaceNotFound)
+            ));
+
             Ok(())
         })
         .await


### PR DESCRIPTION
Make workspace file metadata and directory listings much cheaper on repositories that have accumulated workspaces. Also, don't let one broken workspace fail metadata for every tabular file in the repo.

Answering "does this data frame have a queryable index?" loaded and fully constructed every workspace in the repository, and did it once per tabular file in a directory listing. So listing a directory of CSVs cost a full workspace load per entry per workspace. Each load resolved that workspace's pinned commit out of the merkle tree, re-read and re-parsed the repository config, and built two LocalRepository values, only for the caller to read two fields that were already sitting in the workspace config it had just parsed. Query workspaces are created with random ids and nothing ever collects them, so that multiplier grows for the life of the repository.

The check now decides from each workspace's config alone and loads at most one workspace, or none at all for the boolean the metadata path asks for.

This also fixes a fault-isolation bug. Unrelated workspaces' commits are no longer resolved, so a workspace whose config names a commit the merkle tree no longer holds is skipped rather than failing the request. Previously a single such workspace made metadata fail for every tabular file in the repository.

This mitigates rather than fixes the underlying problem. A queryable index is a derived artifact determined by the source file's content, yet it lives inside a randomly-named mutable container, so it can still only be found by searching every container, and those containers still accumulate without bound. ENG-1415 makes it addressable.