### PR TITLE
Serve repositories whose Merkle nodes were written before v0.25.0

### DIFF
--- a/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
+++ b/crates/liboxen/src/core/db/merkle_node/merkle_node_db.rs
@@ -128,6 +128,21 @@ pub(crate) fn suppress_retired_format_logging() -> RetiredFormatLogGuard {
     RetiredFormatLogGuard { restore_to }
 }
 
+/// Whether this payload was written before the node types gained their enum envelope.
+///
+/// The single definition of "pre-v0.25.0 on disk". Both formats decode, so a read's success says
+/// nothing about which one it was — this is what tells them apart, for the classifier below and
+/// for anything counting the population still awaiting migration.
+///
+/// `FileChunk` never had an envelope, so the tag says nothing about it. A payload carrying an
+/// envelope that names some variant this build does not know is not *older* than v0.25.0, so it
+/// is excluded too.
+pub(crate) fn is_pre_v025_payload(dtype: MerkleTreeNodeType, data: &[u8]) -> bool {
+    dtype != MerkleTreeNodeType::FileChunk
+        && !data.starts_with(CURRENT_NODE_PAYLOAD_TAG)
+        && !data.starts_with(NODE_ENVELOPE_PREFIX)
+}
+
 /// Classify a failure to decode a node payload. A payload carrying no variant tag was written
 /// before the node types gained their enum envelope, which is a property of the repository rather
 /// than a damaged node; telling the two apart keeps a retired format from looking like corruption.
