### PR TITLE
Harden the release permissions / inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,10 @@ on:
     tags:
       - v*
 
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
+# No token by default: every job below grants itself only what it uses, and a job added without a
+# permissions block gets nothing rather than silently inheriting write access. A called workflow can
+# only reduce what its calling job grants, so these are also the ceilings for the reusable workflows.
+permissions: {}
 
 env:
   AWS_ROLE: arn:aws:iam::213020545630:role/github-runner-role
@@ -25,6 +25,7 @@ jobs:
   set_env:
     name: Set env
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       release_version: ${{ steps.set-env.outputs.release_version }}
       aws_role: ${{ steps.set-env.outputs.aws_role }}
@@ -43,6 +44,9 @@ jobs:
   release_docker_arm64:
     name: Docker arm64
     needs: set_env
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/release_docker.yml
     with:
       ARCHITECTURE: arm64
@@ -55,6 +59,9 @@ jobs:
   release_docker_x86_64:
     name: Docker x86_64
     needs: set_env
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/release_docker.yml
     with:
       ARCHITECTURE: amd64
@@ -67,6 +74,9 @@ jobs:
   release_linux_arm64:
     name: Linux arm64
     needs: set_env
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/release_linux.yml
     with:
       ARCHITECTURE: arm64
@@ -80,6 +90,9 @@ jobs:
   release_linux_x86_64:
     name: Linux x86_64
     needs: set_env
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/release_linux.yml
     with:
       ARCHITECTURE: x86_64
@@ -93,6 +106,9 @@ jobs:
   release_macos_arm64_x86_64:
     name: MacOS arm64 and x86_64
     needs: set_env
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/release_macos.yml
     with:
       PYTHON_VERSIONS: ${{ needs.set_env.outputs.python_versions }}
@@ -102,6 +118,9 @@ jobs:
   release_windows_x86_64:
     name: Windows x86_64
     needs: set_env
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/release_windows.yml
     with:
       ARCHITECTURE: x86_64
@@ -114,6 +133,9 @@ jobs:
   create_draft_release:
     name: Create draft release
     runs-on: ubuntu-latest
+    # ncipollo/release-action creates the draft and uploads its assets.
+    permissions:
+      contents: write
     needs:
       - set_env
       - release_docker_arm64

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -200,6 +200,11 @@ jobs:
 
           cd ${{ github.workspace }}\oxen-python
 
