### PR TITLE
Merkle LMDB (1.2.7): Delete repositories the server cannot open

### DIFF
--- a/crates/liboxen/src/error.rs
+++ b/crates/liboxen/src/error.rs
@@ -54,6 +54,11 @@ pub enum OxenError {
     #[error("Repository '{0}' not found")]
     RepoNotFound(Box<RepoNew>),
 
+    /// When a namespace or repository name is not a single ordinary path component, so it could
+    /// name a location outside the directory repositories live in.
+    #[error("Invalid repository identifier: {0}")]
+    InvalidRepoIdentifier(StringError),
+
     /// When a local repository cannot be found at the given path.
     #[error("No oxen repository found at {0}")]
     LocalRepoNotFound(PathBufError),

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -18,7 +18,8 @@ use crate::util::fs::AtomicFile;
 use bytes::Bytes;
 use jwalk::WalkDir;
 use regex::Regex;
-use std::path::{Path, PathBuf};
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock;
 use tokio::task::spawn_blocking;
 
@@ -68,6 +69,34 @@ pub use save::save;
 pub use status::status;
 pub use status::status_from_dir;
 
+/// The directory holding the repositories in `namespace`, under `sync_dir`.
+///
+/// `namespace` must be a single ordinary path component, so the result always stays inside
+/// `sync_dir`.
+pub fn namespace_dir(sync_dir: &Path, namespace: &str) -> Result<PathBuf, OxenError> {
+    Ok(sync_dir.join(plain_segment(namespace)?))
+}
+
+/// The directory holding repository `namespace`/`name`, under `sync_dir`.
+///
+/// `namespace` and `name` must each be a single ordinary path component, so the result always
+/// stays inside `sync_dir`. Build every server-side repository path through this rather than
+/// joining the parts directly, so an identifier that arrived over the network cannot name a
+/// location outside `sync_dir`.
+pub fn repo_dir(sync_dir: &Path, namespace: &str, name: &str) -> Result<PathBuf, OxenError> {
+    Ok(namespace_dir(sync_dir, namespace)?.join(plain_segment(name)?))
+}
+
+/// Rejects anything that is not exactly one ordinary path component: `.`, `..`, a separator, an
+/// absolute path, a Windows prefix, or an empty string.
+fn plain_segment(segment: &str) -> Result<&OsStr, OxenError> {
+    let mut components = Path::new(segment).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(part)), None) => Ok(part),
+        _ => Err(OxenError::InvalidRepoIdentifier(segment.into())),
+    }
+}
+
 pub fn get_by_namespace_and_name(
     sync_dir: &Path,
     namespace: impl AsRef<str>,
@@ -76,7 +105,7 @@ pub fn get_by_namespace_and_name(
 ) -> Result<Option<LocalRepository>, OxenError> {
     let namespace = namespace.as_ref();
     let name = name.as_ref();
-    let repo_dir = sync_dir.join(namespace).join(name);
+    let repo_dir = repo_dir(sync_dir, namespace, name)?;
 
     if !repo_dir.exists() {
         log::debug!("Repo does not exist: {repo_dir:?}");
@@ -172,27 +201,27 @@ pub fn transfer_namespace(
 ) -> Result<LocalRepository, OxenError> {
     log::debug!("transfer_namespace from: {from_namespace} to: {to_namespace}");
 
-    let repo_dir = sync_dir.join(from_namespace).join(repo_name);
-    let new_repo_dir = sync_dir.join(to_namespace).join(repo_name);
+    let from_dir = repo_dir(sync_dir, from_namespace, repo_name)?;
+    let to_dir = repo_dir(sync_dir, to_namespace, repo_name)?;
 
-    if !repo_dir.exists() {
-        log::debug!("Error while transferring repo: repo does not exist: {repo_dir:?}");
+    if !from_dir.exists() {
+        log::debug!("Error while transferring repo: repo does not exist: {from_dir:?}");
         return Err(OxenError::RepoNotFound(Box::new(
             RepoNew::from_namespace_name(from_namespace, repo_name, None),
         )));
     }
 
     // ensure DB instance is closed before we move the repo
-    merkle_tree::merkle_tree_node_cache::remove_from_cache(&repo_dir)?;
-    core::staged::remove_from_cache_with_children(&repo_dir)?;
-    core::refs::remove_from_cache(&repo_dir)?;
+    merkle_tree::merkle_tree_node_cache::remove_from_cache(&from_dir)?;
+    core::staged::remove_from_cache_with_children(&from_dir)?;
+    core::refs::remove_from_cache(&from_dir)?;
 
-    util::fs::create_dir_all(&new_repo_dir)?;
-    util::fs::rename(&repo_dir, &new_repo_dir)?;
+    util::fs::create_dir_all(&to_dir)?;
+    util::fs::rename(&from_dir, &to_dir)?;
 
     // Update path in config
     {
-        let repo = LocalRepository::from_dir_with_server_opts(&new_repo_dir, server_s3_opts)?;
+        let repo = LocalRepository::from_dir_with_server_opts(&to_dir, server_s3_opts)?;
         repo.save()?;
         // ensure drop(repo)
     }
@@ -661,6 +690,49 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    #[test]
+    fn test_repo_dir_rejects_identifiers_that_escape_the_sync_dir() {
+        let sync_dir = Path::new("/data");
+
+        for bad in ["..", ".", "", "/", "a/b", "../..", "/etc", "./x"] {
+            assert!(
+                matches!(
+                    repositories::repo_dir(sync_dir, bad, "repo"),
+                    Err(OxenError::InvalidRepoIdentifier(_))
+                ),
+                "namespace {bad:?} should be rejected"
+            );
+            assert!(
+                matches!(
+                    repositories::repo_dir(sync_dir, "namespace", bad),
+                    Err(OxenError::InvalidRepoIdentifier(_))
+                ),
+                "name {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_repo_dir_accepts_ordinary_identifiers() -> Result<(), OxenError> {
+        let sync_dir = Path::new("/data");
+
+        assert_eq!(
+            repositories::repo_dir(sync_dir, "my-namespace", "my-repo")?,
+            Path::new("/data/my-namespace/my-repo")
+        );
+        // A dot inside a segment is ordinary; only a segment that *is* `.` or `..` is not.
+        assert_eq!(
+            repositories::repo_dir(sync_dir, "ns.1", "repo..name")?,
+            Path::new("/data/ns.1/repo..name")
+        );
+        assert_eq!(
+            repositories::namespace_dir(sync_dir, "my-namespace")?,
+            Path::new("/data/my-namespace")
+        );
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/liboxen/src/repositories.rs
+++ b/crates/liboxen/src/repositories.rs
@@ -317,7 +317,16 @@ pub async fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenErro
     // custom versions_path) they live outside the repo directory.
     repo.version_store().destroy().await?;
 
-    let path = repo.path.clone();
+    delete_dir(&repo.path).await?;
+    Ok(repo)
+}
+
+/// Removes a repository's directory.
+///
+/// Version blobs held outside the directory survive, so prefer [`delete`] whenever the repository
+/// can be opened.
+pub async fn delete_dir(path: &Path) -> Result<(), OxenError> {
+    let path = path.to_path_buf();
     tokio::task::spawn_blocking(move || -> Result<(), OxenError> {
         // Close DB instances before trying to delete the directory
         merkle_tree::merkle_tree_node_cache::remove_from_cache(&path)?;
@@ -333,7 +342,7 @@ pub async fn delete(repo: &LocalRepository) -> Result<&LocalRepository, OxenErro
         Ok(())
     })
     .await??;
-    Ok(repo)
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -516,15 +516,31 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
 
-    let Ok(repository) = get_repo(app_data, &namespace, &name) else {
-        return Ok(HttpResponse::NotFound().json(StatusMessage::resource_not_found()));
+    let repository = match get_repo(app_data, &namespace, &name) {
+        Ok(repository) => Some(repository),
+        Err(OxenHttpError::InternalOxenError(OxenError::RepoNotFound(_))) => {
+            return Ok(HttpResponse::NotFound().json(StatusMessage::resource_not_found()));
+        }
+        // A repository the server cannot open is still deleted. Reporting it as missing would
+        // strand the directory on disk with no way for a caller to reclaim it, and version blobs
+        // held outside the directory are unreachable without the repository config anyway.
+        Err(err) => {
+            log::warn!("Deleting unreadable repo {namespace}/{name}: {err}");
+            None
+        }
     };
+    let repo_dir = app_data.path.join(&namespace).join(&name);
 
     // Delete in a background task because it could take awhile; the blocking directory
     // removal runs inside delete's own spawn_blocking.
     tokio::spawn(async move {
-        match repositories::delete(&repository).await {
-            Ok(_) => log::info!("Deleted repo: {namespace}/{name}"),
+        let result = match &repository {
+            Some(repository) => repositories::delete(repository).await.map(|_| ()),
+            None => repositories::delete_dir(&repo_dir).await,
+        };
+
+        match result {
+            Ok(()) => log::info!("Deleted repo: {namespace}/{name}"),
             Err(err) => log::error!("Err deleting repo: {err}"),
         }
     });
@@ -589,4 +605,74 @@ pub async fn transfer_namespace(
             merkle_node_backend: Some(repo.merkle_node_backend()),
         },
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test;
+    use actix_web::http;
+    use liboxen::config::RepositoryConfig;
+    use liboxen::error::OxenError;
+    use liboxen::util;
+    use std::path::Path;
+    use std::time::{Duration, Instant};
+
+    /// Waits for the handler's background delete to finish.
+    async fn wait_until_gone(path: &Path) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if !path.exists() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        false
+    }
+
+    #[actix_web::test]
+    async fn test_delete_removes_a_repo_the_server_cannot_open() -> Result<(), OxenError> {
+        let sync_dir = test::get_sync_dir()?;
+        let namespace = "Testing-Namespace";
+        let repo_name = "Testing-Repo";
+
+        let repo = test::create_local_repo(&sync_dir, namespace, repo_name)?;
+        let repo_dir = repo.path.clone();
+
+        // Declare an on-disk format this build refuses to load, so the handler cannot open the
+        // repo. Deleting it must still clear the directory: a repo the server can read the name of
+        // but not the contents of is exactly the one an operator needs removed.
+        let config_path = util::fs::config_filepath(&repo_dir);
+        let mut config = RepositoryConfig::from_file(&config_path)?;
+        config.min_version = Some("0.19.0".to_string());
+        config.save(&config_path)?;
+
+        let req = test::repo_request(&sync_dir, "/", namespace, repo_name);
+        let resp = super::delete(req)
+            .await
+            .expect("delete handler should succeed");
+
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        assert!(
+            wait_until_gone(&repo_dir).await,
+            "repo dir should be deleted: {repo_dir:?}"
+        );
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_delete_reports_not_found_for_a_repo_that_is_not_there() -> Result<(), OxenError> {
+        let sync_dir = test::get_sync_dir()?;
+
+        let req = test::repo_request(&sync_dir, "/", "Testing-Namespace", "no-such-repo");
+        let resp = super::delete(req)
+            .await
+            .expect("delete handler should succeed");
+
+        assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
+
+        test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
 }

--- a/crates/oxen-server/src/controllers/repositories.rs
+++ b/crates/oxen-server/src/controllers/repositories.rs
@@ -43,6 +43,7 @@ use utoipa;
     ),
     responses(
         (status = 200, description = "List of repositories", body = ListRepositoryResponse),
+        (status = 400, description = "Namespace is not a single path segment"),
         (status = 404, description = "Namespace not found")
     )
 )]
@@ -50,9 +51,9 @@ pub async fn index(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
 
-    let namespace_path = &app_data.path.join(&namespace);
+    let namespace_path = repositories::namespace_dir(&app_data.path, &namespace)?;
 
-    let repos: Vec<RepositoryListView> = repositories::list_repos_in_namespace(namespace_path)
+    let repos: Vec<RepositoryListView> = repositories::list_repos_in_namespace(&namespace_path)
         .map(|repo| RepositoryListView {
             name: repo.dirname(),
             namespace: namespace.to_string(),
@@ -508,6 +509,7 @@ fn map_create_error_to_response(err: OxenError) -> HttpResponse {
     ),
     responses(
         (status = 200, description = "Repository deletion started", body = StatusMessage),
+        (status = 400, description = "Namespace or repository name is not a single path segment"),
         (status = 404, description = "Repository not found")
     )
 )]
@@ -515,6 +517,12 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?.to_string();
     let name = path_param(&req, "repo_name")?.to_string();
+
+    // Validates the segments, so it also rejects anything that could name a directory outside the
+    // sync dir. Must come before the removal below, which is why the dir is not taken from the
+    // repository lookup (that lookup fails for exactly the repos this endpoint still has to
+    // delete).
+    let repo_dir = repositories::repo_dir(&app_data.path, &namespace, &name)?;
 
     let repository = match get_repo(app_data, &namespace, &name) {
         Ok(repository) => Some(repository),
@@ -529,7 +537,6 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
             None
         }
     };
-    let repo_dir = app_data.path.join(&namespace).join(&name);
 
     // Delete in a background task because it could take awhile; the blocking directory
     // removal runs inside delete's own spawn_blocking.
@@ -609,8 +616,9 @@ pub async fn transfer_namespace(
 
 #[cfg(test)]
 mod tests {
+    use crate::app_data::OxenAppData;
     use crate::test;
-    use actix_web::http;
+    use actix_web::{App, http, web};
     use liboxen::config::RepositoryConfig;
     use liboxen::error::OxenError;
     use liboxen::util;
@@ -658,6 +666,46 @@ mod tests {
         );
 
         test::cleanup_sync_dir(&sync_dir)?;
+        Ok(())
+    }
+
+    /// A `..` namespace or name must not let the delete escape the sync directory. The request
+    /// goes through a real service so actix's own path decoding runs: `%2e%2e` decodes to `..`.
+    #[actix_web::test]
+    async fn test_delete_rejects_path_traversal_segments() -> Result<(), OxenError> {
+        let root = test::get_sync_dir()?;
+        let sync_dir = root.join("level1").join("level2");
+        util::fs::create_dir_all(&sync_dir)?;
+
+        // `sync_dir/../..` resolves to `root`. If the handler acts on that path, this file goes.
+        let canary = root.join("canary.txt");
+        std::fs::write(&canary, b"canary").expect("test fixture write should succeed");
+
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(OxenAppData::new(sync_dir.clone()))
+                .route(
+                    "/repos/{namespace}/{repo_name}",
+                    web::delete().to(super::delete),
+                ),
+        )
+        .await;
+
+        let req = actix_web::test::TestRequest::delete()
+            .uri("/repos/%2e%2e/%2e%2e")
+            .to_request();
+        let resp = actix_web::test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
+
+        // The removal runs in a background task, so give it time to do damage before asserting.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(
+            canary.exists(),
+            "traversal escaped the sync dir: {canary:?} was removed"
+        );
+
+        test::cleanup_sync_dir(&root)?;
         Ok(())
     }
 

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -271,6 +271,14 @@ impl error::ResponseError for OxenHttpError {
                             "Repository '{repo}' not found"
                         )))
                     }
+                    OxenError::InvalidRepoIdentifier(identifier) => {
+                        // Logged louder than an ordinary miss: this error doesn't typically happen
+                        // by accident, and could specify an arbitrary location on disk.
+                        log::warn!("Rejected invalid repo identifier: {identifier:?}");
+                        HttpResponse::BadRequest().json(StatusMessageDescription::bad_request(
+                            "A namespace and a repository name must each be a single path segment",
+                        ))
+                    }
                     OxenError::ResourceNotFound(resource) => {
                         log::debug!("Resource not found: {resource}");
                         let error_json = json!({


### PR DESCRIPTION
A repository whose config declares an on-disk format this build no longer reads could not be deleted: the handler reported it as "not found" while its directory stayed on disk, leaving no way for any caller to reclaim the space.

The handler now returns 404 only when the repository directory is genuinely absent. When the directory is present but the repository will not open, it removes the directory and logs the reason it could not be opened. Version blobs kept outside the directory are unreachable without the config, so they are left in place.

ENG-1542