### PR TITLE
Add new deploy_dev workflow

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -41,10 +41,10 @@ env:
   # Lowercase: registry paths are case-sensitive and the owner name is not.
   REGISTRY_IMAGE: ghcr.io/oxen-ai/oxen-server
 
+# Each job below states what it needs; a job's own block replaces this one rather
+# than adding to it, so nothing inherits a write it has no use for.
 permissions:
-  id-token: write
-  contents: write
-  packages: write
+  contents: read
 
 defaults:
   run:
@@ -54,6 +54,9 @@ jobs:
   start-self-hosted-runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+    # Assumes an AWS role by OIDC. Checks nothing out.
+    permissions:
+      id-token: write
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -84,6 +87,10 @@ jobs:
   release_docker:
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
+    # Reads the source it builds, and publishes the image it produces.
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image: ${{ steps.push.outputs.image }}
 
@@ -149,7 +156,18 @@ jobs:
           docker tag oxen/oxen-server "$tag"
           docker image push "$tag"
 
-          image=$(docker image inspect "$tag" --format '{{ index .RepoDigests 0 }}')
+          # Selected by repository rather than by position: the daemon records a
+          # digest per repository the image has been pushed to, and which one
+          # comes first is not something to depend on.
+          image=$(docker image inspect "$tag" \
+            --format '{{ range .RepoDigests }}{{ println . }}{{ end }}' \
+            | grep -F -- "$REGISTRY_IMAGE@" | head -1 || true)
+
+          if [[ -z "$image" ]]; then
+            echo "::error::the push recorded no digest for $REGISTRY_IMAGE"
+            exit 1
+          fi
+
           echo "image=$image" >> "$GITHUB_OUTPUT"
           echo "Published $image" >> "$GITHUB_STEP_SUMMARY"
 
@@ -160,6 +178,9 @@ jobs:
       - release_docker
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    # Assumes an AWS role by OIDC. Checks nothing out.
+    permissions:
+      id-token: write
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -1,6 +1,22 @@
 name: 🐳 Build branch for docker
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch to build. Also accepts commit sha and tag name."
+        required: true
+        type: string
+      ARCHITECTURE:
+        description: "The architecture to build for. Either amd64 (for x86_64) or arm64."
+        required: false
+        default: "arm64"
+        type: string
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN:
+        description: "GitHub personal access token"
+        required: true
+
   workflow_dispatch:
     inputs:
       branch:
@@ -68,7 +84,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ inputs.branch }}
 
       - name: Set release version
         run: |

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -16,6 +16,10 @@ on:
       GH_PERSONAL_ACCESS_TOKEN:
         description: "GitHub personal access token"
         required: true
+    outputs:
+      image:
+        description: "Digest-pinned reference to the image this built"
+        value: ${{ jobs.release_docker.outputs.image }}
 
   workflow_dispatch:
     inputs:
@@ -34,11 +38,13 @@ on:
 env:
   AWS_REGION: us-west-1
   AWS_ROLE: ${{ vars.EC2_GITHUB_RUNNER_ROLE }}
-  REGISTRY_IMAGE: oxen/oxen-server
+  # Lowercase: registry paths are case-sensitive and the owner name is not.
+  REGISTRY_IMAGE: ghcr.io/oxen-ai/oxen-server
 
 permissions:
   id-token: write
   contents: write
+  packages: write
 
 defaults:
   run:
@@ -78,6 +84,8 @@ jobs:
   release_docker:
     needs: start-self-hosted-runner
     runs-on: ${{ needs.start-self-hosted-runner.outputs.label }}
+    outputs:
+      image: ${{ steps.push.outputs.image }}
 
     steps:
       - name: Checkout
@@ -118,6 +126,32 @@ jobs:
           name: oxen-server-docker-${{ inputs.ARCHITECTURE }}-${{ env.RELEASE_VERSION }}.tar
           path: oxen-server-docker-${{ inputs.ARCHITECTURE }}-${{ env.RELEASE_VERSION }}.tar
           retention-days: 1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Published so a deployment can consume the image by digest rather than by
+      # unpacking a workflow artifact, which expires and can only be fetched
+      # through the Actions API. The tag is for browsing; the digest this outputs
+      # is what identifies the image, and it is the only thing a caller should
+      # deploy from.
+      - name: Push image to GitHub Container Registry
+        id: push
+        env:
+          COMMIT: ${{ steps.metadata.outputs.COMMIT }}
+        run: |
+          tag="$REGISTRY_IMAGE:sha-${COMMIT:0:12}"
+
+          docker tag oxen/oxen-server "$tag"
+          docker image push "$tag"
+
+          image=$(docker image inspect "$tag" --format '{{ index .RepoDigests 0 }}')
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "Published $image" >> "$GITHUB_STEP_SUMMARY"
 
   stop-self-hosted-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -37,6 +37,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # `repositories` alone would still mint a token carrying every permission
+      # the app holds, including write access to the target's contents. This
+      # only needs to start a workflow there, so it asks for nothing else.
       - name: Generate GitHub App token
         uses: actions/create-github-app-token@v3
         id: generate-token