+          # The glob reaches maturin literally, never expanded: it resolves to nothing, so maturin
+          # builds the abi3 wheel from bundled sysconfig (the v0.52.4 and v0.52.6 logs show the abi3
+          # binding line and no interpreter line). Keep the flag even though it selects nothing --
+          # with no interpreter given, maturin falls back to PYO3_PYTHON or whatever python is on
+          # PATH, which is a less predictable input than a glob it ignores.
           foreach ($version in $versions) {
               uvx maturin build --release --interpreter "C:\Users\Administrator\AppData\Roaming\uv\python\cpython-$version.*\python.exe"
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -294,7 +299,16 @@ jobs:
         run: |
           # Skip only on an exact-key hit. A fallback restore still has to write
           # the tree under the current key so the next release hits exactly.
-          if ($env:DEPTREE_EXACT_HIT -eq "1") { exit 0 }
+          if ($env:DEPTREE_EXACT_HIT -eq "1") {
+            # A hit re-archives nothing, so the object's age would keep growing while the tree is
+            # still in active use, and an expiry rule would eventually delete it out from under a
+            # working cache. Copying the key onto itself restarts that clock; a same-key copy needs
+            # --metadata-directive REPLACE to be accepted.
+            cmd /c "aws s3 cp s3://%DEPTREE_BUCKET%/%DEPTREE_PREFIX%/%DEPTREE_KEY%.tar s3://%DEPTREE_BUCKET%/%DEPTREE_PREFIX%/%DEPTREE_KEY%.tar --metadata-directive REPLACE --storage-class INTELLIGENT_TIERING"
+            if ($LASTEXITCODE -ne 0) { Write-Host "::warning::DEPTREE could not refresh the cached tree's age" }
+            else { Write-Host "DEPTREE exact hit, refreshed the tree's age" }
+            exit 0
+          }
           refreshenv
           $target = "${{ github.workspace }}\target\release"
           $rel = $target.Substring(3) -replace '\\','/'

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -84,6 +84,8 @@ jobs:
       # Read as an environment variable by the zip steps rather than expanded into their source, so
       # its contents can never be parsed as PowerShell.
       ARCHITECTURE: ${{ inputs.ARCHITECTURE }}
+      # Override Cargo.toml's LTO setting to save on build time in Windows
+      CARGO_PROFILE_RELEASE_LTO: thin
       DEPTREE_BUCKET: oxen-release-build-cache
       # Generation prefix. Bump it when the archive's layout or the prune's rules change: the
       # fallback restore only ever lists trees under the current prefix, so a bump starts clean.

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -193,12 +193,13 @@ jobs:
           PYTHON_VERSIONS: ${{ inputs.PYTHON_VERSIONS }}
         run: |
           refreshenv
-          uv python install $env:PYTHON_VERSIONS
+          # Splatted, so each version is its own argument; the variable holds them space-separated.
+          $versions = $env:PYTHON_VERSIONS -split ' '
+          uv python install @versions
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           cd ${{ github.workspace }}\oxen-python
 
-          $versions = $env:PYTHON_VERSIONS -split ' '
           foreach ($version in $versions) {
               uvx maturin build --release --interpreter "C:\Users\Administrator\AppData\Roaming\uv\python\cpython-$version.*\python.exe"
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -33,6 +33,10 @@ jobs:
   start-self-hosted-runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    # id-token is for the AWS OIDC assume-role; runner registration uses a PAT, not the job token.
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -67,12 +71,19 @@ jobs:
     name: Build Oxen CLI and Python wheels
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
+    # Checkout is the only step here that uses the token, and it reads. S3 access comes from the
+    # runner's instance profile, so this job needs no AWS OIDC.
+    permissions:
+      contents: read
     defaults:
       run:
         shell: powershell
 
     env:
       CARGO_INCREMENTAL: "0"
+      # Read as an environment variable by the zip steps rather than expanded into their source, so
+      # its contents can never be parsed as PowerShell.
+      ARCHITECTURE: ${{ inputs.ARCHITECTURE }}
       DEPTREE_BUCKET: oxen-release-build-cache
       # Generation prefix. Bump it when the archive's layout or the prune's rules change: the
       # fallback restore only ever lists trees under the current prefix, so a bump starts clean.
@@ -176,34 +187,29 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Build Python wheels
+        # Reaches the script as an environment variable rather than an expression expanded into the
+        # source, so its contents can never be parsed as PowerShell.
+        env:
+          PYTHON_VERSIONS: ${{ inputs.PYTHON_VERSIONS }}
         run: |
           refreshenv
-          uv python install ${{ inputs.PYTHON_VERSIONS }}
+          uv python install $env:PYTHON_VERSIONS
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           cd ${{ github.workspace }}\oxen-python
 
-          $uvPython = "C:\Users\Administrator\AppData\Roaming\uv\python\cpython-{0}.*\python.exe"
-          $versions = "${{ inputs.PYTHON_VERSIONS }}" -split ' '
+          $versions = $env:PYTHON_VERSIONS -split ' '
           foreach ($version in $versions) {
-              uvx maturin build --release --interpreter ($uvPython -f $version)
+              uvx maturin build --release --interpreter "C:\Users\Administrator\AppData\Roaming\uv\python\cpython-$version.*\python.exe"
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
           # Only a fallback restore re-archives the tree, so only it needs the wheel graph named.
           if ($env:DEPTREE_EXACT_HIT -eq "1") { exit 0 }
           # Names the wheel build's units for the prune, fresh ones included, since maturin reports
-          # no artifact list of its own. Mirrors the invocation maturin wraps: pyproject.toml's
-          # manifest and features, plus the interpreter env whose change pyo3's build script
-          # treats as a rebuild trigger. PYO3_ENVIRONMENT_SIGNATURE is maturin's own
-          # "<implementation>-<major>.<minor>-<pointer-width>bit"; matching it keeps this a no-op
-          # rather than a full relink of the cdylib under fat LTO.
-          $last = $versions[-1]
-          $interpreter = (Resolve-Path ($uvPython -f $last) -ErrorAction SilentlyContinue | Select-Object -First 1).Path
-          if ($interpreter) {
-            $env:PYO3_PYTHON = $interpreter
-            $env:PYO3_ENVIRONMENT_SIGNATURE = "cpython-$last-64bit"
-          }
+          # no artifact list of its own. Mirrors the invocation maturin wraps, taking the manifest
+          # and features from oxen-python/pyproject.toml, so every unit is already fresh and nothing
+          # recompiles here; v0.52.6 measured it at 0.76s.
           cargo build --release --manifest-path ${{ github.workspace }}\crates\oxen-py\Cargo.toml --features pyo3/extension-module --message-format=json-render-diagnostics | Add-Content C:\deptree-live.json
           # Best-effort: without this list the wheel's units are pruned and recompile next release.
           if ($LASTEXITCODE -ne 0) { Write-Host "::warning::DEPTREE could not enumerate the wheel graph" }
@@ -259,15 +265,15 @@ jobs:
 
       - name: Create zip with oxen binary
         run: |
-          Compress-Archive -Path "${{ github.workspace }}\target\release\oxen.exe" -DestinationPath "${{ github.workspace }}\release\oxen-windows-${{ inputs.ARCHITECTURE }}.exe.zip"
+          Compress-Archive -Path "${{ github.workspace }}\target\release\oxen.exe" -DestinationPath "${{ github.workspace }}\release\oxen-windows-${env:ARCHITECTURE}.exe.zip"
 
       - name: Create zip with Python wheels
         run: |
-          Compress-Archive -Path ${{ github.workspace }}\target\wheels\* -DestinationPath ${{ github.workspace }}\release\oxen-wheels-windows-${{ inputs.ARCHITECTURE }}.zip
+          Compress-Archive -Path ${{ github.workspace }}\target\wheels\* -DestinationPath "${{ github.workspace }}\release\oxen-wheels-windows-${env:ARCHITECTURE}.zip"
 
       - name: Create zip with all artifacts
         run: |
-          Compress-Archive -Path "${{ github.workspace }}\release\*" -DestinationPath "${{ github.workspace }}\release\oxen-windows-${{ inputs.ARCHITECTURE }}-release.zip"
+          Compress-Archive -Path "${{ github.workspace }}\release\*" -DestinationPath "${{ github.workspace }}\release\oxen-windows-${env:ARCHITECTURE}-release.zip"
 
       - name: Upload all artifacts
         uses: actions/upload-artifact@v7
@@ -321,6 +327,10 @@ jobs:
       - release_windows
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    # id-token is for the AWS OIDC assume-role; runner deregistration uses a PAT, not the job token.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,7 @@ debug-assertions = false
 
 [profile.release]
 codegen-units = 1
+# Windows release overrides this to "thin" through CARGO_PROFILE_RELEASE_LTO to save on build time
 lto = true
 opt-level = "s"
 strip = true

--- a/bin/README.md
+++ b/bin/README.md
@@ -52,7 +52,7 @@ Bumps the project version across the Rust workspace and Python package in one st
 
 ### `patch_dev_version`
 
-Patches `oxen-python`'s `pyproject.toml` and `Cargo.toml` with a PEP 440 dev version (e.g. `0.44.1.dev3`). Used by `publish_test_pypi` and CI workflows to stamp pre-release builds without permanently changing the checked-in version.
+Patches `oxen-python`'s `pyproject.toml` and `Cargo.toml` with a PEP 440 dev version (e.g. `0.44.1.dev3`). Used by `publish_test_pypi` for local dev builds, to stamp pre-release builds without permanently changing the checked-in version.
 
 - Converts the PEP 440 version to a semver pre-release for `Cargo.toml` automatically.
 


### PR DESCRIPTION
Each job in the release now carries only the token permissions it uses, rather than every job inheriting broad permissions. 

Workflow inputs no longer reach a PowerShell body as expanded source. `ARCHITECTURE` and `PYTHON_VERSIONS` arrive as environment variables, so their contents cannot be parsed as script.

The wheel enumeration stops setting pyo3's interpreter variables. They were added to keep that build a no-op, but maturin resolves no runnable interpreter for an abi3 wheel and sets no such variables itself, so matching them reasoned about a mechanism that was never in play. The v0.52.6 release measured the enumeration at 0.76s with nothing recompiled, and the comment now records that number instead of an argument for it.

`bin/README.md` still pointed `patch_dev_version` at CI workflows that no longer exist. It is used only by `publish_test_pypi` for local builds.