### PR TITLE
Stop publishing two HTTP endpoints that don't exist

### DIFF
--- a/crates/oxen-server/src/controllers/commits.rs
+++ b/crates/oxen-server/src/controllers/commits.rs
@@ -70,31 +70,6 @@ pub struct ListMissingFilesQuery {
     pub head: String,
 }
 
-/// List commits
-#[utoipa::path(
-    get,
-    path = "/api/repos/{namespace}/{repo_name}/commits",
-    tag = "Commits",
-    description = "List all commits in the repository's history.",
-    params(
-        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
-        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
-    ),
-    responses(
-        (status = 200, description = "List of commits", body = ListCommitResponse),
-        (status = 404, description = "Repository not found")
-    )
-)]
-pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
-    let app_data = app_data(&req)?;
-    let namespace = path_param(&req, "namespace")?.to_string();
-    let repo_name = path_param(&req, "repo_name")?.to_string();
-    let repo = get_repo(app_data, namespace, repo_name)?;
-
-    let commits = repositories::commits::list(&repo).unwrap_or_default();
-    Ok(HttpResponse::Ok().json(ListCommitResponse::success(commits)))
-}
-
 /// List commit history
 #[utoipa::path(
     get,
@@ -665,7 +640,7 @@ fn compress_commit(repository: &LocalRepository, commit: &Commit) -> Result<Vec<
 #[utoipa::path(
     post,
     path = "/api/repos/{namespace}/{repo_name}/commits",
-    description = "Upload a commit to a branch on the server. This creates an empty commit. To create a commit with children, use the upload_tree endpoint.",
+    description = "Upload a commit to a branch on the server. This creates an empty commit. Its merkle tree nodes are uploaded separately through the tree nodes endpoint.",
     tag = "Commits",
     params(
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
@@ -1087,65 +1062,6 @@ pub async fn complete(req: HttpRequest) -> Result<HttpResponse, Error> {
     }
 }
 
-/// Upload commit tree
-#[utoipa::path(
-    post,
-    path = "/api/repos/{namespace}/{repo_name}/commits/{commit_id}/upload_tree",
-    tag = "Commits",
-    description = "Upload a commit's merkle tree data as a compressed tarball.",
-    params(
-        ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
-        ("repo_name" = String, Path, description = "Name of the repository", example = "ImageNet-1k"),
-        ("commit_id" = String, Path, description = "Client head commit ID", example = "84c76a5b2e9a2637f9091991475c404d"),
-    ),
-    request_body(
-        content_type = "application/octet-stream",
-        description = "Compressed tree data (tar.gz)",
-        content = Vec<u8>
-    ),
-    responses(
-        (status = 200, description = "Tree uploaded successfully", body = CommitResponse),
-    )
-)]
-pub async fn upload_tree(
-    req: HttpRequest,
-    mut body: web::Payload,
-) -> Result<HttpResponse, OxenHttpError> {
-    let app_data = app_data(&req)?;
-    let namespace = path_param(&req, "namespace")?.to_string();
-    let name = path_param(&req, "repo_name")?.to_string();
-    let client_head_id = path_param(&req, "commit_id")?.to_string();
-    let repo = get_repo(app_data, namespace, name)?;
-    // Get head commit on sever repo
-    let server_head_commit = repositories::commits::head_commit(&repo)?;
-
-    // Unpack in tmp/tree/commit_id
-    let tmp_dir = util::fs::oxen_hidden_dir(&repo.path).join("tmp");
-
-    let mut bytes = web::BytesMut::new();
-    while let Some(item) = body.next().await {
-        bytes.extend_from_slice(&item.map_err(|_| OxenHttpError::FailedToReadRequestPayload)?);
-    }
-
-    let total_size: u64 = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
-    log::debug!(
-        "Got compressed data for tree {} -> {}",
-        client_head_id,
-        ByteSize::b(total_size)
-    );
-
-    log::debug!("Decompressing {} bytes to {:?}", bytes.len(), tmp_dir);
-
-    // let mut archive = Archive::new(GzDecoder::new(&bytes[..]));
-
-    unpack_tree_tarball(&tmp_dir, &bytes).await?;
-
-    Ok(HttpResponse::Ok().json(CommitResponse {
-        status: StatusMessage::resource_found(),
-        commit: server_head_commit.to_owned(),
-    }))
-}
-
 /// Get root commit
 #[utoipa::path(
     get,
@@ -1172,53 +1088,6 @@ pub async fn root_commit(req: HttpRequest) -> Result<HttpResponse, OxenHttpError
         status: StatusMessage::resource_found(),
         commit: root,
     }))
