### PR TITLE
Fix oxen-server crash by publishing data frame writes atomically

### DIFF
--- a/crates/liboxen/src/core/df/tabular.rs
+++ b/crates/liboxen/src/core/df/tabular.rs
@@ -22,6 +22,7 @@ use crate::opts::{CountLinesOpts, DFOpts, PaginateOpts};
 use crate::repositories;
 use crate::storage::{VersionLocation, VersionStore};
 use crate::util::fs;
+use crate::util::fs::AtomicFile;
 use crate::util::hasher;
 use std::sync::Arc;
 
@@ -1499,23 +1500,25 @@ pub fn write_df_json<P: AsRef<Path>>(df: &mut DataFrame, output: P) -> Result<()
     let output = output.as_ref();
     log::debug!("Writing file {output:?}");
     log::debug!("{df:?}");
-    let f = std::fs::File::create(output).unwrap();
-    JsonWriter::new(f)
-        .with_json_format(JsonFormat::Json)
-        .finish(df)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
-    Ok(())
+    AtomicFile::new(output).write_with(|w| {
+        JsonWriter::new(w)
+            .with_json_format(JsonFormat::Json)
+            .finish(df)
+            .map_err(|e| OxenError::internal_error(format!("{e:?}")))?;
+        Ok(())
+    })
 }
 
 pub fn write_df_jsonl<P: AsRef<Path>>(df: &mut DataFrame, output: P) -> Result<(), OxenError> {
     let output = output.as_ref();
     log::debug!("Writing file {output:?}");
-    let f = std::fs::File::create(output).unwrap();
-    JsonWriter::new(f)
-        .with_json_format(JsonFormat::JsonLines)
-        .finish(df)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
-    Ok(())
+    AtomicFile::new(output).write_with(|w| {
+        JsonWriter::new(w)
+            .with_json_format(JsonFormat::JsonLines)
+            .finish(df)
+            .map_err(|e| OxenError::internal_error(format!("{e:?}")))?;
+        Ok(())
+    })
 }
 
 pub fn write_df_csv<P: AsRef<Path>>(
@@ -1525,40 +1528,36 @@ pub fn write_df_csv<P: AsRef<Path>>(
 ) -> Result<(), OxenError> {
     let output = output.as_ref();
     log::debug!("Writing file {output:?}");
-    let f = std::fs::File::create(output).unwrap();
-    CsvWriter::new(f)
-        .include_header(true)
-        .with_separator(delimiter)
-        .finish(df)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
-    Ok(())
+    AtomicFile::new(output).write_with(|w| {
+        CsvWriter::new(w)
+            .include_header(true)
+            .with_separator(delimiter)
+            .finish(df)
+            .map_err(|e| OxenError::internal_error(format!("{e:?}")))?;
+        Ok(())
+    })
 }
 
 pub fn write_df_parquet<P: AsRef<Path>>(df: &mut DataFrame, output: P) -> Result<(), OxenError> {
     let output = output.as_ref();
     log::debug!("Writing file {output:?}");
-    match std::fs::File::create(output) {
-        Ok(f) => {
-            ParquetWriter::new(f)
-                .finish(df)
-                .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
-            Ok(())
-        }
-        Err(err) => {
-            let error_str = format!("Could not create file {err:?}");
-            Err(OxenError::basic_str(error_str))
-        }
-    }
+    AtomicFile::new(output).write_with(|w| {
+        ParquetWriter::new(w)
+            .finish(df)
+            .map_err(|e| OxenError::internal_error(format!("{e:?}")))?;
+        Ok(())
+    })
 }
 
 pub fn write_df_arrow<P: AsRef<Path>>(df: &mut DataFrame, output: P) -> Result<(), OxenError> {
     let output = output.as_ref();
     log::debug!("Writing file {output:?}");
-    let f = std::fs::File::create(output).unwrap();
-    IpcWriter::new(f)
-        .finish(df)
-        .map_err(|e| OxenError::basic_str(format!("{e:?}")))?;
-    Ok(())
+    AtomicFile::new(output).write_with(|w| {
+        IpcWriter::new(w)
+            .finish(df)
+            .map_err(|e| OxenError::internal_error(format!("{e:?}")))?;
+        Ok(())
+    })
 }
 
 pub fn write_df(df: &mut DataFrame, path: impl AsRef<Path>) -> Result<(), OxenError> {
@@ -2374,5 +2373,41 @@ mod tests {
         assert_eq!(df.height(), base_height * 2);
         assert_eq!(df.width(), base_df.width());
         Ok(())
+    }
+
+    /// Overwriting a data frame publishes a fresh inode instead of truncating the existing one.
+    /// Readers hold these files memory-mapped (`scan_parquet`, `IpcReader`), and a mapping whose
+    /// inode is truncated underneath it faults with SIGBUS on the next page touch — so every
+    /// `write_df_*` has to rename over its target rather than reopen it with `O_TRUNC`.
+    #[cfg(unix)]
+    #[test]
+    fn test_write_df_publishes_a_new_inode() -> Result<(), OxenError> {
+        use std::os::unix::fs::MetadataExt;
+
+        test::run_empty_dir_test(|dir| {
+            let mut df =
+                df!("a" => [1i64, 2, 3], "b" => ["x", "y", "z"]).expect("df! should build a frame");
+
+            for extension in ["parquet", "arrow", "csv", "tsv", "jsonl", "ndjson", "json"] {
+                let path = dir.join(format!("cache.{extension}"));
+                tabular::write_df(&mut df, &path)?;
+                let first = std::fs::metadata(&path)?.ino();
+
+                tabular::write_df(&mut df, &path)?;
+                let second = std::fs::metadata(&path)?.ino();
+
+                assert_ne!(
+                    first, second,
+                    "overwriting cache.{extension} reused the inode instead of renaming over it",
+                );
+
+                let strays: Vec<_> = std::fs::read_dir(dir)?
+                    .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().to_string()))
+                    .filter(|name| name.contains(".oxentmp."))
+                    .collect();
+                assert!(strays.is_empty(), "leftover scratch files: {strays:?}");
+            }
+            Ok(())
+        })
     }
 }

