### PR TITLE
Async (16): compare/dir_tree to async

### DIFF
--- a/crates/liboxen/src/core/v_latest/diff.rs
+++ b/crates/liboxen/src/core/v_latest/diff.rs
@@ -296,7 +296,19 @@ pub async fn list_diff_entries(
     })
 }
 
-pub fn list_changed_dirs(
+pub async fn list_changed_dirs(
+    repo: &LocalRepository,
+    base_commit: &Commit,
+    head_commit: &Commit,
+) -> Result<Vec<(PathBuf, DiffEntryStatus)>, OxenError> {
+    let repo = repo.clone();
+    let base_commit = base_commit.clone();
+    let head_commit = head_commit.clone();
+    tokio::task::spawn_blocking(move || list_changed_dirs_sync(&repo, &base_commit, &head_commit))
+        .await?
+}
+
+fn list_changed_dirs_sync(
     repo: &LocalRepository,
     base_commit: &Commit,
     head_commit: &Commit,

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -213,7 +213,7 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
     let dir_diffs =
-        repositories::diffs::list_changed_dirs(&repository, &base_commit, &head_commit)?;
+        repositories::diffs::list_changed_dirs(&repository, &base_commit, &head_commit).await?;
     log::debug!("dir_diffs: {dir_diffs:?}");
 
     let dir_diff_tree = group_dir_diffs_by_dir(dir_diffs);


### PR DESCRIPTION
The compare-dir-tree endpoint ran its work on the request worker: reading both commit trees and comparing their directories by hash to find what changed. It now runs on a background thread.

Completes ENG-1292
