### PR TITLE
Async (15): compare/file offload to async

### DIFF
--- a/crates/liboxen/src/repositories/diffs.rs
+++ b/crates/liboxen/src/repositories/diffs.rs
@@ -1077,14 +1077,21 @@ pub async fn compute_new_rows(
     head_df: &DataFrame,
     schema: &Schema,
 ) -> Result<DataFrameDiff, OxenError> {
-    // Compute row indices
-    let (added_indices, removed_indices) = compute_new_row_indices(base_df, head_df)?;
+    // Row hashing and the set-diff are sync CPU over both full frames; run them off the worker.
+    let (added_indices, removed_indices) = {
+        let base_df = base_df.clone();
+        let head_df = head_df.clone();
+        tokio::task::spawn_blocking(move || compute_new_row_indices(&base_df, &head_df)).await??
+    };
 
     // Take added from the current df
     let added_rows = if !added_indices.is_empty() {
         let opts = DFOpts::from_schema_columns(schema);
         let head_df = tabular::transform(head_df.clone(), opts).await?;
-        Some(tabular::take(head_df.lazy(), added_indices)?)
+        let taken =
+            tokio::task::spawn_blocking(move || tabular::take(head_df.lazy(), added_indices))
+                .await??;
+        Some(taken)
     } else {
         None
     };
@@ -1094,7 +1101,10 @@ pub async fn compute_new_rows(
     let removed_rows = if !removed_indices.is_empty() {
         let opts = DFOpts::from_schema_columns(schema);
         let base_df = tabular::transform(base_df.clone(), opts).await?;
-        Some(tabular::take(base_df.lazy(), removed_indices)?)
+        let taken =
+            tokio::task::spawn_blocking(move || tabular::take(base_df.lazy(), removed_indices))
+                .await??;
+        Some(taken)
     } else {
         None
     };
@@ -1121,14 +1131,21 @@ pub async fn compute_new_rows_proj(
     base_schema: &Schema,
     head_schema: &Schema,
 ) -> Result<DataFrameDiff, OxenError> {
-    // Compute row indices
-    let (added_indices, removed_indices) = compute_new_row_indices(base_df, head_df)?;
+    // Row hashing and the set-diff are sync CPU over both full frames; run them off the worker.
+    let (added_indices, removed_indices) = {
+        let base_df = base_df.clone();
+        let head_df = head_df.clone();
+        tokio::task::spawn_blocking(move || compute_new_row_indices(&base_df, &head_df)).await??
+    };
 
     // Take added from the current df
     let added_rows = if !added_indices.is_empty() {
         let opts = DFOpts::from_schema_columns(head_schema);
         let proj_head_df = tabular::transform(proj_head_df.clone(), opts).await?;
-        Some(tabular::take(proj_head_df.lazy(), added_indices)?)
+        let taken =
+            tokio::task::spawn_blocking(move || tabular::take(proj_head_df.lazy(), added_indices))
+                .await??;
+        Some(taken)
     } else {
         None
     };
@@ -1138,7 +1155,11 @@ pub async fn compute_new_rows_proj(
     let removed_rows = if !removed_indices.is_empty() {
         let opts = DFOpts::from_schema_columns(base_schema);
         let proj_base_df = tabular::transform(proj_base_df.clone(), opts).await?;
-        Some(tabular::take(proj_base_df.lazy(), removed_indices)?)
+        let taken = tokio::task::spawn_blocking(move || {
+            tabular::take(proj_base_df.lazy(), removed_indices)
+        })
+        .await??;
+        Some(taken)
     } else {
         None
     };

--- a/crates/liboxen/src/view/tabular_diff_view.rs
+++ b/crates/liboxen/src/view/tabular_diff_view.rs
@@ -131,8 +131,18 @@ impl TabularDiffView {
                 } else {
                     let cols = column_names.iter().map(col).collect::<Vec<Expr>>();
 
-                    let common_base_df = base_df.clone().lazy().select(&cols).collect().unwrap();
-                    let common_head_df = head_df.clone().lazy().select(&cols).collect().unwrap();
+                    // Selecting the common columns and collecting both frames is sync polars CPU.
+                    let (common_base_df, common_head_df) = {
+                        let base_df = base_df.clone();
+                        let head_df = head_df.clone();
+                        tokio::task::spawn_blocking(move || {
+                            let common_base_df = base_df.lazy().select(&cols).collect().unwrap();
+                            let common_head_df = head_df.lazy().select(&cols).collect().unwrap();
+                            (common_base_df, common_head_df)
+                        })
+                        .await
+                        .unwrap()
+                    };
 
                     log::debug!("common_base_df: {common_base_df:?}");
                     log::debug!("common_head_df: {common_head_df:?}");

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -350,8 +350,19 @@ pub async fn file(
     log::debug!("base_commit: {base_commit:?}");
     log::debug!("head_commit: {head_commit:?}");
     log::debug!("resource: {resource:?}");
-    let base_entry = repositories::entries::get_file(&repository, &base_commit, &resource)?;
-    let head_entry = repositories::entries::get_file(&repository, &head_commit, &resource)?;
+    let (base_entry, head_entry) = {
+        let repository = repository.clone();
+        let base_commit = base_commit.clone();
+        let head_commit = head_commit.clone();
+        let resource = resource.clone();
+        tokio::task::spawn_blocking(move || {
+            let base_entry = repositories::entries::get_file(&repository, &base_commit, &resource)?;
+            let head_entry = repositories::entries::get_file(&repository, &head_commit, &resource)?;
+            Ok::<_, OxenError>((base_entry, head_entry))
+        })
+        .await
+        .map_err(OxenError::from)??
+    };
 
     let mut opts = DFOpts::empty();
     opts = df_opts_query::parse_opts(&query, &mut opts);


### PR DESCRIPTION
The compare file endpoint builds a diff between two versions of a data frame. Several parts ran on the request worker: reading the two file versions, hashing both frames to find the changed rows, pulling those rows out, and, on a schema change, selecting the shared columns. All of it now runs on a background thread.

Completes ENG-1291
