### PR TITLE
Report which repositories hold Merkle nodes the current format cannot read

### DIFF
--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -101,12 +101,16 @@ fn retired_format_logging_suppressed() -> bool {
     RETIRED_FORMAT_LOGGING_SUPPRESSED.with(|suppressed| suppressed.get())
 }
 
-/// Restores the per-node retired-format warning when dropped.
-pub(crate) struct RetiredFormatLogGuard;
+/// Restores whatever suppression state was in force when this guard was taken, so a guard nested
+/// inside another does not un-suppress the outer scope on the way out.
+#[must_use = "suppression lasts only as long as the guard is held"]
+pub(crate) struct RetiredFormatLogGuard {
+    restore_to: bool,
+}
 
 impl Drop for RetiredFormatLogGuard {
     fn drop(&mut self) {
-        RETIRED_FORMAT_LOGGING_SUPPRESSED.with(|suppressed| suppressed.set(false));
+        RETIRED_FORMAT_LOGGING_SUPPRESSED.with(|suppressed| suppressed.set(self.restore_to));
     }
 }
 
@@ -120,8 +124,8 @@ impl Drop for RetiredFormatLogGuard {
 /// Only covers the calling thread, so a scan that grows a worker pool has to take the guard on
 /// each worker.
 pub(crate) fn suppress_retired_format_logging() -> RetiredFormatLogGuard {
-    RETIRED_FORMAT_LOGGING_SUPPRESSED.with(|suppressed| suppressed.set(true));
-    RetiredFormatLogGuard
+    let restore_to = RETIRED_FORMAT_LOGGING_SUPPRESSED.with(|suppressed| suppressed.replace(true));
+    RetiredFormatLogGuard { restore_to }
 }
 
 /// Classify a failure to decode a node payload. A payload carrying no variant tag was written
@@ -675,6 +679,14 @@ mod to_node_tests {
         {
             let _quiet = suppress_retired_format_logging();
             assert!(retired_format_logging_suppressed());
+            {
+                let _nested = suppress_retired_format_logging();
+                assert!(retired_format_logging_suppressed());
+            }
+            assert!(
+                retired_format_logging_suppressed(),
+                "an inner guard dropping must not un-suppress the scope still holding one"
+            );
         }
         assert!(!retired_format_logging_suppressed());
     }

--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -46,6 +46,7 @@ For example, data for a vnode of hash 1234 with two children:
     {dir data node}
 */
 
+use std::cell::Cell;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
@@ -84,6 +85,45 @@ pub(crate) fn node_db_path(repo_path: &Path, hash: &MerkleHash) -> PathBuf {
 /// `FileChunk` is the exception — it has no enum wrapper at all, so the tag says nothing about it.
 const CURRENT_NODE_PAYLOAD_TAG: &[u8] = b"\x91\x81\xa7V0_25_0";
 
+/// The envelope alone, without committing to which variant it names. Distinguishes "written
+/// before the envelope existed" from "wrapped, but naming a variant this build does not know" —
+/// a payload tagged by some future variant also fails the [`CURRENT_NODE_PAYLOAD_TAG`] check, and
+/// calling that one *older* than v0.25.0 would be exactly backwards.
+const NODE_ENVELOPE_PREFIX: &[u8] = b"\x91\x81";
+
+thread_local! {
+    /// Set only for the duration of a [`RetiredFormatLogGuard`]. Thread-local rather than global
+    /// so one caller's bulk scan cannot silence the warning for concurrent request handlers.
+    static RETIRED_FORMAT_LOGGING_SUPPRESSED: Cell<bool> = const { Cell::new(false) };
+}
+
+fn retired_format_logging_suppressed() -> bool {
+    RETIRED_FORMAT_LOGGING_SUPPRESSED.with(|suppressed| suppressed.get())
+}
+
+/// Restores the per-node retired-format warning when dropped.
+pub(crate) struct RetiredFormatLogGuard;
+
+impl Drop for RetiredFormatLogGuard {
+    fn drop(&mut self) {
+        RETIRED_FORMAT_LOGGING_SUPPRESSED.with(|suppressed| suppressed.set(false));
+    }
+}
+
+/// Silence the per-node retired-format warning on this thread until the guard drops.
+///
+/// For a caller that reads one repository, the warning is the whole point: it surfaces the
+/// condition even on paths that discard the error. For one that deliberately decodes every node
+/// in a fleet, it is duplication of that caller's own output at a scale — tens of thousands of
+/// lines — that buries the result it was meant to explain.
+///
+/// Only covers the calling thread, so a scan that grows a worker pool has to take the guard on
+/// each worker.
+pub(crate) fn suppress_retired_format_logging() -> RetiredFormatLogGuard {
+    RETIRED_FORMAT_LOGGING_SUPPRESSED.with(|suppressed| suppressed.set(true));
+    RetiredFormatLogGuard
+}
+
 /// Classify a failure to decode a node payload. A payload carrying no variant tag was written
 /// before the node types gained their enum envelope, which is a property of the repository rather
 /// than a damaged node; telling the two apart keeps a retired format from looking like corruption.
@@ -97,7 +137,16 @@ fn classify_decode_failure(
     data: &[u8],
     err: rmp_serde::decode::Error,
 ) -> MerkleDbError {
-    if dtype != MerkleTreeNodeType::FileChunk && !data.starts_with(CURRENT_NODE_PAYLOAD_TAG) {
+    if dtype != MerkleTreeNodeType::FileChunk
+        && !data.starts_with(CURRENT_NODE_PAYLOAD_TAG)
+        && !data.starts_with(NODE_ENVELOPE_PREFIX)
+    {
+        // Logged where the condition is detected rather than where it surfaces: callers that
+        // discard the error still leave a trace, and a repository read from a warm node cache
+        // reports the first time it actually reaches disk.
+        if !retired_format_logging_suppressed() {
+            log::warn!("Merkle node {hash} ({dtype:?}) predates Oxen v0.25.0 and cannot be read");
+        }
         MerkleDbError::PreV025Node { dtype, hash }
     } else {
         MerkleDbError::Decode(err)
@@ -549,10 +598,39 @@ impl Drop for MerkleNodeDB {
 #[cfg(test)]
 mod to_node_tests {
     use super::*;
-    use crate::model::merkle_tree::node::VNode;
+    use crate::model::merkle_tree::node::{CommitNode, DirNode, FileChunkNode, VNode};
 
     fn hash() -> MerkleHash {
         MerkleHash::new(42)
+    }
+
+    // `CURRENT_NODE_PAYLOAD_TAG` is ten bytes of hand-written assumption about what `rmp_serde`
+    // emits: a one-field wrapper struct, an externally-tagged enum, a seven-character variant
+    // name. Nothing else checks it. If any of those shifts — a field added to a *wrapper* struct
+    // turns 0x91 into 0x92 — the tag silently stops matching and every damaged node starts being
+    // reported as a retired format, with no test failing. Compare it against real writer output.
+    #[test]
+    fn the_tag_matches_what_the_writer_emits() {
+        let wrapped = [
+            ("vnode", rmp_serde::to_vec(&VNode::default())),
+            ("dir", rmp_serde::to_vec(&DirNode::default())),
+            ("commit", rmp_serde::to_vec(&CommitNode::default())),
+        ];
+        for (label, bytes) in wrapped {
+            let bytes = bytes.expect("node should serialize");
+            assert!(
+                bytes.starts_with(CURRENT_NODE_PAYLOAD_TAG),
+                "{label} no longer starts with the tag the classifier matches: {bytes:02x?}"
+            );
+        }
+
+        // The exception the classifier special-cases: FileChunk has no enum wrapper, so its
+        // payloads never carry the tag. If it ever gains one, that special case goes stale.
+        let chunk = rmp_serde::to_vec(&FileChunkNode::default()).expect("chunk should serialize");
+        assert!(
+            !chunk.starts_with(CURRENT_NODE_PAYLOAD_TAG),
+            "FileChunk gained an envelope; the dtype special case is now wrong"
+        );
     }
 
     #[test]
@@ -586,6 +664,35 @@ mod to_node_tests {
         assert!(
             matches!(err, MerkleDbError::Decode(_)),
             "expected Decode, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn the_log_guard_restores_the_warning_when_it_drops() {
+        // A leaked suppression would silence the condition for everything that runs afterwards on
+        // this thread, which is worse than the noise it exists to prevent.
+        assert!(!retired_format_logging_suppressed());
+        {
+            let _quiet = suppress_retired_format_logging();
+            assert!(retired_format_logging_suppressed());
+        }
+        assert!(!retired_format_logging_suppressed());
+    }
+
+    #[test]
+    fn a_variant_this_build_does_not_know_is_not_called_old() {
+        // Name tagging exists so a node keeps its bytes across variant changes, which means a
+        // payload written by a *newer* build also fails the V0_25_0 check. Reporting that as
+        // predating v0.25.0 would point the reader in precisely the wrong direction.
+        let mut future = b"\x91\x81\xa7V0_99_0".to_vec();
+        future.extend_from_slice(&[0xc1]);
+
+        let err = MerkleNodeDB::to_node(MerkleTreeNodeType::VNode, hash(), &future)
+            .expect_err("a variant this build has no arm for must not decode");
+
+        assert!(
+            matches!(err, MerkleDbError::Decode(_)),
+            "expected Decode for an unknown-but-tagged payload, got {err:?}"
         );
     }
 

--- a/crates/liboxen/src/repositories/fsck.rs
+++ b/crates/liboxen/src/repositories/fsck.rs
@@ -20,6 +20,7 @@
 
 use rocksdb::{DBWithThreadMode, SingleThreaded};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::core::db;
@@ -27,11 +28,80 @@ use crate::core::db::dir_hashes::dir_hashes_db::{
     dir_hash_db_path_from_commit_id, with_exclusive_access,
 };
 use crate::core::db::key_val::str_val_db;
+use crate::core::db::merkle_node::merkle_node_db::{
+    MerkleDbError, MerkleNodeDB, suppress_retired_format_logging,
+};
 use crate::error::OxenError;
-use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode};
+use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode, MerkleTreeNodeType};
 use crate::model::{Commit, LocalRepository, MerkleHash};
 use crate::repositories;
 use crate::util;
+
+/// What a [`scan_node_format`] pass found in one repository.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct NodeFormatReport {
+    /// Every node the store holds, whatever its format.
+    pub total_nodes: usize,
+    /// Nodes written before the v0.25.0 on-disk format, counted per node type. Absent types
+    /// simply have no such nodes.
+    pub pre_v025: HashMap<MerkleTreeNodeType, usize>,
+    /// Nodes that failed to decode for some other reason. Counted rather than returned so one
+    /// damaged node doesn't abort a fleet-wide scan; a non-zero value wants looking at by hand.
+    pub undecodable: usize,
+}
+
+impl NodeFormatReport {
+    /// Nodes predating v0.25.0, across every node type.
+    pub fn pre_v025_total(&self) -> usize {
+        self.pre_v025.values().sum()
+    }
+
+    /// Whether this repository holds any pre-v0.25.0 nodes. Deliberately narrower than "holds
+    /// anything unreadable": [`Self::undecodable`] nodes are damage, a separate condition with a
+    /// separate remedy, and conflating the two overstates the population awaiting migration.
+    pub fn is_affected(&self) -> bool {
+        self.pre_v025_total() > 0
+    }
+}
+
+/// Count a repository's Merkle nodes that predate the v0.25.0 on-disk format, by node type.
+///
+/// Read-only, and reads every node in the store, so cost scales with tree size. Works on either
+/// merkle-node backend, since it goes through the store rather than the on-disk file layout.
+///
+/// This asks the same decoder the server uses, so its answer cannot drift from what a read
+/// actually does — which is the point of having it rather than matching bytes externally.
+pub fn scan_node_format(repo: &LocalRepository) -> Result<NodeFormatReport, OxenError> {
+    // The report below names every node this would log, so leaving the warning on buries the
+    // result under one line per affected node — order 10^5 across a fleet.
+    let _quiet = suppress_retired_format_logging();
+
+    let store = repo.merkle_node_store();
+    let hashes = store.list_hashes()?;
+
+    let mut report = NodeFormatReport {
+        total_nodes: hashes.len(),
+        ..Default::default()
+    };
+
+    for hash in hashes {
+        // Decoding this node's own payload is what classifies it; a node whose *children* are
+        // legacy is counted when the scan reaches those children by their own hashes.
+        let decoded = MerkleNodeDB::open_read_only(store.clone(), &hash).and_then(|db| db.node());
+        match decoded {
+            Ok(_) => {}
+            Err(MerkleDbError::PreV025Node { dtype, .. }) => {
+                *report.pre_v025.entry(dtype).or_default() += 1;
+            }
+            Err(err) => {
+                log::warn!("Node {hash} in {:?} did not decode: {err}", repo.path);
+                report.undecodable += 1;
+            }
+        }
+    }
+
+    Ok(report)
+}
 
 /// Result of rebuilding a commit's `dir_hash_db`.
 #[derive(Debug, Clone, Serialize)]
@@ -317,6 +387,84 @@ mod tests {
             assert!(
                 repaired.is_some(),
                 "expected dir_with_children to find {child_rel:?} after rebuild"
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// The pre-0.25 shape of a vnode: the same data with no enum envelope and no `num_entries`.
+    #[derive(serde::Serialize)]
+    struct LegacyVNodeData {
+        hash: MerkleHash,
+        node_type: MerkleTreeNodeType,
+    }
+
+    #[tokio::test]
+    async fn test_scan_node_format_finds_planted_pre_v0_25_node() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let clean = scan_node_format(&repo)?;
+            assert!(
+                !clean.is_affected(),
+                "a freshly written repo holds no pre-0.25 nodes, got {clean:?}"
+            );
+            assert!(clean.total_nodes > 0, "fixture repo should have nodes");
+            assert_eq!(clean.undecodable, 0);
+
+            // Rewrite one vnode into the pre-0.25 shape, in place.
+            let nodes_dir = util::fs::oxen_hidden_dir(&repo.path)
+                .join(crate::constants::TREE_DIR)
+                .join(crate::constants::NODES_DIR);
+            let mut planted = false;
+            for prefix in util::fs::list_dirs_in_dir(&nodes_dir)? {
+                for node_dir in util::fs::list_dirs_in_dir(&prefix)? {
+                    let node_file = node_dir.join("node");
+                    let blob = std::fs::read(&node_file)?;
+                    // [dtype u8][parent_id u128 LE][data_len u32 LE][payload][child entries...]
+                    if blob.first() != Some(&MerkleTreeNodeType::VNode.to_u8()) {
+                        continue;
+                    }
+                    let data_len =
+                        u32::from_le_bytes(blob[17..21].try_into().expect("4 bytes")) as usize;
+                    let vnode = crate::model::merkle_tree::node::VNode::deserialize(
+                        &blob[21..21 + data_len],
+                    )
+                    .expect("fixture vnode should decode before rewriting");
+                    let legacy = rmp_serde::to_vec(&LegacyVNodeData {
+                        hash: *vnode.hash(),
+                        node_type: MerkleTreeNodeType::VNode,
+                    })
+                    .expect("legacy vnode should serialize");
+
+                    let mut rewritten = blob[..17].to_vec();
+                    rewritten.extend_from_slice(&(legacy.len() as u32).to_le_bytes());
+                    rewritten.extend_from_slice(&legacy);
+                    rewritten.extend_from_slice(&blob[21 + data_len..]);
+                    std::fs::write(&node_file, rewritten)?;
+                    planted = true;
+                    break;
+                }
+                if planted {
+                    break;
+                }
+            }
+            assert!(planted, "fixture repo should contain a vnode to rewrite");
+
+            let scanned = scan_node_format(&repo)?;
+            assert_eq!(
+                scanned.pre_v025.get(&MerkleTreeNodeType::VNode).copied(),
+                Some(1),
+                "the planted vnode should be counted against its own type, got {scanned:?}"
+            );
+            assert_eq!(scanned.pre_v025_total(), 1);
+            assert_eq!(
+                scanned.total_nodes, clean.total_nodes,
+                "node count is stable"
+            );
+            assert_eq!(
+                scanned.undecodable, 0,
+                "a retired format is not the same as an undecodable node"
             );
 
             Ok(())

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -502,7 +502,8 @@ impl error::ResponseError for OxenHttpError {
                     // declared min_version, which can disagree with the bytes actually on disk.
                     // This arm is reached when a node itself turns out to predate the format.
                     OxenError::MerkleDbError(MerkleDbError::PreV025Node { dtype, hash }) => {
-                        log::warn!("Pre-v0.25.0 merkle node {hash} ({dtype:?})");
+                        // Already logged where the node was classified, which also covers the
+                        // read paths that never reach an HTTP response.
                         let error_json = json!({
                             "error": {
                                 "type": "pre_v0_25_node_format",

--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -637,16 +637,31 @@ fn scan_node_format(
         }
     };
 
-    // Four outcomes, deliberately counted apart: they have different remedies. Pre-0.25 repos get
+    // Outcomes are counted apart because they have different remedies: pre-0.25 repos get
     // migrated, damaged and unscannable ones need a person, and unopenable ones are the
-    // `min_version` population a config sweep already finds.
-    let (mut scanned, mut affected, mut damaged, mut unopenable, mut unscannable) =
-        (0usize, 0usize, 0usize, 0usize, 0usize);
+    // `min_version` population a config sweep already finds. `unlistable` counts namespaces
+    // rather than repos — it is the one that says the totals below are incomplete.
+    let (mut scanned, mut affected, mut damaged, mut unopenable, mut unscannable, mut unlistable) =
+        (0usize, 0usize, 0usize, 0usize, 0usize, 0usize);
     let mut totals: BTreeMap<String, usize> = BTreeMap::new();
 
     'outer: for namespace_dir in namespaces {
-        let Ok(entries) = std::fs::read_dir(&namespace_dir) else {
-            continue;
+        // A namespace that cannot be listed hides an unknown number of repositories, so skipping
+        // it quietly would understate every total below with nothing to say so. Reported and
+        // counted rather than fatal: unlike the explicit-namespace case, which is a caller
+        // mistake with nothing left to do, one bad namespace should not cost the whole run.
+        let entries = match std::fs::read_dir(&namespace_dir) {
+            Ok(entries) => entries,
+            Err(err) => {
+                unlistable += 1;
+                let label = namespace_dir
+                    .strip_prefix(sync_dir)
+                    .unwrap_or(&namespace_dir)
+                    .display();
+                // KEEP as println! -- do not log!
+                println!("{label}\tcannot list namespace: {err}");
+                continue;
+            }
         };
         let mut repo_dirs: Vec<PathBuf> = entries
             .filter_map(|entry| entry.ok().map(|e| e.path()))
@@ -723,7 +738,8 @@ fn scan_node_format(
     // KEEP as println! -- do not log!
     println!(
         "\nscanned={scanned} pre_v0_25_repos={affected} damaged_repos={damaged} \
-         could_not_open={unopenable} could_not_scan={unscannable}"
+         could_not_open={unopenable} could_not_scan={unscannable} \
+         could_not_list_namespaces={unlistable}"
     );
     if !totals.is_empty() {
         let breakdown: Vec<String> = totals

--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -81,9 +81,14 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use clap::{Parser, Subcommand};
 
+use std::collections::BTreeMap;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+
+use liboxen::constants;
+use liboxen::model::LocalRepository;
+use liboxen::repositories;
 
 use crate::config::Config;
 use crate::config::storage_policy::StoragePolicyError;
@@ -380,6 +385,19 @@ enum ServerCommand {
         )]
         output: PathBuf,
     },
+
+    /// Report which repositories hold Merkle nodes predating the v0.25.0 on-disk format
+    #[command(name = "scan-node-format")]
+    ScanNodeFormat {
+        #[arg(long = "namespace", help = "Limit the scan to a single namespace")]
+        namespace: Option<String>,
+
+        #[arg(
+            long = "limit",
+            help = "Stop after scanning this many repositories, for sampling a large fleet"
+        )]
+        limit: Option<usize>,
+    },
 }
 
 /// Initialize Sentry crash reporting when `dsn` is set (from `SENTRY_DSN`). Hold the returned
@@ -467,6 +485,11 @@ enum ServerError {
     },
     #[error("{0}")]
     StoragePolicy(#[from] StoragePolicyError),
+    #[error("No such namespace {namespace:?} under sync dir {sync_dir:?}")]
+    NamespaceNotFound {
+        namespace: String,
+        sync_dir: PathBuf,
+    },
     #[cfg(feature = "metrics")]
     #[error("Invalid OXEN_METRICS_PORT value: {0} (parsing error: {1})")]
     InvalidPort(String, std::num::ParseIntError),
@@ -562,7 +585,154 @@ async fn server() -> Result<(), ServerError> {
             );
             Ok(())
         }
+
+        ServerCommand::ScanNodeFormat { namespace, limit } => {
+            scan_node_format(&sync_dir, namespace.as_deref(), limit)
+        }
     }
+}
+
+/// Whether `path` is a directory and not a symlink to one.
+///
+/// Uses `metadata.is_dir()` rather than `path.is_dir()` to avoid following symlinks — Oxen does
+/// not track them, and a symlinked namespace or repo would otherwise be walked as though it were
+/// a second copy, counting the same repository twice.
+fn is_real_dir(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false)
+}
+
+/// Walk repositories under `sync_dir` and report which hold pre-v0.25.0 Merkle nodes.
+///
+/// Read-only. Repositories the current build refuses to open at all are counted separately from
+/// those that open but contain unreadable nodes: the two have different remedies, and only the
+/// second is invisible to a `min_version` check.
+fn scan_node_format(
+    sync_dir: &Path,
+    namespace: Option<&str>,
+    limit: Option<usize>,
+) -> Result<(), ServerError> {
+    let namespaces = match namespace {
+        // Fail loudly on a namespace that isn't there. Left to the walk below it would read_dir,
+        // fail, and be skipped, printing a zero summary indistinguishable from a clean namespace
+        // — the one output a caller must be able to trust.
+        Some(one) => {
+            let namespace_dir = sync_dir.join(one);
+            if !is_real_dir(&namespace_dir) {
+                return Err(ServerError::NamespaceNotFound {
+                    namespace: one.to_string(),
+                    sync_dir: sync_dir.to_path_buf(),
+                });
+            }
+            vec![namespace_dir]
+        }
+        None => {
+            let mut dirs: Vec<PathBuf> = std::fs::read_dir(sync_dir)?
+                .filter_map(|entry| entry.ok().map(|e| e.path()))
+                .filter(|path| is_real_dir(path))
+                .collect();
+            dirs.sort();
+            dirs
+        }
+    };
+
+    // Four outcomes, deliberately counted apart: they have different remedies. Pre-0.25 repos get
+    // migrated, damaged and unscannable ones need a person, and unopenable ones are the
+    // `min_version` population a config sweep already finds.
+    let (mut scanned, mut affected, mut damaged, mut unopenable, mut unscannable) =
+        (0usize, 0usize, 0usize, 0usize, 0usize);
+    let mut totals: BTreeMap<String, usize> = BTreeMap::new();
+
+    'outer: for namespace_dir in namespaces {
+        let Ok(entries) = std::fs::read_dir(&namespace_dir) else {
+            continue;
+        };
+        let mut repo_dirs: Vec<PathBuf> = entries
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|path| is_real_dir(path) && is_real_dir(&path.join(constants::OXEN_HIDDEN_DIR)))
+            .collect();
+        repo_dirs.sort();
+
+        for repo_dir in repo_dirs {
+            if limit.is_some_and(|max| scanned >= max) {
+                break 'outer;
+            }
+            scanned += 1;
+            let label = repo_dir
+                .strip_prefix(sync_dir)
+                .unwrap_or(&repo_dir)
+                .display()
+                .to_string();
+
+            let repo = match LocalRepository::from_dir(&repo_dir) {
+                Ok(repo) => repo,
+                Err(err) => {
+                    unopenable += 1;
+                    // KEEP as println! -- do not log!
+                    println!("{label}\tcannot open: {err}");
+                    continue;
+                }
+            };
+
+            // One unreadable repo must not end a fleet-wide scan: the caller loses every count
+            // gathered so far, and a truncated run looks much like a short one.
+            let report = match repositories::fsck::scan_node_format(&repo) {
+                Ok(report) => report,
+                Err(err) => {
+                    unscannable += 1;
+                    // KEEP as println! -- do not log!
+                    println!("{label}\tcannot scan: {err}");
+                    continue;
+                }
+            };
+
+            let has_legacy = report.is_affected();
+            let has_damage = report.undecodable > 0;
+            if !has_legacy && !has_damage {
+                continue;
+            }
+            if has_legacy {
+                affected += 1;
+            }
+            if has_damage {
+                damaged += 1;
+            }
+            let mut by_type: Vec<String> = report
+                .pre_v025
+                .iter()
+                .map(|(dtype, count)| {
+                    *totals.entry(format!("{dtype:?}")).or_default() += count;
+                    format!("{dtype:?}={count}")
+                })
+                .collect();
+            by_type.sort();
+            if report.undecodable > 0 {
+                by_type.push(format!("undecodable={}", report.undecodable));
+            }
+            // KEEP as println! -- do not log!
+            println!(
+                "{label}\tnodes={}\tpre_v0_25={}\t{}",
+                report.total_nodes,
+                report.pre_v025_total(),
+                by_type.join(" ")
+            );
+        }
+    }
+
+    // KEEP as println! -- do not log!
+    println!(
+        "\nscanned={scanned} pre_v0_25_repos={affected} damaged_repos={damaged} \
+         could_not_open={unopenable} could_not_scan={unscannable}"
+    );
+    if !totals.is_empty() {
+        let breakdown: Vec<String> = totals
+            .iter()
+            .map(|(dtype, count)| format!("{dtype}={count}"))
+            .collect();
+        println!("pre-v0.25.0 nodes by type: {}", breakdown.join(" "));
+    }
+    Ok(())
 }
 
 /// Initialize the Prometheus metrics server on the port specified by `OXEN_METRICS_PORT`.


### PR DESCRIPTION
Add a way to scan and report repositories with pre-v0.25.0-format merkle nodes.

Another PR will add a migration to fix them.

ENG-1470
ENG-1488