### PR TITLE
Fix directory entry counts that miscounted subdirectories

### DIFF
--- a/crates/liboxen/src/model/merkle_tree/node/dir_node.rs
+++ b/crates/liboxen/src/model/merkle_tree/node/dir_node.rs
@@ -15,7 +15,7 @@ pub trait TDirNode {
     fn name(&self) -> &str;
     fn set_name(&mut self, name: &str);
     fn num_files(&self) -> u64; // This us just the number of files
-    fn num_entries(&self) -> u64; // This is the number of files and directories and vnodes
+    fn num_entries(&self) -> u64; // Number of files and sub directories in the directory
     fn set_num_entries(&mut self, num_entries: u64);
     fn num_bytes(&self) -> u64;
     fn last_commit_id(&self) -> &MerkleHash;
@@ -134,7 +134,7 @@ impl DirNode {
         self.data_type_counts().values().sum()
     }
 
-    /// Number of files and directories and vnodes
+    /// Number of files and sub directories in the directory
     pub fn num_entries(&self) -> u64 {
         self.node().num_entries()
     }

--- a/crates/liboxen/src/repositories/commits.rs
+++ b/crates/liboxen/src/repositories/commits.rs
@@ -285,6 +285,125 @@ mod tests {
 
     use super::*;
 
+    // A directory's stored entry count has to agree with what the directory actually holds,
+    // including after a subdirectory is removed. Both counts are asserted so neither can drift
+    // past the other unnoticed.
+    #[tokio::test]
+    async fn test_removing_a_subdirectory_updates_parent_num_entries() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test_async(|repo| async move {
+            util::fs::write_to_path(repo.path.join("top.txt"), "top")?;
+            test::populate_dir_with_txt_files(repo.path.join("d"), "f", 2)?;
+
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commit(&repo, "add top.txt and d/")?;
+
+            let root = repositories::tree::get_root_with_children(&repo, &commit)?
+                .expect("commit should have a tree");
+            let root_dir = repositories::tree::get_root_dir(&root)?;
+            assert_eq!(repositories::tree::count_dir_entries(root_dir)?, 2);
+            assert_eq!(root_dir.dir()?.num_entries(), 2);
+
+            let rm_opts = RmOpts {
+                path: PathBuf::from("d"),
+                recursive: true,
+                ..Default::default()
+            };
+            repositories::rm(&repo, &rm_opts).await?;
+            let commit = repositories::commit(&repo, "remove d/")?;
+
+            let root = repositories::tree::get_root_with_children(&repo, &commit)?
+                .expect("commit should have a tree");
+            let root_dir = repositories::tree::get_root_dir(&root)?;
+            assert_eq!(repositories::tree::count_dir_entries(root_dir)?, 1);
+            assert_eq!(root_dir.dir()?.num_entries(), 1);
+
+            Ok(())
+        })
+        .await
+    }
+
+    // Entry counts are held across a sequence that exercises every staged status a directory's
+    // children can carry: added, modified, unmodified, and removed, at the root and nested.
+    #[tokio::test]
+    async fn test_dir_num_entries_matches_contents_across_commits() -> Result<(), OxenError> {
+        // Assert the directory's stored count and the count its vnodes actually hold, so a wrong
+        // stored value can't hide behind a correct tree or the reverse.
+        fn assert_entries(
+            repo: &LocalRepository,
+            commit: &Commit,
+            dir: impl AsRef<Path>,
+            expected: u64,
+        ) -> Result<(), OxenError> {
+            let dir = dir.as_ref();
+            let node = repositories::tree::get_dir_with_children(repo, commit, dir, None)?
+                .unwrap_or_else(|| panic!("dir {dir:?} should exist in commit {}", commit.id));
+            assert_eq!(
+                repositories::tree::count_dir_entries(&node)?,
+                expected,
+                "true entry count for {dir:?} at commit {:?}",
+                commit.message
+            );
+            assert_eq!(
+                node.dir()?.num_entries(),
+                expected,
+                "stored num_entries for {dir:?} at commit {:?}",
+                commit.message
+            );
+            Ok(())
+        }
+
+        test::run_empty_local_repo_test_async(|repo| async move {
+            util::fs::write_to_path(repo.path.join("top.txt"), "top")?;
+            util::fs::create_dir_all(repo.path.join("a/b"))?;
+            util::fs::write_to_path(repo.path.join("a/1.txt"), "one")?;
+            util::fs::write_to_path(repo.path.join("a/b/2.txt"), "two")?;
+            util::fs::write_to_path(repo.path.join("a/b/3.txt"), "three")?;
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commit(&repo, "initial tree")?;
+
+            assert_entries(&repo, &commit, "", 2)?; // top.txt, a
+            assert_entries(&repo, &commit, "a", 2)?; // 1.txt, b
+            assert_entries(&repo, &commit, "a/b", 2)?; // 2.txt, 3.txt
+
+            // Add a file and modify another, leaving the rest unmodified
+            util::fs::write_to_path(repo.path.join("a/4.txt"), "four")?;
+            util::fs::write_to_path(repo.path.join("top.txt"), "top, revised")?;
+            repositories::add(&repo, &repo.path).await?;
+            let commit = repositories::commit(&repo, "add a/4.txt, modify top.txt")?;
+
+            assert_entries(&repo, &commit, "", 2)?;
+            assert_entries(&repo, &commit, "a", 3)?; // 1.txt, b, 4.txt
+            assert_entries(&repo, &commit, "a/b", 2)?;
+
+            // Remove a single file from the nested directory
+            let rm_opts = RmOpts {
+                path: PathBuf::from("a/b/2.txt"),
+                ..Default::default()
+            };
+            repositories::rm(&repo, &rm_opts).await?;
+            let commit = repositories::commit(&repo, "remove a/b/2.txt")?;
+
+            assert_entries(&repo, &commit, "", 2)?;
+            assert_entries(&repo, &commit, "a", 3)?;
+            assert_entries(&repo, &commit, "a/b", 1)?; // 3.txt
+
+            // Remove the nested directory outright
+            let rm_opts = RmOpts {
+                path: PathBuf::from("a/b"),
+                recursive: true,
+                ..Default::default()
+            };
+            repositories::rm(&repo, &rm_opts).await?;
+            let commit = repositories::commit(&repo, "remove a/b")?;
+
+            assert_entries(&repo, &commit, "", 2)?;
+            assert_entries(&repo, &commit, "a", 2)?; // 1.txt, 4.txt
+
+            Ok(())
+        })
+        .await
+    }
+
     #[tokio::test]
     async fn test_command_commit_file() -> Result<(), OxenError> {
         test::run_empty_local_repo_test_async(|repo| async move {

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -1005,6 +1005,9 @@ fn compute_dir_node(
     hasher.update(path.to_str().unwrap().as_bytes());
 
     let mut num_bytes = 0;
+    // Counted from the entries this directory actually ends up holding, rather than carried
+    // forward from the previous commit and adjusted. The vnodes below already hold the complete
+    // post-commit child set, with removals applied.
     let mut num_entries = 0;
     let mut data_type_counts: HashMap<String, u64> = HashMap::new();
     let mut data_type_sizes: HashMap<String, u64> = HashMap::new();
@@ -1019,7 +1022,6 @@ fn compute_dir_node(
             repositories::tree::get_dir_without_children(repo, head_commit, &path, Some(dir_hashes))
     {
         let old_dir_node = old_dir_node.dir().unwrap();
-        num_entries = old_dir_node.num_entries();
         num_bytes = old_dir_node.num_bytes();
         data_type_counts = old_dir_node.data_type_counts().clone();
         data_type_sizes = old_dir_node.data_type_sizes().clone();
@@ -1063,12 +1065,13 @@ fn compute_dir_node(
                         hasher.update(file_node.name().as_bytes());
                         hasher.update(&file_node.combined_hash().to_le_bytes());
 
+                        if path == *child {
+                            num_entries += 1;
+                        }
+
                         match entry.status {
                             StagedEntryStatus::Added => {
                                 num_bytes += file_node.num_bytes();
-                                if path == *child {
-                                    num_entries += 1;
-                                }
                                 *data_type_counts
                                     .entry(file_node.data_type().to_string())
                                     .or_insert(0) += 1;
@@ -1114,13 +1117,10 @@ fn compute_dir_node(
         for entry in removed_entries.iter() {
             match &entry.node.node {
                 EMerkleTreeNode::Directory(_) => {
-                    // Do nothing
+                    // Removed entries are already absent from the vnodes num_entries counts
                 }
                 EMerkleTreeNode::File(file_node) => {
                     if entry.status == StagedEntryStatus::Removed {
-                        if path == *child {
-                            num_entries -= 1;
-                        }
                         num_bytes = num_bytes.saturating_sub(file_node.num_bytes());
                         if let Some(count) =
                             data_type_counts.get_mut(&file_node.data_type().to_string())

--- a/crates/liboxen/src/repositories/tree.rs
+++ b/crates/liboxen/src/repositories/tree.rs
@@ -366,6 +366,27 @@ pub fn list_files_and_folders_map(
     Ok(children)
 }
 
+/// Number of files and directories directly inside a directory, counted from the entries its
+/// child VNodes actually hold rather than read from the directory's stored `num_entries`.
+///
+/// The node must already have its VNode children and their entries loaded.
+pub fn count_dir_entries(node: &MerkleTreeNode) -> Result<u64, OxenError> {
+    if MerkleTreeNodeType::Dir != node.node.node_type() {
+        return Err(OxenError::basic_str(format!(
+            "count_dir_entries Merkle tree node is not a directory: '{:?}'",
+            node.node.node_type()
+        )));
+    }
+
+    // The dir node will have vnode children, whose children are the entries
+    Ok(node
+        .children
+        .iter()
+        .filter(|child| matches!(child.node, EMerkleTreeNode::VNode(_)))
+        .map(|vnode| vnode.children.len() as u64)
+        .sum())
+}
+
 /// Will traverse the given paths and return the node hashes in the `hashes` HashSet<MerkleHash>
 /// If starting_node_hashes is provided, it will only add nodes that are not in the starting_node_hashes
 pub fn collect_nodes_along_path(


### PR DESCRIPTION
A directory's stored entry count over-reported, permanently and cumulatively. Each commit seeded the count from the previous one and then re-counted the directory's subdirectories on top of it, so any directory containing a subdirectory gained a phantom entry every time a commit rewrote it. Removing a subdirectory compounded this further, since only file removals ever decremented. `oxen tree` reported counts larger than the directory held.

The count is now taken from the entries the directory actually ends up holding rather than carried forward and adjusted. The vnodes available at that point already hold the complete post-commit child set with removals applied, and vnode entry counts were computed this way all along, which is why they stayed correct while directory counts drifted.

Directory listings were never affected. They count real entries rather than reading the stored field, so the visible reach was tree output and the value carried into the next commit. Existing repositories keep their drifted values in already-written nodes; recomputing them is left to the merkle node format migration, which reuses the true-count helper added here.

Also removes a latent underflow that the old subtraction could hit on directories whose stored count was zero, and corrects the `num_entries` documentation, which claimed the count included vnodes. It counts files and sub directories only.

Sentry: OXEN-SERVER-3