### PR TITLE
Cut the Production Build job from 20 -> 5 minutes

### DIFF
--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -37,6 +37,7 @@ jobs:
           prefix-key: rust-production
           cache-all-crates: true
           cache-on-failure: true
+          cache-bin: false # See the rust-test job in ci_test.yml for rationale.
 
       - name: Load tool versions
         run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"

--- a/.github/workflows/ci_build_production.yml
+++ b/.github/workflows/ci_build_production.yml
@@ -25,6 +25,18 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: clippy
+          cache: false # We use Swatinem/rust-cache directly below for save-if control.
+
+      # Must precede the tool versions load: rust-cache hashes every CARGO*/RUST* environment
+      # variable into its key, so the cargo-tool pins in tool-versions.env would otherwise bust
+      # the whole build cache every time one of them is bumped.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          prefix-key: rust-production
+          cache-all-crates: true
+          cache-on-failure: true
 
       - name: Load tool versions
         run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
@@ -34,14 +46,6 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           python-version: "3.11"
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          prefix-key: rust-production
-          cache-all-crates: true
-          cache-on-failure: true
 
       - name: Install FFmpeg 8
         # Install FFmpeg 8 (the `production` feature enables `ffmpeg`) and point pkg-config

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -34,6 +34,7 @@ jobs:
           # Other branches will still use the cache but won't save it.
           save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: "."
+          cache-bin: false # See the rust-test job in ci_test.yml for rationale.
 
       - name: Load tool versions
         run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -22,6 +22,18 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: clippy, rustfmt
+          cache: false # We use Swatinem/rust-cache directly below for save-if control.
+
+      # Must precede the tool versions load: rust-cache hashes every CARGO*/RUST* environment
+      # variable into its key, so the cargo-tool pins in tool-versions.env would otherwise bust
+      # the whole build cache every time one of them is bumped.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Only cache builds from main. Otherwise our caches will be too big and start to churn. (10 GB limit in GitHub Actions)
+          # Other branches will still use the cache but won't save it.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: "."
 
       - name: Load tool versions
         run: grep -E '^[A-Z0-9_]+=' tool-versions.env >> "$GITHUB_ENV"
@@ -30,14 +42,6 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: ${{ env.UV_VERSION }}
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          # Only cache builds from main. Otherwise our caches will be too big and start to churn. (10 GB limit in GitHub Actions)
-          # Other branches will still use the cache but won't save it.
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          workspaces: "."
 
       - name: Install dependencies and development tools
         run: |


### PR DESCRIPTION
Production Build was the CI critical path at roughly 20 minutes, about twice the next slowest job, while the same job on main finished in about 5 and compiled nothing at all. The gap was entirely cache misses, from two independent faults.

`actions-rust-lang/setup-rust-toolchain` enables `Swatinem/rust-cache` by default, so this job and the Lint job each restored two different caches into the same paths, the second unpacking over the first. The test jobs already pass cache: false for exactly this reason, and both jobs now match.

The cache step also ran after the tool versions load, which puts the `cargo-machete`, `cargo-sort`, and `cargo-llvm-cov` pins into the environment. `rust-cache` hashes every `CARGO`-prefixed variable into its key, so bumping any one of those pins invalidated the whole build cache despite none of them affecting the build. The cache step now runs first, matching the order the test jobs already use.