### PR TITLE
Repo Integrity (1.16.3): Alert on oxen-server errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,10 @@ tracing-actix-web = "0.7"
 tracing-appender = "0.2"
 tracing-log = "0.2"
 tracing-opentelemetry = "0.32"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "registry"] }
+# "tracing-log" installs the log->tracing bridge, without which none of the `log::*` call sites
+# reach a subscriber layer. It is also a default feature; listed explicitly so turning defaults off
+# cannot silently unhook every error report.
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "registry", "tracing-log"] }
 url = "2.4.1"
 urlencoding = "2.1.3"
 utoipa = { version = "5", features = ["time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ sentry = { version = "0.34", default-features = false, features = [
     "panic",
     "reqwest",
     "rustls",
+    "tracing",
 ] }
 sentry-actix = "0.34"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/crates/liboxen/src/util/telemetry.rs
+++ b/crates/liboxen/src/util/telemetry.rs
@@ -29,6 +29,11 @@ pub enum TelemetryError {
     InvalidEndpoint(String),
 }
 
+/// A caller-supplied tracing layer composed into the registry by
+/// [`init_tracing_with_layer`]. Keeps this crate free of any dependency on the destination the
+/// layer reports to.
+pub type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync>;
+
 /// Holds all tracing-related guards. Drop flushes writers and shuts down
 /// the OpenTelemetry pipeline (when enabled). The caller **must** keep this
 /// alive for the application lifetime.
