### PR TITLE
Async (17): data_frames::get offload to async

### DIFF
--- a/crates/liboxen/src/core/v_latest/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames.rs
@@ -7,7 +7,7 @@ use crate::model::data_frame::{DataFrameSchemaSize, DataFrameSlice, DataFrameSli
 use crate::model::merkle_tree::node::EMerkleTreeNode;
 use crate::model::metadata::generic_metadata::GenericMetadata;
 use crate::model::metadata::metadata_tabular::MetadataTabularImpl;
-use crate::model::{Commit, DataFrameSize, LocalRepository, Schema, Workspace};
+use crate::model::{Commit, DataFrameSize, LocalRepository, Schema};
 use crate::opts::DFOpts;
 use crate::repositories;
 use polars::prelude::IntoLazy as _;
@@ -140,23 +140,24 @@ async fn handle_sql_querying(
     data_frame_size: &DataFrameSize,
 ) -> Result<DataFrameSlice, OxenError> {
     let path = path.as_ref();
-    let mut workspace: Option<Workspace> = None;
 
-    if opts.sql.is_some() {
-        match crate::core::v_latest::workspaces::data_frames::get_queryable_data_frame_workspace(
-            repo, path, commit,
-        ) {
-            Ok(found_workspace) => {
-                workspace = Some(found_workspace);
-            }
-            Err(e) => return Err(e),
-        }
-    }
-
-    if let (Some(sql), Some(workspace)) = (opts.sql.clone(), workspace) {
-        let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-        let df = tokio::task::spawn_blocking(move || {
-            with_hardened_query_conn(&db_path, |conn| sql::query_df(conn, sql, None))
+    if let Some(sql) = opts.sql.clone() {
+        // Finding the queryable workspace opens DuckDB to check the index, and the query reads it.
+        // Both are sync DB/filesystem work, so run them as one blocking unit off the worker.
+        let query_repo = repo.clone();
+        let query_commit = commit.clone();
+        let query_path = path.to_path_buf();
+        let (workspace, df) = tokio::task::spawn_blocking(move || -> Result<_, OxenError> {
+            let workspace =
+                crate::core::v_latest::workspaces::data_frames::get_queryable_data_frame_workspace(
+                    &query_repo,
+                    &query_path,
+                    &query_commit,
+                )?;
+            let db_path =
+                repositories::workspaces::data_frames::duckdb_path(&workspace, &query_path);
+            let df = with_hardened_query_conn(&db_path, |conn| sql::query_df(conn, sql, None))?;
+            Ok((workspace, df))
         })
         .await??;
         log::debug!("handle_sql_querying got df {df:?}");

--- a/crates/liboxen/src/core/v_latest/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames.rs
@@ -155,7 +155,10 @@ async fn handle_sql_querying(
 
     if let (Some(sql), Some(workspace)) = (opts.sql.clone(), workspace) {
         let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
-        let df = with_hardened_query_conn(&db_path, |conn| sql::query_df(conn, sql, None))?;
+        let df = tokio::task::spawn_blocking(move || {
+            with_hardened_query_conn(&db_path, |conn| sql::query_df(conn, sql, None))
+        })
+        .await??;
         log::debug!("handle_sql_querying got df {df:?}");
         let paginated_df = tabular::collect_with_opts(df.clone().lazy(), opts.clone()).await?;
 

--- a/crates/liboxen/src/core/v_latest/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames.rs
@@ -163,13 +163,20 @@ async fn handle_sql_querying(
         log::debug!("handle_sql_querying got df {df:?}");
         let paginated_df = tabular::collect_with_opts(df.clone().lazy(), opts.clone()).await?;
 
-        let source_schema = if let Some(schema) =
-            repositories::data_frames::schemas::get_by_path(repo, &workspace.commit, path)?
-        {
-            schema
-        } else {
-            Schema::from_polars(paginated_df.schema())
-        };
+        // Reading the stored schema is a sync repo/tree read; keep it off the worker too.
+        let schema_repo = repo.clone();
+        let schema_commit = workspace.commit.clone();
+        let schema_path = path.to_path_buf();
+        let stored_schema = tokio::task::spawn_blocking(move || {
+            repositories::data_frames::schemas::get_by_path(
+                &schema_repo,
+                &schema_commit,
+                &schema_path,
+            )
+        })
+        .await??;
+        let source_schema =
+            stored_schema.unwrap_or_else(|| Schema::from_polars(paginated_df.schema()));
 
         let mut slice_schema = Schema::from_polars(df.schema());
         slice_schema.update_metadata_from_schema(&source_schema);

--- a/crates/oxen-server/src/controllers/data_frames.rs
+++ b/crates/oxen-server/src/controllers/data_frames.rs
@@ -4,7 +4,7 @@ use crate::params::df_opts_query::{self, DFOptsQuery};
 use crate::params::{app_data, parse_resource, path_param};
 
 use liboxen::constants;
-use liboxen::error::PathBufError;
+use liboxen::error::{OxenError, PathBufError};
 use liboxen::model::{DataFrameSize, NewCommitBody};
 use liboxen::opts::df_opts::DFOptsView;
 use liboxen::repositories;
@@ -85,7 +85,7 @@ pub async fn get(
         repositories::data_frames::get_slice(&repo, &resource.clone(), &resource.path, &opts)
             .await?;
 
-    let mut df = data_frame_slice.slice;
+    let df = data_frame_slice.slice;
     let view_height = if opts.has_filter_transform() {
         data_frame_slice.total_entries
     } else {
@@ -95,17 +95,24 @@ pub async fn get(
     let total_pages = (view_height as f64 / page_opts.page_size as f64).ceil() as usize;
 
     let opts_view = DFOptsView::from_df_opts(&opts);
+    let size = DataFrameSize {
+        height: df.height(),
+        width: df.width(),
+    };
+    let data = tokio::task::spawn_blocking(move || {
+        let mut df = df;
+        JsonDataFrameView::json_from_df(&mut df)
+    })
+    .await
+    .map_err(OxenError::from)?;
     let response = JsonDataFrameViewResponse {
         status: StatusMessage::resource_found(),
         data_frame: JsonDataFrameViews {
             source: data_frame_slice.schemas.source,
             view: JsonDataFrameView {
                 schema: data_frame_slice.schemas.slice.schema,
-                size: DataFrameSize {
-                    height: df.height(),
-                    width: df.width(),
-                },
-                data: JsonDataFrameView::json_from_df(&mut df),
+                size,
+                data,
                 pagination: Pagination {
                     page_number: page_opts.page_num,
                     page_size: page_opts.page_size,


### PR DESCRIPTION
The data-frame endpoint ran two pieces of sync work on the request worker: the DuckDB query for SQL requests, and the JSON encode of every response. Both now run on a background thread.

Completes ENG-1293

I also took the rest of the SQL path (finding the workspace and reading the schema) off the worker for completeness, although it wasn't described in the ticket. A SQL request now does none of its work on the worker thread.
