### PR TITLE
Pin uv version to prevent flaky tests

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -130,7 +130,7 @@ jobs:
           workspaces: "."
 
       - name: Load tool versions
-        run: cat tool-versions.env >> "$GITHUB_ENV"
+        run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -131,6 +131,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.29"
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -129,10 +129,13 @@ jobs:
           shared-key: "release-python"
           workspaces: "."
 
+      - name: Load tool versions
+        run: cat tool-versions.env >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.29"
+          version: ${{ env.UV_VERSION }}
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.29"
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -70,10 +70,13 @@ jobs:
           shared-key: "release-python"
           workspaces: "."
 
+      - name: Load tool versions
+        run: cat tool-versions.env >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.29"
+          version: ${{ env.UV_VERSION }}
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -71,7 +71,7 @@ jobs:
           workspaces: "."
 
       - name: Load tool versions
-        run: cat tool-versions.env >> "$GITHUB_ENV"
+        run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -108,7 +108,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          choco install -y cmake llvm uv rustup.install
+          $uvVersion = (Select-String -Path tool-versions.env -Pattern '^UV_VERSION=(.+)$').Matches.Groups[1].Value
+          if (-not $uvVersion) { throw "UV_VERSION missing from tool-versions.env" }
+          choco install -y cmake llvm rustup.install
+          choco install -y uv --version $uvVersion
           # Install vcpkg for FFmpeg development libraries
           git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
           cd C:\vcpkg

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Load tool versions
-        run: cat tool-versions.env >> "$GITHUB_ENV"
+        run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -50,10 +50,13 @@ jobs:
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
+      - name: Load tool versions
+        run: cat tool-versions.env >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.29"
+          version: ${{ env.UV_VERSION }}
 
       - name: Bump version
         id: bump

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.29"
 
       - name: Bump version
         id: bump

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
+          version: "0.11.29"
           python-version: "3.11"
 
       - name: Cache Rust dependencies

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -26,10 +26,13 @@ jobs:
         with:
           components: clippy
 
+      - name: Load tool versions
+        run: cat tool-versions.env >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.29"
+          version: ${{ env.UV_VERSION }}
           python-version: "3.11"
 
       - name: Cache Rust dependencies

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -27,7 +27,7 @@ jobs:
           components: clippy
 
       - name: Load tool versions
-        run: cat tool-versions.env >> "$GITHUB_ENV"
+        run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.29"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -23,10 +23,13 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Load tool versions
+        run: cat tool-versions.env >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.29"
+          version: ${{ env.UV_VERSION }}
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -24,7 +24,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Load tool versions
-        run: cat tool-versions.env >> "$GITHUB_ENV"
+        run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -215,6 +215,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
+          version: "0.11.29"
           python-version: "3.11" # Test against the earliest supported Python version
 
       - name: Install dependencies (macOS)

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -221,7 +221,7 @@ jobs:
         run: |
           Get-Content tool-versions.env |
             Where-Object { $_ -match '^[A-Z0-9_]+=' } |
-            ForEach-Object { $_ >> $env:GITHUB_ENV }
+            ForEach-Object { Add-Content -Path $env:GITHUB_ENV -Value $_ -Encoding utf8 }
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -213,7 +213,15 @@ jobs:
           cache-bin: false # See rust-test job for rationale.
 
       - name: Load tool versions
+        if: matrix.platform != 'windows'
         run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
+
+      - name: Load tool versions
+        if: matrix.platform == 'windows'
+        run: |
+          Get-Content tool-versions.env |
+            Where-Object { $_ -match '^[A-Z0-9_]+=' } |
+            ForEach-Object { $_ >> $env:GITHUB_ENV }
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -213,7 +213,7 @@ jobs:
           cache-bin: false # See rust-test job for rationale.
 
       - name: Load tool versions
-        run: cat tool-versions.env >> "$GITHUB_ENV"
+        run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -212,10 +212,13 @@ jobs:
           cache-on-failure: true
           cache-bin: false # See rust-test job for rationale.
 
+      - name: Load tool versions
+        run: cat tool-versions.env >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.29"
+          version: ${{ env.UV_VERSION }}
           python-version: "3.11" # Test against the earliest supported Python version
 
       - name: Install dependencies (macOS)

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -120,6 +120,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.29"
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -118,10 +118,13 @@ jobs:
             rubygems \
             pkg-config
 
+      - name: Load tool versions
+        run: cat tool-versions.env >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.29"
+          version: ${{ env.UV_VERSION }}
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -119,7 +119,7 @@ jobs:
             pkg-config
 
       - name: Load tool versions
