### PR TITLE
Share one LOCK-collision retry across the four RocksDB handle registries

### DIFF
--- a/crates/liboxen/src/core/db.rs
+++ b/crates/liboxen/src/core/db.rs
@@ -1,7 +1,24 @@
 //! Interacting with the oxen databases
 //!
 
+use std::time::Duration;
+
 pub mod data_frames;
 pub mod dir_hashes;
 pub mod key_val;
 pub mod merkle_node;
+
+/// How long a weak-handle registry waits out a concurrent close before surfacing a LOCK error.
+pub const OPEN_RETRIES: u32 = 100;
+pub const OPEN_RETRY_INTERVAL: Duration = Duration::from_millis(2);
+
+/// True if `err` is a RocksDB LOCK-file collision — i.e. another opener still holds the
+/// per-directory LOCK. The check is by error-message match rather than a distinct
+/// `ErrorKind` because RocksDB surfaces this as a plain `IOError` across platforms
+/// (Unix "While lock file: …/LOCK: Resource temporarily unavailable",
+/// same-process "lock hold by current process, acquire time …: …/LOCK: No locks available",
+/// Windows "Failed to create lock file: …\\LOCK: The process cannot access the file…").
+pub fn is_lock_collision(err: &rocksdb::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("LOCK") || msg.contains("lock file")
+}

--- a/crates/liboxen/src/core/db.rs
+++ b/crates/liboxen/src/core/db.rs
@@ -12,13 +12,61 @@ pub mod merkle_node;
 pub const OPEN_RETRIES: u32 = 100;
 pub const OPEN_RETRY_INTERVAL: Duration = Duration::from_millis(2);
 
-/// True if `err` is a RocksDB LOCK-file collision — i.e. another opener still holds the
-/// per-directory LOCK. The check is by error-message match rather than a distinct
-/// `ErrorKind` because RocksDB surfaces this as a plain `IOError` across platforms
-/// (Unix "While lock file: …/LOCK: Resource temporarily unavailable",
+/// True if `err` is a RocksDB LOCK-file collision, i.e. another opener still holds the
+/// per-directory LOCK. Matched on the message rather than a distinct `ErrorKind` because
+/// RocksDB surfaces every lock failure as a plain `IOError`:
+/// Unix "While lock file: …/LOCK: Resource temporarily unavailable",
 /// same-process "lock hold by current process, acquire time …: …/LOCK: No locks available",
-/// Windows "Failed to create lock file: …\\LOCK: The process cannot access the file…").
+/// Windows "Failed to create lock file: …\\LOCK: <system message>" (the Windows text is
+/// locale-dependent, so that prefix also covers other failures to open the LOCK file).
 pub fn is_lock_collision(err: &rocksdb::Error) -> bool {
     let msg = err.to_string();
-    msg.contains("LOCK") || msg.contains("lock file")
+    msg.contains("While lock file")
+        || msg.contains("lock hold by current process")
+        || msg.contains("Failed to create lock file")
+}
+
+#[cfg(test)]
+mod tests {
+    use rocksdb::{DBWithThreadMode, MultiThreaded};
+
+    use super::*;
+    use crate::error::OxenError;
+    use crate::test;
+
+    #[test]
+    fn test_is_lock_collision_on_a_held_lock() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let db_path = dir.join("db");
+            let _held: DBWithThreadMode<MultiThreaded> =
+                DBWithThreadMode::open(&key_val::opts::default(), &db_path)?;
+
+            let err = DBWithThreadMode::<MultiThreaded>::open(&key_val::opts::default(), &db_path)
+                .expect_err("a second open of a locked path must fail");
+            assert!(
+                is_lock_collision(&err),
+                "expected a LOCK collision, got: {err}"
+            );
+
+            Ok(())
+        })
+    }
+
+    /// An unrelated failure whose path happens to contain "LOCK" is not a collision.
+    #[test]
+    fn test_is_lock_collision_ignores_lock_in_the_path() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let db_path = dir.join("LOCK").join("db");
+            let mut opts = key_val::opts::default();
+            opts.create_if_missing(false);
+
+            let err = DBWithThreadMode::<MultiThreaded>::open(&opts, &db_path)
+                .expect_err("opening a missing db without create_if_missing must fail");
+            let msg = err.to_string();
+            assert!(msg.contains("LOCK"), "path missing from the error: {msg}");
+            assert!(!is_lock_collision(&err), "misread as a collision: {msg}");
+
+            Ok(())
+        })
+    }
 }