-}
-
-async fn unpack_tree_tarball(tmp_dir: &Path, data: &[u8]) -> Result<(), OxenError> {
-    let reader = Cursor::new(data);
-    let buf_reader = BufReader::new(reader);
-    let decoder = GzipDecoder::new(buf_reader);
-    let mut archive = Archive::new(decoder);
-
-    let mut entries = match archive.entries() {
-        Ok(entries) => entries,
-        Err(e) => {
-            log::error!("Could not unpack tree database from archive...");
-            log::error!("Err: {e:?}");
-            return Err(OxenError::basic_str("Failed to get archive entries"));
-        }
-    };
-
-    while let Some(entry) = entries.next().await {
-        if let Ok(mut file) = entry {
-            let path = file.path().unwrap();
-            log::debug!("unpack_tree_tarball path {path:?}");
-            let stripped_path = if path.starts_with(HISTORY_DIR) {
-                match path.strip_prefix(HISTORY_DIR) {
-                    Ok(stripped) => stripped,
-                    Err(err) => {
-                        log::error!("Could not strip prefix from path {err:?}");
-                        return Err(OxenError::basic_str("Failed to strip path prefix"));
-                    }
-                }
-            } else {
-                &path
-            };
-
-            let mut new_path = PathBuf::from(tmp_dir);
-            new_path.push(stripped_path);
-
-            if let Some(parent) = new_path.parent() {
-                util::fs::create_dir_all(parent).expect("Could not create parent dir");
-            }
-            log::debug!("unpack_tree_tarball new_path {path:?}");
-            file.unpack(&new_path).await.unwrap();
-        } else {
-            log::error!("Could not unpack file in archive...");
-        }
-    }
-
-    Ok(())
 }
 
 async fn unpack_entry_tarball_async(

--- a/crates/oxen-server/src/controllers/oxen_version.rs
+++ b/crates/oxen-server/src/controllers/oxen_version.rs
@@ -1,10 +1,7 @@
-use crate::params::{app_data, path_param};
 use actix_web::{HttpRequest, HttpResponse};
 use liboxen::constants::MIN_OXEN_CLIENT_VERSION;
-use liboxen::repositories;
 use liboxen::view::StatusMessage;
 use liboxen::view::oxen_version::OxenVersionResponse;
-use serde::Serialize;
 
 /// Check Oxen server status
 #[utoipa::path(
@@ -27,51 +24,4 @@ pub async fn min_version(_req: HttpRequest) -> HttpResponse {
         version: MIN_OXEN_CLIENT_VERSION.to_string(),
     };
     HttpResponse::Ok().json(response)
-}
-
-#[derive(Serialize, Debug)]
-struct ResolveResponse {
-    #[serde(flatten)]
-    pub status: StatusMessage,
-    pub repository_api_url: String,
-}
-
-pub async fn resolve(req: HttpRequest) -> HttpResponse {
-    let app_data = app_data(&req).unwrap();
-
-    let namespace: Option<&str> = path_param(&req, "namespace").ok();
-    let name: Option<&str> = path_param(&req, "repo_name").ok();
-    if let (Some(name), Some(namespace)) = (name, namespace) {
-        match repositories::get_by_namespace_and_name(
-            &app_data.path,
-            namespace,
-            name,
-            app_data.config.storage.s3(),
-        ) {
-            Ok(Some(_)) => match req.url_for("repo_root", [namespace, name]) {
-                Ok(url) => {
-                    log::debug!("resolved repo URL: {url}");
-                    HttpResponse::Ok().json(ResolveResponse {
-                        status: StatusMessage::resource_found(),
-                        repository_api_url: url.to_string(),
-                    })
-                }
-                Err(err) => {
-                    log::debug!("Error generating repo URL: {err:?}");
-                    HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
-                }
-            },
-            Ok(None) => {
-                log::debug!("404 Could not find repo: {name}");
-                HttpResponse::NotFound().json(StatusMessage::resource_not_found())
-            }
-            Err(err) => {
-                log::debug!("Err finding repo: {name} => {err:?}");
-                HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
-            }
-        }
-    } else {
-        let msg = "Could not find `name` or `namespace` param...";
-        HttpResponse::BadRequest().json(StatusMessage::error(msg))
-    }
 }

--- a/crates/oxen-server/src/controllers/versions/chunks.rs
+++ b/crates/oxen-server/src/controllers/versions/chunks.rs
@@ -6,7 +6,6 @@ use crate::params::{app_data, path_param};
 
 use actix_web::{HttpRequest, HttpResponse, web};
 use futures_util::stream::StreamExt as _;
-use liboxen::constants::stream_segment_size;
 use liboxen::core;
 use liboxen::repositories;
 use liboxen::view::StatusMessage;
@@ -126,42 +125,6 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
     }
 
     Ok(HttpResponse::BadRequest().json(StatusMessage::error("Invalid request body")))
