### PR TITLE
Handle three-dot ranges correctly in more places

### DIFF
--- a/crates/liboxen/src/api/client/compare.rs
+++ b/crates/liboxen/src/api/client/compare.rs
@@ -143,7 +143,12 @@ pub async fn commits(
     let body = client::parse_json_body(&url, res).await?;
     let response: Result<CompareCommitsResponse, serde_json::Error> = serde_json::from_str(&body);
     match response {
-        Ok(commits) => Ok(commits.compare.commits),
+        Ok(commits) => Ok(commits
+            .compare
+            .commits
+            .into_iter()
+            .map(|c| c.commit)
+            .collect()),
         Err(err) => Err(OxenError::basic_str(format!(
             "commits() Could not deserialize response [{err}]\n{body}"
         ))),

--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -905,8 +905,10 @@ pub async fn list_symmetric_difference(
     base: &Commit,
     head: &Commit,
 ) -> Result<(Vec<Commit>, Vec<Commit>), OxenError> {
-    let head_only = list_between_exclusive(repo, base, head).await?;
-    let base_only = list_between_exclusive(repo, head, base).await?;
+    let (head_only, base_only) = tokio::try_join!(
+        list_between_exclusive(repo, base, head),
+        list_between_exclusive(repo, head, base),
+    )?;
     Ok((base_only, head_only))
 }
 

--- a/crates/liboxen/src/core/v_latest/commits.rs
+++ b/crates/liboxen/src/core/v_latest/commits.rs
@@ -898,6 +898,18 @@ pub fn list_between(
 /// The second walk pops by timestamp only to order the output newest first; a
 /// commit still always precedes its parents because a parent is pushed to the
 /// heap only after its child has been popped.
+/// The commits reachable from exactly one of `base` and `head`, as `(base_only, head_only)`.
+/// Git's `log base...head` shows this set, marking which side each commit came from.
+pub async fn list_symmetric_difference(
+    repo: &LocalRepository,
+    base: &Commit,
+    head: &Commit,
+) -> Result<(Vec<Commit>, Vec<Commit>), OxenError> {
+    let head_only = list_between_exclusive(repo, base, head).await?;
+    let base_only = list_between_exclusive(repo, head, base).await?;
+    Ok((base_only, head_only))
+}
+
 pub async fn list_between_exclusive(
     repo: &LocalRepository,
     base: &Commit,

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -128,6 +128,10 @@ pub enum OxenError {
     #[error("Revision not found: {0}")]
     RevisionNotFound(StringError),
 
+    /// Two revisions share no history, so there is no merge base to compare from.
+    #[error("No merge base between {base} and {head}")]
+    NoMergeBase { base: String, head: String },
+
     /// The repository is empty: it has no commits.
     #[error("No commits found.")]
     NoCommitsFound,
@@ -734,6 +738,9 @@ impl OxenError {
             }
             RevisionNotFound(_) => {
                 "Check available branches with `oxen branch --all` or commits with `oxen log`."
+            }
+            NoMergeBase { .. } => {
+                "The two revisions have no common ancestor. Compare them directly with `..` instead of `...`."
             }
             HeadNotFound | NoCommitsFound => {
                 "This repository has no commits yet. Add files and create your first commit."

--- a/crates/liboxen/src/repositories/commits.rs
+++ b/crates/liboxen/src/repositories/commits.rs
@@ -158,6 +158,9 @@ pub use crate::core::v_latest::commits::list_between;
 /// List commits reachable from head but not base (git `base..head`)
 pub use crate::core::v_latest::commits::list_between_exclusive;
 
+/// Commits reachable from exactly one of two revisions, as `(base_only, head_only)`
+pub use crate::core::v_latest::commits::list_symmetric_difference;
+
 /// Get a list of commits by the commit message
 pub fn get_by_message(
     repo: &LocalRepository,
@@ -834,6 +837,43 @@ mod tests {
                 assert_range_matches_reference(repo, base, head).await;
             }
         }
+    }
+
+    /// Mirrors `git log base...head`: the commits on either side of the fork but not both. A
+    /// merge-base substitution would instead yield only head's side, which is the two-dot answer.
+    #[tokio::test]
+    async fn test_list_symmetric_difference_returns_both_sides() -> Result<(), OxenError> {
+        test::run_one_commit_local_repo_test_async(|repo| async move {
+            let main = repositories::branches::current_branch(&repo)?.unwrap();
+            let fork = add_commit(&repo, "fork").await?;
+
+            repositories::branches::create_checkout(&repo, "feature")?;
+            let d1 = add_commit(&repo, "d1").await?;
+            let head = add_commit(&repo, "d2").await?;
+
+            repositories::checkout(&repo, &main.name).await?;
+            let base = add_commit(&repo, "c1").await?;
+
+            let (base_only, head_only) =
+                repositories::commits::list_symmetric_difference(&repo, &base, &head).await?;
+
+            let base_ids: Vec<&str> = base_only.iter().map(|c| c.id.as_str()).collect();
+            let head_ids: Vec<&str> = head_only.iter().map(|c| c.id.as_str()).collect();
+            assert_eq!(base_ids, vec![base.id.as_str()], "base side is c1 only");
+            assert_eq!(
+                head_ids.len(),
+                2,
+                "head side is d1 and d2, got {head_ids:?}"
+            );
+            assert!(head_ids.contains(&d1.id.as_str()));
+            assert!(head_ids.contains(&head.id.as_str()));
+            assert!(
+                !base_ids.contains(&fork.id.as_str()) && !head_ids.contains(&fork.id.as_str()),
+                "the shared fork point belongs to neither side"
+            );
+            Ok(())
+        })
+        .await
     }
 
     #[tokio::test]

--- a/crates/liboxen/src/view/compare.rs
+++ b/crates/liboxen/src/view/compare.rs
@@ -15,7 +15,25 @@ use super::StatusMessage;
 pub struct CompareCommits {
     pub base_commit: Commit,
     pub head_commit: Commit,
-    pub commits: Vec<Commit>,
+    pub commits: Vec<CompareCommit>,
+}
+
+/// Which side of a comparison a commit came from, mirroring the markers git's
+/// `log --left-right base...head` prints.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitSide {
+    Base,
+    Head,
+}
+
+/// A commit in a comparison, tagged with the side it came from. Every commit of a two-dot
+/// comparison is on the head side; a three-dot comparison reports commits from both.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct CompareCommit {
+    #[serde(flatten)]
+    pub commit: Commit,
+    pub side: CommitSide,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -17,8 +17,8 @@ use liboxen::model::{Commit, CommitEntry, DataFrameSize, LocalRepository, Schema
 use liboxen::opts::DFOpts;
 use liboxen::opts::df_opts::DFOptsView;
 use liboxen::view::compare::{
-    CompareCommits, CompareCommitsResponse, CompareDupes, CompareEntries, CompareEntryResponse,
-    CompareTabular, CompareTabularResponse,
+    CommitSide, CompareCommit, CompareCommits, CompareCommitsResponse, CompareDupes,
+    CompareEntries, CompareEntryResponse, CompareTabular, CompareTabularResponse,
 };
 use liboxen::view::compare::{TabularCompareBody, TabularCompareTargetBody};
 use liboxen::view::diff::{DirDiffStatus, DirDiffTreeSummary, DirTreeDiffResponse};
@@ -33,19 +33,19 @@ use liboxen::{constants, repositories, util};
 use crate::helpers::get_repo;
 use crate::params::{
     DFOptsQuery, PageNumQuery, app_data, df_opts_query, parse_base_head, parse_two_dot, path_param,
-    resolve_base_head,
+    resolve_base_head, resolve_diff_base,
 };
 
 /// List commits between two revisions
 #[utoipa::path(
     get,
     path = "/api/repos/{namespace}/{repo_name}/compare/{base_head}/commits",
-    description = "List commits between a 'base' and 'head' commit.",
+    description = "List commits between a 'base' and 'head' commit. Two dots list what head added; three dots list the commits on either side but not both, each tagged with the side it came from.",
     tags = ["Compare", "Commits"], // confusing that this endpoint isn't in the 'commits' namespace. People will look there, so listing it there as well.
     params(
         ("namespace" = String, Path, description = "Namespace of the repository", example = "ox"),
         ("repo_name" = String, Path, description = "Name of the repository", example = "satellite-images"),
-        ("base_head" = String, Path, description = "The base and head revisions separated by '..'", example = "main..feature/add-labels"),
+        ("base_head" = String, Path, description = "The base and head revisions separated by '..', or '...' for the commits on either side but not both", example = "main...feature/add-labels"),
         ("page" = Option<usize>, Query, description = "Page number for pagination (starts at 1)"),
         ("page_size" = Option<usize>, Query, description = "Page size for pagination")
     ),
@@ -70,16 +70,45 @@ pub async fn commits(
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
 
-    // Parse the base and head from the base..head string
-    let (base, head) = parse_two_dot(&base_head)?;
+    // Parse the base and head from the base..head or base...head string
+    let (base, head, three_dot) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
 
-    let commits =
+    // Three dots (base...head) list the commits on either side of the fork but not both, the way
+    // git's `log base...head` does; two dots list only what head added.
+    let mut commits: Vec<CompareCommit> = if three_dot {
+        let (base_only, head_only) = repositories::commits::list_symmetric_difference(
+            &repository,
+            &base_commit,
+            &head_commit,
+        )
+        .await?;
+        base_only
+            .into_iter()
+            .map(|commit| CompareCommit {
+                commit,
+                side: CommitSide::Base,
+            })
+            .chain(head_only.into_iter().map(|commit| CompareCommit {
+                commit,
+                side: CommitSide::Head,
+            }))
+            .collect()
+    } else {
         repositories::commits::list_between_exclusive(&repository, &base_commit, &head_commit)
-            .await?;
+            .await?
+            .into_iter()
+            .map(|commit| CompareCommit {
+                commit,
+                side: CommitSide::Head,
+            })
+            .collect()
+    };
+    // Newest first across both sides, matching git's default log order.
+    commits.sort_by_key(|c| std::cmp::Reverse(c.commit.timestamp));
     let (paginated, pagination) = util::paginate(commits, page, page_size);
 
     let compare = CompareCommits {
@@ -137,18 +166,7 @@ pub async fn entries(
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    // Three dots (base...head) diff from the merge base, so commits that landed
-    // on the base branch after the fork don't read as part of head's changes.
-    let base_commit = if three_dot {
-        repositories::merge::lowest_common_ancestor_from_commits(
-            &repository,
-            &base_commit,
-            &head_commit,
-        )?
-        .ok_or_else(|| OxenError::basic_str("No merge base between the requested revisions"))?
-    } else {
-        base_commit
-    };
+    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot)?;
 
     let entries_diff = repositories::diffs::list_diff_entries(
         &repository,
@@ -225,18 +243,7 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    // Three dots (base...head) diff from the merge base, so commits that landed
-    // on the base branch after the fork don't read as part of head's changes.
-    let base_commit = if three_dot {
-        repositories::merge::lowest_common_ancestor_from_commits(
-            &repository,
-            &base_commit,
-            &head_commit,
-        )?
-        .ok_or_else(|| OxenError::basic_str("No merge base between the requested revisions"))?
-    } else {
-        base_commit
-    };
+    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot)?;
 
     let dir_diffs =
         repositories::diffs::list_changed_dirs(&repository, &base_commit, &head_commit).await?;
@@ -294,18 +301,7 @@ pub async fn dir_entries(
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    // Three dots (base...head) diff from the merge base, so commits that landed
-    // on the base branch after the fork don't read as part of head's changes.
-    let base_commit = if three_dot {
-        repositories::merge::lowest_common_ancestor_from_commits(
-            &repository,
-            &base_commit,
-            &head_commit,
-        )?
-        .ok_or_else(|| OxenError::basic_str("No merge base between the requested revisions"))?
-    } else {
-        base_commit
-    };
+    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot)?;
     let dir = PathBuf::from(dir);
 
     let entries_diff = repositories::diffs::list_diff_entries(
@@ -907,12 +903,10 @@ fn parse_base_head_resource(
 ) -> Result<(Commit, Commit, PathBuf), OxenHttpError> {
     log::debug!("Parsing base_head_resource: {base_head}");
 
-    // A three-dot range reaching here is refused rather than read as two dots; an unparseable
-    // one stays a missing resource, since head carries the resource path as well as the revision.
-    let (base, head) = parse_two_dot(base_head).map_err(|err| match err {
-        OxenHttpError::BadRequest(_) => err,
-        _ => OxenError::resource_not_found(base_head).into(),
-    })?;
+    // An unparseable range stays a missing resource, since head carries the resource path as well
+    // as the revision.
+    let (base, head, three_dot) =
+        parse_base_head(base_head).map_err(|_| OxenError::resource_not_found(base_head))?;
     let base = base.as_str();
     let head = head.as_str();
 
@@ -944,6 +938,7 @@ fn parse_base_head_resource(
 
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
     let resource = resource.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
+    let base_commit = resolve_diff_base(repo, base_commit, &head_commit, three_dot)?;
 
     Ok((base_commit, head_commit, resource))
 }

--- a/crates/oxen-server/src/controllers/diff.rs
+++ b/crates/oxen-server/src/controllers/diff.rs
@@ -166,7 +166,7 @@ pub async fn entries(
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot)?;
+    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot).await?;
 
     let entries_diff = repositories::diffs::list_diff_entries(
         &repository,
@@ -243,7 +243,7 @@ pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenH
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot)?;
+    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot).await?;
 
     let dir_diffs =
         repositories::diffs::list_changed_dirs(&repository, &base_commit, &head_commit).await?;
@@ -301,7 +301,7 @@ pub async fn dir_entries(
 
     let base_commit = base_commit.ok_or_else(|| OxenError::RevisionNotFound(base.into()))?;
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot)?;
+    let base_commit = resolve_diff_base(&repository, base_commit, &head_commit, three_dot).await?;
     let dir = PathBuf::from(dir);
 
     let entries_diff = repositories::diffs::list_diff_entries(
@@ -380,7 +380,8 @@ pub async fn file(
     // Parse the base and head from the base..head/resource string
     // For Example)
     //   main..feature/add-data/path/to/file.txt
-    let (base_commit, head_commit, resource) = parse_base_head_resource(&repository, &base_head)?;
+    let (base_commit, head_commit, resource) =
+        parse_base_head_resource(&repository, &base_head).await?;
 
     log::debug!("base_commit: {base_commit:?}");
     log::debug!("head_commit: {head_commit:?}");
@@ -897,7 +898,7 @@ pub async fn get_derived_df(
     }
 }
 
-fn parse_base_head_resource(
+async fn parse_base_head_resource(
     repo: &LocalRepository,
     base_head: &str,
 ) -> Result<(Commit, Commit, PathBuf), OxenHttpError> {
@@ -938,7 +939,7 @@ fn parse_base_head_resource(
 
     let head_commit = head_commit.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
     let resource = resource.ok_or_else(|| OxenError::RevisionNotFound(head.into()))?;
-    let base_commit = resolve_diff_base(repo, base_commit, &head_commit, three_dot)?;
+    let base_commit = resolve_diff_base(repo, base_commit, &head_commit, three_dot).await?;
 
     Ok((base_commit, head_commit, resource))
 }

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -323,6 +323,21 @@ impl error::ResponseError for OxenHttpError {
                             .insert_header(("Retry-After", "5"))
                             .json(error_json)
                     }
+                    OxenError::NoMergeBase { base, head } => {
+                        log::debug!("No merge base between {base} and {head}");
+                        let error_json = json!({
+                            "error": {
+                                "type": MSG_BAD_REQUEST,
+                                "title": "No merge base",
+                                "detail": format!(
+                                    "'{base}' and '{head}' share no history, so there is no merge base to compare from"
+                                ),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
                     OxenError::RevisionNotFound(revision) => {
                         let error_json = json!({
                             "error": {

--- a/crates/oxen-server/src/main.rs
+++ b/crates/oxen-server/src/main.rs
@@ -48,8 +48,9 @@ use liboxen::model::metadata::{
 use liboxen::model::{Commit, CommitStats};
 use liboxen::view::commit::CommitTreeValidationResponse;
 use liboxen::view::compare::{
-    CompareCommits, CompareCommitsResponse, CompareDupes, CompareEntries, CompareEntryResponse,
-    CompareTabular, CompareTabularResponse, TabularCompareBody, TabularCompareTargetBody,
+    CommitSide, CompareCommit, CompareCommits, CompareCommitsResponse, CompareDupes,
+    CompareEntries, CompareEntryResponse, CompareTabular, CompareTabularResponse,
+    TabularCompareBody, TabularCompareTargetBody,
 };
 use liboxen::view::data_frames::FromDirectoryRequest;
 use liboxen::view::diff::{DirDiffStatus, DirDiffTreeSummary, DirTreeDiffResponse};
@@ -237,7 +238,8 @@ const START_SERVER_USAGE: &str = "Usage: `oxen-server start -i 0.0.0.0 -p 3000`"
             // Merge Schemas
             MergeSuccessResponse, MergeResult, Mergeable, MergeConflictFile,
             // Compare Schemas
-            CompareCommits, CompareCommitsResponse, CompareDupes, CompareEntries, CompareEntryResponse,
+            CommitSide, CompareCommit, CompareCommits, CompareCommitsResponse, CompareDupes,
+            CompareEntries, CompareEntryResponse,
             CompareTabular, CompareTabularResponse, DirDiffStatus, DirDiffTreeSummary, DirTreeDiffResponse,
             TabularCompareBody, TabularCompareTargetBody,
             // File/Entry Schemas

--- a/crates/oxen-server/src/params.rs
+++ b/crates/oxen-server/src/params.rs
@@ -205,7 +205,7 @@ pub fn maybe_parse_two_dot(base_head: &str) -> Result<(String, Option<String>), 
 /// The commit a diff should compare from. Three dots select the merge base of the two revisions
 /// (git's `base...head`), so commits that landed on base after the fork don't read as part of
 /// head's changes.
-pub fn resolve_diff_base(
+pub async fn resolve_diff_base(
     repo: &LocalRepository,
     base_commit: Commit,
     head_commit: &Commit,
@@ -214,14 +214,19 @@ pub fn resolve_diff_base(
     if !three_dot {
         return Ok(base_commit);
     }
-    repositories::merge::lowest_common_ancestor_from_commits(repo, &base_commit, head_commit)?
-        .ok_or_else(|| {
-            OxenError::NoMergeBase {
+    // Sync core: the merge base walks both commit histories, so keep it off the actix worker.
+    let repo = repo.clone();
+    let head_commit = head_commit.clone();
+    let merge_base = tokio::task::spawn_blocking(move || -> Result<Commit, OxenError> {
+        repositories::merge::lowest_common_ancestor_from_commits(&repo, &base_commit, &head_commit)?
+            .ok_or_else(|| OxenError::NoMergeBase {
                 base: base_commit.id.clone(),
                 head: head_commit.id.clone(),
-            }
-            .into()
-        })
+            })
+    })
+    .await
+    .map_err(OxenError::from)??;
+    Ok(merge_base)
 }
 
 pub fn resolve_base_head_branches(
@@ -437,7 +442,9 @@ mod tests {
     async fn test_resolve_diff_base_two_dots_keeps_the_base_tip() -> Result<(), OxenError> {
         liboxen::test::run_one_commit_local_repo_test_async(|repo| async move {
             let (_, main_tip, feature_tip) = forked_repo(&repo).await?;
-            let resolved = resolve_diff_base(&repo, main_tip.clone(), &feature_tip, false).unwrap();
+            let resolved = resolve_diff_base(&repo, main_tip.clone(), &feature_tip, false)
+                .await
+                .unwrap();
             assert_eq!(resolved.id, main_tip.id);
             Ok(())
         })
@@ -450,7 +457,9 @@ mod tests {
             let (fork_point, main_tip, feature_tip) = forked_repo(&repo).await?;
             // Without this the diff would carry main's post-fork commits as if they were
             // feature's changes.
-            let resolved = resolve_diff_base(&repo, main_tip.clone(), &feature_tip, true).unwrap();
+            let resolved = resolve_diff_base(&repo, main_tip.clone(), &feature_tip, true)
+                .await
+                .unwrap();
             assert_eq!(resolved.id, fork_point.id);
             assert_ne!(resolved.id, main_tip.id);
             Ok(())

--- a/crates/oxen-server/src/params.rs
+++ b/crates/oxen-server/src/params.rs
@@ -202,6 +202,28 @@ pub fn maybe_parse_two_dot(base_head: &str) -> Result<(String, Option<String>), 
     Ok((base, Some(head)))
 }
 
+/// The commit a diff should compare from. Three dots select the merge base of the two revisions
+/// (git's `base...head`), so commits that landed on base after the fork don't read as part of
+/// head's changes.
+pub fn resolve_diff_base(
+    repo: &LocalRepository,
+    base_commit: Commit,
+    head_commit: &Commit,
+    three_dot: bool,
+) -> Result<Commit, OxenHttpError> {
+    if !three_dot {
+        return Ok(base_commit);
+    }
+    repositories::merge::lowest_common_ancestor_from_commits(repo, &base_commit, head_commit)?
+        .ok_or_else(|| {
+            OxenError::NoMergeBase {
+                base: base_commit.id.clone(),
+                head: head_commit.id.clone(),
+            }
+            .into()
+        })
+}
+
 pub fn resolve_base_head_branches(
     repo: &LocalRepository,
     base: &str,
@@ -385,6 +407,55 @@ mod tests {
         assert_eq!(base, "main");
         assert_eq!(head, "feature");
         assert!(three_dot);
+    }
+
+    /// Builds `base` -> `main_tip` on main and `base` -> `feature_tip` on a branch, so the merge
+    /// base of the two tips is the fork point rather than either tip.
+    async fn forked_repo(repo: &LocalRepository) -> Result<(Commit, Commit, Commit), OxenError> {
+        let main = repositories::branches::current_branch(repo)?.unwrap();
+        let base_path = repo.path.join("base.txt");
+        liboxen::util::fs::write_to_path(&base_path, "base")?;
+        repositories::add(repo, &base_path).await?;
+        let fork_point = repositories::commit(repo, "fork point")?;
+
+        repositories::branches::create_checkout(repo, "feature")?;
+        let feature_path = repo.path.join("feature.txt");
+        liboxen::util::fs::write_to_path(&feature_path, "feature")?;
+        repositories::add(repo, &feature_path).await?;
+        let feature_tip = repositories::commit(repo, "feature work")?;
+
+        repositories::checkout(repo, &main.name).await?;
+        let main_path = repo.path.join("main.txt");
+        liboxen::util::fs::write_to_path(&main_path, "main")?;
+        repositories::add(repo, &main_path).await?;
+        let main_tip = repositories::commit(repo, "main work")?;
+
+        Ok((fork_point, main_tip, feature_tip))
+    }
+
+    #[tokio::test]
+    async fn test_resolve_diff_base_two_dots_keeps_the_base_tip() -> Result<(), OxenError> {
+        liboxen::test::run_one_commit_local_repo_test_async(|repo| async move {
+            let (_, main_tip, feature_tip) = forked_repo(&repo).await?;
+            let resolved = resolve_diff_base(&repo, main_tip.clone(), &feature_tip, false).unwrap();
+            assert_eq!(resolved.id, main_tip.id);
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_resolve_diff_base_three_dots_uses_the_fork_point() -> Result<(), OxenError> {
+        liboxen::test::run_one_commit_local_repo_test_async(|repo| async move {
+            let (fork_point, main_tip, feature_tip) = forked_repo(&repo).await?;
+            // Without this the diff would carry main's post-fork commits as if they were
+            // feature's changes.
+            let resolved = resolve_diff_base(&repo, main_tip.clone(), &feature_tip, true).unwrap();
+            assert_eq!(resolved.id, fork_point.id);
+            assert_ne!(resolved.id, main_tip.id);
+            Ok(())
+        })
+        .await
     }
 
     #[test]


### PR DESCRIPTION
(This builds on Eric's #802)

Two compare endpoints took a three-dot range and returned the two-dot answer. Opening a file from a three-dot directory diff compared it against the base tip, so the file view could contradict the summary that listed it, presenting changes that landed on the base branch after the fork as if they were the head branch's. Asking for the commits in `base...head` returned only what head added.

The file endpoint now resolves the merge base, like the directory endpoints it is reached from. The commit listing now returns the commits reachable from exactly one side, which is what git's `log base...head` shows, each tagged with the side it came from the way git's `--left-right` marks them, newest first across both sides as git orders them. Two-dot comparisons are unchanged and tag every commit as head, so the tag means the same thing in both modes, and it serializes alongside the existing commit fields so current readers of the response are unaffected.

Two revisions that share no history now answer 400 instead of 500, since that is a property of the request rather than a server fault, and the response names the pair that has no common ancestor.

The merge-base resolution each directory endpoint had copied is now one helper, so a fifth caller cannot quietly get it wrong.