### PR TITLE
Include curl in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN cargo build --workspace --exclude oxen-py --release --features liboxen/ffmpe
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssl \
+    && apt-get install -y --no-install-recommends openssl curl ca-certificates \
     && rm -rfv /var/lib/apt/lists/*
 
 # FFmpeg 8 shared libraries for the `ffmpeg` video-thumbnail feature (see builder stage).


### PR DESCRIPTION
Add curl to the runtime image for in-container health checks.