-}
-
-// TODO: Add content-type and oxen-revision-id in the response header
-// Currently, this endpoint is not used anywhere.
-pub async fn download(
-    req: HttpRequest,
-    query: web::Query<ChunkQuery>,
-) -> Result<HttpResponse, OxenHttpError> {
-    let app_data = app_data(&req)?;
-    let namespace = path_param(&req, "namespace")?.to_string();
-    let repo_name = path_param(&req, "repo_name")?.to_string();
-    let version_id = path_param(&req, "version_id")?.to_string();
-    let repo = get_repo(app_data, namespace, repo_name)?;
-
-    let offset = query.offset.unwrap_or(0);
-    let size = query.size.unwrap_or_else(stream_segment_size);
-
-    log::debug!(
-        "download_chunk for repo: {:?}, file_hash: {}, offset: {}, size: {}",
-        repo.path,
-        version_id,
-        offset,
-        size
-    );
-
-    let version_store = repo.version_store();
-
-    let chunk_data = version_store
-        .get_version_chunk(&version_id, offset, size)
-        .await?;
-    Ok(HttpResponse::Ok()
-        .insert_header((
-            actix_web::http::header::CONTENT_LENGTH,
-            chunk_data.len().to_string(),
-        ))
-        .body(chunk_data))
 }
 
 pub async fn create(_req: HttpRequest, _body: String) -> Result<HttpResponse, OxenHttpError> {

--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -155,7 +155,6 @@ const START_SERVER_USAGE: &str = "Usage: `oxen-server start -i 0.0.0.0 -p 3000`"
         crate::controllers::branches::maybe_create_merge,
         crate::controllers::branches::list_entry_versions,
         // Commits
-        crate::controllers::commits::index,
         crate::controllers::commits::history,
         crate::controllers::commits::list_all,
         crate::controllers::commits::list_missing,
@@ -168,7 +167,6 @@ const START_SERVER_USAGE: &str = "Usage: `oxen-server start -i 0.0.0.0 -p 3000`"
         crate::controllers::commits::download_commit_entries_db,
         crate::controllers::commits::create,
         crate::controllers::commits::upload_chunk,
-        crate::controllers::commits::upload_tree,
         crate::controllers::commits::root_commit,
         crate::controllers::commits::upload,
         crate::controllers::commits::complete,

--- a/crates/oxen-server/src/routes.rs
+++ b/crates/oxen-server/src/routes.rs
@@ -15,8 +15,6 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         // Get/Delete Repository
         .service(
             web::resource("/{namespace}/{repo_name}")
-                // we give the resource a name here so it can be used with HttpRequest.url_for
-                .name("repo_root")
                 .route(web::get().to(controllers::repositories::show))
                 .route(web::delete().to(controllers::repositories::delete)),
         )

--- a/crates/oxen-server/src/services/commits.rs
+++ b/crates/oxen-server/src/services/commits.rs
@@ -5,8 +5,6 @@ use crate::controllers;
 
 pub fn commits() -> Scope {
     web::scope("/commits")
-        //  This is commented out because the list_commit function reads from the head file, which should not be used server side
-        // .route("", web::get().to(controllers::commits::index))
         .route("", web::post().to(controllers::commits::create))
         .route("/root", web::get().to(controllers::commits::root_commit))
         .route("/all", web::get().to(controllers::commits::list_all))

--- a/crates/oxen-server/src/services/versions.rs
+++ b/crates/oxen-server/src/services/versions.rs
@@ -41,11 +41,6 @@ pub fn versions() -> Scope {
             web::get().to(controllers::versions::download),
         )
         .route(
-            //TODO: The versions chunk download endpoint is not functional now. Needs the same changes mentioned above.
-            "/{version_id}/chunks/download",
-            web::get().to(controllers::versions::chunks::download),
-        )
-        .route(
             "/{version_id}/create",
             web::post().to(controllers::versions::chunks::create),
         )


### PR DESCRIPTION
docs.oxen.ai renders its HTTP API reference from oxen-server's OpenAPI spec, which listed POST /commits/{commit_id}/upload_tree and GET /commits as real endpoints. Neither has a route, so anyone following the reference got a 404. Both are gone from the spec now, along with the handlers behind them and two more handlers that no request could reach either.

Every deletion is unreachable code, so no request behaves differently:

- `commits::upload_tree` lost its route in November 2023 and its client caller in March 2025; only the OpenAPI entry kept it looking alive. Its `unpack_tree_tarball` helper goes with it.
- `commits::index` has had its route commented out in the commits service, but stayed documented.
- `oxen_version::resolve` was never routed, and was the only thing using the `repo_root` route name.
- `versions::chunks::download` was registered six lines after the `GET /versions/{resource:.*}` catch-all that swallows every path it could match. Its own comments recorded it as "not functional" and "not used anywhere". That URL already fell through to the catch-all, and still does.

The commit-upload endpoint's description pointed readers at the deleted upload_tree endpoint; it now points at the tree nodes endpoint, which is where merkle tree nodes actually go.