### PR TITLE
Keep upload file writes off the tokio runtime threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5673,6 +5673,7 @@ dependencies = [
  "astral-tokio-tar",
  "async-compression",
  "async_zip",
+ "bytes",
  "bytesize",
  "clap",
  "derive_more 1.0.0",

--- a/crates/liboxen/src/model/file.rs
+++ b/crates/liboxen/src/model/file.rs
@@ -1,5 +1,6 @@
 use super::User;
 
+use bytes::Bytes;
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -10,6 +11,16 @@ use utoipa::ToSchema;
 pub enum FileContents {
     Text(String),
     Binary(Vec<u8>),
+}
+
+impl FileContents {
+    /// The contents as bytes, reusing the existing allocation rather than copying.
+    pub fn into_bytes(self) -> Bytes {
+        match self {
+            FileContents::Text(text) => Bytes::from(text.into_bytes()),
+            FileContents::Binary(bytes) => Bytes::from(bytes),
+        }
+    }
 }
 
 impl Serialize for FileContents {

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -276,9 +276,9 @@ pub async fn create(
         Ok(())
     })?;
 
-    // If the user supplied files, add and commit them
-    if let Some(files) = new_repo.files.take() {
-        let user = files[0].user.clone();
+    // If the user supplied files, add and commit them. An empty list means none were supplied.
+    let files = new_repo.files.take().unwrap_or_default();
+    if let Some(user) = files.first().map(|file| file.user.clone()) {
         log::debug!("repositories::create files: {:?}", files.len());
         let payloads: Vec<(PathBuf, Bytes)> = files
             .into_iter()
@@ -422,6 +422,27 @@ mod tests {
 
             // Test that we can successful load a repository from that dir
             let _repo = LocalRepository::from_dir(&repo_path)?;
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_local_repository_api_create_with_an_empty_files_list() -> Result<(), OxenError> {
+        test::run_empty_dir_test_async(|sync_dir| async move {
+            let namespace: &str = "test-namespace";
+            let name: &str = "test-repo-name";
+
+            // A client can send `"files": []`, which must behave like sending no files at all.
+            let repo_new = RepoNew::from_files(namespace, name, vec![], None);
+            let repo = repositories::create(&sync_dir, repo_new, None).await?;
+
+            assert!(repo.path.exists());
+            assert!(
+                repositories::commits::list(&repo)?.is_empty(),
+                "an empty files list should not produce a commit"
+            );
 
             Ok(())
         })

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -11,15 +11,16 @@ use crate::core::refs::with_ref_manager;
 use crate::error::OxenError;
 use crate::model::Commit;
 use crate::model::LocalRepository;
-use crate::model::file::FileContents;
 use crate::model::merkle_tree;
 use crate::storage::S3Opts;
 use crate::util;
 use crate::util::fs::AtomicFile;
+use bytes::Bytes;
 use jwalk::WalkDir;
 use regex::Regex;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
+use tokio::task::spawn_blocking;
 
 pub mod add;
 pub mod branches;
@@ -213,7 +214,7 @@ fn is_valid_repo_name(name: &str) -> bool {
 
 pub async fn create(
     root_dir: &Path,
-    new_repo: RepoNew,
+    mut new_repo: RepoNew,
     server_s3_opts: Option<&S3Opts>,
 ) -> Result<LocalRepository, OxenError> {
     // Validate repo name
@@ -276,26 +277,30 @@ pub async fn create(
     })?;
 
     // If the user supplied files, add and commit them
-    if let Some(files) = &new_repo.files {
-        let user = &files[0].user;
-        // Add the files
+    if let Some(files) = new_repo.files.take() {
+        let user = files[0].user.clone();
         log::debug!("repositories::create files: {:?}", files.len());
-        for file in files {
-            let path = &file.path;
-            let contents = &file.contents;
-            // write the data to the path
-            // if the path does not exist within the repo, make it
-            let full_path = repo_dir.join(path);
-            let bytes = match contents {
-                FileContents::Text(text) => text.as_bytes(),
-                FileContents::Binary(bytes) => bytes.as_slice(),
-            };
-            AtomicFile::new(&full_path).write(bytes)?;
-            add(&local_repo, &full_path).await?;
+        let payloads: Vec<(PathBuf, Bytes)> = files
+            .into_iter()
+            .map(|file| (repo_dir.join(file.path), file.contents.into_bytes()))
+            .collect();
+        let paths: Vec<PathBuf> = payloads.iter().map(|(path, _)| path.clone()).collect();
+
+        // Every publish fsyncs, so the whole materialization runs in one offload.
+        spawn_blocking(move || {
+            for (path, bytes) in &payloads {
+                AtomicFile::new(path).write(bytes)?;
+            }
+            Ok::<(), OxenError>(())
+        })
+        .await??;
+
+        for path in &paths {
+            add(&local_repo, path).await?;
         }
 
         let commit =
-            core::v_latest::commits::commit_with_user(&local_repo, "Initial commit", user)?;
+            core::v_latest::commits::commit_with_user(&local_repo, "Initial commit", &user)?;
         branches::create(&local_repo, constants::DEFAULT_BRANCH_NAME, &commit.id)?;
     }
 

--- a/crates/oxen-server/Cargo.toml
+++ b/crates/oxen-server/Cargo.toml
@@ -31,6 +31,7 @@ actix-web-httpauth = { workspace = true }
 astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true }
 async_zip = { workspace = true }
+bytes = { workspace = true }
 bytesize = { workspace = true }
 clap = { workspace = true }
 derive_more = { workspace = true }

--- a/crates/oxen-server/src/controllers/file.rs
+++ b/crates/oxen-server/src/controllers/file.rs
@@ -6,6 +6,7 @@ use actix_multipart::form::text::Text;
 use actix_multipart::form::{FieldReader, Limits, MultipartForm};
 use actix_multipart::{Field, MultipartError};
 use actix_web::{HttpRequest, HttpResponse, web};
+use bytes::Bytes;
 use futures_util::TryStreamExt as _;
 use futures_util::future::LocalBoxFuture;
 use liboxen::core::repo_locks;
@@ -25,6 +26,7 @@ use liboxen::view::{CommitResponse, StatusMessage};
 use serde::Deserialize;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
+use tokio::task::spawn_blocking;
 use utoipa::ToSchema;
 
 #[derive(MultipartForm, ToSchema)]
@@ -333,7 +335,7 @@ pub async fn put(
         ensure_no_file_ancestors_in_tree(&repo, &commit, &file.path, &resource.path)?;
     }
 
-    process_and_add_files(&repo, Some(&workspace), &files).await?;
+    process_and_add_files(&repo, Some(&workspace), files).await?;
 
     // Commit workspace
     let commit_body = NewCommitBody {
@@ -572,12 +574,12 @@ async fn handle_initial_put_empty_repo(
     // If the user supplied files, add and commit them
     let mut commit: Option<Commit> = None;
 
-    process_and_add_files(repo, None, &files).await?;
+    let has_files = !files.is_empty();
+    process_and_add_files(repo, None, files).await?;
 
-    if !files.is_empty() {
-        let user_ref = &files[0].user; // Use the user from the first file, since it's the same for all
+    if has_files {
         let commit_message = message.unwrap_or_else(|| "Initial commit".to_string());
-        commit = Some(commits::commit_with_user(repo, &commit_message, user_ref)?);
+        commit = Some(commits::commit_with_user(repo, &commit_message, &user)?);
         branches::create(repo, &branch_name, &commit.as_ref().unwrap().id)?;
     }
 
@@ -747,31 +749,36 @@ fn ensure_no_file_ancestors_in_tree(
 async fn process_and_add_files(
     repo: &liboxen::model::LocalRepository,
     workspace: Option<&liboxen::repositories::workspaces::TemporaryWorkspace>,
-    files: &[FileNew],
+    files: Vec<FileNew>,
 ) -> Result<(), OxenError> {
-    if !files.is_empty() {
-        log::debug!("repositories::create files: {:?}", files.len());
-        for file in files {
-            let path = &file.path;
-            let contents = &file.contents;
+    if files.is_empty() {
+        return Ok(());
+    }
+    log::debug!("repositories::create files: {:?}", files.len());
+    let root = match workspace {
+        Some(ws) => ws.dir(),
+        None => repo.path.clone(),
+    };
+    let payloads: Vec<(PathBuf, Bytes)> = files
+        .into_iter()
+        .map(|file| (root.join(file.path), file.contents.into_bytes()))
+        .collect();
+    let paths: Vec<PathBuf> = payloads.iter().map(|(path, _)| path.clone()).collect();
 
-            let filepath = if let Some(ws) = workspace {
-                ws.dir().join(path)
-            } else {
-                repo.path.join(path)
-            };
+    // Every publish fsyncs, so the whole materialization runs in one offload.
+    spawn_blocking(move || {
+        for (path, bytes) in &payloads {
+            AtomicFile::new(path).write(bytes)?;
+        }
+        Ok::<(), OxenError>(())
+    })
+    .await??;
 
-            let bytes = match contents {
-                FileContents::Text(text) => text.as_bytes(),
-                FileContents::Binary(bytes) => bytes.as_slice(),
-            };
-            AtomicFile::new(&filepath).write(bytes)?;
-
-            if let Some(ws) = workspace {
-                repositories::workspaces::files::add(ws, &filepath).await?;
-            } else {
-                repositories::add(repo, &filepath).await?;
-            }
+    for filepath in &paths {
+        if let Some(ws) = workspace {
+            repositories::workspaces::files::add(ws, filepath).await?;
+        } else {
+            repositories::add(repo, filepath).await?;
         }
     }
     Ok(())


### PR DESCRIPTION
Repo creation and file uploads no longer stall unrelated requests while writing user-supplied files to disk. 

Both paths publish through `AtomicFile`, whose commit `fsync`s the temp file and then the parent directory, and both ran that inline on an actix worker, blocking every other task scheduled on it for the duration. Those writes now run on the blocking pool.

ENG-1481