### PR TITLE
Merkle LMDB (1.2.4): Clone into the same merkle backend the server uses

### DIFF
--- a/crates/liboxen/src/core/v_latest/clone.rs
+++ b/crates/liboxen/src/core/v_latest/clone.rs
@@ -29,7 +29,11 @@ pub async fn clone_repo(
     util::fs::create_dir_all(&oxen_hidden_path)?;
 
     // save LocalRepository in .oxen directory
-    let mut local_repo = LocalRepository::from_remote(remote_repo.clone(), repo_path)?;
+    let mut local_repo = LocalRepository::from_remote_with_backend(
+        remote_repo.clone(),
+        repo_path,
+        opts.merkle_node_backend,
+    )?;
     local_repo.version_store().init().await?;
     repo_path.clone_into(&mut local_repo.path);
     local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);
@@ -91,7 +95,11 @@ pub async fn clone_repo_remote_mode(
     let name = format!("{}: {workspace_id}", branch_name.clone());
 
     // Save LocalRepository in .oxen directory
-    let mut local_repo = LocalRepository::from_remote(remote_repo.clone(), repo_path)?;
+    let mut local_repo = LocalRepository::from_remote_with_backend(
+        remote_repo.clone(),
+        repo_path,
+        opts.merkle_node_backend,
+    )?;
     local_repo.version_store().init().await?;
     repo_path.clone_into(&mut local_repo.path);
     local_repo.set_remote(DEFAULT_REMOTE_NAME, &remote_repo.remote.url);

--- a/crates/liboxen/src/model/repository/local_repository.rs
+++ b/crates/liboxen/src/model/repository/local_repository.rs
@@ -223,12 +223,28 @@ impl LocalRepository {
         })
     }
 