--- a/crates/liboxen/src/repositories/diffs.rs
+++ b/crates/liboxen/src/repositories/diffs.rs
@@ -27,6 +27,7 @@ use crate::model::{
     Commit, CommitEntry, DataFrameDiff, DiffEntry, EntryDataType, LocalRepository, Schema,
 };
 use crate::storage::version_store::VersionStore;
+use crate::util::fs::AtomicFile;
 use crate::view::Pagination;
 use crate::{constants, repositories, util};
 
@@ -1245,7 +1246,7 @@ fn write_diff_dupes(
 
     let dupes_path = compare_dir.join(DUPES_PATH);
 
-    std::fs::write(dupes_path, serde_json::to_string(&dupes)?)?;
+    AtomicFile::new(dupes_path).write(serde_json::to_string(&dupes)?.as_bytes())?;
 
     Ok(())
 }
@@ -1403,12 +1404,12 @@ fn write_diff_commit_ids(
 
     if let Some(commit_entry) = left_entry {
         let left_id = &commit_entry.commit_id;
-        std::fs::write(left_path, left_id)?;
+        AtomicFile::new(left_path).write(left_id.as_bytes())?;
     }
 
     if let Some(commit_entry) = right_entry {
         let right_id = &commit_entry.commit_id;
-        std::fs::write(right_path, right_id)?;
+        AtomicFile::new(right_path).write(right_id.as_bytes())?;
     }
 
     Ok(())

--- a/crates/liboxen/src/util/CLAUDE.md
+++ b/crates/liboxen/src/util/CLAUDE.md
@@ -21,7 +21,7 @@ The builders are `.with_hash(expected)` and `.with_mtime(t)`; both default to `N
 - **`.with_hash(expected)`** when the bytes are content-addressed (the canonical filename embeds the hash) or arrive from an untrusted / network source. On mismatch the publish aborts without touching the canonical path. `write` hashes the in-memory bytes before opening any temp file (verify-before-publish); the streaming and copy variants hash in-passing and drop the temp on mismatch.
 - **`.with_mtime(t)`** when publishing into the working tree so the `oxen status` size+mtime fast path stays effective on the next pass. The mtime is stamped on the temp file atomically with the rename, so a kill can never leave a complete-but-wrong-mtime file behind.
 
-Terminal methods are `.write(bytes)` (in-memory) / `.stream(reader)` (sync `Read`) / `.stream_async(reader).await` (async `AsyncRead`, via the Channel hand-off pattern) / `.copy_from(src)` (file → file) / `.stream_from_paths(&[path])` (many files → file). Pick by the source-kind you have in hand.
+Terminal methods are `.write(bytes)` (in-memory) / `.write_with(|w| ...)` (an encoder that takes ownership of a `Write` — Polars' `ParquetWriter`/`CsvWriter`/`IpcWriter`/`JsonWriter`, `tar`, `zip`) / `.stream(reader)` (sync `Read`) / `.stream_async(reader).await` (async `AsyncRead`, via the Channel hand-off pattern) / `.copy_from(src)` (file → file) / `.stream_from_paths(&[path])` (many files → file). Pick by the source-kind you have in hand.
 
 `AtomicFile` is `#[must_use]` — forgetting a terminal method is a compile-time warning, not a silent no-op. The full contract (including atime behavior, cancel-safety, and the verify-before-publish guarantee) lives on the struct rustdoc. Read it before adding a new caller.
 

--- a/crates/liboxen/src/util/fs/atomic_file.rs
+++ b/crates/liboxen/src/util/fs/atomic_file.rs
@@ -16,7 +16,7 @@ use xxhash_rust::xxh3::{Xxh3, xxh3_128};
 use crate::constants;
 use crate::error::OxenError;
 use crate::model::MerkleHash;
-use crate::util::hasher::HashingReader;
+use crate::util::hasher::{HashingReader, HashingWriter};
 
 /// Infix used in `AtomicTempFile` scratch file names: `<target_basename>.oxentmp.<random>`. Private
 /// to keep all knowledge of the pattern in this module — when fsck (or any other sweeper) needs to
@@ -163,9 +163,9 @@ impl AtomicTempFile {
 /// leaves either the prior contents at `target` (if any) or the new contents, never a torn file.
 ///
 /// Build with [`new`][Self::new] and chain `with_*` options; finish with a terminal method —
-/// [`write`][Self::write] for in-memory bytes, [`stream`][Self::stream] for sync `Read`,
-/// [`stream_async`][Self::stream_async] for `AsyncRead`, or [`copy_from`][Self::copy_from] for a
-/// source file.
+/// [`write`][Self::write] for in-memory bytes, [`write_with`][Self::write_with] for an encoder that
+/// owns its writer, [`stream`][Self::stream] for sync `Read`, [`stream_async`][Self::stream_async]
+/// for `AsyncRead`, or [`copy_from`][Self::copy_from] for a source file.
 ///
 /// - `with_hash(h)`: the terminal method hashes the published bytes and refuses to publish if the
 ///   XXH3-128 digest doesn't match — `target` is unchanged on mismatch and
@@ -180,7 +180,7 @@ impl AtomicTempFile {
 /// `std::fs` and run inside a `tokio::task::spawn_blocking` provided by the calling operation.
 /// [`stream_async`][Self::stream_async] is the only `async` terminal, and uses the Channel
 /// hand-off pattern to bridge an async reader to a sync writer.
-#[must_use = "AtomicFile does nothing until a terminal method (write/stream/stream_from_paths/stream_async/copy_from) is called"]
+#[must_use = "AtomicFile does nothing until a terminal method (write/write_with/stream/stream_from_paths/stream_async/copy_from) is called"]
 #[derive(Debug, Clone)]
 pub struct AtomicFile {
     target: PathBuf,
@@ -228,6 +228,48 @@ impl AtomicFile {
         }
         let mut tmp = AtomicTempFile::create(&self.target)?;
         tmp.as_writer().write_all(contents)?;
+        if let Some(mtime) = self.mtime {
+            tmp.set_mtime(mtime)?;
+        }
+        tmp.commit()
+    }
+
+    /// Publish whatever `fill` writes to the target path. The fit for third-party encoders that
+    /// take ownership of a `Write` and so can't be driven through [`stream`][Self::stream] —
+    /// Polars' `ParquetWriter` / `CsvWriter` / `IpcWriter` / `JsonWriter`, `tar`, `zip`.
+    ///
+    /// `fill` must write the complete payload; an `Err` from it propagates and leaves the target
+    /// untouched.
+    pub fn write_with<F>(self, fill: F) -> Result<(), OxenError>
+    where
+        F: FnOnce(&mut dyn Write) -> Result<(), OxenError>,
+    {
+        let mut tmp = AtomicTempFile::create(&self.target)?;
+        let actual_hash = {
+            let mut buf_writer =
+                std::io::BufWriter::with_capacity(constants::STREAMING_BUF_SIZE, tmp.as_writer());
+            let actual = if self.expected_hash.is_some() {
+                let mut hashing = HashingWriter::new(&mut buf_writer);
+                fill(&mut hashing)?;
+                Some(MerkleHash::new(hashing.digest128()))
+            } else {
+                fill(&mut buf_writer)?;
+                None
+            };
+            // `std::io::BufWriter::Drop` attempts to flush but silently swallows errors. Flush
+            // explicitly so any IO error propagates before the hash check / mtime stamp / rename.
+            buf_writer.flush()?;
+            actual
+        };
+        if let (Some(expected), Some(actual)) = (self.expected_hash, actual_hash)
+            && actual != expected
+        {
+            return Err(OxenError::HashMismatch {
+                path: self.target,
+                expected,
+                actual,
+            });
+        }
         if let Some(mtime) = self.mtime {
             tmp.set_mtime(mtime)?;
         }

--- a/crates/liboxen/src/util/fs/atomic_file.rs
+++ b/crates/liboxen/src/util/fs/atomic_file.rs
@@ -693,6 +693,166 @@ mod tests {
         .await
     }
 
+    #[test]
+    fn test_atomic_write_with_round_trip() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let target = dir.join("blob.bin");
+            // 200 KB exceeds the buffered-writer path in one go, ruling out a "small enough to
+            // land in a single write" accident.
+            let payload: Vec<u8> = (0..50_000u32).flat_map(u32::to_le_bytes).collect();
+
+            AtomicFile::new(&target).write_with(|w| {
+                w.write_all(&payload)?;
+                Ok(())
+            })?;
+
+            assert_eq!(std::fs::read(&target)?, payload);
+            let names: Vec<_> = std::fs::read_dir(dir)?
+                .filter_map(|e| e.ok().map(|e| e.file_name()))
+                .collect();
+            assert_eq!(names.len(), 1, "unexpected leftover files: {names:?}");
+            Ok(())
+        })
+    }
+
+    /// Nothing is visible at the target until the closure returns and the publish commits. This is
+    /// the guarantee that keeps a concurrent reader's mapping of the previous contents valid.
+    #[test]
+    fn test_atomic_write_with_hides_output_until_commit() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let target = dir.join("blob.bin");
+            std::fs::write(&target, b"previous contents")?;
+
+            AtomicFile::new(&target).write_with(|w| {
+                w.write_all(b"new contents")?;
+                assert_eq!(
+                    std::fs::read(&target)?,
+                    b"previous contents",
+                    "target must still hold the prior contents mid-write"
+                );
+                let scratch: Vec<_> = std::fs::read_dir(dir)?
+                    .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().to_string()))
+                    .filter(|name| name.contains(ATOMIC_TEMP_INFIX))
+                    .collect();
+                assert_eq!(
+                    scratch.len(),
+                    1,
+                    "expected one scratch sibling: {scratch:?}"
+                );
+                Ok(())
+            })?;
+
+            assert_eq!(std::fs::read(&target)?, b"new contents");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_atomic_write_with_verified_commits_on_match() -> Result<(), OxenError> {
+        use xxhash_rust::xxh3::xxh3_128;
+
+        test::run_empty_dir_test(|dir| {
+            let target = dir.join("blob.bin");
+            let payload: Vec<u8> = (0..50_000u32).flat_map(u32::to_le_bytes).collect();
+            let expected = MerkleHash::new(xxh3_128(&payload));
+
+            AtomicFile::new(&target)
+                .with_hash(expected)
+                .write_with(|w| {
+                    // Several writes, so the digest has to accumulate across calls.
+                    for chunk in payload.chunks(9_973) {
+                        w.write_all(chunk)?;
+                    }
+                    Ok(())
+                })?;
+
+            assert_eq!(std::fs::read(&target)?, payload);
+            let names: Vec<_> = std::fs::read_dir(dir)?
+                .filter_map(|e| e.ok().map(|e| e.file_name()))
+                .collect();
+            assert_eq!(names.len(), 1, "unexpected leftover files: {names:?}");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_atomic_write_with_verified_aborts_on_mismatch() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let target = dir.join("blob.bin");
+            let bogus_expected = MerkleHash::new(0xdead_beef_dead_beef_dead_beef_dead_beefu128);
+
+            let result = AtomicFile::new(&target)
+                .with_hash(bogus_expected)
+                .write_with(|w| {
+                    w.write_all(b"payload the caller mispredicted")?;
+                    Ok(())
+                });
+
+            match result {
+                Err(OxenError::HashMismatch {
+                    path,
+                    expected,
+                    actual,
+                }) => {
+                    assert_eq!(path, target);
+                    assert_eq!(expected, bogus_expected);
+                    assert_ne!(actual, bogus_expected);
+                }
+                other => panic!("expected HashMismatch, got {other:?}"),
+            }
+
+            assert!(!target.exists(), "target must not be published on mismatch");
+            let names: Vec<_> = std::fs::read_dir(dir)?
+                .filter_map(|e| e.ok().map(|e| e.file_name()))
+                .collect();
+            assert!(names.is_empty(), "directory should be empty: {names:?}");
+            Ok(())
+        })
+    }
+
+    /// An encoder that fails partway leaves the target untouched and no scratch behind.
+    #[test]
+    fn test_atomic_write_with_cleans_up_on_closure_error() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let target = dir.join("blob.bin");
+
+            let result = AtomicFile::new(&target).write_with(|w| {
+                w.write_all(b"partial")?;
+                Err(OxenError::internal_error("synthetic encoder failure"))
+            });
+            assert!(result.is_err(), "the closure's error should propagate");
+
+            assert!(
+                !target.exists(),
+                "target must not appear when the closure fails"
+            );
+            let leftover: Vec<_> = std::fs::read_dir(dir)?.filter_map(|e| e.ok()).collect();
+            assert!(
+                leftover.is_empty(),
+                "directory should be empty after a failed write, got {} entries",
+                leftover.len()
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_atomic_write_with_mtime_round_trip() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let target = dir.join("blob.bin");
+            let mtime = fixed_mtime();
+
+            AtomicFile::new(&target).with_mtime(mtime).write_with(|w| {
+                w.write_all(b"stamped")?;
+                Ok(())
+            })?;
+
+            assert_eq!(std::fs::read(&target)?, b"stamped");
+            assert_eq!(std::fs::metadata(&target)?.modified()?, mtime);
+            Ok(())
+        })
+    }
+
     #[tokio::test]
     async fn test_atomic_temp_file_name_pattern() -> Result<(), OxenError> {
         // Verify scratch files follow `<target_basename>.oxentmp.<random>` so fsck can match them

--- a/crates/liboxen/src/util/hasher.rs
+++ b/crates/liboxen/src/util/hasher.rs
@@ -268,3 +268,83 @@ mod hashing_reader_tests {
         assert_eq!(hashing.digest128(), xxh3_128(b""));
     }
 }
