### PR TITLE
Recover stale workspace data frames on commit instead of erroring

### DIFF
--- a/crates/liboxen/src/core/v_latest/workspaces/commit.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/commit.rs
@@ -299,10 +299,40 @@ async fn export_tabular_data_frames(
                         node_path = dir_path.join(node_path);
                     }
 
-                    // Only recompute the metadata if the file is tabular and indexed (editable df and eval)
-                    if *file_node.data_type() == EntryDataType::Tabular
-                        && repositories::workspaces::data_frames::is_indexed(workspace, &node_path)?
+                    // Recompute the metadata for tabular data frames that carry
+                    // a staged DuckDB index (editable df and eval).
+                    let is_tabular = *file_node.data_type() == EntryDataType::Tabular;
+                    let mut should_export = is_tabular
+                        && repositories::workspaces::data_frames::is_indexed(
+                            workspace, &node_path,
+                        )?;
+
+                    // A staged table that exists but fails the indexed gate was
+                    // written by an older version of oxen (or left by an
+                    // interrupted index). Rather than committing the base file
+                    // and silently dropping the staged edits, recover the table
+                    // from its own rows — preserving the staged edits and
+                    // honoring the old tombstone deletes — then export it like
+                    // any indexed table. reindex_preserving_rows only errors
+                    // (WorkspaceStaleStagedIndex) when there is no user data to
+                    // recover.
+                    if is_tabular
+                        && !should_export
+                        && repositories::workspaces::data_frames::has_staged_table(
+                            workspace, &node_path,
+                        )?
                     {
+                        log::warn!(
+                            "workspace commit recovering stale staged data frame {node_path:?} before export"
+                        );
+                        repositories::workspaces::data_frames::reindex_preserving_rows(
+                            workspace, &node_path,
+                        )
+                        .await?;
+                        should_export = true;
+                    }
+
+                    if should_export {
                         log::debug!(
                             "Exporting tabular data frame: {:?} -> {:?}",
                             node_path,
@@ -360,28 +390,6 @@ async fn export_tabular_data_frames(
                             .or_default()
                             .push(new_staged_merkle_tree_node);
                     } else {
-                        // A staged table that exists but fails the indexed
-                        // gate was written by an older version and may hold
-                        // edits this code cannot export. The staged entry is
-                        // the BASE file node, so committing it would silently
-                        // discard those edits — fail instead so the user can
-                        // re-index (dropping the stale edits explicitly) or
-                        // unstage.
-                        if *file_node.data_type() == EntryDataType::Tabular
-                            && repositories::workspaces::data_frames::has_staged_table(
-                                workspace, &node_path,
-                            )?
-                        {
-                            return Err(OxenError::WorkspaceStaleStagedIndex(
-                                format!(
-                                    "Cannot commit workspace: the staged data frame {node_path:?} \
-                                     was indexed by an older version of oxen. Re-index the data \
-                                     frame (discarding its staged edits) or unstage it, then \
-                                     commit again."
-                                )
-                                .into(),
-                            ));
-                        }
                         new_dir_entries
                             .entry(dir_path.to_path_buf())
                             .or_default()

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -1,8 +1,8 @@
 use duckdb::Connection;
 
 use crate::constants::{
-    DIFF_STATUS_COL, EVAL_DURATION_COL, EVAL_ERROR_COL, EVAL_STATUS_COL, EXCLUDE_OXEN_COLS,
-    OXEN_ID_COL, OXEN_ROW_ID_COL, TABLE_NAME,
+    EVAL_DURATION_COL, EVAL_ERROR_COL, EVAL_STATUS_COL, EXCLUDE_OXEN_COLS, OXEN_ID_COL,
+    OXEN_ROW_ID_COL, TABLE_NAME,
 };
 use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::df_db;
@@ -249,25 +249,42 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     Ok(())
 }
 
-/// Every column name Oxen has used internally in a staged DuckDB table across
-/// format versions. When recovering a table left by an older version, a column
-/// matching one of these is Oxen-internal and is dropped (never treated as user
-/// data) while rebuilding. This is a superset of [`EXCLUDE_OXEN_COLS`], which
-/// lists only the columns the current indexer emits: `_oxen_diff_status` and
-/// `_oxen_diff_hash` are legacy tracking columns the current format no longer
-/// writes. Matching is exact — a not-fully-indexed table was written by an
-/// indexer that reserved all of these names, so a column named like one of them
-/// is never user data in this context.
+/// Legacy per-row tracking columns older versions of oxen wrote into the staged
+/// table and the current staged format dropped. Frozen here as literals rather
+/// than references to the diff-feature's live constants: they name columns that
+/// exist only in tables already written to disk, so their spelling must not
+/// change even if a same-named live constant is later renamed or removed —
+/// `_oxen_diff_hash` already lost its constant entirely.
+const LEGACY_DIFF_STATUS_COL: &str = "_oxen_diff_status";
+const LEGACY_DIFF_HASH_COL: &str = "_oxen_diff_hash";
+
+/// Every column name Oxen has written internally to a staged DuckDB table, past
+/// or present. When recovering a table left by an older version (or an
+/// interrupted current index), a column matching one of these is Oxen-internal
+/// and is dropped — never treated as user data — while rebuilding. Superset of
+/// [`EXCLUDE_OXEN_COLS`], which lists only what the current indexer emits.
+///
+/// Columns the current format still writes reference their live constants, so
+/// this list follows whatever today's indexer emits. Columns only older versions
+/// wrote are frozen literals ([`LEGACY_DIFF_STATUS_COL`]/[`LEGACY_DIFF_HASH_COL`]):
+/// they must keep their exact on-disk spelling regardless of what any current
+/// constant is later renamed to. Treat the list as append-only — add names,
+/// never repurpose one.
+///
+/// Matching is exact — a not-fully-indexed table was written by an indexer that
+/// reserved all of these names, so a column named like one of them is never user
+/// data in this context.
 const LEGACY_AND_CURRENT_INTERNAL_COLS: [&str; 7] = [
+    // Current staged-table columns (see index_file_with_id).
     OXEN_ID_COL,
     OXEN_ROW_ID_COL,
-    DIFF_STATUS_COL,
-    // Legacy per-row change hash, dropped along with the other tracking columns;
-    // it no longer has a named constant, so it appears here as a literal.
-    "_oxen_diff_hash",
+    // Auxiliary columns the eval flow may add.
     EVAL_STATUS_COL,
     EVAL_ERROR_COL,
     EVAL_DURATION_COL,
+    // Present only in tables older versions wrote.
+    LEGACY_DIFF_STATUS_COL,
+    LEGACY_DIFF_HASH_COL,
 ];
 
 /// Rebuild a staged DuckDB table left by an older version of oxen (or an
@@ -339,8 +356,8 @@ pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Resu
 
                 // Honor the old soft-delete semantics: a row tombstoned as
                 // 'removed' is a pending deletion and must not be resurrected.
-                let where_clause = if has_col(DIFF_STATUS_COL) {
-                    format!("WHERE \"{DIFF_STATUS_COL}\" IS DISTINCT FROM 'removed'")
+                let where_clause = if has_col(LEGACY_DIFF_STATUS_COL) {
+                    format!("WHERE \"{LEGACY_DIFF_STATUS_COL}\" IS DISTINCT FROM 'removed'")
                 } else {
                     String::new()
                 };

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -1,6 +1,9 @@
 use duckdb::Connection;
 
-use crate::constants::{EXCLUDE_OXEN_COLS, OXEN_ROW_ID_COL, TABLE_NAME};
+use crate::constants::{
+    DIFF_STATUS_COL, EVAL_DURATION_COL, EVAL_ERROR_COL, EVAL_STATUS_COL, EXCLUDE_OXEN_COLS,
+    OXEN_ID_COL, OXEN_ROW_ID_COL, TABLE_NAME,
+};
 use crate::core::db::data_frames::DataFrameError;
 use crate::core::db::data_frames::df_db;
 use crate::core::db::data_frames::df_db::with_df_db_manager;
@@ -242,6 +245,152 @@ pub async fn index(workspace: &Workspace, path: &Path) -> Result<(), OxenError> 
     .await??;
 
     log::debug!("core::v_latest::index::workspaces::data_frames::index({path:?}) finished!");
+
+    Ok(())
+}
+
+/// Every column name Oxen has used internally in a staged DuckDB table across
+/// format versions. When recovering a table left by an older version, a column
+/// matching one of these is Oxen-internal and is dropped (never treated as user
+/// data) while rebuilding. This is a superset of [`EXCLUDE_OXEN_COLS`], which
+/// lists only the columns the current indexer emits: `_oxen_diff_status` and
+/// `_oxen_diff_hash` are legacy tracking columns the current format no longer
+/// writes. Matching is exact — a not-fully-indexed table was written by an
+/// indexer that reserved all of these names, so a column named like one of them
+/// is never user data in this context.
+const LEGACY_AND_CURRENT_INTERNAL_COLS: [&str; 7] = [
+    OXEN_ID_COL,
+    OXEN_ROW_ID_COL,
+    DIFF_STATUS_COL,
+    // Legacy per-row change hash, dropped along with the other tracking columns;
+    // it no longer has a named constant, so it appears here as a literal.
+    "_oxen_diff_hash",
+    EVAL_STATUS_COL,
+    EVAL_ERROR_COL,
+    EVAL_DURATION_COL,
+];
+
+/// Rebuild a staged DuckDB table left by an older version of oxen (or an
+/// interrupted index) from its OWN current rows, preserving the staged edits —
+/// unlike [`index`], which rebuilds from the committed base version file and so
+/// discards anything staged but not yet committed.
+///
+/// Older versions tracked edits with extra internal columns and soft-deleted
+/// rows by tombstoning them (`_oxen_diff_status = 'removed'`) instead of removing
+/// them. This drops every historical internal column and omits tombstoned rows,
+/// so the rebuilt table holds exactly the data the staged edits intended —
+/// appended and modified rows kept, deleted rows gone — re-keyed in the current
+/// index format (fresh `_oxen_id`/`_oxen_row_id` and the index marker).
+///
+/// Call only for a table that exists but fails
+/// [`is_indexed`](crate::repositories::workspaces::data_frames::is_indexed);
+/// afterward it passes that gate and exports/commits like any freshly indexed
+/// table. Returns [`OxenError::WorkspaceStaleStagedIndex`] when the table has no
+/// user columns to recover.
+pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
+    let db_path = repositories::workspaces::data_frames::duckdb_path(workspace, path);
+    let extension = util::fs::extension_from_path(path);
+
+    let Some(parent) = db_path.parent().map(Path::to_path_buf) else {
+        return Err(OxenError::basic_str(format!(
+            "Failed to get parent directory for {db_path:?}"
+        )));
+    };
+
+    // Export to a sibling temp file, then re-index it through the current
+    // indexer. The intermediate carries the data frame's own extension so the
+    // rebuilt table matches what committing and then re-indexing would produce.
+    let recover_path = parent.join(format!(".oxen-recover.{}.{extension}", std::process::id()));
+    if !is_valid_export_extension(&recover_path) {
+        return Err(OxenError::WorkspaceStaleStagedIndex(
+            format!("Cannot recover staged data frame {path:?}: unsupported format {extension:?}.")
+                .into(),
+        ));
+    }
+
+    let recovered = tokio::task::spawn_blocking(move || -> Result<bool, OxenError> {
+        let outcome = with_df_db_manager(&db_path, |manager| {
+            manager.with_conn(|conn| -> Result<bool, DataFrameError> {
+                let schema = df_db::get_schema(conn, TABLE_NAME)?;
+                let has_col = |name: &str| schema.fields.iter().any(|f| f.name == name);
+                let has_user_col = schema
+                    .fields
+                    .iter()
+                    .any(|f| !LEGACY_AND_CURRENT_INTERNAL_COLS.contains(&f.name.as_str()));
+                if !has_user_col {
+                    // Nothing but internal columns — no user data to preserve.
+                    return Ok(false);
+                }
+
+                let projection = build_export_projection_excluding(
+                    conn,
+                    TABLE_NAME,
+                    &LEGACY_AND_CURRENT_INTERNAL_COLS,
+                )?;
+
+                // Keep row order: prefer the persisted ordering column, falling
+                // back to DuckDB's physical rowid (insertion order) for older
+                // tables that predate it.
+                let order_by = if has_col(OXEN_ROW_ID_COL) {
+                    format!("ORDER BY {OXEN_ROW_ID_COL}")
+                } else {
+                    "ORDER BY rowid".to_string()
+                };
+
+                // Honor the old soft-delete semantics: a row tombstoned as
+                // 'removed' is a pending deletion and must not be resurrected.
+                let where_clause = if has_col(DIFF_STATUS_COL) {
+                    format!("WHERE \"{DIFF_STATUS_COL}\" IS DISTINCT FROM 'removed'")
+                } else {
+                    String::new()
+                };
+
+                let select =
+                    format!("SELECT {projection} FROM '{TABLE_NAME}' {where_clause} {order_by}");
+                let copy = wrap_sql_for_export(&select, &recover_path);
+                conn.execute(&copy, [])?;
+
+                // Rebuild inside a transaction: drop the stale table, then index
+                // the exported rows in the current format. On failure roll back
+                // so the original stale table is left intact.
+                conn.execute_batch("BEGIN TRANSACTION")?;
+                let build = (|| -> Result<(), DataFrameError> {
+                    df_db::drop_table(conn, TABLE_NAME)?;
+                    df_db::index_file_with_id(&recover_path, conn, &extension)?;
+                    Ok(())
+                })();
+                match build {
+                    Ok(()) => {
+                        conn.execute_batch("COMMIT")?;
+                        if let Err(e) = conn.execute_batch("CHECKPOINT") {
+                            log::warn!(
+                                "reindex_preserving_rows: CHECKPOINT failed for {db_path:?}: {e}"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        let _ = conn.execute_batch("ROLLBACK");
+                        return Err(e);
+                    }
+                }
+                Ok(true)
+            })
+        });
+        // Clean up the intermediate export regardless of the rebuild's result.
+        let _ = std::fs::remove_file(&recover_path);
+        Ok(outcome?)
+    })
+    .await??;
+
+    if !recovered {
+        return Err(OxenError::WorkspaceStaleStagedIndex(
+            format!(
+                "Cannot recover staged data frame {path:?}: the staged table has no user \
+                 columns. Re-index the data frame or unstage it, then commit again."
+            )
+            .into(),
+        ));
+    }
 
     Ok(())
 }
@@ -502,6 +651,20 @@ pub fn wrap_sql_for_export(sql: &str, path: &Path) -> String {
 /// Columns are emitted in `ordinal_position` order so the exported schema matches
 /// the table.
 fn build_export_projection(conn: &Connection, table_name: &str) -> Result<String, duckdb::Error> {
+    build_export_projection_excluding(conn, table_name, &EXCLUDE_OXEN_COLS)
+}
+
+/// As [`build_export_projection`], but omits exactly the columns in `exclude`
+/// rather than the current [`EXCLUDE_OXEN_COLS`]. Recovering a table left by an
+/// older version passes the full historical internal-column set
+/// ([`LEGACY_AND_CURRENT_INTERNAL_COLS`]) so legacy tracking columns
+/// (`_oxen_diff_status`, `_oxen_diff_hash`) don't leak into the export as user
+/// data.
+fn build_export_projection_excluding(
+    conn: &Connection,
+    table_name: &str,
+    exclude: &[&str],
+) -> Result<String, duckdb::Error> {
     let cols_query = format!(
         "SELECT column_name, data_type FROM information_schema.columns \
          WHERE table_name = '{table_name}' ORDER BY ordinal_position"
@@ -518,7 +681,7 @@ fn build_export_projection(conn: &Connection, table_name: &str) -> Result<String
 
     let projection: Vec<String> = cols
         .into_iter()
-        .filter(|(name, _)| !EXCLUDE_OXEN_COLS.contains(&name.as_str()))
+        .filter(|(name, _)| !exclude.contains(&name.as_str()))
         .map(|(name, data_type)| {
             if data_type == "JSON" || data_type == "JSON[]" {
                 json_tolerant_export_expr(&name)

--- a/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/data_frames.rs
@@ -345,8 +345,13 @@ pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Resu
                     String::new()
                 };
 
-                let select =
-                    format!("SELECT {projection} FROM '{TABLE_NAME}' {where_clause} {order_by}");
+                // Quote the table name as an identifier so it binds as a table
+                // reference rather than relying on DuckDB's string-literal
+                // replacement-scan fallback.
+                let select = format!(
+                    "SELECT {projection} FROM {} {where_clause} {order_by}",
+                    df_db::quote_ident(TABLE_NAME)
+                );
                 let copy = wrap_sql_for_export(&select, &recover_path);
                 conn.execute(&copy, [])?;
 

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -74,6 +74,13 @@ pub async fn index(
     core::v_latest::workspaces::data_frames::index(workspace, path.as_ref()).await
 }
 
+/// Rebuild a staged data frame left by an older version of oxen from its own
+/// rows, preserving the staged edits rather than discarding them. See
+/// [`core::v_latest::workspaces::data_frames::reindex_preserving_rows`].
+pub async fn reindex_preserving_rows(workspace: &Workspace, path: &Path) -> Result<(), OxenError> {
+    core::v_latest::workspaces::data_frames::reindex_preserving_rows(workspace, path).await
+}
+
 pub use crate::core::v_latest::workspaces::data_frames::rename;
 
 pub fn unindex(workspace: &Workspace, path: impl AsRef<Path>) -> Result<(), DataFrameError> {
@@ -1367,17 +1374,19 @@ mod tests {
         .await
     }
 
-    /// Committing a workspace whose staged table was left by an older version
-    /// (no index marker) must fail loudly — the alternative is committing the
-    /// base file and silently discarding the staged edits.
+    /// Committing a workspace whose staged table was left by an older version of
+    /// oxen (legacy tracking columns, tombstoned deletes, no index marker) must
+    /// recover the staged rows rather than error or drop them: the staged append
+    /// survives the commit and a row the old flow tombstoned as 'removed' stays
+    /// deleted.
     #[tokio::test]
-    async fn test_commit_stale_staged_table_errors_instead_of_dropping_edits()
-    -> Result<(), OxenError> {
+    async fn test_commit_stale_staged_table_recovers_and_preserves_edits() -> Result<(), OxenError>
+    {
         if std::env::consts::OS == "windows" {
             return Ok(());
         }
         test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
-            let branch_name = "test-stale-commit";
+            let branch_name = "test-stale-recover";
             let branch = repositories::branches::create_checkout(&repo, branch_name)?;
             let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
             let workspace_id = UserConfig::identifier()?;
@@ -1387,16 +1396,106 @@ mod tests {
                 .join("bounding_box.csv");
             workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
 
-            // Stage an edit, then simulate a table written by an older
-            // version by removing the index marker.
+            // Stage an append — the kind of per-generation row a client appends
+            // to a persistent workspace data frame.
             let json_data = json!({
                 "file": "stale.jpg", "label": "dog",
                 "min_x": 1, "min_y": 2, "width": 3, "height": 4
             });
             workspaces::data_frames::rows::add(&repo, &workspace, &file_path, &json_data)?;
+
+            // Downgrade the DuckDB table to what an older version of oxen left
+            // behind: legacy tracking columns, one committed row tombstoned as
+            // 'removed', no `_oxen_row_id` ordering column, and no index marker.
             let db_path = workspaces::data_frames::duckdb_path(&workspace, &file_path);
             super::with_df_db_manager(&db_path, |manager| {
                 manager.with_conn(|conn| {
+                    conn.execute_batch(&format!(
+                        "ALTER TABLE \"{t}\" ADD COLUMN \"{status}\" VARCHAR DEFAULT 'unchanged'; \
+                         ALTER TABLE \"{t}\" ADD COLUMN \"_oxen_diff_hash\" VARCHAR DEFAULT '0'; \
+                         UPDATE \"{t}\" SET \"{status}\" = 'added' WHERE \"file\" = 'stale.jpg'; \
+                         UPDATE \"{t}\" SET \"{status}\" = 'removed' WHERE \"file\" = 'train/cat_2.jpg'; \
+                         ALTER TABLE \"{t}\" DROP COLUMN \"{row_id}\"; \
+                         DROP TABLE \"{marker}\";",
+                        t = crate::constants::TABLE_NAME,
+                        status = crate::constants::DIFF_STATUS_COL,
+                        row_id = OXEN_ROW_ID_COL,
+                        marker = crate::constants::INDEX_META_TABLE,
+                    ))?;
+                    Ok(())
+                })
+            })?;
+
+            // The table now reads as not indexed, but the staged rows are still
+            // physically present in DuckDB (6 committed + 1 appended = 7).
+            assert!(!workspaces::data_frames::is_indexed(&workspace, &file_path)?);
+            assert_eq!(workspaces::data_frames::count(&workspace, &file_path)?, 7);
+
+            // Commit succeeds — the stale table is recovered from its own rows.
+            let new_commit = NewCommitBody {
+                author: "author".to_string(),
+                email: "email".to_string(),
+                message: "Committing recovered stale staged df".to_string(),
+            };
+            let committed = workspaces::commit(&workspace, &new_commit, branch_name).await?;
+
+            // The committed file keeps the appended row and drops the tombstoned
+            // one: 6 committed - 1 removed + 1 appended = 6 rows.
+            let entry = repositories::entries::get_commit_entry(&repo, &committed, &file_path)?
+                .expect("committed entry should exist");
+            let version_store = repo.version_store();
+            let df =
+                df::tabular::read_version_df(&version_store, &entry.hash, "csv", &DFOpts::empty())
+                    .await?;
+            assert_eq!(df.height(), 6, "recovered commit row count: {df}");
+
+            let rendered = format!("{df}");
+            assert!(
+                rendered.contains("stale.jpg"),
+                "staged append must survive recovery: {rendered}"
+            );
+            assert!(
+                !rendered.contains("cat_2"),
+                "tombstoned row must stay deleted: {rendered}"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// Recovery preserves the deliberate strictness for the one case where there
+    /// is genuinely nothing to recover: a stale table holding only internal
+    /// columns fails loudly (WorkspaceStaleStagedIndex) rather than committing an
+    /// empty data frame.
+    #[tokio::test]
+    async fn test_reindex_preserving_rows_errors_when_no_user_columns() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_bounding_box_csv_repo_test_fully_committed_async(|repo| async move {
+            let branch = repositories::branches::create_checkout(&repo, "test-no-user-cols")?;
+            let commit = repositories::commits::get_by_id(&repo, &branch.commit_id)?.unwrap();
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            let file_path = Path::new("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+            workspaces::data_frames::index(&repo, &workspace, &file_path).await?;
+
+            // Strip the table down to internal columns only — no user data left.
+            let db_path = workspaces::data_frames::duckdb_path(&workspace, &file_path);
+            super::with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| {
+                    for col in ["file", "label", "min_x", "min_y", "width", "height"] {
+                        conn.execute(
+                            &format!(
+                                "ALTER TABLE \"{}\" DROP COLUMN \"{col}\"",
+                                crate::constants::TABLE_NAME
+                            ),
+                            [],
+                        )?;
+                    }
                     conn.execute(
                         &format!("DROP TABLE \"{}\"", crate::constants::INDEX_META_TABLE),
                         [],
@@ -1405,23 +1504,12 @@ mod tests {
                 })
             })?;
 
-            let new_commit = NewCommitBody {
-                author: "author".to_string(),
-                email: "email".to_string(),
-                message: "Committing stale staged df".to_string(),
-            };
-            let result = workspaces::commit(&workspace, &new_commit, branch_name).await;
-            // Must be the typed stale-index error (maps to 409, not a retryable
-            // 500), since the user has to re-index or unstage first.
+            let result =
+                workspaces::data_frames::reindex_preserving_rows(&workspace, &file_path).await;
             assert!(
                 matches!(result, Err(OxenError::WorkspaceStaleStagedIndex(_))),
-                "commit of a stale staged data frame must fail with WorkspaceStaleStagedIndex, got {result:?}"
+                "recovery with no user columns must fail with WorkspaceStaleStagedIndex, got {result:?}"
             );
-
-            // The base version is still intact and readable.
-            let file_node = repositories::tree::get_file_by_path(&repo, &commit, &file_path)?
-                .expect("base file node should still exist");
-            assert!(file_node.metadata().is_some());
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories/workspaces/data_frames.rs
+++ b/crates/liboxen/src/repositories/workspaces/data_frames.rs
@@ -1516,6 +1516,105 @@ mod tests {
         .await
     }
 
+    /// Recovering a stale `.jsonl` frame exercises the JSON export/import path a
+    /// csv frame does not: the export wraps the JSON column and writes it through
+    /// `COPY ... (FORMAT JSON)`, and the re-index runs the STRUCT/JSON handling in
+    /// `index_file_with_id`. The staged append survives, the JSON column
+    /// round-trips, and a row tombstoned as 'removed' stays deleted.
+    #[tokio::test]
+    async fn test_commit_stale_staged_table_recovers_jsonl_json_column() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+        test::run_empty_local_repo_test_async(|repo| async move {
+            // Object values make read_json (and the workspace index) type
+            // `error_details` as a JSON column.
+            let path = Path::new("media.jsonl");
+            let full_path = repo.path.join(path);
+            std::fs::write(
+                &full_path,
+                "{\"id\":1,\"error_details\":{\"code\":402,\"msg\":\"x\"}}\n\
+                 {\"id\":2,\"error_details\":{\"code\":200,\"msg\":\"ok\"}}\n",
+            )?;
+            repositories::add(&repo, &full_path).await?;
+            let commit = repositories::commit(&repo, "add media jsonl")?;
+
+            let workspace_id = UserConfig::identifier()?;
+            let workspace = repositories::workspaces::create(&repo, &commit, workspace_id, true)?;
+            workspaces::data_frames::index(&repo, &workspace, path).await?;
+
+            // Stage an append whose JSON column holds a valid object.
+            let json_data = json!({"id": 3, "error_details": {"code": 500, "msg": "err"}});
+            workspaces::data_frames::rows::add(&repo, &workspace, path, &json_data)?;
+
+            // Downgrade to a table left by an older version of oxen: legacy
+            // tracking columns, one committed row tombstoned as 'removed', no
+            // `_oxen_row_id` ordering column, and no index marker.
+            let db_path = workspaces::data_frames::duckdb_path(&workspace, path);
+            super::with_df_db_manager(&db_path, |manager| {
+                manager.with_conn(|conn| {
+                    conn.execute_batch(&format!(
+                        "ALTER TABLE \"{t}\" ADD COLUMN \"{status}\" VARCHAR DEFAULT 'unchanged'; \
+                         ALTER TABLE \"{t}\" ADD COLUMN \"_oxen_diff_hash\" VARCHAR DEFAULT '0'; \
+                         UPDATE \"{t}\" SET \"{status}\" = 'added' WHERE \"id\" = 3; \
+                         UPDATE \"{t}\" SET \"{status}\" = 'removed' WHERE \"id\" = 1; \
+                         ALTER TABLE \"{t}\" DROP COLUMN \"{row_id}\"; \
+                         DROP TABLE \"{marker}\";",
+                        t = crate::constants::TABLE_NAME,
+                        status = crate::constants::DIFF_STATUS_COL,
+                        row_id = OXEN_ROW_ID_COL,
+                        marker = crate::constants::INDEX_META_TABLE,
+                    ))?;
+                    Ok(())
+                })
+            })?;
+
+            assert!(!workspaces::data_frames::is_indexed(&workspace, path)?);
+            assert_eq!(workspaces::data_frames::count(&workspace, path)?, 3);
+
+            // Commit succeeds — the stale jsonl table is recovered from its own
+            // rows, JSON column and all.
+            let new_commit = NewCommitBody {
+                author: "author".to_string(),
+                email: "email".to_string(),
+                message: "Committing recovered stale jsonl df".to_string(),
+            };
+            let committed =
+                workspaces::commit(&workspace, &new_commit, DEFAULT_BRANCH_NAME).await?;
+
+            // 2 committed - 1 removed + 1 appended = 2 rows, and the JSON column
+            // round-tripped through the recovery.
+            let entry = repositories::entries::get_commit_entry(&repo, &committed, path)?
+                .expect("committed entry should exist");
+            let version_store = repo.version_store();
+            let df = df::tabular::read_version_df(
+                &version_store,
+                &entry.hash,
+                "jsonl",
+                &DFOpts::empty(),
+            )
+            .await?;
+            assert_eq!(df.height(), 2, "recovered jsonl row count: {df}");
+            assert!(
+                df.column("error_details").is_ok(),
+                "JSON column must survive recovery: {df}"
+            );
+
+            let rendered = format!("{df}");
+            assert!(
+                rendered.contains("500"),
+                "staged append must survive recovery: {rendered}"
+            );
+            assert!(
+                !rendered.contains("402"),
+                "tombstoned row must stay deleted: {rendered}"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
     /// add_column_metadata reconciles the staged metadata schema with the
     /// workspace table: a column deleted by a workspace edit is dropped from
     /// the schema (not left as a phantom), and the reconciled schema matches


### PR DESCRIPTION
A staged DuckDB table that exists but fails the fully-indexed gate was either left by an older version of oxen (which tracked edits in extra columns and soft-deleted rows by tombstoning them as 'removed') or by an interrupted index. Committing such a workspace previously returned WorkspaceStaleStagedIndex: the base file could not be committed without silently dropping the staged edits, and the edits could not be recovered because re-indexing rebuilds from the committed base version file.

Add reindex_preserving_rows, which rebuilds a stale-but-present staged table from its own current rows rather than from the committed base: it drops every historical internal tracking column, omits rows the old flow tombstoned as 'removed' (honoring the pending deletion), preserves row order, and re-indexes through the current indexer so the table lands in the current format (fresh _oxen_id/_oxen_row_id and the index marker).

export_tabular_data_frames now recovers such a table and exports it like any indexed one, so appended and modified rows survive the commit while deleted rows stay deleted. WorkspaceStaleStagedIndex is retained only for the genuinely-unrecoverable case where the table has no user columns.