### PR TITLE
Return client mistakes as client errors instead of server failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5682,6 +5682,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "hex",
+ "image",
  "jsonwebtoken",
  "libc",
  "liboxen",

--- a/crates/liboxen/src/core/v_latest/data_frames.rs
+++ b/crates/liboxen/src/core/v_latest/data_frames.rs
@@ -43,9 +43,7 @@ pub async fn get_slice(
             if let Some(staged_node) = staged_db_manager.read_from_staged_db(&path)? {
                 match staged_node.node.node {
                     EMerkleTreeNode::File(f) => Ok(f),
-                    _ => Err(OxenError::basic_str(
-                        "Only single file download is supported",
-                    )),
+                    _ => Err(OxenError::NotAFile(path.as_ref().to_path_buf().into())),
                 }?
             } else {
                 // Fall back to commit tree using workspace's commit

--- a/crates/liboxen/src/core/v_latest/workspaces/files.rs
+++ b/crates/liboxen/src/core/v_latest/workspaces/files.rs
@@ -1191,9 +1191,9 @@ pub fn mv(
 
     let staged_db_manager = get_staged_db_manager(workspace_repo)?;
     if staged_db_manager.read_from_staged_db(new_path)?.is_some() {
-        return Err(OxenError::basic_str(format!(
-            "Destination already staged: {new_path:?}"
-        )));
+        return Err(OxenError::DestinationAlreadyStaged(
+            new_path.to_path_buf().into(),
+        ));
     }
     // Add the file node at the new path
     staged_db_manager.upsert_file_node(new_path, new_status, &new_file_node)?;

--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -213,6 +213,15 @@ pub enum OxenError {
     #[error("Not a real directory: {0}")]
     NotADirectory(PathBuf),
 
+    /// A single-file operation was given a path that resolves to a directory. Carries the path,
+    /// which is what identifies the request that got it wrong.
+    #[error("Not a single file: {0}")]
+    NotAFile(PathBufError),
+
+    /// A move or rename targeted a path that already has a staged entry.
+    #[error("Destination already staged: {0}")]
+    DestinationAlreadyStaged(PathBufError),
+
     #[error("No paths to add!")]
     NoPathsToAdd,
 
@@ -850,6 +859,16 @@ impl OxenError {
     /// Is this error's source an authentication problem?
     pub fn is_auth_error(&self) -> bool {
         matches!(self, OxenError::Authentication(_))
+    }
+
+    /// Did an image operation fail because the format itself is unsupported? That is the caller's
+    /// input rather than a server fault, unlike every other image failure. Lives here because
+    /// `image::ImageError` is not in scope for callers that don't depend on the `image` crate.
+    pub fn is_unsupported_image_format(&self) -> bool {
+        matches!(
+            self,
+            OxenError::ImageError(image::ImageError::Unsupported(_))
+        )
     }
 
     /// Is this error considered as something not existing?

--- a/crates/liboxen/src/repositories/commits/commit_writer.rs
+++ b/crates/liboxen/src/repositories/commits/commit_writer.rs
@@ -412,7 +412,7 @@ pub fn commit_dir_entries(
     }
 
     if dir_entries.is_empty() {
-        return Err(OxenError::basic_str("No changes to commit"));
+        return Err(OxenError::NoChanges);
     }
 
     let message = &new_commit.message;

--- a/crates/oxen-server/Cargo.toml
+++ b/crates/oxen-server/Cargo.toml
@@ -76,6 +76,9 @@ signal-hook = { workspace = true }
 
 [dev-dependencies]
 actix-multipart-test = { workspace = true }
+# Only so the error-mapping tests can construct an `image::ImageError`; the crate itself reaches
+# image handling through liboxen.
+image = { workspace = true }
 liboxen = { workspace = true, features = ["test-utils"] }
 mockito = { workspace = true }
 # "test" swaps in a capturing transport, so the `tasks` tests can assert what reaches Sentry. Kept a

--- a/crates/oxen-server/src/controllers/file.rs
+++ b/crates/oxen-server/src/controllers/file.rs
@@ -163,9 +163,7 @@ pub async fn get(
             if let Some(staged_node) = staged_db_manager.read_from_staged_db(&path)? {
                 match staged_node.node.node {
                     EMerkleTreeNode::File(f) => Ok(f),
-                    _ => Err(OxenError::basic_str(
-                        "Only single file download is supported",
-                    )),
+                    _ => Err(OxenError::NotAFile(path.clone().into())),
                 }?
             } else {
                 // Fall back to commit tree using workspace's commit

--- a/crates/oxen-server/src/controllers/workspaces.rs
+++ b/crates/oxen-server/src/controllers/workspaces.rs
@@ -449,7 +449,9 @@ pub async fn commit(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
             })))
         }
         Err(err) => {
-            log::error!("unable to commit branch {branch_name:?}. Err: {err}");
+            // The 422 below already tells the caller they got this wrong, so `warn!` rather than
+            // `error!` — an `error!` here reports every rejected commit as a server fault.
+            log::warn!("unable to commit branch {branch_name:?}. Err: {err}");
             Ok(HttpResponse::UnprocessableEntity().json(StatusMessage::error(format!("{err:?}"))))
         }
     }

--- a/crates/oxen-server/src/controllers/workspaces/files.rs
+++ b/crates/oxen-server/src/controllers/workspaces/files.rs
@@ -99,9 +99,7 @@ pub async fn get(
     let file_node = match staged_db_manager.read_from_staged_db(&path)? {
         Some(staged_node) => match staged_node.node.node {
             EMerkleTreeNode::File(f) => Ok(f),
-            _ => Err(OxenError::basic_str(
-                "Only single file download is supported",
-            )),
+            _ => Err(OxenError::NotAFile(PathBuf::from(&path).into())),
         }?,
         None => {
             // If the file isn't in the workspace staged_db, look for it in the base repo

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -376,6 +376,63 @@ impl error::ResponseError for OxenHttpError {
                         });
                         HttpResponse::NotFound().json(error_json)
                     }
+                    // The next four are things a caller got wrong. Each returns a terminal 4xx at
+                    // `warn!`, so it stops both the client retrying and the alert that a 5xx at
+                    // `error!` raises.
+                    OxenError::NotAFile(path) => {
+                        log::warn!("Single-file endpoint given a directory: {path}");
+                        let error_json = json!({
+                            "error": {
+                                "type": "not_a_file",
+                                "title": "Not a single file",
+                                "detail": format!("This endpoint serves one file at a time, and {path} is a directory."),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::BadRequest().json(error_json)
+                    }
+                    OxenError::NoChanges => {
+                        log::warn!("Commit refused, nothing staged differs from the parent commit");
+                        let error_json = json!({
+                            "error": {
+                                "type": "no_changes",
+                                "title": "No changes to commit",
+                                "detail": "Nothing staged differs from the parent commit, so there is nothing to commit.",
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::UnprocessableEntity().json(error_json)
+                    }
+                    OxenError::DestinationAlreadyStaged(path) => {
+                        log::warn!("Move refused, destination already staged: {path}");
+                        let error_json = json!({
+                            "error": {
+                                "type": "destination_already_staged",
+                                "title": "Destination already staged",
+                                "detail": format!("{path} already has a staged entry. Unstage it first, or choose another destination."),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_CONFLICT,
+                        });
+                        HttpResponse::Conflict().json(error_json)
+                    }
+                    // Only the unsupported-format case is the caller's: they uploaded an image
+                    // this build cannot decode. Every other image failure stays a server error.
+                    OxenError::ImageError(_) if error.is_unsupported_image_format() => {
+                        log::warn!("Unsupported image format: {error}");
+                        let error_json = json!({
+                            "error": {
+                                "type": "unsupported_image_format",
+                                "title": "Unsupported Image Format",
+                                "detail": format!("This image cannot be decoded by the server: {error}"),
+                            },
+                            "status": STATUS_ERROR,
+                            "status_message": MSG_BAD_REQUEST,
+                        });
+                        HttpResponse::UnsupportedMediaType().json(error_json)
+                    }
                     OxenError::PathStagedForRemoval(path) => {
                         log::warn!("Edit refused, path staged for removal: {path}");
                         let error_json = json!({
@@ -910,6 +967,7 @@ mod tests {
     use super::*;
     use actix_web::ResponseError;
     use actix_web::http::StatusCode;
+    use std::path::PathBuf;
 
     #[test]
     fn test_unsupported_repo_version_is_a_client_error() {
@@ -933,6 +991,51 @@ mod tests {
         let status = error.error_response().status();
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(!status.is_server_error());
+    }
+
+    #[test]
+    fn test_client_mistakes_are_not_server_errors() {
+        // Each of these is something a caller got wrong. As a 5xx each one alerted us and invited
+        // the client to retry a request that can never succeed, so the status has to be a terminal
+        // 4xx. `tracing_actix_web` levels its own event off the response status, so getting the
+        // status right is also what stops the Sentry report.
+        let cases = [
+            (
+                OxenError::NotAFile(PathBuf::from("some/dir").into()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (OxenError::NoChanges, StatusCode::UNPROCESSABLE_ENTITY),
+            (
+                OxenError::DestinationAlreadyStaged(PathBuf::from("a.txt").into()),
+                StatusCode::CONFLICT,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            let rendered = format!("{error}");
+            let status = OxenHttpError::from(error).error_response().status();
+            assert_eq!(status, expected, "wrong status for {rendered}");
+            assert!(!status.is_server_error(), "{rendered} reported as a 5xx");
+        }
+    }
+
+    #[test]
+    fn test_unsupported_image_format_is_a_client_error() {
+        // An image this build cannot decode is the caller's input. Every other image failure is
+        // still a server error, so the arm is guarded rather than matching all of `ImageError`.
+        let error = OxenError::ImageError(image::ImageError::Unsupported(
+            image::error::UnsupportedError::from_format_and_kind(
+                image::error::ImageFormatHint::Name("AVIF".to_string()),
+                image::error::UnsupportedErrorKind::Format(image::error::ImageFormatHint::Name(
+                    "AVIF".to_string(),
+                )),
+            ),
+        ));
+        assert!(error.is_unsupported_image_format());
+
+        let status = OxenHttpError::from(error).error_response().status();
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
         assert!(!status.is_server_error());
     }
 }


### PR DESCRIPTION
The motivation for this PR is to avoid creating Sentry issues for bad requests that clients make. Sentry issues should be generated for problems we can fix in the server, not bad requests from clients, like attempting to download a directory as a file.

Four conditions a caller can trigger were reported as HTTP 500: asking a single-file endpoint for a directory, committing with nothing staged, moving onto an already-staged path, and uploading an image the server cannot decode. Each one alerted us as though the server were broken, and each invited the client to retry a request that could never succeed.

They now return terminal 4xx statuses -- 400, 422, 409, and 415 -- and log at warning level. The request middleware takes its own log level from the response status, so correcting the status is also what stops these being reported as server faults.

Asking for a directory now names the path that was asked for, which the previous message omitted, and committing with nothing staged raises the existing no-changes error rather than an untyped string carrying the same text. Rejecting a workspace commit no longer logs at error level; the 422 it already returned says the caller got it wrong.

ENG-1473