### PR TITLE
Stop listing staged schemas from taking an exclusive database lock

### DIFF
--- a/crates/liboxen/src/core/v_latest/data_frames/schemas.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames/schemas.rs
@@ -133,8 +133,11 @@ pub fn get_staged_schema_with_staged_db_manager(
 
 /// List all the staged schemas
 pub fn list_staged(repo: &LocalRepository) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-    let db = get_staged_db(repo)?;
     let mut results = HashMap::new();
+
+    let Some(db) = get_staged_db_read_only(repo)? else {
+        return Ok(results);
+    };
 
     let iter = db.iterator(IteratorMode::Start);
     for item in iter {

--- a/crates/liboxen/src/repositories/data_frames/schemas.rs
+++ b/crates/liboxen/src/repositories/data_frames/schemas.rs
@@ -83,6 +83,38 @@ mod tests {
 
     use serde_json::json;
     use std::path::{Path, PathBuf};
+    use std::sync::Barrier;
+
+    #[tokio::test]
+    async fn test_list_staged_serves_simultaneous_callers() -> Result<(), OxenError> {
+        // Listing staged schemas is a read. Concurrent readers all have to get an answer rather
+        // than one of them failing on RocksDB's exclusive per-path lock.
+        test::run_empty_local_repo_test_async(|repo| async move {
+            const CALLERS: usize = 8;
+            let barrier = Barrier::new(CALLERS);
+            let results = std::thread::scope(|scope| {
+                let threads: Vec<_> = (0..CALLERS)
+                    .map(|_| {
+                        scope.spawn(|| {
+                            barrier.wait();
+                            repositories::data_frames::schemas::list_staged(&repo)
+                        })
+                    })
+                    .collect();
+                threads
+                    .into_iter()
+                    .map(|thread| thread.join().expect("listing thread panicked"))
+                    .collect::<Vec<_>>()
+            });
+
+            for result in results {
+                assert!(result?.is_empty(), "nothing is staged in an empty repo");
+            }
+
+            Ok(())
+        })
+        .await
+    }
 
     #[tokio::test]
     async fn test_command_schema_list() -> Result<(), OxenError> {


### PR DESCRIPTION
Listing staged schemas opened the staged database read-write, so two callers at once collided on RocksDB's per-path lock and one failed with "No locks available". The same call also created the staged directory for repositories that had none, leaving state behind for an operation that only reads.

It now opens read-only through the helper the neighboring staged-schema reader already uses, which reports an absent database as nothing staged rather than bringing one into existence.

Reached through `oxen schemas list --staged`; the server's schema endpoints read committed schemas and were never affected.

ENG-1475