+    /// Builds the local repo a clone writes to. It adopts the remote's Merkle node backend, so a
+    /// clone of an LMDB-backed repo is itself LMDB-backed. A remote that reports no backend — a
+    /// server predating the field — resolves to the create-time default.
     pub fn from_remote(repo: RemoteRepository, path: &Path) -> Result<LocalRepository, OxenError> {
+        Self::from_remote_with_backend(repo, path, None)
+    }
+
+    /// [`Self::from_remote`] with an explicit backend that wins over the one the remote reports,
+    /// for a clone that asks for a specific local backend.
+    pub fn from_remote_with_backend(
+        repo: RemoteRepository,
+        path: &Path,
+        backend: Option<MerkleNodeBackend>,
+    ) -> Result<LocalRepository, OxenError> {
         let path = path.to_owned();
         let storage_config = StorageConfig::default();
         let version_store = create_version_store(&path, &storage_config, None)?;
+        let resolved_backend = backend
+            .or(repo.merkle_node_backend)
+            .unwrap_or(DEFAULT_MERKLE_NODE_BACKEND);
         let (merkle_node_store, merkle_node_backend) =
-            create_merkle_node_store(&path, Some(DEFAULT_MERKLE_NODE_BACKEND))?;
+            create_merkle_node_store(&path, Some(resolved_backend))?;
         Ok(LocalRepository {
             path,
             remotes: vec![repo.remote],
@@ -638,8 +654,10 @@ mod tests {
 
     use crate::api::requests::RepoNew;
     use crate::config::RepositoryConfig;
+    use crate::core::db::merkle_node::{DEFAULT_MERKLE_NODE_BACKEND, MerkleNodeBackend};
     use crate::error::OxenError;
-    use crate::model::LocalRepository;
+    use crate::model::{LocalRepository, Remote, RemoteRepository};
+    use crate::storage::StorageKind;
     use crate::test;
     use tempfile::TempDir;
 
@@ -879,6 +897,83 @@ mod tests {
                 },
             )?;
         }
+
+        Ok(())
+    }
+
+    fn remote_repo_reporting(backend: Option<MerkleNodeBackend>) -> RemoteRepository {
+        RemoteRepository {
+            namespace: String::from("ns"),
+            name: String::from("repo"),
+            remote: Remote {
+                name: String::from("origin"),
+                url: String::from("http://localhost:3000/ns/repo"),
+            },
+            min_version: None,
+            is_empty: true,
+            storage_kind: StorageKind::Local,
+            merkle_node_backend: backend,
+        }
+    }
+
+    #[test]
+    fn test_from_remote_adopts_the_remotes_merkle_backend() -> Result<(), OxenError> {
+        for backend in [MerkleNodeBackend::Lmdb, MerkleNodeBackend::Filesystem] {
+            let temp_dir = TempDir::new()?;
+            let repo = LocalRepository::from_remote(
+                remote_repo_reporting(Some(backend)),
+                temp_dir.path(),
+            )?;
+
+            assert_eq!(repo.merkle_node_backend(), backend);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_remote_backend_override_beats_the_remote() -> Result<(), OxenError> {
+        // Both directions, so the test can't pass by coincidence with the create-time default.
+        for (remote_backend, requested) in [
+            (MerkleNodeBackend::Filesystem, MerkleNodeBackend::Lmdb),
+            (MerkleNodeBackend::Lmdb, MerkleNodeBackend::Filesystem),
+        ] {
+            let temp_dir = TempDir::new()?;
+            let repo = LocalRepository::from_remote_with_backend(
+                remote_repo_reporting(Some(remote_backend)),
+                temp_dir.path(),
+                Some(requested),
+            )?;
+
+            assert_eq!(repo.merkle_node_backend(), requested);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_remote_falls_back_when_the_remote_reports_no_backend() -> Result<(), OxenError> {
+        let temp_dir = TempDir::new()?;
+        let repo = LocalRepository::from_remote(remote_repo_reporting(None), temp_dir.path())?;
+
+        assert_eq!(repo.merkle_node_backend(), DEFAULT_MERKLE_NODE_BACKEND);
+
+        Ok(())
+    }
+
+    /// The adopted backend has to reach `config.toml`, since that is what a later load resolves
+    /// from — clone saves the repo right after building it.
+    #[test]
+    fn test_from_remote_persists_the_adopted_backend() -> Result<(), OxenError> {
+        let temp_dir = TempDir::new()?;
+        let repo = LocalRepository::from_remote(
+            remote_repo_reporting(Some(MerkleNodeBackend::Lmdb)),
+            temp_dir.path(),
+        )?;
+        repo.save()?;
+
+        let reloaded = LocalRepository::from_dir(temp_dir.path())?;
+        assert_eq!(reloaded.merkle_node_backend(), MerkleNodeBackend::Lmdb);
 
         Ok(())
     }

--- a/crates/liboxen/src/model/repository/remote_repository.rs
+++ b/crates/liboxen/src/model/repository/remote_repository.rs
@@ -16,8 +16,8 @@ pub struct RemoteRepository {
     pub is_empty: bool,
     /// The server's version-store backend for this repo (local filesystem or S3).
     pub storage_kind: StorageKind,
-    /// The repo's Merkle node backend (filesystem / lmdb), read-only observability. `None` from a
-    /// server that predates the field.
+    /// The repo's Merkle node backend (filesystem / lmdb). A clone adopts it for the local repo it
+    /// creates. `None` from a server that predates the field.
     pub merkle_node_backend: Option<MerkleNodeBackend>,
 }
 

--- a/crates/liboxen/src/opts/clone_opts.rs
+++ b/crates/liboxen/src/opts/clone_opts.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::core::db::merkle_node::MerkleNodeBackend;
 use crate::opts::FetchOpts;
 
 #[derive(Clone, Debug, Default)]
@@ -14,6 +15,9 @@ pub struct CloneOpts {
     pub is_vfs: bool,
     // Flag for remote mode
     pub is_remote: bool,
+    /// Merkle node backend for the local repo, overriding the one the remote reports. `None`
+    /// inherits from the remote.
+    pub merkle_node_backend: Option<MerkleNodeBackend>,
 }
 
 impl CloneOpts {
@@ -25,6 +29,7 @@ impl CloneOpts {
             fetch_opts: FetchOpts::new(),
             is_vfs: false,
             is_remote: false,
+            merkle_node_backend: None,
         }
     }
 
@@ -35,8 +40,6 @@ impl CloneOpts {
     ) -> CloneOpts {
         CloneOpts {
             fetch_opts: FetchOpts::from_branch(branch.as_ref()),
-            is_vfs: false,
-            is_remote: false,
             ..CloneOpts::new(url, dst)
         }
     }

--- a/crates/liboxen/src/repositories/clone.rs
+++ b/crates/liboxen/src/repositories/clone.rs
@@ -43,11 +43,8 @@ async fn _clone(
     fetch_opts: FetchOpts,
 ) -> Result<LocalRepository, OxenError> {
     let opts = CloneOpts {
-        url: url.as_ref().to_string(),
-        dst: dst.as_ref().to_owned(),
         fetch_opts,
-        is_vfs: false,
-        is_remote: false,
+        ..CloneOpts::new(url, dst)
     };
     clone(&opts).await
 }

--- a/crates/oxen-cli/src/cmd/clone.rs
+++ b/crates/oxen-cli/src/cmd/clone.rs
@@ -1,9 +1,11 @@
 use async_trait::async_trait;
 use clap::{Arg, Command, arg};
 use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
 
 use liboxen::api;
 use liboxen::constants::DEFAULT_BRANCH_NAME;
+use liboxen::core::db::merkle_node::MerkleNodeBackend;
 use liboxen::error::OxenError;
 use liboxen::opts::CloneOpts;
 use liboxen::opts::FetchOpts;
@@ -38,6 +40,13 @@ impl RunCmd for CloneCmd {
                 Arg::new("depth")
                     .long("depth")
                     .help("Used in combination with --filter. The depth at which to clone a subtree. If not provided, the entire subtree will be cloned.")
+                    .action(clap::ArgAction::Set),
+            )
+            .arg(
+                Arg::new("merkle-backend")
+                    .long("merkle-backend")
+                    .help("Which engine backs the local repo's Merkle node store (default: match the remote)")
+                    .value_parser(["filesystem", "lmdb"])
                     .action(clap::ArgAction::Set),
             )
             .arg(
@@ -86,6 +95,10 @@ impl RunCmd for CloneCmd {
             .get_one::<String>("depth")
             .map(|s| s.parse::<i32>().map_err(OxenError::ParseIntError))
             .transpose()?;
+        let merkle_node_backend = args
+            .get_one::<String>("merkle-backend")
+            .map(|s| MerkleNodeBackend::from_str(s))
+            .transpose()?;
         let is_vfs = args.get_flag("vfs");
         let is_remote = args.get_flag("remote");
 
@@ -129,6 +142,7 @@ impl RunCmd for CloneCmd {
             },
             is_vfs,
             is_remote,
+            merkle_node_backend,
         };
 
         let (scheme, host) = api::client::get_scheme_and_host_from_url(&opts.url)?;


### PR DESCRIPTION
Cloning an LMDB-backed repository produced a filesystem-backed local one, so there was no way to get an LMDB repository locally at all short of migrating it by hand afterward.

A clone now adopts the backend the remote reports, and `oxen clone --merkle-backend` overrides it — the same flag `oxen init` and `oxen create-remote` already take. A remote that reports no backend, which is any server predating the field, still resolves to the create-time default.