### PR TITLE
Identify which file is missing when the server cannot read its contents

### DIFF
--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -272,6 +272,14 @@ pub enum OxenError {
         target_path: PathBufError,
     },
 
+    /// A read of the version store found no file data for a file hash in the Merkle tree. On the
+    /// client, this may mean the content may need to be restored from the server. On the server,
+    /// this should never™ happen, but has happened in the past due to bugs (especially via
+    /// interrupted pushes) and can be recovered from by re-pushing the content with
+    /// "oxen push --missing-files" if the original content is still available.
+    #[error("Version store has no data for hash {hash}")]
+    VersionStoreBlobMissing { hash: String },
+
     /// A caller supplied a storage backend kind that isn't recognized.
     #[error("Unsupported storage kind: {0}")]
     UnsupportedStorageKind(String),
@@ -766,11 +774,16 @@ impl OxenError {
             VersionStoreDataMissing { .. } => {
                 "Run `oxen fetch --missing-files` to re-fetch missing version-store data, then retry `oxen restore`."
             }
+            VersionStoreBlobMissing { .. } => {
+                "Run `oxen fetch --missing-files` to re-fetch missing version-store data."
+            }
             RestoreFailed { failures } => {
-                if failures
-                    .iter()
-                    .any(|(_, err)| matches!(err.as_ref(), VersionStoreDataMissing { .. }))
-                {
+                if failures.iter().any(|(_, err)| {
+                    matches!(
+                        err.as_ref(),
+                        VersionStoreDataMissing { .. } | VersionStoreBlobMissing { .. }
+                    )
+                }) {
                     "Some files could not be restored because their version-store data is missing. Run `oxen fetch --missing-files` to re-fetch, then retry `oxen restore`."
                 } else {
                     "Run with RUST_LOG=debug for per-file details, or check `oxen status`."

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -882,6 +882,7 @@ impl OxenError {
             OxenError::ReachableObjectsMissing { .. } => true,
             OxenError::DirHashIndexMissing { .. } => true,
             OxenError::VersionStoreDataMissing { .. } => true,
+            OxenError::VersionStoreBlobMissing { .. } => true,
             OxenError::UnknownRemoteResponseStatus(_) => true,
             _ => false,
         }
@@ -1382,6 +1383,25 @@ mod tests {
             hashes: vec!["abc".to_string()],
         };
         assert!(err.is_fatal_for_retry());
+    }
+
+    #[test]
+    fn is_fatal_for_retry_short_circuits_on_missing_version_store_data() {
+        // A hash the store has no data for reads the same on every attempt, so backing off
+        // only delays the recovery guidance. Both spellings of the condition are fatal.
+        assert!(
+            OxenError::VersionStoreBlobMissing {
+                hash: "abc".to_string(),
+            }
+            .is_fatal_for_retry()
+        );
+        assert!(
+            OxenError::VersionStoreDataMissing {
+                hash: "abc".to_string(),
+                target_path: PathBuf::from("a.txt").into(),
+            }
+            .is_fatal_for_retry()
+        );
     }
 
     #[test]

--- a/crates/liboxen/src/storage/local.rs
+++ b/crates/liboxen/src/storage/local.rs
@@ -24,6 +24,20 @@ use tokio::sync::Semaphore;
 use tokio::task::spawn_blocking;
 use tokio_util::io::ReaderStream;
 
+/// Classifies a failed read of a version file. An absent file means the store holds no data for
+/// `hash`; every other cause keeps its message and names the file that could not be read, so a
+/// failure identifies the blob behind it rather than surfacing as a bare `NotFound`.
+fn version_read_error(hash: &str, path: &Path, source: io::Error) -> OxenError {
+    if source.kind() == ErrorKind::NotFound {
+        return OxenError::VersionStoreBlobMissing {
+            hash: hash.to_string(),
+        };
+    }
+    OxenError::InternalError(
+        format!("Failed to read version file {path:?} for hash {hash}: {source}").into(),
+    )
+}
+
 /// Local filesystem implementation of version storage
 #[derive(Debug)]
 pub struct LocalVersionStore {
@@ -133,13 +147,17 @@ impl VersionStore for LocalVersionStore {
 
     async fn get_version_size(&self, hash: &str) -> Result<u64, OxenError> {
         let path = self.version_path(hash);
-        let metadata = fs::metadata(&path).await?;
+        let metadata = fs::metadata(&path)
+            .await
+            .map_err(|source| version_read_error(hash, &path, source))?;
         Ok(metadata.len())
     }
 
     async fn get_version(&self, hash: &str) -> Result<Vec<u8>, OxenError> {
         let path = self.version_path(hash);
-        let data = fs::read(&path).await?;
+        let data = fs::read(&path)
+            .await
+            .map_err(|source| version_read_error(hash, &path, source))?;
         Ok(data)
     }
 
@@ -149,13 +167,17 @@ impl VersionStore for LocalVersionStore {
         derived_filename: &str,
     ) -> Result<u64, OxenError> {
         let path = self.version_dir(orig_hash).join(derived_filename);
-        let metadata = fs::metadata(&path).await?;
+        let metadata = fs::metadata(&path)
+            .await
+            .map_err(|source| version_read_error(orig_hash, &path, source))?;
         Ok(metadata.len())
     }
 
     async fn get_version_stream(&self, hash: &str) -> Result<BoxedByteStream, OxenError> {
         let path = self.version_path(hash);
-        let file = File::open(&path).await?;
+        let file = File::open(&path)
+            .await
+            .map_err(|source| version_read_error(hash, &path, source))?;
         let reader = BufReader::new(file);
         let stream = ReaderStream::new(reader);
 
@@ -168,7 +190,9 @@ impl VersionStore for LocalVersionStore {
         derived_filename: &str,
     ) -> Result<BoxedByteStream, OxenError> {
         let path = self.version_dir(orig_hash).join(derived_filename);
-        let file = File::open(&path).await?;
+        let file = File::open(&path)
+            .await
+            .map_err(|source| version_read_error(orig_hash, &path, source))?;
         let reader = BufReader::new(file);
         let stream = ReaderStream::new(reader);
 
@@ -307,7 +331,9 @@ impl VersionStore for LocalVersionStore {
     ) -> Result<Vec<u8>, OxenError> {
         let version_file_path = self.version_path(hash);
 
-        let mut file = File::open(&version_file_path).await?;
+        let mut file = File::open(&version_file_path)
+            .await
+            .map_err(|source| version_read_error(hash, &version_file_path, source))?;
         let metadata = file.metadata().await?;
         let file_len = metadata.len();
 
@@ -764,8 +790,8 @@ mod tests {
 
         match store.get_version(hash).await {
             Ok(_) => panic!("Expected error when getting non-existent version"),
-            Err(OxenError::IO(e)) => {
-                assert_eq!(e.kind(), io::ErrorKind::NotFound);
+            Err(OxenError::VersionStoreBlobMissing { hash: missing }) => {
+                assert_eq!(missing, hash);
             }
             Err(e) => {
                 panic!("Unexpected error when getting non-existent version: {e:?}");
@@ -846,8 +872,8 @@ mod tests {
 
         match store.get_version_chunk(hash, offset, size).await {
             Ok(_) => panic!("Expected error when getting non-existent chunk"),
-            Err(OxenError::IO(e)) => {
-                assert_eq!(e.kind(), io::ErrorKind::NotFound);
+            Err(OxenError::VersionStoreBlobMissing { hash: missing }) => {
+                assert_eq!(missing, hash);
             }
             Err(e) => {
                 panic!("Unexpected error when getting non-existent chunk: {e:?}");

--- a/crates/liboxen/src/storage/s3.rs
+++ b/crates/liboxen/src/storage/s3.rs
@@ -1,9 +1,11 @@
 use crate::error::OxenError;
 use async_trait::async_trait;
 use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::operation::get_object::GetObjectError;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier};
 use aws_sdk_s3::{Client, config::Region, primitives::ByteStream};
+use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use bytes::Bytes;
 use futures::stream;
 use futures::{StreamExt, TryStreamExt};
@@ -39,6 +41,41 @@ const DELETE_OBJECTS_MAX_KEYS: usize = 1000;
 pub struct S3Opts {
     pub bucket: String,
     pub region: String,
+}
+
+/// Classifies a failed `get_object`. An absent key means the store holds no data for `hash`;
+/// every other cause keeps its message and names the key that could not be read, so a failure
+/// identifies the blob behind it.
+fn object_read_error(
+    hash: &str,
+    key: &str,
+    err: SdkError<GetObjectError, HttpResponse>,
+) -> OxenError {
+    if let SdkError::ServiceError(service_err) = &err
+        && matches!(service_err.err(), GetObjectError::NoSuchKey(_))
+    {
+        return OxenError::VersionStoreBlobMissing {
+            hash: hash.to_string(),
+        };
+    }
+    OxenError::InternalError(format!("S3 get_object failed for key {key}: {err}").into())
+}
+
+/// Classifies a failed `head_object`. An absent key means the store holds no data for `hash`;
+/// every other cause keeps its message and names the key that could not be read.
+fn object_head_error(
+    hash: &str,
+    key: &str,
+    err: SdkError<HeadObjectError, HttpResponse>,
+) -> OxenError {
+    if let SdkError::ServiceError(service_err) = &err
+        && matches!(service_err.err(), HeadObjectError::NotFound(_))
+    {
+        return OxenError::VersionStoreBlobMissing {
+            hash: hash.to_string(),
+        };
+    }
+    OxenError::InternalError(format!("S3 head_object failed for key {key}: {err}").into())
 }
 
 /// S3 implementation of version storage
@@ -546,7 +583,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 head_object failed: {e}")))?;
+            .map_err(|e| object_head_error(hash, &key, e))?;
 
         let size = resp
             .content_length()
@@ -565,7 +602,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| object_read_error(hash, &key, e))?;
 
         let data = resp
             .body
@@ -592,7 +629,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 head_object failed: {e}")))?;
+            .map_err(|e| object_head_error(orig_hash, &key, e))?;
 
         let size = resp
             .content_length()
@@ -611,7 +648,7 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| object_read_error(hash, &key, e))?;
 
         let adapter = ByteStreamAdapter { inner: resp.body };
 
@@ -629,10 +666,10 @@ impl VersionStore for S3VersionStore {
         let resp = client
             .get_object()
             .bucket(&self.bucket)
-            .key(key)
+            .key(&key)
             .send()
             .await
-            .map_err(|e| OxenError::basic_str(format!("S3 get_object failed: {e}")))?;
+            .map_err(|e| object_read_error(orig_hash, &key, e))?;
 
         let adapter = ByteStreamAdapter { inner: resp.body };
         Ok(Box::new(adapter) as Box<_>)
@@ -739,7 +776,8 @@ impl VersionStore for S3VersionStore {
             .key(&key)
             .range(&range)
             .send()
-            .await?;
+            .await
+            .map_err(|e| object_read_error(hash, &key, e))?;
 
         let bytes = resp
             .body
@@ -1747,6 +1785,47 @@ mod tests {
         assert!(
             chunk_keys.is_empty(),
             "chunks should be deleted after combine, found: {chunk_keys:?}"
+        );
+    }
+
+    // An absent key reaches us through two different SDK error enums — GetObjectError for reads
+    // and HeadObjectError for size lookups — so both classifiers are checked against a live
+    // endpoint rather than assumed from the SDK's types.
+    #[tokio::test]
+    async fn test_reads_of_absent_key_report_missing_blob() {
+        let (store, _tmp, _server) = setup().await;
+        let hash = "deadbeefdeadbeefdeadbeefdeadbeef";
+
+        let missing = |err: &Option<OxenError>| matches!(err, Some(OxenError::VersionStoreBlobMissing { hash: h }) if h == hash);
+
+        let get = store.get_version(hash).await.err();
+        assert!(missing(&get), "get_version: got {get:?}");
+
+        let size = store.get_version_size(hash).await.err();
+        assert!(missing(&size), "get_version_size: got {size:?}");
+
+        let stream = store.get_version_stream(hash).await.err();
+        assert!(missing(&stream), "get_version_stream: got {stream:?}");
+
+        let chunk = store.get_version_chunk(hash, 0, 8).await.err();
+        assert!(missing(&chunk), "get_version_chunk: got {chunk:?}");
+
+        let derived_size = store
+            .get_version_derived_size(hash, "100x100.png")
+            .await
+            .err();
+        assert!(
+            missing(&derived_size),
+            "get_version_derived_size: got {derived_size:?}"
+        );
+
+        let derived = store
+            .get_version_derived_stream(hash, "100x100.png")
+            .await
+            .err();
+        assert!(
+            missing(&derived),
+            "get_version_derived_stream: got {derived:?}"
         );
     }
 

--- a/crates/oxen-server/src/controllers/file.rs
+++ b/crates/oxen-server/src/controllers/file.rs
@@ -924,6 +924,98 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn test_controllers_file_get_missing_version_blob() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Missing-Blob";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        util::fs::create_dir_all(repo.path.join("data"))?;
+        let hello_file = repo.path.join("data/hello.txt");
+        util::fs::write_to_path(&hello_file, "Hello")?;
+        repositories::add(&repo, &hello_file).await?;
+        let commit = repositories::commit(&repo, "First commit")?;
+
+        // Drop the backing blob while the tree keeps referencing it
+        let entry =
+            repositories::entries::get_file(&repo, &commit, PathBuf::from("data/hello.txt"))?
+                .expect("committed file should be in the tree");
+        let hash = entry.hash().to_string();
+        repo.version_store().delete_version(&hash).await?;
+
+        let uri = format!("/oxen/{namespace}/{repo_name}/file/main/data/hello.txt");
+        let req = actix_web::test::TestRequest::get()
+            .uri(&uri)
+            .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+            .to_request();
+
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.clone()))
+                .route(
+                    "/oxen/{namespace}/{repo_name}/file/{resource:.*}",
+                    web::get().to(controllers::file::get),
+                ),
+        )
+        .await;
+
+        let resp = actix_web::test::call_service(&app, req).await;
+
+        // A blob the tree still references is server-side data loss, not an absent resource, so
+        // this stays a 5xx and names the hash instead of reporting a bare NotFound.
+        assert_eq!(
+            resp.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let body = actix_http::body::to_bytes(resp.into_body()).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"]["type"], "version_blob_missing");
+        assert_eq!(body["error"]["hash"], hash);
+
+        test::cleanup_repo_and_sync_dir(repo, &sync_dir)?;
+        Ok(())
+    }
+
+    // The counterpart to the missing-blob case: a path no commit contains is an ordinary 404 and
+    // must not be confused with the server having lost data.
+    #[actix_web::test]
+    async fn test_controllers_file_get_unknown_path_is_not_found() -> Result<(), OxenError> {
+        liboxen::test::init_test_env();
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Unknown-Path";
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+
+        let readme_file = repo.path.join("README.md");
+        util::fs::write_to_path(&readme_file, "Initial commit")?;
+        repositories::add(&repo, &readme_file).await?;
+        let _commit = repositories::commit(&repo, "First commit")?;
+
+        let uri = format!("/oxen/{namespace}/{repo_name}/file/main/never/committed.txt");
+        let req = actix_web::test::TestRequest::get()
+            .uri(&uri)
+            .app_data(OxenAppData::new(sync_dir.to_path_buf()))
+            .to_request();
+
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.clone()))
+                .route(
+                    "/oxen/{namespace}/{repo_name}/file/{resource:.*}",
+                    web::get().to(controllers::file::get),
+                ),
+        )
+        .await;
+
+        let resp = actix_web::test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::NOT_FOUND);
+
+        test::cleanup_repo_and_sync_dir(repo, &sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
     async fn test_controllers_file_put_single_file_to_full_resource_path() -> Result<(), OxenError>
     {
         liboxen::test::init_test_env();

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -387,6 +387,23 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::BadRequest().json(error_json)
                     }
+                    OxenError::VersionStoreBlobMissing { hash } => {
+                        // Not a 404: the commit still lists this file, so the resource exists and
+                        // the server cannot produce its bytes. Reported separately from generic
+                        // IO so it is visible as data loss rather than lost among read failures.
+                        log::error!("Version store has no data for hash {hash}");
+                        let error_json = json!({
+                            "error": {
+                                "type": "version_blob_missing",
+                                "title": "Version data missing",
+                                "detail": format!("No stored data for hash {hash}"),
+                                "hash": hash,
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_INTERNAL_SERVER_ERROR,
+                        });
+                        HttpResponse::InternalServerError().json(error_json)
+                    }
                     OxenError::WorkspaceNotFound(workspace) => {
                         log::warn!("Workspace not found: {workspace}");
                         let error_json = json!({


### PR DESCRIPTION
A version blob missing from the store returned HTTP 500 with an error that named nothing -- no hash, no path -- so a real data-loss incident was indistinguishable from any other read failure and there was no way to tell from the report which file was affected.

Reads of the version store now report a missing blob as its own error carrying the hash, and the server returns it as a distinct response type that groups separately from ordinary IO failures. Combined with the request URL, a report now identifies the repository, the path, and the blob.

Every read in both the local and S3 stores is covered, so the image-resize and thumbnail paths cannot produce the same unattributable error. Read failures with other causes, such as permissions or corruption, keep their message and now name the file or key they could not read.

Also fixes a restore against S3 storage falling back to a generic hint when a blob was missing, instead of pointing at re-fetching the missing data.

Sentry: OXEN-SERVER-6, OXEN-SERVER-5
ENG-1472