@@ -136,6 +141,18 @@ mod atexit_flush {
 /// **must** hold the guard in a named binding for the lifetime of the
 /// application — dropping it flushes the non-blocking writer.
 pub fn init_tracing(app_name: &str, default: LevelFilter) -> Result<TracingGuard, TelemetryError> {
+    init_tracing_with_layer(app_name, default, None)
+}
+
+/// [`init_tracing`] with an additional caller-supplied layer composed into the registry.
+///
+/// `extra` receives every event that passes the `RUST_LOG` filter, including those emitted through
+/// the `log` macros via the `tracing-log` bridge.
+pub fn init_tracing_with_layer(
+    app_name: &str,
+    default: LevelFilter,
+    extra: Option<BoxedLayer>,
+) -> Result<TracingGuard, TelemetryError> {
     let log_level = log_env_filter(default);
 
     // FmtSpan configuration for stderr
@@ -177,8 +194,10 @@ pub fn init_tracing(app_name: &str, default: LevelFilter) -> Result<TracingGuard
         (None, None)
     };
 
-    // Base registry with all non-OTel layers
+    // Base registry with all non-OTel layers. `extra` goes innermost so its subscriber type is
+    // `Registry`, which is what `BoxedLayer` names.
     let registry = tracing_subscriber::registry()
+        .with(extra)
         .with(m_json_layer)
         .with(stderr_layer)
         .with(log_level);
@@ -292,7 +311,10 @@ fn create_log_dir(oxen_log_dir: &str) -> Result<PathBuf, TelemetryError> {
 }
 
 /// Configure ND-JSON file logging with daily log rotation in the given log directory.
-fn json_file_logging(app_name: &str, log_dir: &Path) -> (impl Layer<Registry>, WorkerGuard) {
+fn json_file_logging<S>(app_name: &str, log_dir: &Path) -> (impl Layer<S>, WorkerGuard)
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
     let file_appender = tracing_appender::rolling::daily(log_dir, app_name);
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 

--- a/crates/oxen-server/src/controllers/commits.rs
+++ b/crates/oxen-server/src/controllers/commits.rs
@@ -255,7 +255,7 @@ pub async fn list_missing(
 
     let data: Result<MerkleHashes, serde_json::Error> = serde_json::from_str(&body);
     let Ok(merkle_hashes) = data else {
-        log::error!("list_missing invalid JSON: {body:?}");
+        log::warn!("list_missing invalid JSON: {body:?}");
         return Ok(HttpResponse::BadRequest().json(StatusMessage::error("Invalid JSON")));
     };
 
@@ -701,7 +701,7 @@ pub async fn create(
     let new_commit: Commit = match serde_json::from_str(&body) {
         Ok(commit) => commit,
         Err(_) => {
-            log::error!("commits create got invalid commit data {body}");
+            log::warn!("commits create got invalid commit data {body}");
             return Err(OxenHttpError::BadRequest("Invalid commit data".into()));
         }
     };
@@ -1066,7 +1066,7 @@ pub async fn complete(req: HttpRequest) -> Result<HttpResponse, Error> {
                     Ok(HttpResponse::Ok().json(response))
                 }
                 Ok(None) => {
-                    log::error!("Could not find commit [{commit_id}]");
+                    log::warn!("Could not find commit [{commit_id}]");
                     Ok(HttpResponse::NotFound().json(StatusMessage::resource_not_found()))
                 }
                 Err(err) => {

--- a/crates/oxen-server/src/controllers/data_frames.rs
+++ b/crates/oxen-server/src/controllers/data_frames.rs
@@ -220,7 +220,7 @@ pub async fn from_directory(
     let data = match data {
         Ok(data) => data,
         Err(err) => {
-            log::error!("Unable to parse body. Err: {err}\n{body}");
+            log::warn!("Unable to parse body. Err: {err}\n{body}");
             return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
         }
     };

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -416,7 +416,7 @@ pub async fn create_df_diff(
     let data = match data {
         Ok(data) => data,
         Err(err) => {
-            log::error!("unable to parse tabular comparison data. Err: {err}\n{body}");
+            log::warn!("unable to parse tabular comparison data. Err: {err}\n{body}");
             return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
         }
     };
@@ -523,7 +523,7 @@ pub async fn update_df_diff(
     let data = match data {
         Ok(data) => data,
         Err(err) => {
-            log::error!("unable to parse tabular comparison data. Err: {err}\n{body}");
+            log::warn!("unable to parse tabular comparison data. Err: {err}\n{body}");
             return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
         }
     };
@@ -849,7 +849,7 @@ pub async fn get_derived_df(
             Ok(HttpResponse::Ok().json(response))
         }
         Err(OxenError::SQLParseError(sql)) => {
-            log::error!("Error parsing SQL: {sql}");
+            log::warn!("Error parsing SQL: {sql}");
             Err(OxenHttpError::SQLParseError(sql))
         }
         Err(e) => {

--- a/crates/oxen-server/src/controllers/workspaces.rs
+++ b/crates/oxen-server/src/controllers/workspaces.rs
@@ -57,7 +57,7 @@ pub async fn get_or_create(
     let data = match data {
         Ok(data) => data,
         Err(err) => {
-            log::error!("Unable to parse body. Err: {err}\n{body}");
+            log::warn!("Unable to parse body. Err: {err}\n{body}");
             return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
         }
     };
@@ -401,7 +401,7 @@ pub async fn commit(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
     let data = match data {
         Ok(data) => data,
         Err(err) => {
-            log::error!("unable to parse commit data. Err: {err}\n{body}");
+            log::warn!("unable to parse commit data. Err: {err}\n{body}");
             return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
         }
     };

--- a/crates/oxen-server/src/controllers/workspaces/data_frames.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames.rs
@@ -189,7 +189,7 @@ pub async fn get(
     let Some(mut df_schema) =
         repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, &file_path)?
     else {
-        log::error!("Failed to get schema for data frame {file_path:?}");
+        log::warn!("Failed to get schema for data frame {file_path:?}");
         return Err(OxenHttpError::NotFound);
     };
 
@@ -300,7 +300,7 @@ pub async fn download(
     };
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(filename) = file_path.file_name().and_then(|n| n.to_str()) else {
-        log::error!(
+        log::warn!(
             "Unable to get filename from request param path: {}",
             file_path.display()
         );
@@ -339,7 +339,7 @@ pub async fn download(
         Ok(_) => (),
         Err(e) => {
             let error_str = format!("{e:?}");
-            log::error!("Error exporting data frame {file_path:?}: {error_str}");
+            log::warn!("Error exporting data frame {file_path:?}: {error_str}");
             let response = StatusMessageDescription::bad_request(error_str);
             return Ok(HttpResponse::BadRequest().json(response));
         }
@@ -429,7 +429,7 @@ pub async fn download_streaming(
     };
     let file_path = PathBuf::from(path_param(&req, "path")?);
     let Some(filename) = file_path.file_name().and_then(|n| n.to_str()) else {
-        log::error!(
+        log::warn!(
             "Unable to get filename from request param path: {}",
             file_path.display()
         );
@@ -465,7 +465,7 @@ pub async fn download_streaming(
     match repositories::workspaces::data_frames::export(&workspace, &file_path, &opts, &temp_file) {
         Ok(_) => (),
         Err(e) => {
-            log::error!("Error exporting data frame {file_path:?}: {e:?}");
+            log::warn!("Error exporting data frame {file_path:?}: {e:?}");
             let error_str = format!("{e:?}");
             let response = StatusMessageDescription::bad_request(error_str);
             return Ok(HttpResponse::BadRequest().json(response));

--- a/crates/oxen-server/src/controllers/workspaces/data_frames/columns.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames/columns.rs
@@ -129,7 +129,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     ) {
         Ok(df) => df,
         Err(e) => {
-            log::error!("Error deleting column: {e:?}");
+            log::warn!("Error deleting column: {e:?}");
             return Err(OxenHttpError::BasicError(StringError::from(e.to_string())));
         }
     };

--- a/crates/oxen-server/src/controllers/workspaces/data_frames/embeddings.rs
+++ b/crates/oxen-server/src/controllers/workspaces/data_frames/embeddings.rs
@@ -97,7 +97,7 @@ pub async fn neighbors(req: HttpRequest, body: String) -> Result<HttpResponse, O
     let Some(mut df_schema) =
         repositories::data_frames::schemas::get_by_path(&repo, &workspace.commit, file_path)?
     else {
-        log::error!("Failed to get schema for data frame {file_path:?}");
+        log::warn!("Failed to get schema for data frame {file_path:?}");
         return Err(OxenHttpError::NotFound);
     };
 

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -105,6 +105,11 @@ impl error::ResponseError for OxenHttpError {
     //
     //         Do not add a `status_code()` method definition here :)
 
+    /// Log level tracks who caused the failure: `error!` for a server-side defect, `warn!` for a
+    /// request the client got wrong, `debug!` only when there is no identifying detail worth
+    /// recording. `error!` is what reaches Sentry as an issue and `debug!` is filtered out in
+    /// production, so a 4xx arm at `error!` turns ordinary client traffic into alerts, and a
+    /// named-resource miss at `debug!` leaves nothing to debug from.
     fn error_response(&self) -> HttpResponse {
         log::debug!("OxenHttpError: {self:?}");
         match self {
@@ -356,7 +361,7 @@ impl error::ResponseError for OxenHttpError {
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::WorkspaceNotFound(workspace) => {
-                        log::error!("Workspace not found: {workspace}");
+                        log::warn!("Workspace not found: {workspace}");
                         let error_json = json!({
                             "error": {
                                 "type": MSG_RESOURCE_NOT_FOUND,
@@ -392,7 +397,7 @@ impl error::ResponseError for OxenHttpError {
                         )))
                     }
                     OxenError::CommitEntryNotFound(msg) => {
-                        log::error!("{msg}");
+                        log::warn!("{msg}");
                         let error_json = json!({
                             "error": {
                                 "type": MSG_RESOURCE_NOT_FOUND,
@@ -405,7 +410,7 @@ impl error::ResponseError for OxenHttpError {
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::UpstreamMergeConflict(desc) => {
-                        log::error!("Upstream merge conflict: {desc}");
+                        log::warn!("Upstream merge conflict: {desc}");
                         let error_json = json!({
                             "error": {
                                 "type": MSG_CONFLICT,
@@ -433,13 +438,13 @@ impl error::ResponseError for OxenHttpError {
                         HttpResponse::Conflict().json(error_json)
                     }
                     OxenError::InvalidSchema(schema) => {
-                        log::error!("Invalid schema: {schema}");
+                        log::warn!("Invalid schema: {schema}");
                         HttpResponse::BadRequest().json(StatusMessageDescription::bad_request(
                             format!("Schema is invalid: '{schema}'"),
                         ))
                     }
                     OxenError::IncompatibleSchemas(schema) => {
-                        log::error!("Incompatible schemas: {schema}");
+                        log::warn!("Incompatible schemas: {schema}");
 
                         let schema_vals = &schema
                             .fields
@@ -498,7 +503,7 @@ impl error::ResponseError for OxenHttpError {
                         DataFrameError::Polars(error) => handle_polars(error),
                         DataFrameError::SerdeJson(_) => handle_serde(),
                         DataFrameError::ColumnNameAlreadyExists(column_name) => {
-                            log::error!("Column Name Already Exists: {column_name}");
+                            log::warn!("Column Name Already Exists: {column_name}");
                             let error_json = json!({
                                 "error": {
                                     "type": "column_error",
@@ -513,7 +518,7 @@ impl error::ResponseError for OxenHttpError {
                             HttpResponse::BadRequest().json(error_json)
                         }
                         DataFrameError::ReservedColumnName(column_name) => {
-                            log::error!("Reserved column name: {column_name}");
+                            log::warn!("Reserved column name: {column_name}");
                             let error_json = json!({
                                 "error": {
                                     "type": "column_error",
@@ -527,7 +532,7 @@ impl error::ResponseError for OxenHttpError {
                             HttpResponse::BadRequest().json(error_json)
                         }
                         DataFrameError::SqlParse(e) => {
-                            log::error!("SQL parse error: {e}");
+                            log::warn!("SQL parse error: {e}");
                             let error_json = json!({
                                 "error": {
                                     "type": "sql_parse_error",
@@ -540,7 +545,7 @@ impl error::ResponseError for OxenHttpError {
                             HttpResponse::BadRequest().json(error_json)
                         }
                         DataFrameError::ColumnNameNotFound(column_name) => {
-                            log::error!("Column Name Not Found: {column_name}");
+                            log::warn!("Column Name Not Found: {column_name}");
                             let error_json = json!({
                                 "error": {
                                     "type": "column_error",
@@ -555,7 +560,7 @@ impl error::ResponseError for OxenHttpError {
                             HttpResponse::BadRequest().json(error_json)
                         }
                         e @ DataFrameError::NoRowsFound => {
-                            log::error!("No rows found: {e}");
+                            log::debug!("No rows found: {e}");
                             let error_json = json!({
                                 "error": {
                                     "type": "no_rows_found",
@@ -582,6 +587,8 @@ impl error::ResponseError for OxenHttpError {
                         }
                     },
                     thumbnail_error @ OxenError::ThumbnailingNotEnabled => {
+                        // Both release images build with `liboxen/ffmpeg`, so reaching this arm means
+                        // a build lost the feature and every video-thumbnail request 500s.
                         log::error!("Thumbnailing not enabled: {thumbnail_error}");
                         let error_json = json!({
                             "error": {
@@ -673,7 +680,7 @@ impl error::ResponseError for OxenHttpError {
                         HttpResponse::NotFound().json(error_json)
                     }
                     OxenError::WorkspaceBehind(workspace) => {
-                        log::error!("Workspace behind: {workspace}");
+                        log::warn!("Workspace behind: {workspace}");
                         let error_json = json!({
                             "error": {
                                 "type": MSG_CONFLICT,
@@ -772,7 +779,7 @@ impl error::ResponseError for OxenHttpError {
 
 /// Convert a [`duckdb::Error`] into a HTTP bad request error.
 fn handle_duckdb(error: &impl std::error::Error) -> HttpResponse {
-    log::error!("DuckDB error: {error}");
+    log::warn!("DuckDB error: {error}");
     let error_json = json!({
         "error": {
             "type": "query_error",

--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -9,6 +9,7 @@ use liboxen::model::merkle_tree::merkle_tree_node_cache;
 use liboxen::model::metadata::metadata_image::ImgResize;
 
 use liboxen::util;
+use liboxen::util::telemetry;
 
 mod crash_diagnostics;
 
@@ -72,6 +73,7 @@ use liboxen::view::{
     ParseResourceResponse, RepositoryResponse, RepositoryView, RootCommitResponse, StatusMessage,
 };
 
+use sentry::integrations::tracing as sentry_tracing;
 use tracing::level_filters::LevelFilter;
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
@@ -400,17 +402,46 @@ fn init_sentry(dsn: Option<String>) -> Option<sentry::ClientInitGuard> {
     Some(sentry::init((dsn, options)))
 }
 
+/// The tracing layer that forwards events to Sentry, or `None` when Sentry is disabled, in which
+/// case no event-processing cost is paid at all.
+///
+/// Keeps `sentry-tracing`'s default event mapping: an `error!` becomes an issue, `warn!` and `info!`
+/// become breadcrumbs giving whatever issue follows some context, and `debug!` and below are
+/// dropped. The level a failure is logged at is therefore what decides whether it alerts — see the
+/// level convention on `OxenHttpError::error_response`. Spans are filtered out entirely: with
+/// performance tracing disabled every span would build a Sentry transaction that is never sampled.
+fn sentry_tracing_layer(enabled: bool) -> Option<telemetry::BoxedLayer> {
+    if !enabled {
+        return None;
+    }
+    Some(Box::new(sentry_tracing::layer().span_filter(|_| false)))
+}
+
 #[actix_web::main]
 async fn main() {
     crash_diagnostics::install().expect("failed to install crash diagnostics");
 
-    // fail-fast if we cannot initialize logging
-    let _tracing_guard = util::telemetry::init_tracing("oxen-server", LevelFilter::WARN)
-        .expect("Failed to initialize tracing & logging for oxen-server.");
     // Capture panics when a Sentry DSN is configured; held for the whole process so the client
-    // flushes on exit. Must stay after `crash_diagnostics::install` — Sentry's panic hook chains
-    // onto whichever hook is already installed.
-    let _sentry_guard = init_sentry(env::var("SENTRY_DSN").ok());
+    // flushes on exit. Sits after `crash_diagnostics::install`, whose panic hook Sentry's chains
+    // onto, and before tracing init, which needs to know whether to compose the Sentry layer.
+    let dsn = env::var("SENTRY_DSN").ok();
+    let dsn_configured = dsn.as_ref().is_some_and(|dsn| !dsn.is_empty());
+    let _sentry_guard = init_sentry(dsn);
+    // `sentry::init` returns a guard even for a DSN it could not parse, so ask the client itself.
+    let sentry_enabled = _sentry_guard
+        .as_ref()
+        .is_some_and(|guard| guard.is_enabled());
+    // fail-fast if we cannot initialize logging
+    let _tracing_guard = telemetry::init_tracing_with_layer(
+        "oxen-server",
+        LevelFilter::WARN,
+        sentry_tracing_layer(sentry_enabled),
+    )
+    .expect("Failed to initialize tracing & logging for oxen-server.");
+    // Logged here rather than next to `init_sentry` because no subscriber exists yet at that point.
+    if dsn_configured && !sentry_enabled {
+        log::error!("SENTRY_DSN is set but Sentry is disabled; no errors will be reported");
+    }
     // We want to show the error's display(), not the debug() representation.
     // actix_web::main() will show the error's debug() representation.
     if let Err(e) = server().await {
@@ -808,5 +839,11 @@ mod tests {
     fn init_sentry_is_disabled_without_dsn() {
         assert!(init_sentry(None).is_none());
         assert!(init_sentry(Some(String::new())).is_none());
+    }
+
+    #[test]
+    fn sentry_tracing_layer_is_absent_without_sentry() {
+        assert!(sentry_tracing_layer(false).is_none());
+        assert!(sentry_tracing_layer(true).is_some());
     }
 }


### PR DESCRIPTION
Forward `oxen-server`'s error-level events to Sentry so a failure that never panics still raises an alert instead of sitting in a log. Panic reporting already covers crashes. This covers the larger class of non-fatal errors.

This PR also reclassifies a bunch of oxen-server's error sites. The idea is to make any `error!(...)` logging be a server problem (e.g. 5xx errors) that we want a Sentry issue for. Then use `warn!(...)` (or lower) for customer-caused errors that don't need a code fix.

We don't add Sentry to liboxen itself, per se. We just inject it from oxen-server into liboxen via a caller-supplied tracing layer. The CLI and the Python bindings don't have any Sentry functionality at this point. We may choose to add a way to optionally enable it in the future.