+
+#[cfg(test)]
+mod hashing_writer_tests {
+    use super::*;
+
+    #[test]
+    fn sync_writer_matches_one_shot() -> Result<(), OxenError> {
+        let payload = b"the quick brown fox jumps over the lazy dog";
+        let mut sink = Vec::new();
+        let digest = {
+            let mut hashing = HashingWriter::new(&mut sink);
+            hashing.write_all(payload)?;
+            hashing.flush()?;
+            hashing.digest128()
+        };
+        assert_eq!(digest, xxh3_128(payload));
+        assert_eq!(sink, payload);
+        Ok(())
+    }
+
+    /// Bytes arriving across many `write` calls hash the same as the concatenation in one shot —
+    /// the property every streaming caller relies on.
+    #[test]
+    fn sync_writer_accumulates_across_writes() -> Result<(), OxenError> {
+        let chunks: [&[u8]; 3] = [b"hello ", b"brave ", b"world"];
+        let expected = chunks.concat();
+        let mut sink = Vec::new();
+        let digest = {
+            let mut hashing = HashingWriter::new(&mut sink);
+            for chunk in chunks {
+                hashing.write_all(chunk)?;
+            }
+            hashing.digest128()
+        };
+        assert_eq!(digest, xxh3_128(&expected));
+        assert_eq!(sink, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn sync_writer_empty_input() -> Result<(), OxenError> {
+        let mut sink = Vec::new();
+        let digest = HashingWriter::new(&mut sink).digest128();
+        assert_eq!(digest, xxh3_128(b""));
+        assert!(sink.is_empty());
+        Ok(())
+    }
+
+    /// A short write hashes only the bytes the inner writer accepted; hashing the whole buffer
+    /// would digest bytes that never reached the file.
+    #[test]
+    fn sync_writer_hashes_only_accepted_bytes() -> Result<(), OxenError> {
+        struct ShortWriter {
+            written: Vec<u8>,
+        }
+        impl Write for ShortWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                let n = buf.len().min(4);
+                self.written.extend_from_slice(&buf[..n]);
+                Ok(n)
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut inner = ShortWriter {
+            written: Vec::new(),
+        };
+        let digest = {
+            let mut hashing = HashingWriter::new(&mut inner);
+            let accepted = hashing.write(b"0123456789")?;
+            assert_eq!(accepted, 4, "inner writer should accept only 4 bytes");
+            hashing.digest128()
+        };
+        assert_eq!(inner.written, b"0123");
+        assert_eq!(digest, xxh3_128(b"0123"));
+        Ok(())
+    }
+}

--- a/crates/liboxen/src/util/hasher.rs
+++ b/crates/liboxen/src/util/hasher.rs
@@ -208,6 +208,41 @@ impl<R: Read + ?Sized> Read for HashingReader<'_, R> {
     }
 }
 
