### PR TITLE
Report each error condition as one issue instead of one per identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5711,6 +5711,7 @@ dependencies = [
  "tracing",
  "tracing-actix-web",
  "tracing-opentelemetry",
+ "tracing-subscriber",
  "url",
  "utoipa",
  "utoipa-swagger-ui",

--- a/crates/oxen-server/Cargo.toml
+++ b/crates/oxen-server/Cargo.toml
@@ -84,6 +84,9 @@ mockito = { workspace = true }
 # "test" swaps in a capturing transport, so the `tasks` tests can assert what reaches Sentry. Kept a
 # dev-dependency feature so the resolver leaves it out of the shipped binary.
 sentry = { workspace = true, features = ["test"] }
+# Lets the fingerprint test drive error_response through the same tracing -> Sentry layer main
+# installs, and assert what the reporting backend would actually receive.
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/oxen-server/src/controllers/commits.rs
+++ b/crates/oxen-server/src/controllers/commits.rs
@@ -1059,7 +1059,7 @@ pub async fn complete(req: HttpRequest) -> Result<HttpResponse, Error> {
                     Ok(HttpResponse::NotFound().json(StatusMessage::resource_not_found()))
                 }
                 Err(err) => {
-                    log::error!("Error finding commit [{commit_id}]: {err}");
+                    tracing::error!(commit_id = %commit_id, cause = %err, "Error finding commit");
                     Ok(HttpResponse::InternalServerError()
                         .json(StatusMessage::internal_server_error()))
                 }

--- a/crates/oxen-server/src/controllers/entries.rs
+++ b/crates/oxen-server/src/controllers/entries.rs
@@ -84,7 +84,7 @@ pub async fn download_data_from_version_paths(
         if path_to_read.exists() {
             tar.append_path_with_name(path_to_read, content_file)?;
         } else {
-            log::error!("Could not find content: {content_file:?} -> {path_to_read:?}");
+            tracing::error!(content_file = ?content_file, path = ?path_to_read, "Could not find content");
             return Err(OxenError::path_does_not_exist(path_to_read).into());
         }
     }

--- a/crates/oxen-server/src/controllers/versions.rs
+++ b/crates/oxen-server/src/controllers/versions.rs
@@ -263,7 +263,7 @@ pub async fn stream_versions_tar_gz(
                     let file_size = match version_store_clone.get_version_size(file_hash).await {
                         Ok(size) => size,
                         Err(e) => {
-                            log::error!("Failed to get version file size for {file_hash}: {e}");
+                            tracing::error!(file_hash = %file_hash, cause = %e, "Failed to get version file size");
                             error_tx
                                 .send(OxenError::VersionFetchFailed {
                                     file_hash: file_hash.clone(),
@@ -278,7 +278,7 @@ pub async fn stream_versions_tar_gz(
                     let mut header = tokio_tar::Header::new_gnu();
                     header.set_size(file_size as u64);
                     if let Err(e) = header.set_path(file_hash) {
-                        log::error!("Failed to set path for {file_hash}: {e}");
+                        tracing::error!(file_hash = %file_hash, cause = %e, "Failed to set tar path for version");
                         error_tx
                             .send(OxenError::basic_str(format!(
                                 "Failed to set path for {file_hash}: {e}"
@@ -294,7 +294,7 @@ pub async fn stream_versions_tar_gz(
 
                     let mut reader = StreamReader::new(data);
                     if let Err(e) = tar.append(&header, &mut reader).await {
-                        log::error!("Failed to append {file_hash} to tar: {e}");
+                        tracing::error!(file_hash = %file_hash, cause = %e, "Failed to append version to tar");
                         error_tx.send(OxenError::IO(e)).ok();
                         had_error = true;
                         break;
@@ -305,7 +305,7 @@ pub async fn stream_versions_tar_gz(
                     );
                 }
                 Err(e) => {
-                    log::error!("Failed to get version {file_hash}: {e}");
+                    tracing::error!(file_hash = %file_hash, cause = %e, "Failed to get version");
                     // Wrap with the hash so the streaming-response error names the specific
                     // content blob that couldn't be served. The HTTP 200 has already been sent
                     // by the time we reach this branch, so this is the only way the client side

--- a/crates/oxen-server/src/errors.rs
+++ b/crates/oxen-server/src/errors.rs
@@ -513,7 +513,10 @@ impl error::ResponseError for OxenHttpError {
                         // Not a 404: the commit still lists this file, so the resource exists and
                         // the server cannot produce its bytes. Reported separately from generic
                         // IO so it is visible as data loss rather than lost among read failures.
-                        log::error!("Version store has no data for hash {hash}");
+                        tracing::error!(
+                            hash = %hash,
+                            "Version store is missing data for a hash the tree references"
+                        );
                         let error_json = json!({
                             "error": {
                                 "type": "version_blob_missing",
@@ -543,7 +546,11 @@ impl error::ResponseError for OxenHttpError {
                         workspace_id,
                         source,
                     } => {
-                        log::error!("Workspace '{workspace_id}' staged db corrupted: {source}");
+                        tracing::error!(
+                            workspace_id = %workspace_id,
+                            cause = %source,
+                            "Workspace staged db is corrupted"
+                        );
                         let error_json = json!({
                             "error": {
                                 "type": "workspace_staged_db_corrupted",
@@ -960,6 +967,12 @@ impl error::ResponseError for OxenHttpError {
                     err => {
                         // Surface the error's message so unmapped variants return a real reason
                         // instead of a bare "internal_server_error" that lives only in the logs.
+                        //
+                        // The error text stays in the message here, unlike the arms above. Error
+                        // reporting groups by message, and every unmapped variant reaches this
+                        // one line — a constant message would collapse every unrelated failure
+                        // into a single bucket. An unmapped error carrying an id still splits per
+                        // id; the fix for that is giving it its own arm, not flattening this one.
                         log::error!("Internal server error: {err:?}");
                         let error_json = json!({
                             "error": {
@@ -1068,6 +1081,77 @@ mod tests {
             assert_eq!(status, expected, "wrong status for {rendered}");
             assert!(!status.is_server_error(), "{rendered} reported as a 5xx");
         }
+    }
+
+    /// Reports two blob-missing errors with different hashes and returns what the reporting
+    /// backend received, driving the real `error_response` through the same tracing layer `main`
+    /// installs.
+    ///
+    /// The subscriber here is scoped rather than global, so the `log` -> `tracing` bridge is not
+    /// active: a site written with `log::error!` produces no event at all rather than a
+    /// differently-grouped one. Reverting a converted site therefore fails the count assertion
+    /// below instead of the message one.
+    fn reported_events_for_two_hashes() -> Vec<sentry::protocol::Event<'static>> {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let transport = sentry::test::TestTransport::new();
+        let options = sentry::ClientOptions {
+            dsn: Some(
+                "https://public@sentry.invalid/1"
+                    .parse()
+                    .expect("the test DSN should parse"),
+            ),
+            transport: Some(std::sync::Arc::new(std::sync::Arc::clone(&transport))),
+            ..Default::default()
+        };
+        let hub = std::sync::Arc::new(sentry::Hub::new(
+            Some(std::sync::Arc::new(options.into())),
+            std::sync::Arc::new(Default::default()),
+        ));
+
+        sentry::Hub::run(hub, || {
+            let subscriber =
+                tracing_subscriber::registry().with(sentry::integrations::tracing::layer());
+            tracing::subscriber::with_default(subscriber, || {
+                for hash in ["aaa111", "bbb222"] {
+                    let error = OxenError::VersionStoreBlobMissing {
+                        hash: hash.to_string(),
+                    };
+                    let _ = OxenHttpError::from(error).error_response();
+                }
+            });
+        });
+
+        transport.fetch_and_clear_events()
+    }
+
+    #[test]
+    fn missing_blob_reports_group_together_and_keep_the_hash() {
+        // Reports are grouped by message, so a hash in the message would file every missing blob
+        // as its own issue and a resolved one would never reopen — the recurrence arrives under a
+        // new fingerprint. The hash still has to survive somewhere or the report is unactionable.
+        let events = reported_events_for_two_hashes();
+        assert_eq!(events.len(), 2, "expected one report per call");
+
+        assert_eq!(
+            events[0].message, events[1].message,
+            "two hashes must share one message, or they group as separate issues"
+        );
+
+        let hashes: Vec<String> = events
+            .iter()
+            .map(|event| {
+                format!(
+                    "{:?}",
+                    event
+                        .contexts
+                        .get("Rust Tracing Fields")
+                        .expect("the hash should ride along as a structured field")
+                )
+            })
+            .collect();
+        assert!(hashes[0].contains("aaa111"), "got {}", hashes[0]);
+        assert!(hashes[1].contains("bbb222"), "got {}", hashes[1]);
     }
 
     #[test]


### PR DESCRIPTION
Error reports are grouped by message text, so a hash, commit id, or path interpolated into an error message filed a separate issue for every distinct value. One missing version blob produced its own issue, a resolved one never reopened on recurrence because the repeat arrived under a new fingerprint, and a systemic condition looked like many unrelated one-off failures.

Eight reporting sites now log a constant message and carry the identifier as a structured field instead, so a condition groups as one issue while every occurrence keeps the value needed to act on it.

The unmapped-error fallback deliberately keeps its error text in the message. Every variant without its own arm reaches that single line, so a constant message there would collapse unrelated failures into one bucket. An unmapped error carrying an identifier still splits, and the remedy for that is giving it its own arm.

ENG-1540