@@ -141,10 +156,7 @@ fn classify_decode_failure(
     data: &[u8],
     err: rmp_serde::decode::Error,
 ) -> MerkleDbError {
-    if dtype != MerkleTreeNodeType::FileChunk
-        && !data.starts_with(CURRENT_NODE_PAYLOAD_TAG)
-        && !data.starts_with(NODE_ENVELOPE_PREFIX)
-    {
+    if is_pre_v025_payload(dtype, data) {
         // Logged where the condition is detected rather than where it surfaces: callers that
         // discard the error still leave a trace, and a repository read from a warm node cache
         // reports the first time it actually reaches disk.
@@ -604,8 +616,10 @@ mod to_node_tests {
     use super::*;
     use crate::model::merkle_tree::node::{CommitNode, DirNode, FileChunkNode, VNode};
 
+    const HASH_VALUE: u128 = 42;
+
     fn hash() -> MerkleHash {
-        MerkleHash::new(42)
+        MerkleHash::new(HASH_VALUE)
     }
 
     // `CURRENT_NODE_PAYLOAD_TAG` is ten bytes of hand-written assumption about what `rmp_serde`
@@ -638,16 +652,37 @@ mod to_node_tests {
     }
 
     #[test]
-    fn untagged_payload_reports_the_retired_format() {
+    fn a_pre_v025_payload_reads_through_the_legacy_fallback() {
         // The pre-0.25 shape: the bare data struct, with no enum envelope around it.
         // Built positionally rather than from a struct so the test pins the bytes, not a type
         // that could drift alongside the code under test.
+        // A hash inside the msgpack payload is a `u128` encoded big-endian, which is the opposite
+        // of the container header around it — that one writes hashes with `to_le_bytes`.
         let mut legacy = vec![0x92, 0xc4, 0x10];
-        legacy.extend_from_slice(&hash().to_le_bytes());
+        legacy.extend_from_slice(&HASH_VALUE.to_be_bytes());
         legacy.extend_from_slice(b"\xa5VNode");
 
-        let err = MerkleNodeDB::to_node(MerkleTreeNodeType::VNode, hash(), &legacy)
-            .expect_err("an untagged payload must not decode");
+        let node = MerkleNodeDB::to_node(MerkleTreeNodeType::VNode, hash(), &legacy)
+            .expect("a pre-0.25 payload must read");
+
+        let EMerkleTreeNode::VNode(vnode) = node else {
+            panic!("expected a vnode, got {node:?}");
+        };
+        assert_eq!(*vnode.hash(), hash());
+        // The old shape carries no entry count and a listing does not need one — it counts what
+        // it returns. Deriving the real value belongs to the migration that rewrites these nodes.
+        assert_eq!(vnode.num_entries(), 0);
+    }
+
+    #[test]
+    fn untagged_bytes_of_no_known_shape_report_the_retired_format() {
+        // No envelope, and not readable as the pre-0.25 struct either. The classifier still has
+        // something useful to say about these: they predate the format and cannot be recovered,
+        // which is a different problem from a damaged current-format node.
+        let untagged = vec![0x92, 0xc1, 0xc1];
+
+        let err = MerkleNodeDB::to_node(MerkleTreeNodeType::VNode, hash(), &untagged)
+            .expect_err("bytes of no known shape must not decode");
 
         assert!(
             matches!(err, MerkleDbError::PreV025Node { .. }),

--- a/crates/liboxen/src/model/merkle_tree/node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node.rs
@@ -7,6 +7,7 @@ pub mod file_chunk_node;
 pub mod file_node;
 pub mod file_node_types;
 pub mod file_node_with_dir;
+pub mod legacy_pre_025;
 pub mod merkle_tree_node;
 pub mod merkle_tree_node_cache;
 pub mod staged_merkle_tree_node;

--- a/crates/liboxen/src/model/merkle_tree/node/dir_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/dir_node.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 use crate::core::v_latest::model::merkle_tree::node::dir_node::DirNodeData as DirNodeDataV0_25_0;
 use crate::error::OxenError;
+use crate::model::merkle_tree::node::legacy_pre_025::DirNodeDataPre025;
 use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode};
 use crate::view::DataTypeCount;
 
@@ -86,7 +87,20 @@ impl DirNode {
 
     #[inline(always)]
     pub fn deserialize(data: &[u8]) -> Result<DirNode, rmp_serde::decode::Error> {
-        rmp_serde::from_slice(data)
+        match rmp_serde::from_slice(data) {
+            Ok(dir_node) => Ok(dir_node),
+            Err(primary_error) => {
+                // Payloads written before v0.25.0 are the bare data struct with no envelope.
+                match rmp_serde::from_slice::<DirNodeDataPre025>(data) {
+                    Ok(legacy) => Ok(Self {
+                        node: EDirNode::V0_25_0(legacy.into()),
+                    }),
+                    // Report why the current shape failed, not why the older one did — the
+                    // second attempt is a fallback, so its error describes the wrong thing.
+                    Err(_) => Err(primary_error),
+                }
+            }
+        }
     }
 
     fn node(&self) -> &dyn TDirNode {

--- a/crates/liboxen/src/model/merkle_tree/node/legacy_pre_025.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/legacy_pre_025.rs
@@ -1,0 +1,67 @@
+//! Node payload shapes from before v0.25.0, kept so repositories written then stay readable.
+//!
+//! Harvested verbatim from `aa8f564b8^:crates/liboxen/src/core/v_old/v0_19_0/model/merkle_tree/`,
+//! the commit that deleted the old read path. Only the two shapes that actually changed live here:
+//! `CommitNodeData` kept the same seven fields in the same order and decodes unchanged, and
+//! `FileNode` already carries its own fallback.
+//!
+//! The difference from the current structs is one field. Both gained `num_entries`, which these
+//! payloads simply do not contain, so a conversion has to supply it. Reads do not need it — a
+//! directory listing counts the entries it actually returns — so the conversions below leave it
+//! zero, matching what the pre-removal code did. Deriving the real value belongs to the migration
+//! that rewrites these nodes, where the child counts are being walked anyway.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::core::v_latest::model::merkle_tree::node::dir_node::DirNodeData;
+use crate::core::v_latest::model::merkle_tree::node::vnode::VNodeData;
+use crate::model::{MerkleHash, MerkleTreeNodeType};
+
+/// A vnode as written before v0.25.0: no `num_entries`.
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct VNodeDataPre025 {
+    pub hash: MerkleHash,
+    pub node_type: MerkleTreeNodeType,
+}
+
+impl From<VNodeDataPre025> for VNodeData {
+    fn from(legacy: VNodeDataPre025) -> Self {
+        VNodeData {
+            hash: legacy.hash,
+            node_type: legacy.node_type,
+            num_entries: 0,
+        }
+    }
+}
+
+/// A directory node as written before v0.25.0: no `num_entries`.
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct DirNodeDataPre025 {
+    pub node_type: MerkleTreeNodeType,
+    pub name: String,
+    pub hash: MerkleHash,
+    pub num_bytes: u64,
+    pub last_commit_id: MerkleHash,
+    pub last_modified_seconds: i64,
+    pub last_modified_nanoseconds: u32,
+    pub data_type_counts: HashMap<String, u64>,
+    pub data_type_sizes: HashMap<String, u64>,
+}
+
+impl From<DirNodeDataPre025> for DirNodeData {
+    fn from(legacy: DirNodeDataPre025) -> Self {
+        DirNodeData {
+            node_type: legacy.node_type,
+            name: legacy.name,
+            hash: legacy.hash,
+            num_entries: 0,
+            num_bytes: legacy.num_bytes,
+            last_commit_id: legacy.last_commit_id,
+            last_modified_seconds: legacy.last_modified_seconds,
+            last_modified_nanoseconds: legacy.last_modified_nanoseconds,
+            data_type_counts: legacy.data_type_counts,
+            data_type_sizes: legacy.data_type_sizes,
+        }
+    }
+}

--- a/crates/liboxen/src/model/merkle_tree/node/vnode.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/vnode.rs
@@ -7,6 +7,7 @@ use std::fmt;
 
 use crate::core::v_latest::model::merkle_tree::node::vnode::VNodeData as VNodeImplV0_25_0;
 use crate::error::OxenError;
+use crate::model::merkle_tree::node::legacy_pre_025::VNodeDataPre025;
 use crate::model::{MerkleHash, MerkleTreeNodeIdType, MerkleTreeNodeType, TMerkleTreeNode};
 
 pub trait TVNode {
@@ -44,7 +45,20 @@ impl VNode {
 
     #[inline(always)]
     pub fn deserialize(data: &[u8]) -> Result<VNode, rmp_serde::decode::Error> {
-        rmp_serde::from_slice(data)
+        match rmp_serde::from_slice(data) {
+            Ok(vnode) => Ok(vnode),
+            Err(primary_error) => {
+                // Payloads written before v0.25.0 are the bare data struct with no envelope.
+                match rmp_serde::from_slice::<VNodeDataPre025>(data) {
+                    Ok(legacy) => Ok(Self {
+                        node: EVNode::V0_25_0(legacy.into()),
+                    }),
+                    // Report why the current shape failed, not why the older one did — the
+                    // second attempt is a fallback, so its error describes the wrong thing.
+                    Err(_) => Err(primary_error),
+                }
+            }
+        }
     }
 
     pub fn get_opts(&self) -> VNodeOpts {

--- a/crates/liboxen/src/repositories/fsck.rs
+++ b/crates/liboxen/src/repositories/fsck.rs
@@ -91,9 +91,10 @@ pub fn scan_node_format(repo: &LocalRepository) -> Result<NodeFormatReport, Oxen
         // when the scan reaches those children by their own hashes.
         match MerkleNodeDB::open_read_only(store.clone(), &hash) {
             Ok(db) => {
-                if is_pre_v025_payload(db.dtype, &db.data()) {
+                let payload = db.data();
+                if is_pre_v025_payload(db.dtype, &payload) {
                     *report.pre_v025.entry(db.dtype).or_default() += 1;
-                } else if let Err(err) = db.node() {
+                } else if let Err(err) = EMerkleTreeNode::from_type_and_bytes(db.dtype, &payload) {
                     log::warn!("Node {hash} in {:?} did not decode: {err}", repo.path);
                     report.undecodable += 1;
                 }

--- a/crates/liboxen/src/repositories/fsck.rs
+++ b/crates/liboxen/src/repositories/fsck.rs
@@ -29,7 +29,7 @@ use crate::core::db::dir_hashes::dir_hashes_db::{
 };
 use crate::core::db::key_val::str_val_db;
 use crate::core::db::merkle_node::merkle_node_db::{
-    MerkleDbError, MerkleNodeDB, suppress_retired_format_logging,
+    MerkleNodeDB, is_pre_v025_payload, suppress_retired_format_logging,
 };
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::{EMerkleTreeNode, MerkleTreeNode, MerkleTreeNodeType};
@@ -69,8 +69,10 @@ impl NodeFormatReport {
 /// Read-only, and reads every node in the store, so cost scales with tree size. Works on either
 /// merkle-node backend, since it goes through the store rather than the on-disk file layout.
 ///
-/// This asks the same decoder the server uses, so its answer cannot drift from what a read
-/// actually does — which is the point of having it rather than matching bytes externally.
+/// Shares its definition of "pre-v0.25.0" with the read path rather than restating it, so the
+/// count cannot drift from what the server considers old. Note this is a question about the bytes,
+/// not about whether they decode: both formats read successfully, so a successful decode says
+/// nothing either way.
 pub fn scan_node_format(repo: &LocalRepository) -> Result<NodeFormatReport, OxenError> {
     // The report below names every node this would log, so leaving the warning on buries the
     // result under one line per affected node — order 10^5 across a fleet.
@@ -85,16 +87,19 @@ pub fn scan_node_format(repo: &LocalRepository) -> Result<NodeFormatReport, Oxen
     };
 
     for hash in hashes {
-        // Decoding this node's own payload is what classifies it; a node whose *children* are
-        // legacy is counted when the scan reaches those children by their own hashes.
-        let decoded = MerkleNodeDB::open_read_only(store.clone(), &hash).and_then(|db| db.node());
-        match decoded {
-            Ok(_) => {}
-            Err(MerkleDbError::PreV025Node { dtype, .. }) => {
-                *report.pre_v025.entry(dtype).or_default() += 1;
+        // Each node is judged on its own payload; a node whose *children* are legacy is counted
+        // when the scan reaches those children by their own hashes.
+        match MerkleNodeDB::open_read_only(store.clone(), &hash) {
+            Ok(db) => {
+                if is_pre_v025_payload(db.dtype, &db.data()) {
+                    *report.pre_v025.entry(db.dtype).or_default() += 1;
+                } else if let Err(err) = db.node() {
+                    log::warn!("Node {hash} in {:?} did not decode: {err}", repo.path);
+                    report.undecodable += 1;
+                }
             }
             Err(err) => {
-                log::warn!("Node {hash} in {:?} did not decode: {err}", repo.path);
+                log::warn!("Node {hash} in {:?} could not be opened: {err}", repo.path);
                 report.undecodable += 1;
             }
         }

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -3479,7 +3479,7 @@ mod tests {
                 .join(constants::NODES_DIR);
 
             // Rewrite the first dir node we find into the pre-0.25 shape, in place.
-            let mut rewrote = false;
+            let mut rewritten_hash: Option<MerkleHash> = None;
             for prefix in util::fs::list_dirs_in_dir(&nodes_dir)? {
                 for node_dir in util::fs::list_dirs_in_dir(&prefix)? {
                     let node_file = node_dir.join("node");
@@ -3510,30 +3510,43 @@ mod tests {
                     rewritten.extend_from_slice(&legacy);
                     rewritten.extend_from_slice(&blob[21 + data_len..]);
                     std::fs::write(&node_file, rewritten)?;
-                    rewrote = true;
+                    rewritten_hash = Some(*dir.hash());
                     break;
                 }
-                if rewrote {
+                if rewritten_hash.is_some() {
                     break;
                 }
             }
-            assert!(rewrote, "fixture repo should contain a dir node to rewrite");
+            let rewritten_hash =
+                rewritten_hash.expect("fixture repo should contain a dir node to rewrite");
 
             let node = repositories::tree::get_node_by_id_with_children(&repo, &commit_hash)?
                 .expect("the commit should still resolve with a pre-0.25 dir node in the tree");
 
-            // The listing has to come back whole, not merely without an error: the fallback
-            // supplies a zero entry count, and a walk that silently returned nothing would look
-            // just as successful from the outside.
-            let dirs = node
-                .children
-                .iter()
-                .filter(|child| matches!(child.node, EMerkleTreeNode::Directory(_)))
-                .count();
+            // The walk has to come back whole, not merely without an error — one that silently
+            // returned nothing would look just as successful from the outside. Reaching the
+            // directory's children is what opens the rewritten blob, which is why this walk
+            // failed outright before the fallback existed.
             assert!(
-                dirs > 0,
+                node.children.iter().any(|child| matches!(&child.node,
+                        EMerkleTreeNode::Directory(dir) if *dir.hash() == rewritten_hash)),
                 "the rewritten dir node should still appear among the commit's children"
             );
+
+            // Read by its own hash to reach the rewritten blob itself. The copy carried in the
+            // commit's `children` is still current-format and keeps the original count, so
+            // asserting on the child above would check the wrong bytes.
+            let recovered = repositories::tree::get_node_by_id(&repo, &rewritten_hash)?
+                .expect("the rewritten dir node should be readable by its own hash");
+            let EMerkleTreeNode::Directory(recovered) = &recovered.node else {
+                panic!("expected a directory, got {:?}", recovered.node);
+            };
+
+            // The pre-0.25 shape carries no entry count, so the conversion supplies zero. Pinned
+            // deliberately: the migration that rewrites these nodes has to replace it with a
+            // derived value, and this is what tells whoever does that they have changed a
+            // contract rather than an implementation detail.
+            assert_eq!(recovered.num_entries(), 0);
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -3471,7 +3471,9 @@ mod tests {
     // the decoder alone.
     #[tokio::test]
     async fn test_pre_v0_25_dir_node_is_still_readable() -> Result<(), OxenError> {
-        test::run_one_commit_local_repo_test_async(|repo| async move {
+        // FS-pinned: the rewrite below edits node blobs in the on-disk `tree/nodes` layout, which
+        // only the filesystem backend produces.
+        test::run_one_commit_local_repo_test_async_fs_backend(|repo| async move {
             let commit_hash: MerkleHash = repositories::commits::head_commit(&repo)?.id.parse()?;
 
             let nodes_dir = util::fs::oxen_hidden_dir(&repo.path)

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -3465,15 +3465,13 @@ mod tests {
         data_type_sizes: std::collections::HashMap<String, u64>,
     }
 
-    // A repo written before v0.25.0 must report *why* it cannot be read, not surface a raw
-    // msgpack error as a server fault. Reading such a node reaches the decode through
-    // `MerkleNodeDB::map`, which is a different call site than `MerkleNodeDB::node` — an earlier
-    // attempt at this classified only the latter and left the failure looking like corruption.
+    // A repository whose directory nodes predate v0.25.0 has to stay readable. The read reaches
+    // the decode through `MerkleNodeDB::map`, a different call site than `MerkleNodeDB::node`, and
+    // an earlier change here covered only the latter — so exercise the whole tree walk rather than
+    // the decoder alone.
     #[tokio::test]
-    async fn test_pre_v0_25_dir_node_is_reported_as_a_retired_format() -> Result<(), OxenError> {
+    async fn test_pre_v0_25_dir_node_is_still_readable() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {
-            // Resolve HEAD before corrupting anything: reading the commit also walks into the
-            // dir node, so afterwards even this lookup fails.
             let commit_hash: MerkleHash = repositories::commits::head_commit(&repo)?.id.parse()?;
 
             let nodes_dir = util::fs::oxen_hidden_dir(&repo.path)
@@ -3521,19 +3519,20 @@ mod tests {
             }
             assert!(rewrote, "fixture repo should contain a dir node to rewrite");
 
-            let err = repositories::tree::get_node_by_id_with_children(&repo, &commit_hash)
-                .expect_err("a pre-0.25 dir node must not read as though it were current");
+            let node = repositories::tree::get_node_by_id_with_children(&repo, &commit_hash)?
+                .expect("the commit should still resolve with a pre-0.25 dir node in the tree");
 
+            // The listing has to come back whole, not merely without an error: the fallback
+            // supplies a zero entry count, and a walk that silently returned nothing would look
+            // just as successful from the outside.
+            let dirs = node
+                .children
+                .iter()
+                .filter(|child| matches!(child.node, EMerkleTreeNode::Directory(_)))
+                .count();
             assert!(
-                matches!(
-                    err,
-                    OxenError::MerkleDbError(
-                        crate::core::db::merkle_node::merkle_node_db::MerkleDbError::PreV025Node {
-                            ..
-                        }
-                    )
-                ),
-                "expected PreV025Node, got {err:?}"
+                dirs > 0,
+                "the rewritten dir node should still appear among the commit's children"
             );
 
             Ok(())


### PR DESCRIPTION
This PR restores the ability to read pre-v0.25.0 merkle tree nodes.

I spot-checked 2,000 production repositories and ~18% of them still had merkle node payloads that were created before v0.25.0. This is because merkle node payloads have been passed back-and-forth as opaque binary blobs since pre-v0.25.0, and nothing ever transcoded them to the newer format. So, in v0.52.4 when we removed support for reading pre-v0.25.0 repositories, suddenly those repositories' old merkle nodes could no longer be read when we traversed back to them.

The next PR will add a migration to migrate pre-v0.25.0 merkle tree nodes to the current format.

ENG-1469