### PR TITLE
Keep a hung telemetry smoke test from stalling CI for hours

### DIFF
--- a/bin/fmt-span-test
+++ b/bin/fmt-span-test
@@ -15,11 +15,21 @@ REPO_ROOT="$SCRIPT_DIR/.."
 SERVER="$REPO_ROOT/target/debug/oxen-server"
 SERVER_PID=""
 
+# Stop oxen-server, escalating to SIGKILL if it hasn't exited within 10s.
+stop_server() {
+    [ -n "$SERVER_PID" ] || return 0
+    kill "$SERVER_PID" 2>/dev/null || true
+    for _i in $(seq 1 10); do
+        kill -0 "$SERVER_PID" 2>/dev/null || break
+        sleep 1
+    done
+    kill -9 "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+}
+
 cleanup() {
-    if [ -n "$SERVER_PID" ]; then
-        kill "$SERVER_PID" 2>/dev/null || true
-        wait "$SERVER_PID" 2>/dev/null || true
-    fi
+    stop_server
     rm -f /tmp/span-stderr.txt
 }
 trap cleanup EXIT INT TERM
@@ -50,12 +60,10 @@ if ! curl -sf --max-time 2 http://localhost:3000/api/health > /dev/null 2>&1; th
 fi
 
 # Hit an endpoint so TracingLogger creates (and closes) a span
-curl -sf http://localhost:3000/api/health > /dev/null
+curl -sf --max-time 10 http://localhost:3000/api/health > /dev/null
 sleep 1
 
-kill "$SERVER_PID" 2>/dev/null || true
-wait "$SERVER_PID" 2>/dev/null || true
-SERVER_PID=""
+stop_server
 
 # Span CLOSE events include "time.busy" / "time.idle"
 if grep -q "time.busy" /tmp/span-stderr.txt; then

--- a/bin/otel-metrics-test
+++ b/bin/otel-metrics-test
@@ -50,8 +50,14 @@ has_valid_user_config() {
 }
 
 cleanup() {
+    # Stop oxen-server, escalating to SIGKILL if it hasn't exited within 10s.
     if [ -n "$SERVER_PID" ]; then
         kill "$SERVER_PID" 2>/dev/null || true
+        for _i in $(seq 1 10); do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep 1
+        done
+        kill -9 "$SERVER_PID" 2>/dev/null || true
         wait "$SERVER_PID" 2>/dev/null || true
     fi
     if [ -n "$JAEGER_NAME" ]; then
@@ -190,7 +196,7 @@ fi
 # ── oxen client: Full push / clone / modify / push / pull workflow ──
 
 # Create remote repository (namespace "ox", name "otel-metrics-test")
-curl -sf -H "Authorization: Bearer $TOKEN" \
+curl -sf --max-time 30 -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -X POST -d '{"namespace":"ox","name":"otel-metrics-test"}' \
   http://localhost:3000/api/repos


### PR DESCRIPTION
`bin/fmt-span-test` hung for 215 minutes on a main CI run before being cancelled, holding the Production Build job open and occupying main's concurrency slot. Nine consecutive main runs were cancelled while pending behind it, which stalled the Rust cache refresh and left every pull request doing a cold build.

Both the request that exercises the span and the server shutdown were unbounded. The shutdown now escalates to `SIGKILL` if oxen-server has not exited within ten seconds, and the request carries a timeout, so a wedged server fails the test in seconds instead of running to the six hour job limit.

`bin/otel-metrics-test` carried the same unbounded shutdown and an untimed request, and gets the same treatment.