@@ -44,6 +47,7 @@ jobs:
           app-id: ${{ vars.OXBOT_APP_ID }}
           private-key: ${{ secrets.OXBOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          permission-actions: write
           repositories: ${{ vars.DEPLOY_REPOSITORY_NAME }}
 
       # The build uploaded the server image as an artifact of this run, so the

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -26,8 +26,10 @@ permissions:
 jobs:
   build:
     name: Build oxen-server
+    # Caps what the called workflow's jobs can ask for, so it is the union of
+    # what they need and nothing wider.
     permissions:
-      contents: write
+      contents: read
       id-token: write
       packages: write
     uses: ./.github/workflows/build_branch.yml

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,0 +1,60 @@
+name: 🚀 Deploy dev
+
+run-name: Deploy ${{ github.sha }} to dev
+
+on:
+  push:
+    branches:
+      - main
+
+# Coalesce a burst of merges onto the newest commit rather than deploying every
+# one of them: while a build runs GitHub holds at most one run pending per group
+# and cancels any earlier pending run. Deliberately not cancel-in-progress — a
+# build already under way is the work a pending run would otherwise repeat.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build oxen-server
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/build_branch.yml
+    with:
+      branch: ${{ github.sha }}
+      ARCHITECTURE: arm64
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+  deploy:
+    name: Dispatch deploy
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ vars.OXBOT_APP_ID }}
+          private-key: ${{ secrets.OXBOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ vars.DEPLOY_REPOSITORY_NAME }}
+
+      # The build uploaded the server image as an artifact of this run, so the
+      # deployment fetches it by run ID instead of rebuilding.
+      - name: Dispatch the dev deploy
+        env:
+          DEPLOY_REPOSITORY: ${{ github.repository_owner }}/${{ vars.DEPLOY_REPOSITORY_NAME }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          gh workflow run deploy_dev_oxen_server.yml \
+            --repo "$DEPLOY_REPOSITORY" \
+            --field run_id="$GITHUB_RUN_ID" \
+            --field sha="$SHA"

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      packages: write
     uses: ./.github/workflows/build_branch.yml
     with:
       branch: ${{ github.sha }}
@@ -55,17 +56,19 @@ jobs:
           permission-actions: write
           repositories: ${{ vars.DEPLOY_REPOSITORY_NAME }}
 
-      # The build uploaded the server image as an artifact of this run, so the
-      # deployment fetches it by run ID instead of rebuilding.
+      # The build published the image, so the deployment is handed the digest and
+      # pulls it. A digest names exactly one image, which a tag in a registry
+      # that allows overwriting them does not.
       - name: Dispatch the dev deploy
         env:
           DEPLOY_REPOSITORY: ${{ github.repository_owner }}/${{ vars.DEPLOY_REPOSITORY_NAME }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          IMAGE: ${{ needs.build.outputs.image }}
           SHA: ${{ github.sha }}
         run: |
           gh workflow run deploy_dev_oxen_server.yml \
             --repo "$DEPLOY_REPOSITORY" \
-            --field run_id="$GITHUB_RUN_ID" \
+            --field image="$IMAGE" \
             --field sha="$SHA"
 
   # The build runs as a called workflow, so reporting its failures from inside it

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+  # Recovery path. A failure here leaves dev on the previous commit until the
+  # next merge, however long that is, and the cause is usually transient — a
+  # runner that would not register, capacity that was not there.
+  workflow_dispatch:
+
 # Coalesce a burst of merges onto the newest commit rather than deploying every
 # one of them: while a build runs GitHub holds at most one run pending per group
 # and cancels any earlier pending run. Deliberately not cancel-in-progress — a
@@ -62,3 +67,36 @@ jobs:
             --repo "$DEPLOY_REPOSITORY" \
             --field run_id="$GITHUB_RUN_ID" \
             --field sha="$SHA"
+
+  # The build runs as a called workflow, so reporting its failures from inside it
+  # would change the manual build path too. Reporting from here covers either
+  # half, including a build that never reaches the dispatch. A run cancelled to
+  # coalesce onto a newer commit is not a failure and stays quiet.
+  report-failure:
+    name: Report failure
+    needs:
+      - build
+      - deploy
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send failure to Slack channel
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          # eng-alerts Slack channel
+          webhook: ${{ secrets.ENG_ALERTS_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Status :: failure :: Deploy oxen-server ${{ github.sha }} to dev",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Status :: failure :: Deploy oxen-server ${{ github.sha }} to dev\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/prune_server_images.yml
+++ b/.github/workflows/prune_server_images.yml
@@ -9,13 +9,22 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  packages: write
+# A scheduled run and a dispatched one would otherwise enumerate and delete the
+# same versions concurrently, which fails on whichever loses the race.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   prune:
     name: Prune old images
     runs-on: ubuntu-latest
+    # Deleting a package version is a write to the package. Scoped to this job
+    # rather than the workflow so a later job cannot inherit the ability to
+    # delete images without asking for it.
+    permissions:
+      contents: none
+      packages: write
 
     steps:
       - name: Delete all but the newest images

--- a/.github/workflows/prune_server_images.yml
+++ b/.github/workflows/prune_server_images.yml
@@ -1,0 +1,26 @@
+name: 🧹 Prune oxen-server images
+
+# The container registry expires nothing on its own, and a build is published for
+# every merge to main, so without this the package grows without bound. The
+# number kept sets how far back a deployment can be rolled to without rebuilding.
+on:
+  schedule:
+    - cron: "0 5 * * 0"
+
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  prune:
+    name: Prune old images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete all but the newest images
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: oxen-server
+          package-type: container
+          min-versions-to-keep: 20


### PR DESCRIPTION
Every merge to `main` now builds the `oxen-server` image and deploys it to the dev environment, so dev tracks main instead of waiting for a manual deploy.

`deploy_dev.yml` builds via `build_branch.yml`, then dispatches the deployment workflow in the repository named by `vars.DEPLOY_REPOSITORY_NAME`, passing the digest of the published image and the commit it was built from.

### Test run

This pushed to the new GHCR registry:

https://github.com/Oxen-AI/Oxen/actions/runs/30565161776

Then this deployed from GHCR to dev:

https://github.com/Oxen-AI/oxen-infra/actions/runs/30583330759