+/// Wraps a `std::io::Write` and feeds every byte successfully written into an `Xxh3` hasher;
+/// `digest128()` returns the running XXH3-128. The write-side counterpart to [`HashingReader`],
+/// for payloads produced by an encoder that owns the writer and so offers no reader to wrap.
+pub struct HashingWriter<'a, W: ?Sized> {
+    inner: &'a mut W,
+    hasher: Xxh3,
+}
+
+impl<'a, W: Write + ?Sized> HashingWriter<'a, W> {
+    pub fn new(inner: &'a mut W) -> Self {
+        Self {
+            inner,
+            hasher: Xxh3::new(),
+        }
+    }
+
+    pub fn digest128(&self) -> u128 {
+        self.hasher.digest128()
+    }
+}
+
+impl<W: Write + ?Sized> Write for HashingWriter<'_, W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        if n > 0 {
+            self.hasher.update(&buf[..n]);
+        }
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 #[cfg(test)]
 mod hashing_reader_tests {
     use super::*;


### PR DESCRIPTION
Rewriting a cached data frame truncated the file in place, so any request still holding the old contents memory-mapped faulted on its next page touch and killed the whole server process with `SIGBUS`. A running server hit this repeatedly, dropping every in-flight request each time. Data frame writes now land in a sibling temp file and rename over the target, so a reader that already mapped the previous version keeps a valid file until it finishes.

We fix two other kinds of problems in this PR as well: Four of the five data frame writers turned a failed file create into a panic instead of a returned error. And the compare cache's commit-id markers were written non-atomically, so a crash mid-write could leave a torn marker that makes a stale cache look current.

We add the `AtomicFile::write_with` terminal method and the `HashingWriter` helper struct as part of this PR.

ENG-1420