### PR TITLE
Tell clients a repository uses a retired storage format instead of failing as a server error

### DIFF
--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -78,6 +78,32 @@ pub(crate) fn node_db_path(repo_path: &Path, hash: &MerkleHash) -> PathBuf {
         .join(dir_prefix)
 }
 
+/// Prefix every current node payload starts with: `rmp_serde` encodes the one-field wrapper
+/// struct as a 1-element array holding an externally-tagged enum, so the variant name lands in
+/// the bytes. Payloads written before v0.25.0 are the bare data struct and carry no tag.
+/// `FileChunk` is the exception — it has no enum wrapper at all, so the tag says nothing about it.
+const CURRENT_NODE_PAYLOAD_TAG: &[u8] = b"\x91\x81\xa7V0_25_0";
+
+/// Classify a failure to decode a node payload. A payload carrying no variant tag was written
+/// before the node types gained their enum envelope, which is a property of the repository rather
+/// than a damaged node; telling the two apart keeps a retired format from looking like corruption.
+///
+/// Every conversion from a decode error into a [`MerkleDbError`] goes through here — the `#[from]`
+/// on [`MerkleDbError::Decode`] will silently classify a retired-format node as corruption if a
+/// new decode site reaches for `?` instead.
+fn classify_decode_failure(
+    dtype: MerkleTreeNodeType,
+    hash: MerkleHash,
+    data: &[u8],
+    err: rmp_serde::decode::Error,
+) -> MerkleDbError {
+    if dtype != MerkleTreeNodeType::FileChunk && !data.starts_with(CURRENT_NODE_PAYLOAD_TAG) {
+        MerkleDbError::PreV025Node { dtype, hash }
+    } else {
+        MerkleDbError::Decode(err)
+    }
+}
+
 /// Errors that the Merkle node database can encounter when reading and writing nodes.
 #[derive(Debug, thiserror::Error)]
 pub enum MerkleDbError {
@@ -101,6 +127,11 @@ pub enum MerkleDbError {
     Encode(#[from] rmp_serde::encode::Error),
     #[error("Cannot decode a Merkle node: {0}")]
     Decode(#[from] rmp_serde::decode::Error),
+    #[error("Merkle node {hash} ({dtype:?}) predates Oxen v0.25.0 and cannot be read")]
+    PreV025Node {
+        dtype: MerkleTreeNodeType,
+        hash: MerkleHash,
+    },
     #[error("{0}")]
     TypeMismatch(#[from] InvalidMerkleTreeNodeType),
     #[error("Failed to create directory: {0}")]
@@ -289,15 +320,17 @@ impl MerkleNodeDB {
     }
 
     pub fn node(&self) -> Result<EMerkleTreeNode, MerkleDbError> {
-        let node = Self::to_node(self.dtype, &self.data())?;
+        let node = Self::to_node(self.dtype, self.node_id, &self.data())?;
         Ok(node)
     }
 
     fn to_node(
         dtype: MerkleTreeNodeType,
+        hash: MerkleHash,
         data: &[u8],
-    ) -> Result<EMerkleTreeNode, rmp_serde::decode::Error> {
+    ) -> Result<EMerkleTreeNode, MerkleDbError> {
         EMerkleTreeNode::from_type_and_bytes(dtype, data)
+            .map_err(|err| classify_decode_failure(dtype, hash, data, err))
     }
 
     pub(crate) fn open_read_only(
@@ -444,13 +477,15 @@ impl MerkleNodeDB {
 
     pub(crate) fn map(&mut self) -> Result<Vec<(MerkleHash, MerkleTreeNode)>, MerkleDbError> {
         // log::debug!("Loading merkle node db map");
+        let node_id = self.node_id;
         let Some(lookup) = self.lookup.as_ref() else {
             return Err(MerkleDbError::ReadBeforeOpen);
         };
 
         // Parse the node parent id
         let data_type = MerkleTreeNodeType::from_u8(lookup.data_type)?;
-        let parent_id = MerkleTreeNode::deserialize_id(&lookup.data, data_type)?;
+        let parent_id = MerkleTreeNode::deserialize_id(&lookup.data, data_type)
+            .map_err(|err| classify_decode_failure(data_type, node_id, &lookup.data, err))?;
 
         let children_bytes = self.store.read_children(&self.node_id)?;
         // log::debug!("Loading merkle node db map got {} bytes", children_bytes.len());
@@ -471,7 +506,7 @@ impl MerkleNodeDB {
             let node = MerkleTreeNode {
                 parent_id: Some(parent_id),
                 hash: MerkleHash::new(*hash),
-                node: Self::to_node(dtype, &data)?,
+                node: Self::to_node(dtype, MerkleHash::new(*hash), &data)?,
                 children: Vec::new(),
             };
             // log::debug!("Loaded node {:?}", node);
@@ -508,5 +543,70 @@ impl Drop for MerkleNodeDB {
             "MerkleNodeDB for node {} dropped without close(); buffered node discarded unwritten",
             self.node_id
         );
+    }
+}
+
+#[cfg(test)]
+mod to_node_tests {
+    use super::*;
+    use crate::model::merkle_tree::node::VNode;
+
+    fn hash() -> MerkleHash {
+        MerkleHash::new(42)
+    }
+
+    #[test]
+    fn untagged_payload_reports_the_retired_format() {
+        // The pre-0.25 shape: the bare data struct, with no enum envelope around it.
+        // Built positionally rather than from a struct so the test pins the bytes, not a type
+        // that could drift alongside the code under test.
+        let mut legacy = vec![0x92, 0xc4, 0x10];
+        legacy.extend_from_slice(&hash().to_le_bytes());
+        legacy.extend_from_slice(b"\xa5VNode");
+
+        let err = MerkleNodeDB::to_node(MerkleTreeNodeType::VNode, hash(), &legacy)
+            .expect_err("an untagged payload must not decode");
+
+        assert!(
+            matches!(err, MerkleDbError::PreV025Node { .. }),
+            "expected PreV025Node, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn damaged_current_payload_still_reports_a_decode_error() {
+        // Carries the variant tag, so it is a current-format node that is simply broken.
+        // Misreporting this as a retired format would send the reader chasing the wrong problem.
+        let mut damaged = CURRENT_NODE_PAYLOAD_TAG.to_vec();
+        damaged.extend_from_slice(&[0xc1]); // never a valid msgpack byte
+
+        let err = MerkleNodeDB::to_node(MerkleTreeNodeType::VNode, hash(), &damaged)
+            .expect_err("a damaged payload must not decode");
+
+        assert!(
+            matches!(err, MerkleDbError::Decode(_)),
+            "expected Decode, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn file_chunk_is_never_reported_as_the_retired_format() {
+        // FileChunk has no enum wrapper by design, so its payloads never carry the tag. Judging
+        // it by the tag would label every damaged chunk a retired-format node.
+        let err = MerkleNodeDB::to_node(MerkleTreeNodeType::FileChunk, hash(), &[0xc1])
+            .expect_err("a damaged payload must not decode");
+
+        assert!(
+            matches!(err, MerkleDbError::Decode(_)),
+            "expected Decode, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn current_payload_still_decodes() {
+        let bytes = rmp_serde::to_vec(&VNode::default()).expect("VNode should serialize");
+
+        MerkleNodeDB::to_node(MerkleTreeNodeType::VNode, hash(), &bytes)
+            .expect("a current-format payload must decode");
     }
 }

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -1925,9 +1925,11 @@ fn insert_entry(entries: &mut HashMap<String, DirEntry>, hash: MerkleHash, node:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants;
     use crate::core::db::merkle_node::merkle_node_db::node_db_path;
     use crate::error::OxenError;
     use crate::model::Commit;
+    use crate::model::merkle_tree::node::DirNode;
     use crate::opts::RmOpts;
     use crate::repositories;
     use crate::test;
@@ -3441,6 +3443,97 @@ mod tests {
                 repositories::tree::get_file_by_path_async(&repo, &commit, "")
                     .await?
                     .is_none()
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// The pre-0.25 shape of a dir node: the same data with no enum envelope and no
+    /// `num_entries`. Serialized positionally, matching how `rmp_serde::to_vec` writes structs.
+    #[derive(serde::Serialize)]
+    struct LegacyDirNodeData {
+        node_type: MerkleTreeNodeType,
+        name: String,
+        hash: MerkleHash,
+        num_bytes: u64,
+        last_commit_id: MerkleHash,
+        last_modified_seconds: i64,
+        last_modified_nanoseconds: u32,
+        data_type_counts: std::collections::HashMap<String, u64>,
+        data_type_sizes: std::collections::HashMap<String, u64>,
+    }
+
+    // A repo written before v0.25.0 must report *why* it cannot be read, not surface a raw
+    // msgpack error as a server fault. Reading such a node reaches the decode through
+    // `MerkleNodeDB::map`, which is a different call site than `MerkleNodeDB::node` — an earlier
+    // attempt at this classified only the latter and left the failure looking like corruption.
+    #[tokio::test]
+    async fn test_pre_v0_25_dir_node_is_reported_as_a_retired_format() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            // Resolve HEAD before corrupting anything: reading the commit also walks into the
+            // dir node, so afterwards even this lookup fails.
+            let commit_hash: MerkleHash = repositories::commits::head_commit(&repo)?.id.parse()?;
+
+            let nodes_dir = util::fs::oxen_hidden_dir(&repo.path)
+                .join(constants::TREE_DIR)
+                .join(constants::NODES_DIR);
+
+            // Rewrite the first dir node we find into the pre-0.25 shape, in place.
+            let mut rewrote = false;
+            for prefix in util::fs::list_dirs_in_dir(&nodes_dir)? {
+                for node_dir in util::fs::list_dirs_in_dir(&prefix)? {
+                    let node_file = node_dir.join("node");
+                    let blob = std::fs::read(&node_file)?;
+                    // [dtype u8][parent_id u128 LE][data_len u32 LE][payload][child entries...]
+                    if blob.first() != Some(&MerkleTreeNodeType::Dir.to_u8()) {
+                        continue;
+                    }
+                    let data_len =
+                        u32::from_le_bytes(blob[17..21].try_into().expect("4 bytes")) as usize;
+                    let dir = DirNode::deserialize(&blob[21..21 + data_len])
+                        .expect("fixture dir node should decode before rewriting");
+                    let legacy = rmp_serde::to_vec(&LegacyDirNodeData {
+                        node_type: *dir.node_type(),
+                        name: dir.name().to_string(),
+                        hash: *dir.hash(),
+                        num_bytes: dir.num_bytes(),
+                        last_commit_id: *dir.last_commit_id(),
+                        last_modified_seconds: dir.last_modified_seconds(),
+                        last_modified_nanoseconds: dir.last_modified_nanoseconds(),
+                        data_type_counts: dir.data_type_counts().clone(),
+                        data_type_sizes: dir.data_type_sizes().clone(),
+                    })
+                    .expect("legacy dir node should serialize");
+
+                    let mut rewritten = blob[..17].to_vec();
+                    rewritten.extend_from_slice(&(legacy.len() as u32).to_le_bytes());
+                    rewritten.extend_from_slice(&legacy);
+                    rewritten.extend_from_slice(&blob[21 + data_len..]);
+                    std::fs::write(&node_file, rewritten)?;
+                    rewrote = true;
+                    break;
+                }
+                if rewrote {
+                    break;
+                }
+            }
+            assert!(rewrote, "fixture repo should contain a dir node to rewrite");
+
+            let err = repositories::tree::get_node_by_id_with_children(&repo, &commit_hash)
+                .expect_err("a pre-0.25 dir node must not read as though it were current");
+
+            assert!(
+                matches!(
+                    err,
+                    OxenError::MerkleDbError(
+                        crate::core::db::merkle_node::merkle_node_db::MerkleDbError::PreV025Node {
+                            ..
+                        }
+                    )
+                ),
+                "expected PreV025Node, got {err:?}"
             );
 
             Ok(())

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -3,6 +3,7 @@ use actix_web::{HttpResponse, error};
 use derive_more::{Display, Error};
 use liboxen::constants;
 use liboxen::core::db::data_frames::DataFrameError;
+use liboxen::core::db::merkle_node::merkle_node_db::MerkleDbError;
 use liboxen::error::{OxenError, PathBufError, StringError};
 use liboxen::model::{Branch, Workspace};
 use liboxen::view::http::{
@@ -497,6 +498,24 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
+                    // Distinct from UnsupportedRepoVersion above: that one trusts the repo's
+                    // declared min_version, which can disagree with the bytes actually on disk.
+                    // This arm is reached when a node itself turns out to predate the format.
+                    OxenError::MerkleDbError(MerkleDbError::PreV025Node { dtype, hash }) => {
+                        log::warn!("Pre-v0.25.0 merkle node {hash} ({dtype:?})");
+                        let error_json = json!({
+                            "error": {
+                                "type": "pre_v0_25_node_format",
+                                "title":
+                                    "Retired Repository Storage Format",
+                                "detail":
+                                    format!("This repository contains Merkle nodes written before Oxen v0.25.0, which this server cannot read (first encountered: {dtype:?} node {hash})."),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
                     OxenError::ImportFileError(desc) => {
                         let error_json = json!({
                             "error": {
@@ -838,6 +857,20 @@ mod tests {
         // A 5xx here reads as transient to clients, which retry it with backoff. The repo's
         // on-disk format never changes on its own, so the status has to be terminal.
         let error = OxenHttpError::from(OxenError::UnsupportedRepoVersion("0.19.0".into()));
+        let status = error.error_response().status();
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(!status.is_server_error());
+    }
+
+    #[test]
+    fn test_pre_v0_25_node_is_a_client_error() {
+        // Same reasoning as above: a node that predates the format never becomes readable by
+        // retrying, so the status has to be terminal rather than the 500 this used to return.
+        let error = OxenHttpError::from(OxenError::MerkleDbError(MerkleDbError::PreV025Node {
+            dtype: liboxen::model::MerkleTreeNodeType::VNode,
+            hash: liboxen::model::MerkleHash::new(42),
+        }));
         let status = error.error_response().status();
 
         assert_eq!(status, StatusCode::BAD_REQUEST);


### PR DESCRIPTION
A repository whose Merkle nodes were written before Oxen v0.25.0 returned server errors for directory listings, so clients would retry a request that can never succeed, and it tells nobody what is actually wrong.

We now return a 400 error identifying the condition and naming the node that tripped it. The wording stays neutral on remedy: these repositories are recoverable, and a fix to convert them is being built next, so the message deliberately avoids prescribing a workaround that is about to become unnecessary. This PR does not make the repositories readable.

ENG-1469