### PR TITLE
Name the ref when dispatching the dev deploy

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -68,8 +68,13 @@ jobs:
           IMAGE: ${{ needs.build.outputs.image }}
           SHA: ${{ github.sha }}
         run: |
+          # --ref is named rather than left to default. Without it the dispatch
+          # first resolves the target's default branch, and that lookup reads the
+          # target's contents — which this token is deliberately not scoped for,
+          # so the dispatch fails before it is attempted.
           gh workflow run deploy_dev_oxen_server.yml \
             --repo "$DEPLOY_REPOSITORY" \
+            --ref main \
             --field image="$IMAGE" \
             --field sha="$SHA"
 


### PR DESCRIPTION
`gh workflow run` resolves the target repository's default branch when no --ref is given, and that resolution reads the target's contents. The token minted here asks only for permission to start a workflow, so the lookup is refused and the dispatch fails before it is attempted:

    unable to determine default branch: GraphQL: Resource not accessible by
    integration (repository.defaultBranchRef)

Naming the ref skips the lookup entirely, which keeps the token scoped to the one thing this step does rather than widening it to read contents it has no use for.