-        run: cat tool-versions.env >> "$GITHUB_ENV"
+        run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -55,7 +55,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
       - name: Load tool versions
-        run: cat tool-versions.env >> "$GITHUB_ENV"
+        run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -54,10 +54,13 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
+      - name: Load tool versions
+        run: cat tool-versions.env >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.29"
+          version: ${{ env.UV_VERSION }}
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.29"
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -103,7 +103,11 @@ jobs:
           # install would be masked by the next command and only surface later
           # as a confusing build error. Check each critical command. choco
           # returns 3010 to mean "installed, reboot pending", which is success.
-          choco install -y cmake llvm uv rustup.install nasm
+          $uvVersion = (Select-String -Path tool-versions.env -Pattern '^UV_VERSION=(.+)$').Matches.Groups[1].Value
+          if (-not $uvVersion) { throw "UV_VERSION missing from tool-versions.env" }
+          choco install -y cmake llvm rustup.install nasm
+          if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { exit $LASTEXITCODE }
+          choco install -y uv --version $uvVersion
           if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { exit $LASTEXITCODE }
           if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
             choco install -y awscli

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ brew install cmake
 
 The [Python interface](./oxen-python/README.md) uses [`liboxen`](./crates/liboxen/) bindings provided by PyO3.
 
-The `oxen-python` codebase requires installing [`uv`](https://docs.astral.sh/uv/getting-started/installation/):
+The `oxen-python` codebase requires installing [`uv`](https://docs.astral.sh/uv/getting-started/installation/). Use the version pinned in `tool-versions.env`:
 
 ```bash
-curl --LsSf https://astral.sh/uv/install.sh | sh
+source ./tool-versions.env && curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
 ```
 
 If you use [`mise`](https://mise.jdx.dev/) to manage your Python installs, you may run into an error where the oxen-py crate can't find the Python dynamic library to link with, e.g., `dyld[31558]: Library not loaded: @rpath/libpython3.13.dylib`

--- a/bin/install-prereqs
+++ b/bin/install-prereqs
@@ -213,11 +213,22 @@ install_cargo_tool cargo-sort     cargo-sort     "$CARGO_SORT_VERSION" "--locked
 
 info "Checking uv..."
 
+NEED_UV=false
 if command_exists uv; then
-    ok "uv already installed"
+    INSTALLED_UV_VERSION="$(uv --version | awk '{print $2}')"
+    if [ "$INSTALLED_UV_VERSION" = "$UV_VERSION" ]; then
+        ok "uv already installed at $UV_VERSION"
+    else
+        warn "uv version mismatch: installed=$INSTALLED_UV_VERSION, want=$UV_VERSION"
+        NEED_UV=true
+    fi
 else
-    info "Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    NEED_UV=true
+fi
+
+if $NEED_UV; then
+    info "Installing uv $UV_VERSION..."
+    curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
     INSTALLED_UV=true
     # Make uv available for the rest of this script
     UV_BIN_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"

--- a/tool-versions.env
+++ b/tool-versions.env
@@ -2,7 +2,8 @@
 #
 # This file is the single source of truth read by:
 #   - bin/install-prereqs
-#   - .github/workflows/ci_lint.yml
+#   - bin/install-ffmpeg
+#   - .github/workflows that install uv (setup-uv and Windows choco)
 #   - .pre-commit-config.yaml (local hooks)
 #
 # Format: KEY=VALUE (no spaces around '=', no quoting needed).
@@ -26,6 +27,9 @@ SHELLCHECK_VERSION=0.11.0
 FFMPEG_VERSION=8.1.2
 FFMPEG_SHA256_LINUX_X86_64=9d9de50c45777c84721719f281618e6e6ea387f02815a75d8eb97a2910c7e19f
 FFMPEG_SHA256_LINUX_AARCH64=8f6bd90024beb2bd2ee3bcae1e0f8c9a61f2bda41487cbc3fddfe55029b364d4
+
+# uv (Python package/project manager). Pinned so setup-uv uses a fixed release and its cache.
+UV_VERSION=0.11.29
 
 # Python tools (installed via uvx / uv tool)
 RUFF_VERSION=0.15.13


### PR DESCRIPTION
Every Install uv step left the version unpinned, so the action fetched the latest-version manifest from raw.githubusercontent.com on each run. That fetch is flaky and periodically fails CI.

Pin uv to 0.11.29 in tool-versions.env and have every install path read it: bin/install-prereqs, the eight setup-uv workflows, and the Windows choco installs. With the version fixed, setup-uv skips that lookup and uses its cache, so the flaky call is gone and local and CI stay on the same uv.