### PR TITLE
Async (14): compare/entries offload to async

### DIFF
--- a/crates/liboxen/src/core/v_latest/diff.rs
+++ b/crates/liboxen/src/core/v_latest/diff.rs
@@ -24,11 +24,22 @@ pub async fn list_diff_entries(
     page: usize,
     page_size: usize,
 ) -> Result<DiffEntriesCounts, OxenError> {
-    log::debug!(
-        "list_diff_entries base_dir: '{base_path:?}', head_dir: '{head_path:?}' base_commit: '{base_commit}', head_commit: '{head_commit}'"
-    );
+    // Tree reads, directory/entry collection, and the first pagination are sync; run them off the
+    // worker in one blocking unit, then keep the file-entry fan-out on the async side below.
+    let base_path_for_fanout = base_path.clone();
+    let (files, pagination, dir_entries, counts, combined_len) = {
+        let repo = repo.clone();
+        let base_commit = base_commit.clone();
+        let head_commit = head_commit.clone();
+        tokio::task::spawn_blocking(move || -> Result<_, OxenError> {
+            let repo = &repo;
+            let base_commit = &base_commit;
+            let head_commit = &head_commit;
+            log::debug!(
+                "list_diff_entries base_dir: '{base_path:?}', head_dir: '{head_path:?}' base_commit: '{base_commit}', head_commit: '{head_commit}'"
+            );
 
-    let base_tree = CommitMerkleTree::read_from_path_maybe(repo, base_commit, &base_path, true)?;
+            let base_tree = CommitMerkleTree::read_from_path_maybe(repo, base_commit, &base_path, true)?;
     let head_tree = CommitMerkleTree::read_from_path_maybe(repo, head_commit, &head_path, true)?;
 
     let mut base_files: HashSet<FileNodeWithDir> = HashSet::new();
@@ -248,18 +259,27 @@ pub async fn list_diff_entries(
         combined.len()
     );
 
-    let (files, pagination) =
-        util::paginate::paginate_files_assuming_dirs(&combined, dir_entries.len(), page, page_size);
-    log::debug!(
-        "list_diff_entries dir: '{:?}' got {} initial dirs",
-        base_path,
-        dir_entries.len()
-    );
-    log::debug!(
-        "list_diff_entries dir: '{:?}' got {} files",
-        base_path,
-        files.len()
-    );
+            let (files, pagination) = util::paginate::paginate_files_assuming_dirs(
+                &combined,
+                dir_entries.len(),
+                page,
+                page_size,
+            );
+            log::debug!(
+                "list_diff_entries dir: '{:?}' got {} initial dirs",
+                base_path,
+                dir_entries.len()
+            );
+            log::debug!(
+                "list_diff_entries dir: '{:?}' got {} files",
+                base_path,
+                files.len()
+            );
+            Ok((files, pagination, dir_entries, counts, combined.len()))
+        })
+        .await??
+    };
+
     let file_entries: Vec<DiffEntry> = stream::iter(files)
         .map(|entry| async move {
             DiffEntry::from_file_nodes(
@@ -280,13 +300,15 @@ pub async fn list_diff_entries(
         .await?;
 
     let (dirs, _) =
-        util::paginate::paginate_dirs_assuming_files(&dir_entries, combined.len(), page, page_size);
+        util::paginate::paginate_dirs_assuming_files(&dir_entries, combined_len, page, page_size);
     log::debug!(
         "list_diff_entries dir: '{:?}' got {} filtered dirs",
-        base_path,
+        base_path_for_fanout,
         dirs.len()
     );
-    log::debug!("list_diff_entries dir: '{base_path:?}' Page num {page} Page size {page_size}");
+    log::debug!(
+        "list_diff_entries dir: '{base_path_for_fanout:?}' Page num {page} Page size {page_size}"
+    );
     let all = dirs.into_iter().chain(file_entries).collect();
 
     Ok(DiffEntriesCounts {
@@ -364,7 +386,23 @@ pub fn list_changed_dirs(
     Ok(changed_dirs)
 }
 
-pub fn get_dir_diff_entry_with_summary(
+pub async fn get_dir_diff_entry_with_summary(
+    repo: &LocalRepository,
+    dir: PathBuf,
+    base_commit: &Commit,
+    head_commit: &Commit,
+    summary: GenericDiffSummary,
+) -> Result<Option<DiffEntry>, OxenError> {
+    let repo = repo.clone();
+    let base_commit = base_commit.clone();
+    let head_commit = head_commit.clone();
+    tokio::task::spawn_blocking(move || {
+        get_dir_diff_entry_with_summary_sync(&repo, dir, &base_commit, &head_commit, summary)
+    })
+    .await?
+}
+
+fn get_dir_diff_entry_with_summary_sync(
     repo: &LocalRepository,
     dir: PathBuf,
     base_commit: &Commit,

--- a/crates/liboxen/src/core/v_latest/diff.rs
+++ b/crates/liboxen/src/core/v_latest/diff.rs
@@ -35,229 +35,230 @@ pub async fn list_diff_entries(
             let repo = &repo;
             let base_commit = &base_commit;
             let head_commit = &head_commit;
+
+            let base_tree =
+                CommitMerkleTree::read_from_path_maybe(repo, base_commit, &base_path, true)?;
+            let head_tree =
+                CommitMerkleTree::read_from_path_maybe(repo, head_commit, &head_path, true)?;
+
+            let mut base_files: HashSet<FileNodeWithDir> = HashSet::new();
+            let mut head_files: HashSet<FileNodeWithDir> = HashSet::new();
+            let mut base_dirs: HashSet<DirNodeWithPath> = HashSet::new();
+            let mut head_dirs: HashSet<DirNodeWithPath> = HashSet::new();
+
+            match (base_tree, head_tree) {
+                (Some(base_tree), Some(head_tree)) => {
+                    //we found some nodes
+
+                    match (base_tree.node.node_type(), head_tree.node.node_type()) {
+                        (MerkleTreeNodeType::File, MerkleTreeNodeType::File) => {
+                            base_files.insert(FileNodeWithDir {
+                                file_node: base_tree.file()?,
+                                dir: base_path
+                                    .parent()
+                                    .unwrap_or(&PathBuf::from(""))
+                                    .to_path_buf(),
+                            });
+                            head_files.insert(FileNodeWithDir {
+                                file_node: head_tree.file()?,
+                                dir: head_path
+                                    .parent()
+                                    .unwrap_or(&PathBuf::from(""))
+                                    .to_path_buf(),
+                            });
+                        }
+                        (MerkleTreeNodeType::Dir, MerkleTreeNodeType::Dir) => {
+                            let (files, dirs) =
+                                repositories::tree::list_files_and_dirs(&base_tree)?;
+
+                            base_files.extend(files);
+                            base_dirs.extend(dirs);
+
+                            let (files, dirs) =
+                                repositories::tree::list_files_and_dirs(&head_tree)?;
+
+                            head_files.extend(files);
+                            head_dirs.extend(dirs);
+                        }
+                        _ => {
+                            return Err(OxenError::basic_str(format!(
+                                "Failed to get base tree for commit: {base_commit}"
+                            )));
+                        }
+                    }
+                }
+
+                (Some(base_tree), None) => match base_tree.node.node_type() {
+                    MerkleTreeNodeType::File => {
+                        base_files.insert(FileNodeWithDir {
+                            file_node: base_tree.file()?,
+                            dir: base_path
+                                .parent()
+                                .unwrap_or(&PathBuf::from(""))
+                                .to_path_buf(),
+                        });
+                    }
+                    MerkleTreeNodeType::Dir => {
+                        let (files, dirs) = repositories::tree::list_files_and_dirs(&base_tree)?;
+
+                        base_files.extend(files);
+                        base_dirs.extend(dirs);
+                    }
+                    _ => {
+                        return Err(OxenError::basic_str(format!(
+                            "Failed to get base tree for commit: {base_commit}"
+                        )));
+                    }
+                },
+
+                (None, Some(head_tree)) => match head_tree.node.node_type() {
+                    MerkleTreeNodeType::File => {
+                        head_files.insert(FileNodeWithDir {
+                            file_node: head_tree.file()?,
+                            dir: head_path
+                                .parent()
+                                .unwrap_or(&PathBuf::from(""))
+                                .to_path_buf(),
+                        });
+                    }
+                    MerkleTreeNodeType::Dir => {
+                        let (files, dirs) = repositories::tree::list_files_and_dirs(&head_tree)?;
+
+                        head_files.extend(files);
+                        head_dirs.extend(dirs);
+                    }
+                    _ => {
+                        return Err(OxenError::basic_str(format!(
+                            "Failed to get head tree for commit: {head_commit}"
+                        )));
+                    }
+                },
+
+                (None, None) => {
+                    log::debug!("no trees found");
+                }
+            };
+
             log::debug!(
-                "list_diff_entries base_dir: '{base_path:?}', head_dir: '{head_path:?}' base_commit: '{base_commit}', head_commit: '{head_commit}'"
+                "list_diff_entries dir: '{:?}' collected {} head_dirs",
+                base_path,
+                head_dirs.len()
+            );
+            log::debug!(
+                "list_diff_entries dir: '{:?}' collected {} base_files",
+                base_path,
+                base_files.len()
+            );
+            log::debug!(
+                "list_diff_entries dir: '{:?}' collected {} base_dirs",
+                base_path,
+                base_dirs.len()
             );
 
-            let base_tree = CommitMerkleTree::read_from_path_maybe(repo, base_commit, &base_path, true)?;
-    let head_tree = CommitMerkleTree::read_from_path_maybe(repo, head_commit, &head_path, true)?;
+            let mut dir_entries: Vec<DiffEntry> = vec![];
+            collect_added_directories(
+                repo,
+                &base_dirs,
+                base_commit,
+                &head_dirs,
+                head_commit,
+                &mut dir_entries,
+                &base_path,
+            )?;
+            log::debug!(
+                "list_diff_entries dir: '{:?}' collected {} added_dirs dir_entries",
+                base_path,
+                dir_entries.len()
+            );
+            collect_removed_directories(
+                repo,
+                &base_dirs,
+                base_commit,
+                &head_dirs,
+                head_commit,
+                &mut dir_entries,
+                &base_path,
+            )?;
+            log::debug!(
+                "list_diff_entries dir: '{:?}' collected {} removed_dirs dir_entries",
+                base_path,
+                dir_entries.len()
+            );
+            collect_modified_directories(
+                repo,
+                &base_dirs,
+                base_commit,
+                &head_dirs,
+                head_commit,
+                &mut dir_entries,
+                &base_path,
+                &base_files,
+                &head_files,
+            )?;
+            dir_entries.sort_by(|a, b| a.filename.cmp(&b.filename));
+            log::debug!(
+                "list_diff_entries dir: '{:?}' collected {} modified_dirs dir_entries",
+                base_path,
+                dir_entries.len()
+            );
 
-    let mut base_files: HashSet<FileNodeWithDir> = HashSet::new();
-    let mut head_files: HashSet<FileNodeWithDir> = HashSet::new();
-    let mut base_dirs: HashSet<DirNodeWithPath> = HashSet::new();
-    let mut head_dirs: HashSet<DirNodeWithPath> = HashSet::new();
+            // the DiffEntry takes a little bit of time to compute, so want to just find the commit entries
+            // then filter them down to the ones we need
+            let mut added_commit_entries: Vec<DiffFileNode> = vec![];
+            collect_added_entries(
+                &base_files,
+                &head_files,
+                &mut added_commit_entries,
+                &base_path,
+            )?;
+            log::debug!(
+                "list_diff_entries dir: '{:?}' collected {} collect_added_entries",
+                base_path,
+                added_commit_entries.len()
+            );
 
-    match (base_tree, head_tree) {
-        (Some(base_tree), Some(head_tree)) => {
-            //we found some nodes
+            let mut removed_commit_entries: Vec<DiffFileNode> = vec![];
+            collect_removed_entries(
+                &base_files,
+                &head_files,
+                &mut removed_commit_entries,
+                &base_path,
+            )?;
+            log::debug!(
+                "list_diff_entries dir: '{:?}' collected {} collect_removed_entries",
+                base_path,
+                removed_commit_entries.len()
+            );
 
-            match (base_tree.node.node_type(), head_tree.node.node_type()) {
-                (MerkleTreeNodeType::File, MerkleTreeNodeType::File) => {
-                    base_files.insert(FileNodeWithDir {
-                        file_node: base_tree.file()?,
-                        dir: base_path
-                            .parent()
-                            .unwrap_or(&PathBuf::from(""))
-                            .to_path_buf(),
-                    });
-                    head_files.insert(FileNodeWithDir {
-                        file_node: head_tree.file()?,
-                        dir: head_path
-                            .parent()
-                            .unwrap_or(&PathBuf::from(""))
-                            .to_path_buf(),
-                    });
-                }
-                (MerkleTreeNodeType::Dir, MerkleTreeNodeType::Dir) => {
-                    let (files, dirs) = repositories::tree::list_files_and_dirs(&base_tree)?;
+            let mut modified_commit_entries: Vec<DiffFileNode> = vec![];
+            collect_modified_entries(
+                &base_files,
+                &head_files,
+                &mut modified_commit_entries,
+                &base_path,
+            )?;
+            log::debug!(
+                "list_diff_entries dir: '{:?}' collected {} collect_modified_entries",
+                base_path,
+                modified_commit_entries.len()
+            );
+            let counts = AddRemoveModifyCounts {
+                added: added_commit_entries.len(),
+                removed: removed_commit_entries.len(),
+                modified: modified_commit_entries.len(),
+            };
+            let mut combined: Vec<_> = added_commit_entries
+                .into_iter()
+                .chain(removed_commit_entries)
+                .chain(modified_commit_entries)
+                .collect();
+            combined.sort_by(|a, b| a.path.cmp(&b.path));
 
-                    base_files.extend(files);
-                    base_dirs.extend(dirs);
-
-                    let (files, dirs) = repositories::tree::list_files_and_dirs(&head_tree)?;
-
-                    head_files.extend(files);
-                    head_dirs.extend(dirs);
-                }
-                _ => {
-                    return Err(OxenError::basic_str(format!(
-                        "Failed to get base tree for commit: {base_commit}"
-                    )));
-                }
-            }
-        }
-
-        (Some(base_tree), None) => match base_tree.node.node_type() {
-            MerkleTreeNodeType::File => {
-                base_files.insert(FileNodeWithDir {
-                    file_node: base_tree.file()?,
-                    dir: base_path
-                        .parent()
-                        .unwrap_or(&PathBuf::from(""))
-                        .to_path_buf(),
-                });
-            }
-            MerkleTreeNodeType::Dir => {
-                let (files, dirs) = repositories::tree::list_files_and_dirs(&base_tree)?;
-
-                base_files.extend(files);
-                base_dirs.extend(dirs);
-            }
-            _ => {
-                return Err(OxenError::basic_str(format!(
-                    "Failed to get base tree for commit: {base_commit}"
-                )));
-            }
-        },
-
-        (None, Some(head_tree)) => match head_tree.node.node_type() {
-            MerkleTreeNodeType::File => {
-                head_files.insert(FileNodeWithDir {
-                    file_node: head_tree.file()?,
-                    dir: head_path
-                        .parent()
-                        .unwrap_or(&PathBuf::from(""))
-                        .to_path_buf(),
-                });
-            }
-            MerkleTreeNodeType::Dir => {
-                let (files, dirs) = repositories::tree::list_files_and_dirs(&head_tree)?;
-
-                head_files.extend(files);
-                head_dirs.extend(dirs);
-            }
-            _ => {
-                return Err(OxenError::basic_str(format!(
-                    "Failed to get head tree for commit: {head_commit}"
-                )));
-            }
-        },
-
-        (None, None) => {
-            log::debug!("no trees found");
-        }
-    };
-
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} head_dirs",
-        base_path,
-        head_dirs.len()
-    );
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} base_files",
-        base_path,
-        base_files.len()
-    );
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} base_dirs",
-        base_path,
-        base_dirs.len()
-    );
-
-    let mut dir_entries: Vec<DiffEntry> = vec![];
-    collect_added_directories(
-        repo,
-        &base_dirs,
-        base_commit,
-        &head_dirs,
-        head_commit,
-        &mut dir_entries,
-        &base_path,
-    )?;
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} added_dirs dir_entries",
-        base_path,
-        dir_entries.len()
-    );
-    collect_removed_directories(
-        repo,
-        &base_dirs,
-        base_commit,
-        &head_dirs,
-        head_commit,
-        &mut dir_entries,
-        &base_path,
-    )?;
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} removed_dirs dir_entries",
-        base_path,
-        dir_entries.len()
-    );
-    collect_modified_directories(
-        repo,
-        &base_dirs,
-        base_commit,
-        &head_dirs,
-        head_commit,
-        &mut dir_entries,
-        &base_path,
-        &base_files,
-        &head_files,
-    )?;
-    dir_entries.sort_by(|a, b| a.filename.cmp(&b.filename));
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} modified_dirs dir_entries",
-        base_path,
-        dir_entries.len()
-    );
-
-    // the DiffEntry takes a little bit of time to compute, so want to just find the commit entries
-    // then filter them down to the ones we need
-    let mut added_commit_entries: Vec<DiffFileNode> = vec![];
-    collect_added_entries(
-        &base_files,
-        &head_files,
-        &mut added_commit_entries,
-        &base_path,
-    )?;
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} collect_added_entries",
-        base_path,
-        added_commit_entries.len()
-    );
-
-    let mut removed_commit_entries: Vec<DiffFileNode> = vec![];
-    collect_removed_entries(
-        &base_files,
-        &head_files,
-        &mut removed_commit_entries,
-        &base_path,
-    )?;
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} collect_removed_entries",
-        base_path,
-        removed_commit_entries.len()
-    );
-
-    let mut modified_commit_entries: Vec<DiffFileNode> = vec![];
-    collect_modified_entries(
-        &base_files,
-        &head_files,
-        &mut modified_commit_entries,
-        &base_path,
-    )?;
-    log::debug!(
-        "list_diff_entries dir: '{:?}' collected {} collect_modified_entries",
-        base_path,
-        modified_commit_entries.len()
-    );
-    let counts = AddRemoveModifyCounts {
-        added: added_commit_entries.len(),
-        removed: removed_commit_entries.len(),
-        modified: modified_commit_entries.len(),
-    };
-    let mut combined: Vec<_> = added_commit_entries
-        .into_iter()
-        .chain(removed_commit_entries)
-        .chain(modified_commit_entries)
-        .collect();
-    combined.sort_by(|a, b| a.path.cmp(&b.path));
-
-    log::debug!(
-        "list_diff_entries dir: '{:?}' got {} combined files",
-        base_path,
-        combined.len()
-    );
+            log::debug!(
+                "list_diff_entries dir: '{:?}' got {} combined files",
+                base_path,
+                combined.len()
+            );
 
             let (files, pagination) = util::paginate::paginate_files_assuming_dirs(
                 &combined,

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -163,7 +163,8 @@ pub async fn entries(
         &base_commit,
         &head_commit,
         summary,
-    )?;
+    )
+    .await?;
 
     let compare = CompareEntries {
         base_commit,
@@ -294,7 +295,8 @@ pub async fn dir_entries(
     log::debug!("summary: {summary:?}");
 
     let self_entry =
-        get_dir_diff_entry_with_summary(&repository, dir, &base_commit, &head_commit, summary)?;
+        get_dir_diff_entry_with_summary(&repository, dir, &base_commit, &head_commit, summary)
+            .await?;
 
     let compare = CompareEntries {
         base_commit,


### PR DESCRIPTION
The compare-entries endpoints ran their tree work on the request worker: reading both commit trees, collecting which files and directories changed, and building the top-level directory summary. All of it now runs on a background thread.

Completes ENG-1290