--- a/crates/liboxen/src/core/db.rs
+++ b/crates/liboxen/src/core/db.rs
@@ -33,6 +33,7 @@ mod tests {
     use super::*;
     use crate::error::OxenError;
     use crate::test;
+    use crate::util;
 
     #[test]
     fn test_is_lock_collision_on_a_held_lock() -> Result<(), OxenError> {
@@ -64,6 +65,29 @@ mod tests {
                 .expect_err("opening a missing db without create_if_missing must fail");
             let msg = err.to_string();
             assert!(msg.contains("LOCK"), "path missing from the error: {msg}");
+            assert!(!is_lock_collision(&err), "misread as a collision: {msg}");
+
+            Ok(())
+        })
+    }
+
+    /// A LOCK path RocksDB cannot open as a file is not a collision. Unix only: the same setup
+    /// reports "Access is denied" on Windows, which is indistinguishable from a sharing
+    /// violation without matching localized system text.
+    #[cfg(unix)]
+    #[test]
+    fn test_is_lock_collision_ignores_an_unopenable_lock_path() -> Result<(), OxenError> {
+        test::run_empty_dir_test(|dir| {
+            let db_path = dir.join("db");
+            util::fs::create_dir_all(db_path.join("LOCK"))?;
+
+            let err = DBWithThreadMode::<MultiThreaded>::open(&key_val::opts::default(), &db_path)
+                .expect_err("a db whose LOCK path is a directory must fail to open");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("while open a file for lock"),
+                "expected a failure to open the LOCK file, got: {msg}"
+            );
             assert!(!is_lock_collision(&err), "misread as a collision: {msg}");
 
             Ok(())

--- a/crates/liboxen/src/core/db.rs
+++ b/crates/liboxen/src/core/db.rs
@@ -33,6 +33,7 @@ mod tests {
     use super::*;
     use crate::error::OxenError;
     use crate::test;
+    #[cfg(unix)]
     use crate::util;
 
     #[test]

--- a/crates/liboxen/src/core/refs/ref_manager.rs
+++ b/crates/liboxen/src/core/refs/ref_manager.rs
@@ -9,7 +9,6 @@ use std::path::{Path, PathBuf};
 use std::str;
 use std::sync::{Arc, LazyLock, Weak};
 use std::thread::sleep;
-use std::time::Duration;
 
 use parking_lot::{Mutex, RwLock};
 use rocksdb::{DB, IteratorMode};
@@ -33,10 +32,6 @@ use crate::util::fs::AtomicFile;
 // already hit zero); see [`with_ref_manager`] for the bounded-retry that waits it out.
 static DB_INSTANCES: LazyLock<Mutex<HashMap<PathBuf, Weak<RwLock<DB>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// How long `with_ref_manager` waits out a concurrent close before surfacing a LOCK error.
-const OPEN_RETRIES: u32 = 100;
-const OPEN_RETRY_INTERVAL: Duration = Duration::from_millis(2);
 
 /// Removes this repository's tombstone entry from the registry. Live entries (someone still
 /// holds the `Arc`) are unaffected; the DB closes when the last strong reference drops.
@@ -108,13 +103,13 @@ fn open_refs_db(refs_dir: &Path) -> Result<Arc<RwLock<DB>>, OxenError> {
                 instances.retain(|_, weak| weak.strong_count() > 0);
                 return Ok(arc_db);
             }
-            Err(err) if is_lock_collision(&err) => {
+            Err(err) if db::is_lock_collision(&err) => {
                 drop(instances);
                 attempts += 1;
-                if attempts >= OPEN_RETRIES {
+                if attempts >= db::OPEN_RETRIES {
                     return Err(refs_db_open_failed(refs_dir, err));
                 }
-                sleep(OPEN_RETRY_INTERVAL);
+                sleep(db::OPEN_RETRY_INTERVAL);
             }
             Err(err) => return Err(refs_db_open_failed(refs_dir, err)),
         }
@@ -124,16 +119,6 @@ fn open_refs_db(refs_dir: &Path) -> Result<Arc<RwLock<DB>>, OxenError> {
 fn lookup_live(refs_dir: &Path) -> Option<Arc<RwLock<DB>>> {
     let instances = DB_INSTANCES.lock();
     instances.get(refs_dir)?.upgrade()
-}
-
-/// True if `err` is a RocksDB LOCK-file collision — i.e. another opener still holds the
-/// per-directory LOCK. The check is by error-message match rather than a distinct
-/// `ErrorKind` because RocksDB surfaces this as a plain `IOError` across platforms
-/// (Unix "While lock file: …/LOCK: Resource temporarily unavailable",
-/// Windows "Failed to create lock file: …\\LOCK: The process cannot access the file…").
-fn is_lock_collision(err: &rocksdb::Error) -> bool {
-    let msg = err.to_string();
-    msg.contains("LOCK") || msg.contains("lock file")
 }
 
 fn refs_db_open_failed(refs_dir: &Path, source: rocksdb::Error) -> OxenError {

--- a/crates/liboxen/src/core/staged/staged_db_manager.rs
+++ b/crates/liboxen/src/core/staged/staged_db_manager.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::str;
 use std::sync::{Arc, LazyLock, Weak};
 use std::thread::sleep;
-use std::time::Duration;
 
 use indicatif::ProgressBar;
 use parking_lot::{Mutex, RwLock};
@@ -33,10 +32,6 @@ use crate::util;
 // see [`get_staged_db_manager`] for the bounded-retry that waits it out.
 static DB_INSTANCES: LazyLock<Mutex<HashMap<PathBuf, Weak<RwLock<DB>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// How long `get_staged_db_manager` waits out a concurrent close before surfacing a LOCK error.
-const OPEN_RETRIES: u32 = 100;
-const OPEN_RETRY_INTERVAL: Duration = Duration::from_millis(2);
 
 /// Removes this repository's tombstone entry from the registry. Live entries (someone still
 /// holds the `Arc`) are unaffected; the DB closes when the last strong reference drops.
@@ -129,13 +124,13 @@ fn open_staged_db(staged_db_dir: &Path) -> Result<Arc<RwLock<DB>>, OxenError> {
                 instances.retain(|_, weak| weak.strong_count() > 0);
                 return Ok(arc_db);
             }
-            Err(err) if is_lock_collision(&err) => {
+            Err(err) if db::is_lock_collision(&err) => {
                 drop(instances);
                 attempts += 1;
-                if attempts >= OPEN_RETRIES {
+                if attempts >= db::OPEN_RETRIES {
                     return Err(staged_db_open_failed(err));
                 }
-                sleep(OPEN_RETRY_INTERVAL);
+                sleep(db::OPEN_RETRY_INTERVAL);
             }
             Err(err) => return Err(staged_db_open_failed(err)),
         }
@@ -145,16 +140,6 @@ fn open_staged_db(staged_db_dir: &Path) -> Result<Arc<RwLock<DB>>, OxenError> {
 fn lookup_live(staged_db_dir: &Path) -> Option<Arc<RwLock<DB>>> {
     let instances = DB_INSTANCES.lock();
     instances.get(staged_db_dir)?.upgrade()
-}
-
-/// True if `err` is a RocksDB LOCK-file collision — i.e. another opener still holds the
-/// per-directory LOCK. The check is by error-message match rather than a distinct
-/// `ErrorKind` because RocksDB surfaces this as a plain `IOError` across platforms
-/// (Unix "While lock file: …/LOCK: Resource temporarily unavailable",
-/// Windows "Failed to create lock file: …\\LOCK: The process cannot access the file…").
-fn is_lock_collision(err: &rocksdb::Error) -> bool {
-    let msg = err.to_string();
-    msg.contains("LOCK") || msg.contains("lock file")
 }
 
 fn staged_db_open_failed(source: rocksdb::Error) -> OxenError {

--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use std::str;
 use std::sync::{Arc, LazyLock, Weak};
 use std::thread::sleep;
-use std::time::Duration;
 
 use glob::Pattern;
 use parking_lot::Mutex;
@@ -13,6 +12,7 @@ use time::OffsetDateTime;
 
 use crate::config::UserConfig;
 use crate::constants::COMMIT_COUNT_DIR;
+use crate::core::db;
 use crate::core::db::key_val::{opts, str_val_db};
 use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::refs::with_ref_manager;
@@ -766,10 +766,6 @@ fn list_recursive_with_depth(
 static COMMIT_COUNT_DBS: LazyLock<Mutex<HashMap<PathBuf, Weak<DBWithThreadMode<MultiThreaded>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// How long `open_commit_count_db` waits out a concurrent close before surfacing a LOCK error.
-const OPEN_RETRIES: u32 = 100;
-const OPEN_RETRY_INTERVAL: Duration = Duration::from_millis(2);
-
 /// Return the shared commit-count cache DB for `repo`, opening it on first access.
 /// Retries briefly on a LOCK-collision race with a concurrent close (see static docs).
 fn open_commit_count_db(
@@ -777,6 +773,7 @@ fn open_commit_count_db(
 ) -> Result<Arc<DBWithThreadMode<MultiThreaded>>, OxenError> {
     let db_path = util::fs::oxen_hidden_dir(&repo.path).join(COMMIT_COUNT_DIR);
 
+    // Fast path: a cache hit does no filesystem work.
     if let Some(db) = lookup_live_commit_count_db(&db_path) {
         return Ok(db);
     }
@@ -792,16 +789,17 @@ fn open_commit_count_db(
             Ok(db) => {
                 let db = Arc::new(db);
                 handles.insert(db_path, Arc::downgrade(&db));
+                // Drop tombstones left by handles whose last caller has already finished.
                 handles.retain(|_, weak| weak.strong_count() > 0);
                 return Ok(db);
             }
-            Err(err) if is_lock_collision(&err) => {
+            Err(err) if db::is_lock_collision(&err) => {
                 drop(handles);
                 attempts += 1;
-                if attempts >= OPEN_RETRIES {
+                if attempts >= db::OPEN_RETRIES {
                     return Err(OxenError::from(err));
                 }
-                sleep(OPEN_RETRY_INTERVAL);
+                sleep(db::OPEN_RETRY_INTERVAL);
             }
             Err(err) => return Err(OxenError::from(err)),
         }
@@ -811,14 +809,6 @@ fn open_commit_count_db(
 fn lookup_live_commit_count_db(db_path: &Path) -> Option<Arc<DBWithThreadMode<MultiThreaded>>> {
     let handles = COMMIT_COUNT_DBS.lock();
     handles.get(db_path)?.upgrade()
-}
-
-/// True if `err` is a RocksDB LOCK-file collision — i.e. another opener still holds the
-/// per-directory LOCK. Message match rather than a distinct `ErrorKind` because RocksDB
-/// surfaces this as a plain `IOError` across platforms.
-fn is_lock_collision(err: &rocksdb::Error) -> bool {
-    let msg = err.to_string();
-    msg.contains("LOCK") || msg.contains("lock file")
 }
 
 fn get_cached_count(
@@ -1351,7 +1341,7 @@ mod tests {
             )
             .expect_err("a second open of a locked path must fail");
             assert!(
-                is_lock_collision(&collision),
+                db::is_lock_collision(&collision),
                 "expected a LOCK collision, got: {collision}"
             );
 
@@ -1361,7 +1351,7 @@ mod tests {
             let err = open_commit_count_db(&repo).expect_err("open under a held LOCK must fail");
             let elapsed = start.elapsed();
             assert!(
-                elapsed >= OPEN_RETRY_INTERVAL * (OPEN_RETRIES - 1),
+                elapsed >= db::OPEN_RETRY_INTERVAL * (db::OPEN_RETRIES - 1),
                 "open gave up after {elapsed:?}, before exhausting its retries"
             );
             let msg = err.to_string();
@@ -1372,7 +1362,7 @@ mod tests {
 
             // Releasing the LOCK part way through the retry window lets the open through.
             let releaser = std::thread::spawn(move || {
-                sleep(OPEN_RETRY_INTERVAL * 10);
+                sleep(db::OPEN_RETRY_INTERVAL * 10);
                 drop(blocker);
             });
             open_commit_count_db(&repo)?;

--- a/crates/liboxen/src/core/workspaces/workspace_name_index.rs
+++ b/crates/liboxen/src/core/workspaces/workspace_name_index.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use std::str::{self, Utf8Error};
 use std::sync::{Arc, LazyLock, Weak};
 use std::thread::sleep;
-use std::time::Duration;
 
 use parking_lot::{Mutex, RwLock};
 use rocksdb::{DB, IteratorMode};
@@ -26,11 +25,6 @@ use crate::util;
 // serializes compound read-modify-write sequences; never hold its guard across `.await`.
 static DB_INSTANCES: LazyLock<Mutex<HashMap<PathBuf, Weak<RwLock<DB>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// How long `get_index` waits out a concurrent close before surfacing a LOCK error.
-/// See the retry loop in [`get_index`] for the race this covers.
-const OPEN_RETRIES: u32 = 100;
-const OPEN_RETRY_INTERVAL: Duration = Duration::from_millis(2);
 
 #[derive(Debug, thiserror::Error)]
 pub enum WsError {
@@ -126,13 +120,13 @@ pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, WsError> 
                 instances.retain(|_, weak| weak.strong_count() > 0);
                 return Ok(WorkspaceNameIndex { db: arc_db });
             }
-            Err(err) if is_lock_collision(&err) => {
+            Err(err) if db::is_lock_collision(&err) => {
                 drop(instances);
                 attempts += 1;
-                if attempts >= OPEN_RETRIES {
+                if attempts >= db::OPEN_RETRIES {
                     return Err(WsError::OpenError(err));
                 }
-                sleep(OPEN_RETRY_INTERVAL);
+                sleep(db::OPEN_RETRY_INTERVAL);
             }
             Err(err) => return Err(WsError::OpenError(err)),
         }
@@ -142,16 +136,6 @@ pub fn get_index(repo: &LocalRepository) -> Result<WorkspaceNameIndex, WsError> 
 fn lookup_live(dir: &Path) -> Option<Arc<RwLock<DB>>> {
     let instances = DB_INSTANCES.lock();
     instances.get(dir)?.upgrade()
-}
-
-/// True if `err` is a RocksDB LOCK-file collision — i.e. another opener still holds the
-/// per-directory LOCK. The check is by error-message match rather than a distinct
-/// `ErrorKind` because RocksDB surfaces this as a plain `IOError` across platforms
-/// (Unix "While lock file: …/LOCK: Resource temporarily unavailable",
-/// Windows "Failed to create lock file: …\\LOCK: The process cannot access the file…").
-fn is_lock_collision(err: &rocksdb::Error) -> bool {
-    let msg = err.to_string();
-    msg.contains("LOCK") || msg.contains("lock file")
 }
 
 impl WorkspaceNameIndex {

--- a/crates/oxen-server/src/controllers/commits.rs
+++ b/crates/oxen-server/src/controllers/commits.rs
@@ -28,6 +28,7 @@ use crate::helpers::{get_repo, get_repo_async};
 use crate::params::PageNumQuery;
 use crate::params::parse_resource_async;
 use crate::params::{app_data, maybe_parse_two_dot, path_param};
+use crate::tasks;
 
 use actix_web::{Error, HttpRequest, HttpResponse, web};
 use async_compression::tokio::bufread::GzipDecoder;
@@ -415,9 +416,15 @@ pub async fn parents(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHt
     let name = path_param(&req, "repo_name")?.to_string();
     let commit_or_branch = path_param(&req, "commit_or_branch")?.to_string();
     let repository = get_repo(app_data, namespace, name)?;
-    let commit = repositories::revisions::get(&repository, &commit_or_branch)?
-        .ok_or_else(|| OxenError::RevisionNotFound(commit_or_branch.into()))?;
-    let parents = repositories::commits::list_from(&repository, &commit.id)?;
+    // Resolving the revision and walking its history are sync RocksDB reads, and opening the
+    // commit-count cache can spin for the whole LOCK-retry window.
+    let parents = tasks::spawn_blocking(move || {
+        let commit = repositories::revisions::get(&repository, &commit_or_branch)?
+            .ok_or_else(|| OxenError::RevisionNotFound(commit_or_branch.into()))?;
+        repositories::commits::list_from(&repository, &commit.id)
+    })
+    .await
+    .map_err(OxenError::from)??;
     Ok(HttpResponse::Ok().json(ListCommitResponse {
         status: StatusMessage::resource_found(),
         commits: parents,
@@ -504,18 +511,26 @@ pub async fn download_dir_hashes_db(
 
     // Let user pass in base..head to download a range of commits
     // or we just get all the commits from the base commit to the first commit
-    let commits = match maybe_parse_two_dot(&base_head)? {
-        (base_commit_id, Some(head_commit_id)) => {
-            let base_commit = repositories::revisions::get(&repository, &base_commit_id)?
-                .ok_or_else(|| OxenError::RevisionNotFound(base_commit_id.into()))?;
-            let head_commit = repositories::revisions::get(&repository, &head_commit_id)?
-                .ok_or_else(|| OxenError::RevisionNotFound(head_commit_id.into()))?;
+    let range = maybe_parse_two_dot(&base_head)?;
 
-            repositories::commits::list_between(&repository, &base_commit, &head_commit)?
-        }
-        (revision, None) => repositories::commits::list_from(&repository, &revision)?,
-    };
-    let buffer = compress_commits(&repository, &commits)?;
+    // Resolving revisions, walking history, and tarring the dir_hashes DBs are all sync RocksDB
+    // and gzip work, and opening the commit-count cache can spin for the whole LOCK-retry window.
+    let buffer = tasks::spawn_blocking(move || -> Result<Vec<u8>, OxenError> {
+        let commits = match range {
+            (base_commit_id, Some(head_commit_id)) => {
+                let base_commit = repositories::revisions::get(&repository, &base_commit_id)?
+                    .ok_or_else(|| OxenError::RevisionNotFound(base_commit_id.into()))?;
+                let head_commit = repositories::revisions::get(&repository, &head_commit_id)?
+                    .ok_or_else(|| OxenError::RevisionNotFound(head_commit_id.into()))?;
+
+                repositories::commits::list_between(&repository, &base_commit, &head_commit)?
+            }
+            (revision, None) => repositories::commits::list_from(&repository, &revision)?,
+        };
+        compress_commits(&repository, &commits)
+    })
+    .await
+    .map_err(OxenError::from)??;
 
     Ok(HttpResponse::Ok().body(buffer))
 }

--- a/crates/oxen-server/src/controllers/tree.rs
+++ b/crates/oxen-server/src/controllers/tree.rs
@@ -365,43 +365,52 @@ pub async fn download_tree_nodes(
     );
 
     let (base_commit_id, maybe_head_commit_id) = maybe_parse_two_dot(&base_head_str)?;
-    let base_commit = repositories::commits::get_by_id(&repository, &base_commit_id)?
-        .ok_or_else(|| OxenError::RevisionNotFound(base_commit_id.into()))?;
 
     // Parse the subtrees
     let subtrees = get_subtree_paths(&query.subtrees)?;
+    let depth = query.depth;
 
-    // Could be a single commit or a range of commits
-    let commits = get_commit_list(&repository, &base_commit, &maybe_head_commit_id, &subtrees)?;
-    log::debug!("download_tree_nodes got {} commits", commits.len());
+    // Resolving the commits, collecting node hashes, and compressing them are all sync RocksDB
+    // and gzip work, and opening the commit-count cache can spin for the whole LOCK-retry window.
+    let buffer = tasks::spawn_blocking(move || -> Result<Vec<u8>, OxenError> {
+        let base_commit = repositories::commits::get_by_id(&repository, &base_commit_id)?
+            .ok_or_else(|| OxenError::RevisionNotFound(base_commit_id.into()))?;
 
-    let node_hashes = if maybe_head_commit_id.is_some() {
-        // Collect the new node hashes between the base and head commits
-        repositories::tree::get_node_hashes_between_commits(
-            &repository,
-            &commits,
-            &subtrees,
-            &query.depth,
-            is_download,
-        )?
-    } else {
-        // Collect all the node hashes for the commits
-        repositories::tree::get_all_node_hashes_for_commits(
-            &repository,
-            &commits,
-            &subtrees,
-            &query.depth,
-            is_download,
-        )?
-    };
+        // Could be a single commit or a range of commits
+        let commits = get_commit_list(&repository, &base_commit, &maybe_head_commit_id, &subtrees)?;
+        log::debug!("download_tree_nodes got {} commits", commits.len());
 
-    let buffer = repositories::tree::compress_nodes(&repository, &node_hashes)?;
-    let total_size: u64 = u64::try_from(buffer.len()).unwrap_or(u64::MAX);
-    log::debug!(
-        "Compressed {} commits size is {}",
-        commits.len(),
-        ByteSize::b(total_size)
-    );
+        let node_hashes = if maybe_head_commit_id.is_some() {
+            // Collect the new node hashes between the base and head commits
+            repositories::tree::get_node_hashes_between_commits(
+                &repository,
+                &commits,
+                &subtrees,
+                &depth,
+                is_download,
+            )?
+        } else {
+            // Collect all the node hashes for the commits
+            repositories::tree::get_all_node_hashes_for_commits(
+                &repository,
+                &commits,
+                &subtrees,
+                &depth,
+                is_download,
+            )?
+        };
+
+        let buffer = repositories::tree::compress_nodes(&repository, &node_hashes)?;
+        let total_size: u64 = u64::try_from(buffer.len()).unwrap_or(u64::MAX);
+        log::debug!(
+            "Compressed {} commits size is {}",
+            commits.len(),
+            ByteSize::b(total_size)
+        );
+        Ok(buffer)
+    })
+    .await
+    .map_err(OxenError::from)??;
 
     Ok(HttpResponse::Ok().body(buffer))
 }


### PR DESCRIPTION
The retry that waits out a closing RocksDB handle now has a single definition, so a new
weak-handle registry can no longer silently omit the retry that
makes it safe.

The refs, staged, workspace-name-index, and commit-count registries each carried their own copy
of the retry ceiling, the retry interval, and the message-matching lock-collision predicate. All
three now live in core::db and every registry calls into them.

ENG-1471