### PR TITLE
Return the merge base git would pick, and the same one every time

### DIFF
--- a/crates/liboxen/src/core/v_latest/merge.rs
+++ b/crates/liboxen/src/core/v_latest/merge.rs
@@ -1114,6 +1114,13 @@ fn create_empty_merge_commit(
     Ok(commit_node.to_commit())
 }
 
+/// The common ancestor of `base_commit` and `merge_commit` that is nearest to `base_commit`, or
+/// `None` when the two share no history.
+///
+/// A criss-cross history (each branch merged the other before either was pushed) leaves several
+/// common ancestors tied at that distance, all of them merge bases. The most recent one wins, as
+/// it does in git, and an equal timestamp falls back to the lowest commit id so the same pair of
+/// commits always resolves to the same base.
 pub fn lowest_common_ancestor_from_commits(
     repo: &LocalRepository,
     base_commit: &Commit,
@@ -1134,27 +1141,39 @@ pub fn lowest_common_ancestor_from_commits(
     let commit_depths_from_merge =
         repositories::commits::list_from_with_depth(repo, merge_commit.id.as_str())?;
 
-    // If the commits have no common ancestor (new repository), return None
-    let mut has_common_ancestor = false;
-    let mut min_depth = usize::MAX;
-    let mut lca: Commit = commit_depths_from_head.keys().next().unwrap().clone();
-    for commit in commit_depths_from_merge.keys() {
-        if let Some(depth) = commit_depths_from_head.get(commit) {
-            has_common_ancestor = true;
+    let common: Vec<(usize, &Commit)> = commit_depths_from_merge
+        .keys()
+        .filter_map(|commit| {
+            commit_depths_from_head
+                .get(commit)
+                .map(|depth| (*depth, commit))
+        })
+        .collect();
 
-            if depth < &min_depth {
-                min_depth = *depth;
-                log::debug!("setting new lca, {commit:?}");
-                lca = commit.clone();
-            }
-        }
-    }
+    // No shared history (e.g. unrelated repositories)
+    let Some(&(min_depth, _)) = common.iter().min_by_key(|(depth, _)| *depth) else {
+        return Ok(None);
+    };
 
-    if has_common_ancestor {
-        Ok(Some(lca))
-    } else {
-        Ok(None)
+    let mut merge_bases: Vec<&Commit> = common
+        .iter()
+        .filter(|(depth, _)| *depth == min_depth)
+        .map(|(_, commit)| *commit)
+        .collect();
+    merge_bases.sort_by(|a, b| b.timestamp.cmp(&a.timestamp).then_with(|| a.id.cmp(&b.id)));
+
+    let Some(lca) = merge_bases.first() else {
+        return Ok(None);
+    };
+    if merge_bases.len() > 1 {
+        log::warn!(
+            "multiple merge bases between {} and {}, using {}",
+            base_commit.id,
+            merge_commit.id,
+            lca.id
+        );
     }
+    Ok(Some((*lca).clone()))
 }
 
 /// Analyze a three-way merge between commits. Always returns conflicts and files changed on the

--- a/crates/liboxen/src/repositories/merge.rs
+++ b/crates/liboxen/src/repositories/merge.rs
@@ -254,6 +254,71 @@ mod tests {
         })
         .await
     }
+    /// A criss-cross history leaves two commits tied as merge bases. The depth maps backing the
+    /// search iterate in arbitrary order, so without a tie-break the same request resolved to a
+    /// different base call to call, and three-dot diffs built on it varied per request.
+    #[tokio::test]
+    async fn test_lowest_common_ancestor_is_deterministic_with_multiple_merge_bases()
+    -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let main_branch = repositories::branches::current_branch(&repo)?.unwrap();
+
+            repositories::branches::create_checkout(&repo, "X")?;
+            let x_path = repo.path.join("x.txt");
+            util::fs::write_to_path(&x_path, "x")?;
+            repositories::add(&repo, &x_path).await?;
+            let x1 = repositories::commit(&repo, "x1")?;
+
+            repositories::checkout(&repo, &main_branch.name).await?;
+            repositories::branches::create_checkout(&repo, "Y")?;
+            let y_path = repo.path.join("y.txt");
+            util::fs::write_to_path(&y_path, "y")?;
+            repositories::add(&repo, &y_path).await?;
+            let y1 = repositories::commit(&repo, "y1")?;
+
+            // Each side merges the other's commit, the way two collaborators merging in opposite
+            // directions before either pushes would. Both merges have exactly two parents.
+            let my = repositories::merge::merge_commit_into_base(&repo, &x1, &y1)
+                .await?
+                .expect("merging x1 into y1 should produce a commit");
+            repositories::checkout(&repo, "X").await?;
+            let mx = repositories::merge::merge_commit_into_base(&repo, &y1, &x1)
+                .await?
+                .expect("merging y1 into x1 should produce a commit");
+            assert_eq!(mx.parent_ids.len(), 2);
+            assert_eq!(my.parent_ids.len(), 2);
+
+            // x1 and y1 are both common ancestors one step from each merge, so this is the
+            // ambiguous case and not an accidentally-unique one. y1 was committed second, so
+            // the git rule (most recent merge base wins) selects it.
+            assert!(
+                y1.timestamp > x1.timestamp,
+                "y1 should be the newer merge base"
+            );
+            let expected = &y1.id;
+
+            let mut answers = std::collections::HashSet::new();
+            for _ in 0..200 {
+                let lca =
+                    repositories::merge::lowest_common_ancestor_from_commits(&repo, &mx, &my)?
+                        .expect("the two merges share history");
+                answers.insert(lca.id);
+            }
+            assert_eq!(
+                answers.len(),
+                1,
+                "the merge base must not vary between calls, got {answers:?}"
+            );
+            assert_eq!(
+                answers.iter().next().map(String::as_str),
+                Some(expected.as_str()),
+                "the most recent merge base should win, as it does in git"
+            );
+            Ok(())
+        })
+        .await
+    }
+
     #[tokio::test]
     async fn test_merge_get_lowest_common_ancestor() -> Result<(), OxenError> {
         test::run_one_commit_local_repo_test_async(|repo| async move {


### PR DESCRIPTION
Diffing two revisions with three-dot syntax could return a different result on each request. When two collaborators merge in opposite directions before either pushes, the history has two merge bases tied at the same distance, and the search picked whichever the backing hash maps happened to yield first.

The most recent merge base now wins, matching git's rule so a three-dot comparison of the same two revisions agrees between the two tools, with the lowest commit id breaking an exact timestamp tie where git falls back to its own walk order. An ambiguous base is logged the way git reports it, so an operator can see which one was chosen.